### PR TITLE
Remove Maven/Gradle/Ivy reference until release is completed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,55 +49,6 @@ MutableList<String> sortedLastNames = people.collect(Person::getLastName).sortTh
 * Adds new containers including Bag, Interval, Multimap, BiMap, and immutable versions of all types
 * Has been under active development since 2005 and is a mature library
 
-## Acquiring Eclipse Collections
-
-### Maven
-```xml
-<dependency>
-  <groupId>org.eclipse.collections</groupId>
-  <artifactId>eclipse-collections-api</artifactId>
-  <version>7.0.0</version>
-</dependency>
-
-<dependency>
-  <groupId>org.eclipse.collections</groupId>
-  <artifactId>eclipse-collections</artifactId>
-  <version>7.0.0</version>
-</dependency>
-
-<dependency>
-  <groupId>org.eclipse.collections</groupId>
-  <artifactId>eclipse-collections-testutils</artifactId>
-  <version>7.0.0</version>
-  <scope>test</scope>
-</dependency>
-
-<dependency>
-  <groupId>org.eclipse.collections</groupId>
-  <artifactId>eclipse-collections-forkjoin</artifactId>
-  <version>7.0.0</version>
-</dependency>
-```
-
-### Gradle
-
-```groovy
-compile 'org.eclipse.collections:eclipse-collections-api:7.0.0'
-compile 'org.eclipse.collections:eclipse-collections:7.0.0'
-testCompile 'org.eclipse.collections:eclipse-collections-testutils:7.0.0'
-compile 'org.eclipse.collections:eclipse-collections-forkjoin:7.0.0'
-```
-
-### Ivy
-
-```xml
-<dependency org="org.eclipse.collections" name="eclipse-collections-api" rev="7.0.0" />
-<dependency org="org.eclipse.collections" name="eclipse-collections" rev="7.0.0" />
-<dependency org="org.eclipse.collections" name="eclipse-collections-testutils" rev="7.0.0" />
-<dependency org="org.eclipse.collections" name="eclipse-collections-forkjoin" rev="7.0.0"/>
-```
-
-
 [maven]:http://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
 [maven img]:https://maven-badges.herokuapp.com/maven-central/org.eclipse.collections/eclipse-collections/badge.svg
 


### PR DESCRIPTION
To avoid confusion for those who visit GitHub repo.