### PR TITLE
Several improvements to the build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,13 @@ matrix:
   include:
     - jdk: oraclejdk8
       env:
-        - DESC="compile all modules"
-        - CMD="mvn install --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - DESC="findbugs"
+        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+
+    - jdk: oraclejdk8
+      env:
+        - DESC="checkstyle"
+        - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:
@@ -25,13 +30,8 @@ matrix:
 
     - jdk: oraclejdk8
       env:
-        - DESC="checkstyle"
-        - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
-
-    - jdk: oraclejdk8
-      env:
-        - DESC="findbugs"
-        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - DESC="compile all modules"
+        - CMD="mvn install --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
 script: eval $CMD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 
-before_install: echo "MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS'" > ~/.mavenrc
+before_install: echo "MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx1g -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS'" > ~/.mavenrc
 install:
   -
 
@@ -32,6 +32,11 @@ matrix:
       env:
         - DESC="compile all modules"
         - CMD="mvn install --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+
+    - jdk: oraclejdk7
+      env:
+        - DESC="compile with Java 7"
+        - CMD="mvn install --projects eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin,eclipse-collections,eclipse-collections-api,eclipse-collections-testutils,eclipse-collections-forkjoin,serialization-tests -Dmaven.compiler.verbose=true --batch-mode --show-version --errors; jdk_switcher use oraclejdk8; mvn install --projects eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin,unit-tests,junit-trait-runner,unit-tests-java8 -Dmaven.compiler.verbose=true --batch-mode --show-version --errors"
 
 script: eval $CMD
 

--- a/README.md
+++ b/README.md
@@ -50,18 +50,6 @@ MutableList<String> sortedLastNames = people.collect(Person::getLastName).sortTh
 * Adds new containers including Bag, Interval, Multimap, BiMap, and immutable versions of all types
 * Has been under active development since 2005 and is a mature library
 
-[travis]:https://travis-ci.org/eclipse/eclipse-collections
-[travis img]:https://travis-ci.org/eclipse/eclipse-collections.svg?branch=master
-
-[maven]:http://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
-[maven img]:https://maven-badges.herokuapp.com/maven-central/org.eclipse.collections/eclipse-collections/badge.svg
-
-[license-epl]:LICENSE-EPL-1.0.txt
-[license-epl img]:https://img.shields.io/badge/License-EPL-blue.svg
-
-[license-edl]:LICENSE-EDL-1.0.txt
-[license-edl img]:https://img.shields.io/badge/License-EDL-blue.svg
-
 ## Acquiring Eclipse Collections
 
 ### Maven
@@ -110,3 +98,14 @@ compile 'org.eclipse.collections:eclipse-collections-forkjoin:7.0.0'
 <dependency org="org.eclipse.collections" name="eclipse-collections-forkjoin" rev="7.0.0"/>
 ```
 
+[travis]:https://travis-ci.org/eclipse/eclipse-collections
+[travis img]:https://travis-ci.org/eclipse/eclipse-collections.svg?branch=master
+
+[maven]:http://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
+[maven img]:https://maven-badges.herokuapp.com/maven-central/org.eclipse.collections/eclipse-collections/badge.svg
+
+[license-epl]:LICENSE-EPL-1.0.txt
+[license-epl img]:https://img.shields.io/badge/License-EPL-blue.svg
+
+[license-edl]:LICENSE-EDL-1.0.txt
+[license-edl img]:https://img.shields.io/badge/License-EDL-blue.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Eclipse Collections
 
+[![][travis img]][travis]
 [![][maven img]][maven]
 [![][license-epl img]][license-epl]
 [![][license-edl img]][license-edl]
@@ -48,6 +49,9 @@ MutableList<String> sortedLastNames = people.collect(Person::getLastName).sortTh
 * Encapsulates a lot of the structural complexity of parallel iteration and lazy evaluation
 * Adds new containers including Bag, Interval, Multimap, BiMap, and immutable versions of all types
 * Has been under active development since 2005 and is a mature library
+
+[travis]:https://travis-ci.org/eclipse/eclipse-collections
+[travis img]:https://travis-ci.org/eclipse/eclipse-collections.svg?branch=master
 
 [maven]:http://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
 [maven img]:https://maven-badges.herokuapp.com/maven-central/org.eclipse.collections/eclipse-collections/badge.svg

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -26,6 +26,9 @@
     <name>Eclipse Collections Acceptance Test Suite</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -81,17 +84,6 @@
 
     <build>
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -17,71 +17,20 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>eclipse-collections-api</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Eclipse Collections API</name>
 
-    <description>Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map
-        implementations with a rich API and set of utility classes that work with any JDK compatible Collections,
-        Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
-    </description>
-
-    <url>https://github.com/eclipse/eclipse-collections</url>
-
-    <inceptionYear>2004</inceptionYear>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License - v 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>Eclipse Distribution License - v 1.0</name>
-            <url>https://www.eclipse.org/licenses/edl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <url>https://github.com/eclipse/eclipse-collections</url>
-        <connection>scm:git:https://github.com/eclipse/eclipse-collections.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse/eclipse-collections.git</developerConnection>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Craig P. Motlin</name>
-            <email>craig.motlin@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Donald Raab</name>
-            <email>donald.raab@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Mohammad A. Rezaei</name>
-            <email>mohammad.rezaei@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Hiroshi Ito</name>
-            <email>hiroshi.ito@gs.com</email>
-        </developer>
-    </developers>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <clover.version>4.0.6</clover.version>
-        <checkstyle.version>2.16</checkstyle.version>
-        <sonar.surefire.reportsPath>${project.basedir}/target/clover/surefire-reports</sonar.surefire.reportsPath>
-        <!-- this setting is needed for TeamCity -->
-        <maven.deploy.skip>${build.is.personal}</maven.deploy.skip>
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -91,129 +40,19 @@
         <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
             <optional>true</optional>
         </dependency>
 
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
 
             <plugin>
                 <groupId>org.eclipse.collections</groupId>
                 <artifactId>eclipse-collections-code-generator-maven-plugin</artifactId>
-                <version>7.1.0-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -225,17 +64,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -339,7 +167,8 @@
                             <rules>
                                 <DependencyConvergence />
                                 <requirePluginVersions>
-                                    <unCheckedPluginList>org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
+                                    <unCheckedPluginList>
+                                        org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
                                     </unCheckedPluginList>
                                 </requirePluginVersions>
                                 <requireJavaVersion>

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -205,12 +205,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections-code-generator-ant/pom.xml
+++ b/eclipse-collections-code-generator-ant/pom.xml
@@ -13,11 +13,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
     <artifactId>eclipse-collections-code-generator-ant</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
 
     <name>Eclipse Collections Code Generator Ant Task</name>
 
@@ -27,6 +31,9 @@
         <clover.version>4.0.6</clover.version>
         <checkstyle.version>2.16</checkstyle.version>
 
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -34,7 +41,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-code-generator</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -46,128 +53,8 @@
 
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-code-generator-ant/pom.xml
+++ b/eclipse-collections-code-generator-ant/pom.xml
@@ -153,12 +153,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -14,9 +14,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>eclipse-collections-code-generator-maven-plugin</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -28,6 +32,9 @@
         <clover.version>4.0.6</clover.version>
         <checkstyle.version>2.16</checkstyle.version>
 
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -36,7 +43,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-code-generator</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -54,128 +61,8 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -161,12 +161,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -13,11 +13,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>eclipse-collections-code-generator</artifactId>
-    <groupId>org.eclipse.collections</groupId>
-    <version>7.1.0-SNAPSHOT</version>
 
     <name>Eclipse Collections Code Generator</name>
 
@@ -26,6 +30,9 @@
 
         <clover.version>4.0.6</clover.version>
         <checkstyle.version>2.16</checkstyle.version>
+
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
 
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -45,128 +52,8 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -152,12 +152,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -15,74 +15,22 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
     <artifactId>eclipse-collections-forkjoin</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Eclipse Collections Fork Join Utilities</name>
 
-    <description>Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map
-        implementations with a rich API and set of utility classes that work with any JDK compatible Collections,
-        Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
-    </description>
-
-    <url>https://github.com/eclipse/eclipse-collections</url>
-
-    <inceptionYear>2004</inceptionYear>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License - v 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>Eclipse Distribution License - v 1.0</name>
-            <url>https://www.eclipse.org/licenses/edl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <url>https://github.com/eclipse/eclipse-collections</url>
-        <connection>scm:git:https://github.com/eclipse/eclipse-collections.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse/eclipse-collections.git</developerConnection>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Craig P. Motlin</name>
-            <email>craig.motlin@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Donald Raab</name>
-            <email>donald.raab@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Mohammad A. Rezaei</name>
-            <email>mohammad.rezaei@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Hiroshi Ito</name>
-            <email>hiroshi.ito@gs.com</email>
-        </developer>
-    </developers>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <clover.version>4.0.6</clover.version>
-        <checkstyle.version>2.16</checkstyle.version>
-        <sonar.clover.reportPath>${project.basedir}/target/site/clover/clover.xml</sonar.clover.reportPath>
-        <sonar.surefire.reportsPath>${project.basedir}/target/clover/surefire-reports</sonar.surefire.reportsPath>
-        <!-- this setting is needed for TeamCity -->
-        <maven.deploy.skip>${build.is.personal}</maven.deploy.skip>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -90,13 +38,13 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Testing Dependencies -->
@@ -104,142 +52,21 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-testutils</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -225,12 +225,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -15,74 +15,22 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
     <artifactId>eclipse-collections-testutils</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Eclipse Collections Test Utilities</name>
 
-    <description>Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map
-        implementations with a rich API and set of utility classes that work with any JDK compatible Collections,
-        Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
-    </description>
-
-    <url>https://github.com/eclipse/eclipse-collections</url>
-
-    <inceptionYear>2004</inceptionYear>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License - v 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>Eclipse Distribution License - v 1.0</name>
-            <url>https://www.eclipse.org/licenses/edl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <url>https://github.com/eclipse/eclipse-collections</url>
-        <connection>scm:git:https://github.com/eclipse/eclipse-collections.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse/eclipse-collections.git</developerConnection>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Craig P. Motlin</name>
-            <email>craig.motlin@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Donald Raab</name>
-            <email>donald.raab@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Mohammad A. Rezaei</name>
-            <email>mohammad.rezaei@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Hiroshi Ito</name>
-            <email>hiroshi.ito@gs.com</email>
-        </developer>
-    </developers>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <clover.version>4.0.6</clover.version>
-        <checkstyle.version>2.16</checkstyle.version>
-        <sonar.clover.reportPath>${project.basedir}/target/site/clover/clover.xml</sonar.clover.reportPath>
-        <sonar.surefire.reportsPath>${project.basedir}/target/clover/surefire-reports</sonar.surefire.reportsPath>
-        <!-- this setting is needed for TeamCity -->
-        <maven.deploy.skip>${build.is.personal}</maven.deploy.skip>
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -90,13 +38,13 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -110,135 +58,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
 
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -224,12 +224,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -212,12 +212,6 @@
                     <version>2.8.1</version>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
             </plugins>
         </pluginManagement>
 

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -15,74 +15,22 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.collections</groupId>
     <artifactId>eclipse-collections</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Eclipse Collections Main Library</name>
 
-    <description>Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map
-        implementations with a rich API and set of utility classes that work with any JDK compatible Collections,
-        Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
-    </description>
-
-    <url>https://github.com/eclipse/eclipse-collections</url>
-
-    <inceptionYear>2004</inceptionYear>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License - v 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>Eclipse Distribution License - v 1.0</name>
-            <url>https://www.eclipse.org/licenses/edl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <url>https://github.com/eclipse/eclipse-collections</url>
-        <connection>scm:git:https://github.com/eclipse/eclipse-collections.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse/eclipse-collections.git</developerConnection>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Craig P. Motlin</name>
-            <email>craig.motlin@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Donald Raab</name>
-            <email>donald.raab@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Mohammad A. Rezaei</name>
-            <email>mohammad.rezaei@gs.com</email>
-        </developer>
-
-        <developer>
-            <name>Hiroshi Ito</name>
-            <email>hiroshi.ito@gs.com</email>
-        </developer>
-    </developers>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <clover.version>4.0.6</clover.version>
-        <checkstyle.version>2.16</checkstyle.version>
-        <sonar.clover.reportPath>${project.basedir}/target/site/clover/clover.xml</sonar.clover.reportPath>
-        <sonar.surefire.reportsPath>${project.basedir}/target/clover/surefire-reports</sonar.surefire.reportsPath>
-        <!-- this setting is needed for TeamCity -->
-        <maven.deploy.skip>${build.is.personal}</maven.deploy.skip>
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -90,7 +38,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- External dependencies -->
@@ -98,129 +46,19 @@
         <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
             <optional>true</optional>
         </dependency>
 
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
 
         <plugins>
 
             <plugin>
                 <groupId>org.eclipse.collections</groupId>
                 <artifactId>eclipse-collections-code-generator-maven-plugin</artifactId>
-                <version>7.1.0-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -232,17 +70,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -347,7 +174,8 @@
                             <rules>
                                 <DependencyConvergence />
                                 <requirePluginVersions>
-                                    <unCheckedPluginList>org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
+                                    <unCheckedPluginList>
+                                        org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
                                     </unCheckedPluginList>
                                 </requirePluginVersions>
                                 <requireJavaVersion>

--- a/jmh-scala-tests/pom.xml
+++ b/jmh-scala-tests/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
 

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -25,6 +25,9 @@
     <name>Eclipse Collections JMH Test Suite</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
         <jmh.version>1.11.1</jmh.version>
     </properties>
@@ -81,7 +84,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
 
@@ -127,17 +129,6 @@
     <build>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -25,6 +25,11 @@
 
     <name>Eclipse Collections Test Trait JUnit Runner</name>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <prerequisites>
         <maven>3.0.5</maven>
     </prerequisites>
@@ -34,7 +39,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
 
@@ -42,17 +46,6 @@
 
     <build>
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -80,7 +73,8 @@
                             <rules>
                                 <!-- <DependencyConvergence /> -->
                                 <requirePluginVersions>
-                                    <unCheckedPluginList>org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
+                                    <unCheckedPluginList>
+                                        org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
                                     </unCheckedPluginList>
                                 </requirePluginVersions>
                                 <requireJavaVersion>

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -104,17 +104,6 @@
         <plugins>
 
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -281,12 +281,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.fortify.ps.maven.plugin</groupId>
-                    <artifactId>maven-sca-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>2.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,19 @@
         <clover.version>4.0.6</clover.version>
         <checkstyle.version>2.16</checkstyle.version>
         <scala.version>2.11.7</scala.version>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.fork>true</maven.compiler.fork>
+        <maven.compiler.verbose>true</maven.compiler.verbose>
+        <maven.compiler.meminitial>2048m</maven.compiler.meminitial>
+        <maven.compiler.maxmem>2048m</maven.compiler.maxmem>
+
         <!--Sonar settings-->
         <sonar.language>java</sonar.language>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
         <sonar.clover.version>${clover.version}</sonar.clover.version>
-        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencyManagement>
@@ -171,12 +178,7 @@
 
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
-                    <configuration>
-                        <fork>true</fork>
-                        <maxmem>2048m</maxmem>
-                        <verbose>true</verbose>
-                    </configuration>
+                    <version>3.3</version>
                 </plugin>
 
                 <plugin>

--- a/serialization-tests/pom.xml
+++ b/serialization-tests/pom.xml
@@ -26,6 +26,9 @@
     <name>Eclipse Collections Serialization Test Suite</name>
 
     <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -70,17 +73,6 @@
     <build>
 
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -27,6 +27,9 @@
     <name>Eclipse Collections Java 8 Unit Test Suite</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -60,7 +63,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 
@@ -74,7 +76,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>junit-trait-runner</artifactId>
-            <version>7.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -101,17 +103,6 @@
 
     <build>
         <plugins>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/unit-tests/pom.xml
+++ b/unit-tests/pom.xml
@@ -26,6 +26,9 @@
     <name>Eclipse Collections Unit Test Suite</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
@@ -86,7 +89,7 @@
             <plugin>
                 <groupId>org.eclipse.collections</groupId>
                 <artifactId>eclipse-collections-code-generator-maven-plugin</artifactId>
-                <version>7.1.0-SNAPSHOT</version>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <id>list</id>
@@ -99,17 +102,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <fork>true</fork>
-                    <maxmem>2048m</maxmem>
-                    <verbose>true</verbose>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
* Add Travis badge to README.
* Rearrange the final two sections of the README so that the links are gathered at the end.
* Sort the travis builds by the typical amount of time they take to run, descending. If they are kicked off in order, they'll be more likely to finish around the same time.
* Configure a Travis job that uses Java 7 for the modules that are backwards compatible.
* Remove unused maven plugin.
* Configure all modules to use the parent pom.xml.
* Configure maven-compiler-plugin through properties.