### PR TITLE
Fix UnifiedSet$ChainedBucket.removeLongChain() method.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
@@ -1719,6 +1719,12 @@ public class UnifiedSet<T>
                         bucket.three = null;
                         return;
                     default:
+                        if (bucket.three instanceof ChainedBucket)
+                        {
+                            i -= 3;
+                            oldBucket = bucket;
+                            continue;
+                        }
                         throw new AssertionError();
                 }
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -1757,6 +1757,12 @@ public class UnifiedSetWithHashingStrategy<T>
                         bucket.three = null;
                         return;
                     default:
+                        if (bucket.three instanceof ChainedBucket)
+                        {
+                            i -= 3;
+                            oldBucket = bucket;
+                            continue;
+                        }
                         throw new AssertionError();
                 }
             }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
@@ -25,6 +25,8 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
@@ -54,6 +56,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
             Lists.mutable.of(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5);
     protected static final MutableList<Integer> MORE_COLLISIONS = FastList.newList(COLLISIONS)
             .with(COLLISION_6, COLLISION_7, COLLISION_8, COLLISION_9);
+    protected static final String[] FREQUENT_COLLISIONS = {"\u9103\ufffe", "\u9104\uffdf",
+        "\u9105\uffc0", "\u9106\uffa1", "\u9107\uff82", "\u9108\uff63", "\u9109\uff44",
+        "\u910a\uff25", "\u910b\uff06", "\u910c\ufee7"};
 
     @Test
     public void valuesCollection_toArray()
@@ -822,6 +827,29 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         Assert.assertNotEquals(mapC, mapD);
 
         Assert.assertEquals(0, this.newMapWithKeyValue(null, null).hashCode());
+    }
+
+    @Test
+    public void frequentCollision()
+    {
+        String[] expected = ArrayAdapter.adapt(FREQUENT_COLLISIONS)
+                .subList(0, FREQUENT_COLLISIONS.length - 2)
+                .toArray(new String[FREQUENT_COLLISIONS.length - 2]);
+        MutableMap<String, String> map = this.newMap();
+        MutableSet<String> set = Sets.mutable.of(expected);
+
+        ArrayIterate.forEach(FREQUENT_COLLISIONS, each -> map.put(each, each));
+
+        Iterator<String> itr = map.iterator();
+        while (itr.hasNext())
+        {
+            if (!set.contains(itr.next()))
+            {
+                itr.remove();
+            }
+        }
+
+        Assert.assertArrayEquals(expected, map.keysView().toArray());
     }
 
     private static final class NoInstanceOfInEquals

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
@@ -33,6 +33,7 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -62,6 +63,9 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     protected static final MutableList<Integer> MORE_COLLISIONS = FastList.newList(COLLISIONS)
             .with(COLLISION_6, COLLISION_7, COLLISION_8, COLLISION_9);
     protected static final int SIZE = 8;
+    protected static final String[] FREQUENT_COLLISIONS = {"\u9103\ufffe", "\u9104\uffdf",
+            "\u9105\uffc0", "\u9106\uffa1", "\u9107\uff82", "\u9108\uff63", "\u9109\uff44",
+            "\u910a\uff25", "\u910b\uff06", "\u910c\ufee7"};
 
     @Override
     protected abstract <T> MutableSet<T> newWith(T... littleElements);
@@ -880,5 +884,22 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         MutableSortedBag<Integer> bag = integers.toSortedBagBy(String::valueOf);
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(1, 2, 3, 4), bag);
+    }
+
+    @Test
+    public void frequentCollisions()
+    {
+        String[] expected = ArrayAdapter.adapt(FREQUENT_COLLISIONS)
+                .subList(0, FREQUENT_COLLISIONS.length - 2)
+                .toArray(new String[FREQUENT_COLLISIONS.length - 2]);
+        MutableSet<String> set1 = this.newWith();
+        MutableSet<String> set2 = this.newWith();
+
+        Collections.addAll(set1, FREQUENT_COLLISIONS);
+        Collections.addAll(set2, expected);
+
+        set1.retainAll(set2);
+
+        Assert.assertArrayEquals(expected, set1.toArray());
     }
 }


### PR DESCRIPTION
Corresponding to the 2 changes below.

https://github.com/goldmansachs/gs-collections/commit/4fd18e9121dfbbc2eb53ada8ded73bba25269ad7
https://github.com/goldmansachs/gs-collections/commit/bd31d1c74a032ee1c1f11eb5f9a5fd80f5bfad24
