### PR TITLE
Add community references to README.md and CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+Contributor License
+-------------------
+
+If this is your first time contributing to an Eclipse Foundation project, you'll need to sign the [Eclipse Foundation Contributor License Agreement][CLA].
+
+- [Create an account](https://dev.eclipse.org/site_login/createaccount.php) on dev.eclipse.org
+- Open your [Account Settings tab](https://dev.eclipse.org/site_login/myaccount.php#open_tab_accountsettings), enter your GitHub ID and click Update Account
+- Read and [sign the CLA](https://projects.eclipse.org/user/sign/cla)
+- Your git commits must use the same email address as your Eclipse account
+- [Sign your commits](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit)
+
+Issues
+--------------
+
+This project uses [GitHub issues](https://github.com/eclipse/eclipse-collections/issues) to track ongoing development and issues. Be sure to search for existing issues before you create another one. Remember 
+that contributions are always welcome!
+
+Making changes
+--------------
+
+Fork the repository in GitHub, make changes in your fork, and submit a pull request.
+
+Contact us
+----------
+
+[Join the mailing list][mailing-list] and email the community at collections-dev@eclipse.org to discuss your ideas and get help.
+
+Build
+-----
+
+The Eclipse Collections build performs code generation to create primitive collections. Run the full build once before opening your IDE.
+
+```bash
+$ mvn install -DskipTests=true
+```
+
+Now you can open the project in your IDE and it won't complain about missing files. You'll be able to use the IDE to perform incremental builds and run tests. You should rarely need to run the maven build, except when:
+
+- you want to force a clean build
+- you work on [JMH][jmh] tests
+- your changes affect code generation
+- you want to see if your changes will pass [the same builds that Travis CI runs][travis]
+
+Semantic Versioning
+-------------------
+
+Eclipse Collections version numbers follow [Semantic Versioning][semver]. This means we increment the major version when we make incompatible API changes. This includes any changes which
+
+- break binary compatibility
+- break source compatibility
+- break serialization compatibility
+
+Normally, collections will have the same serialized form across major releases, indefinitely. But if we have to break serialization for some reason, it will be in a major release. Eclipse Collections includes a suite of serialization tests to prevent accidental changes.
+
+While preparing a minor release, the master branch won't contain any compatibility breaking changes. Feel free to work on major, compatibility-breaking changes whenever you'd like. However, if you submit a pull request to master while we're preparing a minor release, you'll have to be patient and you'll need to rebase your changes once the release is complete.
+
+Coding Style
+------------
+
+Eclipse Collections follows a coding style that is similar to [Google's Style Guide for Java][style-guide], but with curly braces on their own lines. Many aspects of the style guide are enforced by CheckStyle, but not all, so please take care.
+
+```bash
+$ mvn clean install checkstyle:check findbugs:check -DskipTests=true
+```
+
+Avoid changing whitespace on lines that are unrelated to your pull request. This helps preserve the accuracy of the git blame view, and makes code reviews easier.
+
+Commit messages
+---------------
+
+- [Use the imperative mood][imperative-mood] as in "Fix bug" or "Add feature" rather than "Fixed bug" or "Added feature"
+- [Mention the GitHub issue][github-issue] when relevant
+- It's a good idea to follow the [advice in Pro Git](https://git-scm.com/book/ch5-2.html)
+
+Pull requests
+-------------
+
+Excessive branching and merging can make git history confusing. With that in mind
+
+- Squash your commits down to a few commits, or one commit, before submitting a pull request
+- [Rebase your pull request changes on top of the current master][rebase]. Pull requests shouldn't include merge commits.
+
+Submit your pull request when ready. Three checks will be kicked off automatically.
+
+- IP Validation: Checks that all committers signed the Eclipse CLA and signed their commits.
+- Continuous integration: [Travis builds][travis] that run JUnit tests, CheckStyle, and FindBugs.
+- The standard GitHub check that the pull request has no conflicts with the base branch.
+
+Make sure all the checks pass. One of the committers will take a look and provide feedback or merge your contribution.
+
+Please add a description of your changes to the draft release notes in the wiki.
+
+That's it! Thanks for contributing to Eclipse Collections!
+
+[CLA]:             https://www.eclipse.org/legal/CLA.php
+[jmh]:             http://openjdk.java.net/projects/code-tools/jmh/
+[semver]:          http://semver.org/
+[style-guide]:     https://google.github.io/styleguide/javaguide.html
+[rebase]:          https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
+[travis]:          https://travis-ci.org/eclipse/eclipse-collections
+[imperative-mood]: https://github.com/git/git/blob/master/Documentation/SubmittingPatches
+[github-issue]:    https://help.github.com/articles/closing-issues-via-commit-messages/
+[mailing-list]:    https://dev.eclipse.org/mailman/listinfo/collections-dev

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![][license-epl img]][license-epl]
 [![][license-edl img]][license-edl]
 
-Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map implementations with a rich API and set of utility classes that work with any JDK compatible Collections, Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
+Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map implementations with a rich API, additional types not found in the JDK like Bags, Multimaps and set of utility classes that work with any JDK compatible Collections, Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
 
 ## Quick Example
 Eclipse Collections puts iteration methods on the container types. Lambdas are simulated using anonymous inner classes. Here's a code example that demonstrates the usual style of programming with Eclipse Collections.
@@ -98,6 +98,27 @@ compile 'org.eclipse.collections:eclipse-collections-forkjoin:7.0.0'
 <dependency org="org.eclipse.collections" name="eclipse-collections-forkjoin" rev="7.0.0"/>
 ```
 
+## License
+Eclipse Collections is open sourced under the Eclipse Public License v1.0 and the Eclipse Distribution License v1.0.
+
+## How to Contribute
+We welcome contributions to the Eclipse Collections project!!
+
+The Eclipse Collections project accepts contributions via pull requests in this GitHub. Please see [How To Contribute](CONTRIBUTING.md) for more detail.
+
+## Project Roadmap
+* Project Roadmap: https://github.com/eclipse/eclipse-collections/wiki/Roadmap
+
+## Links
+* Project Website: http://www.eclipse.org/collections
+* Eclipse PME: https://projects.eclipse.org/projects/technology.collections
+* GitHub: https://github.com/eclipse/eclipse-collections
+* Issues: https://github.com/eclipse/eclipse-collections/issues
+* Mailing lists: https://dev.eclipse.org/mailman/listinfo/collections-dev
+* Wiki: https://github.com/eclipse/eclipse-collections/wiki
+* Forum: https://www.eclipse.org/forums/index.php?t=thread&frm_id=329
+* StackOverflow: http://stackoverflow.com/questions/tagged/eclipse-collections
+
 [travis]:https://travis-ci.org/eclipse/eclipse-collections
 [travis img]:https://travis-ci.org/eclipse/eclipse-collections.svg?branch=master
 
@@ -109,3 +130,4 @@ compile 'org.eclipse.collections:eclipse-collections-forkjoin:7.0.0'
 
 [license-edl]:LICENSE-EDL-1.0.txt
 [license-edl img]:https://img.shields.io/badge/License-EDL-blue.svg
+


### PR DESCRIPTION
It would be easier to browse the markdown from my repo.

https://github.com/itohro/eclipse-collections/blob/master/README.md
https://github.com/itohro/eclipse-collections/blob/master/CONTRIBUTING.md

The changes assumes the links to Wiki below exists in original repo. Please also have a look at Wiki links below. I've added you as a collaborator to my repo, so feel free to edit these Wiki pages if you find necessary. Once they look good, I'll put them into eclipse/eclipse-collections Wiki.

https://github.com/itohro/eclipse-collections/wiki (we can enrich this page later)
https://github.com/itohro/eclipse-collections/wiki/Eclipse-Collections-Developers-Guide
https://github.com/itohro/eclipse-collections/wiki/Roadmap

