### PR TITLE
Implement Verify.assertListMultimapsEqual(), Verify.assertSetMultimapsEqual(), Verify.assertBagMultimapsEqual(), Verify.assertSortedSetMultimapsEqual(), Verify.assertSortedBagMultimapsEqual().

### DIFF
--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -44,6 +44,9 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.sorted.SortedMapIterable;
 import org.eclipse.collections.api.multimap.Multimap;
+import org.eclipse.collections.api.multimap.bag.BagMultimap;
+import org.eclipse.collections.api.multimap.list.ListMultimap;
+import org.eclipse.collections.api.multimap.set.SetMultimap;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.Comparators;
@@ -2331,6 +2334,120 @@ public final class Verify extends Assert
                     Assert.assertEquals("Occurrences of " + expectedKey, expectedValue, actualValue);
                 }
             });
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertListMultimapsEqual(ListMultimap<K, V> expectedListMultimap, ListMultimap<K, V> actualListMultimap)
+    {
+        try
+        {
+            Verify.assertListMultimapsEqual("ListMultimap", expectedListMultimap, actualListMultimap);
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertListMultimapsEqual(String multimapName, ListMultimap<K, V> expectedListMultimap, ListMultimap<K, V> actualListMultimap)
+    {
+        try
+        {
+            if (expectedListMultimap == null)
+            {
+                Assert.assertNull(multimapName + " should be null", actualListMultimap);
+                return;
+            }
+
+            Assert.assertNotNull(multimapName + " should not be null", actualListMultimap);
+
+            Assert.assertEquals(multimapName + " size", expectedListMultimap.size(), actualListMultimap.size());
+            Verify.assertBagsEqual(multimapName + " keyBag", expectedListMultimap.keyBag(), actualListMultimap.keyBag());
+
+            for (K key : expectedListMultimap.keysView())
+            {
+                Verify.assertListsEqual(multimapName + " value list for key:" + key, (List<V>) expectedListMultimap.get(key), (List<V>) actualListMultimap.get(key));
+            }
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSetMultimapsEqual(SetMultimap<K, V> expectedSetMultimap, SetMultimap<K, V> actualSetMultimap)
+    {
+        try
+        {
+            Verify.assertSetMultimapsEqual("SetMultimap", expectedSetMultimap, actualSetMultimap);
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSetMultimapsEqual(String multimapName, SetMultimap<K, V> expectedSetMultimap, SetMultimap<K, V> actualSetMultimap)
+    {
+        try
+        {
+            if (expectedSetMultimap == null)
+            {
+                Assert.assertNull(multimapName + " should be null", actualSetMultimap);
+                return;
+            }
+
+            Assert.assertNotNull(multimapName + " should not be null", actualSetMultimap);
+
+            Assert.assertEquals(multimapName + " size", expectedSetMultimap.size(), actualSetMultimap.size());
+            Verify.assertBagsEqual(multimapName + " keyBag", expectedSetMultimap.keyBag(), actualSetMultimap.keyBag());
+
+            for (K key : expectedSetMultimap.keysView())
+            {
+                Verify.assertSetsEqual(multimapName + " value set for key:" + key, (Set<V>) expectedSetMultimap.get(key), (Set<V>) actualSetMultimap.get(key));
+            }
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertBagMultimapsEqual(BagMultimap<K, V> expectedBagMultimap, BagMultimap<K, V> actualBagMultimap)
+    {
+        try
+        {
+            Verify.assertBagMultimapsEqual("BagMultimap", expectedBagMultimap, actualBagMultimap);
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertBagMultimapsEqual(String multimapName, BagMultimap<K, V> expectedBagMultimap, BagMultimap<K, V> actualBagMultimap)
+    {
+        try
+        {
+            if (expectedBagMultimap == null)
+            {
+                Assert.assertNull(multimapName + " should be null", actualBagMultimap);
+                return;
+            }
+
+            Assert.assertNotNull(multimapName + " should not be null", actualBagMultimap);
+
+            Assert.assertEquals(multimapName + " size", expectedBagMultimap.size(), actualBagMultimap.size());
+            Verify.assertBagsEqual(multimapName + " keyBag", expectedBagMultimap.keyBag(), actualBagMultimap.keyBag());
+
+            for (K key : expectedBagMultimap.keysView())
+            {
+                Verify.assertBagsEqual(multimapName + " value bag for key:" + key, (Bag<V>) expectedBagMultimap.get(key), (Bag<V>) actualBagMultimap.get(key));
+            }
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -47,6 +47,8 @@ import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.multimap.bag.BagMultimap;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.api.multimap.set.SetMultimap;
+import org.eclipse.collections.api.multimap.sortedbag.SortedBagMultimap;
+import org.eclipse.collections.api.multimap.sortedset.SortedSetMultimap;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.Comparators;
@@ -2447,6 +2449,82 @@ public final class Verify extends Assert
             for (K key : expectedBagMultimap.keysView())
             {
                 Verify.assertBagsEqual(multimapName + " value bag for key:" + key, (Bag<V>) expectedBagMultimap.get(key), (Bag<V>) actualBagMultimap.get(key));
+            }
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSortedSetMultimapsEqual(SortedSetMultimap<K, V> expectedSortedSetMultimap, SortedSetMultimap<K, V> actualSortedSetMultimap)
+    {
+        try
+        {
+            Verify.assertSortedSetMultimapsEqual("SortedSetMultimap", expectedSortedSetMultimap, actualSortedSetMultimap);
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSortedSetMultimapsEqual(String multimapName, SortedSetMultimap<K, V> expectedSortedSetMultimap, SortedSetMultimap<K, V> actualSortedSetMultimap)
+    {
+        try
+        {
+            if (expectedSortedSetMultimap == null)
+            {
+                Assert.assertNull(multimapName + " should be null", actualSortedSetMultimap);
+                return;
+            }
+
+            Assert.assertNotNull(multimapName + " should not be null", actualSortedSetMultimap);
+
+            Assert.assertEquals(multimapName + " size", expectedSortedSetMultimap.size(), actualSortedSetMultimap.size());
+            Verify.assertBagsEqual(multimapName + " keyBag", expectedSortedSetMultimap.keyBag(), actualSortedSetMultimap.keyBag());
+
+            for (K key : expectedSortedSetMultimap.keysView())
+            {
+                Verify.assertSortedSetsEqual(multimapName + " value set for key:" + key, (SortedSet<V>) expectedSortedSetMultimap.get(key), (SortedSet<V>) actualSortedSetMultimap.get(key));
+            }
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSortedBagMultimapsEqual(SortedBagMultimap<K, V> expectedSortedBagMultimap, SortedBagMultimap<K, V> actualSortedBagMultimap)
+    {
+        try
+        {
+            Verify.assertSortedBagMultimapsEqual("SortedBagMultimap", expectedSortedBagMultimap, actualSortedBagMultimap);
+        }
+        catch (AssertionError e)
+        {
+            Verify.throwMangledException(e);
+        }
+    }
+
+    public static <K, V> void assertSortedBagMultimapsEqual(String multimapName, SortedBagMultimap<K, V> expectedSortedBagMultimap, SortedBagMultimap<K, V> actualSortedBagMultimap)
+    {
+        try
+        {
+            if (expectedSortedBagMultimap == null)
+            {
+                Assert.assertNull(multimapName + " should be null", actualSortedBagMultimap);
+                return;
+            }
+
+            Assert.assertNotNull(multimapName + " should not be null", actualSortedBagMultimap);
+
+            Assert.assertEquals(multimapName + " size", expectedSortedBagMultimap.size(), actualSortedBagMultimap.size());
+            Verify.assertBagsEqual(multimapName + " keyBag", expectedSortedBagMultimap.keyBag(), actualSortedBagMultimap.keyBag());
+
+            for (K key : expectedSortedBagMultimap.keysView())
+            {
+                Verify.assertSortedBagsEqual(multimapName + " value set for key:" + key, (SortedBag<V>) expectedSortedBagMultimap.get(key), (SortedBag<V>) actualSortedBagMultimap.get(key));
             }
         }
         catch (AssertionError e)

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -2374,6 +2374,7 @@ public final class Verify extends Assert
             {
                 Verify.assertListsEqual(multimapName + " value list for key:" + key, (List<V>) expectedListMultimap.get(key), (List<V>) actualListMultimap.get(key));
             }
+            Assert.assertEquals(multimapName, expectedListMultimap, actualListMultimap);
         }
         catch (AssertionError e)
         {
@@ -2412,6 +2413,7 @@ public final class Verify extends Assert
             {
                 Verify.assertSetsEqual(multimapName + " value set for key:" + key, (Set<V>) expectedSetMultimap.get(key), (Set<V>) actualSetMultimap.get(key));
             }
+            Assert.assertEquals(multimapName, expectedSetMultimap, actualSetMultimap);
         }
         catch (AssertionError e)
         {
@@ -2450,6 +2452,7 @@ public final class Verify extends Assert
             {
                 Verify.assertBagsEqual(multimapName + " value bag for key:" + key, (Bag<V>) expectedBagMultimap.get(key), (Bag<V>) actualBagMultimap.get(key));
             }
+            Assert.assertEquals(multimapName, expectedBagMultimap, actualBagMultimap);
         }
         catch (AssertionError e)
         {
@@ -2488,6 +2491,7 @@ public final class Verify extends Assert
             {
                 Verify.assertSortedSetsEqual(multimapName + " value set for key:" + key, (SortedSet<V>) expectedSortedSetMultimap.get(key), (SortedSet<V>) actualSortedSetMultimap.get(key));
             }
+            Assert.assertEquals(multimapName, expectedSortedSetMultimap, actualSortedSetMultimap);
         }
         catch (AssertionError e)
         {
@@ -2526,6 +2530,7 @@ public final class Verify extends Assert
             {
                 Verify.assertSortedBagsEqual(multimapName + " value set for key:" + key, (SortedBag<V>) expectedSortedBagMultimap.get(key), (SortedBag<V>) actualSortedBagMultimap.get(key));
             }
+            Assert.assertEquals(multimapName, expectedSortedBagMultimap, actualSortedBagMultimap);
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -401,12 +401,13 @@ public class VerifyTest
     @Test
     public void assertListMultimapsEquals()
     {
+        ListMultimap<Integer, String> nullMultimap = null;
+        Verify.assertListMultimapsEqual(null, nullMultimap);
+        ListMultimap<Integer, String> emptyMultimap = FastListMultimap.newMultimap();
+        Verify.assertListMultimapsEqual(FastListMultimap.<Integer, String>newMultimap(), emptyMultimap);
         final ListMultimap<Integer, String> multimap1 = FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
-        MutableListMultimap<Integer, String> multimap2 = null;
-        Verify.assertListMultimapsEqual(null, multimap2);
-        multimap2 = FastListMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        MutableListMultimap<Integer, String> multimap2 = FastListMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
         Verify.assertListMultimapsEqual(multimap1, multimap2);
-
         final MutableListMultimap<Integer, String> multimap3 = FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
         Verify.assertListMultimapsEqual(multimap1, multimap3);
         multimap2.put(2, "TwoTwo");
@@ -428,6 +429,13 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertListMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, FastListMultimap.<Integer, String>newMultimap());
             }
         });
         Verify.assertError(AssertionFailedError.class, new Runnable()
@@ -470,12 +478,13 @@ public class VerifyTest
     @Test
     public void assertSetMultimapsEquals()
     {
+        SetMultimap<Integer, String> nullMultimap = null;
+        Verify.assertSetMultimapsEqual(null, nullMultimap);
+        SetMultimap<Integer, String> emptyMultimap = UnifiedSetMultimap.newMultimap();
+        Verify.assertSetMultimapsEqual(UnifiedSetMultimap.<Integer, String>newMultimap(), emptyMultimap);
         final SetMultimap<Integer, String> multimap1 = UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
-        MutableSetMultimap<Integer, String> multimap2 = null;
-        Verify.assertSetMultimapsEqual(null, multimap2);
-        multimap2 = UnifiedSetMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        MutableSetMultimap<Integer, String> multimap2 = UnifiedSetMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
         Verify.assertSetMultimapsEqual(multimap1, multimap2);
-
         final MutableSetMultimap<Integer, String> multimap3 = UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(2, "TwoTwo"));
         Verify.assertSetMultimapsEqual(multimap1, multimap3);
         Verify.assertSetMultimapsEqual(multimap3, multimap2);
@@ -496,6 +505,13 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertSetMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, UnifiedSetMultimap.<Integer, String>newMultimap());
             }
         });
         Verify.assertError(AssertionFailedError.class, new Runnable()
@@ -531,12 +547,13 @@ public class VerifyTest
     @Test
     public void assertBagMultimapsEquals()
     {
+        BagMultimap<Integer, String> nullMultimap = null;
+        Verify.assertBagMultimapsEqual(null, nullMultimap);
+        BagMultimap<Integer, String> emptyMultimap = HashBagMultimap.newMultimap();
+        Verify.assertBagMultimapsEqual(HashBagMultimap.<Integer, String>newMultimap(), emptyMultimap);
         final BagMultimap<Integer, String> multimap1 = HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
-        MutableBagMultimap<Integer, String> multimap2 = null;
-        Verify.assertBagMultimapsEqual(null, multimap2);
-        multimap2 = HashBagMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        MutableBagMultimap<Integer, String> multimap2 = HashBagMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
         Verify.assertBagMultimapsEqual(multimap1, multimap2);
-
         final MutableBagMultimap<Integer, String> multimap3 = HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
         Verify.assertBagMultimapsEqual(multimap1, multimap3);
         multimap2.put(2, "TwoTwo");
@@ -558,6 +575,13 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertBagMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, HashBagMultimap.<Integer, String>newMultimap());
             }
         });
 
@@ -602,19 +626,19 @@ public class VerifyTest
     @Test
     public void assertSortedSetMultimapsEquals()
     {
+        SortedSetMultimap<Integer, Integer> nullMultimap = null;
+        Verify.assertSortedSetMultimapsEqual(null, nullMultimap);
+        SortedSetMultimap<Integer, Integer> emptyMultimap = TreeSortedSetMultimap.newMultimap();
+        Verify.assertSortedSetMultimapsEqual(TreeSortedSetMultimap.<Integer, Integer>newMultimap(), emptyMultimap);
         final SortedSetMultimap<Integer, Integer> multimap1 = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
-        MutableSortedSetMultimap<Integer, Integer> multimap2 = null;
-        Verify.assertSortedSetMultimapsEqual(null, multimap2);
-        multimap2 = TreeSortedSetMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        SortedSetMultimap<Integer, Integer> multimap2 = TreeSortedSetMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
         Verify.assertSortedSetMultimapsEqual(multimap1, multimap2);
-
         final MutableSortedSetMultimap<Integer, Integer> multimap3 = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2), Tuples.pair(2, 2));
         Verify.assertSortedSetMultimapsEqual(multimap1, multimap3);
         Verify.assertSortedSetMultimapsEqual(multimap3, multimap2);
         SortedSetMultimap<Integer, Integer> multimap4 = TreeSortedSetMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2)).toImmutable();
         Verify.assertSortedSetMultimapsEqual(multimap3, multimap4);
         Verify.assertSortedSetMultimapsEqual("message", multimap3.toImmutable(), multimap4);
-
         final MutableSortedSetMultimap<Integer, Integer> multimap5 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         multimap5.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
         MutableSortedSetMultimap<Integer, Integer> multimap6 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
@@ -643,6 +667,13 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertSortedSetMultimapsEqual(multimap1, multimap5);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, TreeSortedSetMultimap.<Integer, Integer>newMultimap());
             }
         });
         Verify.assertError(AssertionError.class, new Runnable()
@@ -678,12 +709,13 @@ public class VerifyTest
     @Test
     public void assertSortedBagMultimapsEquals()
     {
+        SortedBagMultimap<Integer, Integer> nullMultimap = null;
+        Verify.assertSortedBagMultimapsEqual(null, nullMultimap);
+        SortedBagMultimap<Integer, Integer> blankMultimap = TreeBagMultimap.newMultimap();
+        Verify.assertSortedBagMultimapsEqual(TreeBagMultimap.<Integer, Integer>newMultimap(), blankMultimap);
         final SortedBagMultimap<Integer, Integer> multimap1 = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
-        MutableSortedBagMultimap<Integer, Integer> multimap2 = null;
-        Verify.assertSortedBagMultimapsEqual(null, multimap2);
-        multimap2 = TreeBagMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        MutableSortedBagMultimap<Integer, Integer> multimap2 = TreeBagMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
         Verify.assertSortedBagMultimapsEqual(multimap1, multimap2);
-
         final MutableSortedBagMultimap<Integer, Integer> multimap3 = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
         Verify.assertSortedBagMultimapsEqual(multimap1, multimap3);
         multimap2.put(2, 2);
@@ -692,7 +724,6 @@ public class VerifyTest
         final ImmutableSortedBagMultimap<Integer, Integer> multimap4 = TreeBagMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(2, 2)).toImmutable();
         Verify.assertSortedBagMultimapsEqual(multimap3, multimap4);
         Verify.assertSortedBagMultimapsEqual("message", multimap3.toImmutable(), multimap4);
-
         final MutableSortedBagMultimap<Integer, Integer> multimap5 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
         multimap5.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
         MutableSortedBagMultimap<Integer, Integer> multimap6 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
@@ -722,7 +753,13 @@ public class VerifyTest
                 Verify.assertSortedBagMultimapsEqual(multimap1, multimap5);
             }
         });
-
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, TreeBagMultimap.<Integer, Integer>newMultimap());
+            }
+        });
         multimap3.put(2, 3);
         Verify.assertError(AssertionError.class, new Runnable()
         {

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -25,6 +25,12 @@ import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.multimap.set.SetMultimap;
+import org.eclipse.collections.api.multimap.sortedbag.ImmutableSortedBagMultimap;
+import org.eclipse.collections.api.multimap.sortedbag.MutableSortedBagMultimap;
+import org.eclipse.collections.api.multimap.sortedbag.SortedBagMultimap;
+import org.eclipse.collections.api.multimap.sortedset.ImmutableSortedSetMultimap;
+import org.eclipse.collections.api.multimap.sortedset.MutableSortedSetMultimap;
+import org.eclipse.collections.api.multimap.sortedset.SortedSetMultimap;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.IntegerPredicates;
@@ -35,8 +41,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
+import org.eclipse.collections.impl.multimap.bag.sorted.mutable.TreeBagMultimap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
+import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -587,6 +595,168 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertBagMultimapsEqual(multimap1, HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(3, "Three")));
+            }
+        });
+    }
+
+    @Test
+    public void assertSortedSetMultimapsEquals()
+    {
+        final SortedSetMultimap<Integer, Integer> multimap1 = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
+        MutableSortedSetMultimap<Integer, Integer> multimap2 = null;
+        Verify.assertSortedSetMultimapsEqual(null, multimap2);
+        multimap2 = TreeSortedSetMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        Verify.assertSortedSetMultimapsEqual(multimap1, multimap2);
+
+        final MutableSortedSetMultimap<Integer, Integer> multimap3 = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2), Tuples.pair(2, 2));
+        Verify.assertSortedSetMultimapsEqual(multimap1, multimap3);
+        Verify.assertSortedSetMultimapsEqual(multimap3, multimap2);
+        SortedSetMultimap<Integer, Integer> multimap4 = TreeSortedSetMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2)).toImmutable();
+        Verify.assertSortedSetMultimapsEqual(multimap3, multimap4);
+        Verify.assertSortedSetMultimapsEqual("message", multimap3.toImmutable(), multimap4);
+
+        final MutableSortedSetMultimap<Integer, Integer> multimap5 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        multimap5.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        MutableSortedSetMultimap<Integer, Integer> multimap6 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        multimap6.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        Verify.assertSortedSetMultimapsEqual(multimap5, multimap6);
+        Verify.assertSortedSetMultimapsEqual(multimap5, multimap6.toImmutable());
+        Verify.assertSortedSetMultimapsEqual(multimap5.toImmutable(), multimap6.toImmutable());
+
+        multimap3.put(2, 3);
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, null);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, multimap5);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual("message", multimap1, TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 2), Tuples.pair(2, 1), Tuples.pair(2, 2)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, TreeSortedSetMultimap.newMultimap(Tuples.pair(3, 1), Tuples.pair(2, 1), Tuples.pair(2, 2)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(2, 3)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedSetMultimapsEqual(multimap1, TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2), Tuples.pair(3, 1)));
+            }
+        });
+    }
+
+    @Test
+    public void assertSortedBagMultimapsEquals()
+    {
+        final SortedBagMultimap<Integer, Integer> multimap1 = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
+        MutableSortedBagMultimap<Integer, Integer> multimap2 = null;
+        Verify.assertSortedBagMultimapsEqual(null, multimap2);
+        multimap2 = TreeBagMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        Verify.assertSortedBagMultimapsEqual(multimap1, multimap2);
+
+        final MutableSortedBagMultimap<Integer, Integer> multimap3 = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2));
+        Verify.assertSortedBagMultimapsEqual(multimap1, multimap3);
+        multimap2.put(2, 2);
+        multimap3.put(2, 2);
+        Verify.assertSortedBagMultimapsEqual(multimap3, multimap2);
+        final ImmutableSortedBagMultimap<Integer, Integer> multimap4 = TreeBagMultimap.newMultimap(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(2, 2)).toImmutable();
+        Verify.assertSortedBagMultimapsEqual(multimap3, multimap4);
+        Verify.assertSortedBagMultimapsEqual("message", multimap3.toImmutable(), multimap4);
+
+        final MutableSortedBagMultimap<Integer, Integer> multimap5 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        multimap5.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        MutableSortedBagMultimap<Integer, Integer> multimap6 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        multimap6.putAllPairs(Tuples.pair(2, 1), Tuples.pair(1, 1), Tuples.pair(2, 2));
+        Verify.assertSortedBagMultimapsEqual(multimap5, multimap6);
+        Verify.assertSortedBagMultimapsEqual(multimap5, multimap6.toImmutable());
+        Verify.assertSortedBagMultimapsEqual(multimap5.toImmutable(), multimap6.toImmutable());
+
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, null);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, multimap5);
+            }
+        });
+
+        multimap3.put(2, 3);
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap3, multimap4);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual("message", multimap1, TreeBagMultimap.newMultimap(Tuples.pair(1, 2), Tuples.pair(2, 1), Tuples.pair(2, 2)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, TreeBagMultimap.newMultimap(Tuples.pair(3, 1), Tuples.pair(2, 1), Tuples.pair(2, 2)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(2, 2)));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSortedBagMultimapsEqual(multimap1, TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 1), Tuples.pair(2, 2), Tuples.pair(3, 1)));
             }
         });
     }

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -15,7 +15,16 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 
+import junit.framework.AssertionFailedError;
+import org.eclipse.collections.api.multimap.bag.BagMultimap;
+import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
+import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
+import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
+import org.eclipse.collections.api.multimap.set.SetMultimap;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.IntegerPredicates;
@@ -25,7 +34,9 @@ import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
+import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -375,6 +386,207 @@ public class VerifyTest
             public void run()
             {
                 Verify.assertBagsEqual("message", HashBag.newBagWith(1, 1, 2, 2, 4, 4), HashBag.newBagWith(1, 1, 2, 2, 3, 3));
+            }
+        });
+    }
+
+    @Test
+    public void assertListMultimapsEquals()
+    {
+        final ListMultimap<Integer, String> multimap1 = FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
+        MutableListMultimap<Integer, String> multimap2 = null;
+        Verify.assertListMultimapsEqual(null, multimap2);
+        multimap2 = FastListMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertListMultimapsEqual(multimap1, multimap2);
+
+        final MutableListMultimap<Integer, String> multimap3 = FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertListMultimapsEqual(multimap1, multimap3);
+        multimap2.put(2, "TwoTwo");
+        multimap3.put(2, "TwoTwo");
+        Verify.assertListMultimapsEqual(multimap3, multimap2);
+        ImmutableListMultimap<Integer, String> multimap4 = FastListMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"), Tuples.pair(2, "TwoTwo")).toImmutable();
+        Verify.assertListMultimapsEqual(multimap3, multimap4);
+        Verify.assertListMultimapsEqual("message", multimap3.toImmutable(), multimap4);
+
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, null);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual("message", multimap1, FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"), Tuples.pair(2, "Two")));
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, FastListMultimap.newMultimap(Tuples.pair(1, "OneOne"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, FastListMultimap.newMultimap(Tuples.pair(3, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, FastListMultimap.newMultimap(Tuples.pair(1, "OneOne"), Tuples.pair(2, "One"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertListMultimapsEqual(multimap1, FastListMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(3, "Three")));
+            }
+        });
+    }
+
+    @Test
+    public void assertSetMultimapsEquals()
+    {
+        final SetMultimap<Integer, String> multimap1 = UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
+        MutableSetMultimap<Integer, String> multimap2 = null;
+        Verify.assertSetMultimapsEqual(null, multimap2);
+        multimap2 = UnifiedSetMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertSetMultimapsEqual(multimap1, multimap2);
+
+        final MutableSetMultimap<Integer, String> multimap3 = UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertSetMultimapsEqual(multimap1, multimap3);
+        Verify.assertSetMultimapsEqual(multimap3, multimap2);
+        ImmutableSetMultimap<Integer, String> multimap4 = UnifiedSetMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo")).toImmutable();
+        Verify.assertSetMultimapsEqual(multimap3, multimap4);
+        Verify.assertSetMultimapsEqual("message", multimap3.toImmutable(), multimap4);
+
+        multimap3.put(2, "TwoTwoTwo");
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, null);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, multimap3);
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual("message", multimap1, UnifiedSetMultimap.newMultimap(Tuples.pair(1, "OneOne"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, UnifiedSetMultimap.newMultimap(Tuples.pair(3, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionFailedError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "One"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertSetMultimapsEqual(multimap1, UnifiedSetMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(3, "Three")));
+            }
+        });
+    }
+
+    @Test
+    public void assertBagMultimapsEquals()
+    {
+        final BagMultimap<Integer, String> multimap1 = HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
+        MutableBagMultimap<Integer, String> multimap2 = null;
+        Verify.assertBagMultimapsEqual(null, multimap2);
+        multimap2 = HashBagMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertBagMultimapsEqual(multimap1, multimap2);
+
+        final MutableBagMultimap<Integer, String> multimap3 = HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"));
+        Verify.assertBagMultimapsEqual(multimap1, multimap3);
+        multimap2.put(2, "TwoTwo");
+        multimap3.put(2, "TwoTwo");
+        Verify.assertBagMultimapsEqual(multimap3, multimap2);
+        final ImmutableBagMultimap<Integer, String> multimap4 = HashBagMultimap.newMultimap(Tuples.pair(2, "Two"), Tuples.pair(1, "One"), Tuples.pair(2, "TwoTwo"), Tuples.pair(2, "TwoTwo")).toImmutable();
+        Verify.assertBagMultimapsEqual(multimap3, multimap4);
+        Verify.assertBagMultimapsEqual("message", multimap3.toImmutable(), multimap4);
+
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, null);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, multimap3);
+            }
+        });
+
+        multimap3.put(2, "TwoTwoTwo");
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap3, multimap4);
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual("message", multimap1, HashBagMultimap.newMultimap(Tuples.pair(1, "OneOne"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, HashBagMultimap.newMultimap(Tuples.pair(3, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "One"), Tuples.pair(2, "TwoTwo")));
+            }
+        });
+        Verify.assertError(AssertionError.class, new Runnable()
+        {
+            public void run()
+            {
+                Verify.assertBagMultimapsEqual(multimap1, HashBagMultimap.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(2, "TwoTwo"), Tuples.pair(3, "Three")));
             }
         });
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
@@ -79,7 +79,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
         MutableBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, selectedMultimap);
     }
 
     @Override
@@ -94,7 +94,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
         MutableBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3, 1));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, rejectedMultimap);
     }
 
     @Override
@@ -111,7 +111,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<Integer, String> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, selectedMultimap);
     }
 
     @Override
@@ -128,7 +128,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<Integer, String> rejectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
         MutableBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, rejectedMultimap);
     }
 
     @Override
@@ -144,13 +144,13 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, collectedMultimap);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -166,7 +166,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBagMultimap<String, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.bag;
 
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
@@ -19,6 +20,7 @@ import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.AbstractImmutableMultimapTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.Assert;
@@ -75,15 +77,15 @@ public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
     @Test
     public void selectKeysValues()
     {
-        HashBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
         mutableMultimap.putAll("One", FastList.newListWith(1, 2, 3, 4, 2));
         mutableMultimap.putAll("Two", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableBagMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<String, Integer> selectedMultimap = immutableMap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
-        HashBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4, 2));
         ImmutableBagMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
@@ -95,82 +97,82 @@ public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
         mutableMultimap.putAll("Two", FastList.newListWith(2, 3, 4, 5, 1));
         ImmutableBagMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<String, Integer> rejectedMultimap = immutableMap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
-        HashBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, Integer> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3, 1));
         ImmutableBagMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
     @Test
     public void selectKeysMultiValues()
     {
-        HashBagMultimap<Integer, String> mutableMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> mutableMultimap = HashBagMultimap.newMultimap();
         mutableMultimap.putAll(1, FastList.newListWith("1", "3", "4"));
         mutableMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
         mutableMultimap.putAll(3, FastList.newListWith("2", "3", "4", "5", "2"));
         mutableMultimap.putAll(4, FastList.newListWith("1", "3", "4"));
         ImmutableBagMultimap<Integer, String> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<Integer, String> selectedMultimap = immutableMap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
-        HashBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
     @Test
     public void rejectKeysMultiValues()
     {
-        HashBagMultimap<Integer, String> mutableMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> mutableMultimap = HashBagMultimap.newMultimap();
         mutableMultimap.putAll(1, FastList.newListWith("1", "2", "3", "4", "1"));
         mutableMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "1"));
         mutableMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
         mutableMultimap.putAll(4, FastList.newListWith("1", "3", "4", "5"));
         ImmutableBagMultimap<Integer, String> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<Integer, String> rejectedMultimap = immutableMap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
-        HashBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
     @Test
     public void collectKeysValues()
     {
-        HashBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
         mutableMultimap.putAll("1", FastList.newListWith(1, 2, 3, 4, 1));
         mutableMultimap.putAll("2", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableBagMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<Integer, String> collectedMultimap = immutableMap.collectKeysValues((key, value) -> Tuples.pair(Integer.valueOf(key), value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap1 = expectedMultimap1.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap1, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap1, collectedMultimap);
 
         ImmutableBagMultimap<Integer, String> collectedMultimap2 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap2 = expectedMultimap2.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap2, collectedMultimap2);
     }
 
     @Override
     @Test
     public void collectValues()
     {
-        HashBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, Integer> mutableMultimap = HashBagMultimap.newMultimap();
         mutableMultimap.putAll("1", FastList.newListWith(1, 2, 3, 4, 1));
         mutableMultimap.putAll("2", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableBagMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<String, String> collectedMultimap = immutableMap.collectValues(value -> value + "Value");
-        HashBagMultimap<String, String> expectedMultimap = HashBagMultimap.newMultimap();
+        MutableBagMultimap<String, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableBagMultimap<String, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
@@ -120,8 +120,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -135,8 +134,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1, 1));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get("One"), rejectedMultimap.get("One"));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, rejectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
@@ -152,8 +150,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -169,9 +166,8 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> selectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get(3), selectedMultimap.get(3));
-        Assert.assertEquals(expectedMultimap.comparator(), selectedMultimap.comparator());
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
+        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -185,13 +181,13 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -205,8 +201,6 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get("1"), collectedMultimap.get("1"));
-        Verify.assertListsEqual(expectedMultimap.get("2"), collectedMultimap.get("2"));
+        Verify.assertListMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
@@ -14,6 +14,7 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.multimap.ImmutableMultimap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.multimap.sortedbag.ImmutableSortedBagMultimap;
 import org.eclipse.collections.api.multimap.sortedbag.MutableSortedBagMultimap;
 import org.eclipse.collections.impl.block.factory.Comparators;
@@ -70,33 +71,32 @@ public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultima
     @Test
     public void collectValues()
     {
-        TreeBagMultimap<String, Integer> mutableMultimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedBagMultimap<String, Integer> mutableMultimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll("1", FastList.newListWith(4, 3, 2, 1, 1));
         mutableMultimap.putAll("2", FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedBagMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<String, String> collectedMultimap = immutableMap.collectValues(value -> value + "Value");
-        FastListMultimap<String, String> expectedMultimap = FastListMultimap.<String, String>newMultimap();
+        MutableListMultimap<String, String> expectedMultimap = FastListMultimap.<String, String>newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
         ImmutableListMultimap<String, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
     }
 
     @Override
     @Test
     public void rejectKeysMultiValues()
     {
-        TreeBagMultimap<Integer, Integer> multimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedBagMultimap<Integer, Integer> multimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         multimap.putAll(1, FastList.newListWith(4, 3, 2, 1, 1));
         multimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         multimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
         multimap.putAll(4, FastList.newListWith(4, 3, 1));
         ImmutableSortedBagMultimap<Integer, Integer> immutableMultimap = multimap.toImmutable();
         ImmutableSortedBagMultimap<Integer, Integer> selectedMultimap = immutableMultimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
-        TreeBagMultimap<Integer, Integer> expectedMultimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedBagMultimap<Integer, Integer> expectedMultimap = TreeBagMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.toImmutable().get(3), selectedMultimap.get(3));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertEquals(expectedMultimap.toImmutable().comparator(), selectedMultimap.comparator());
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
@@ -127,8 +127,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -142,8 +141,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1, 1));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get("One"), rejectedMultimap.get("One"));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, rejectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
@@ -159,8 +157,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -176,8 +173,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> selectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedBagsEqual(expectedMultimap.get(3), selectedMultimap.get(3));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -192,13 +188,13 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -212,8 +208,6 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("4Value", "3Value", "2Value", "1Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("5Value", "4Value", "3Value", "2Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get("1"), collectedMultimap.get("1"));
-        Verify.assertListsEqual(expectedMultimap.get("2"), collectedMultimap.get("2"));
+        Verify.assertListMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
@@ -125,8 +125,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableListMultimap<Integer, String> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertListMultimapsEqual(expectedMultimap, selectedMultimap);
     }
 
     @Override
@@ -143,8 +142,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableListMultimap<Integer, String> rejectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
         MutableListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get(3), rejectedMultimap.get(3));
+        Verify.assertListMultimapsEqual(expectedMultimap, rejectedMultimap);
     }
 
     @Override
@@ -159,13 +157,13 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -181,8 +179,6 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value", "4Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get("1"), collectedMultimap.get("1"));
-        Verify.assertListsEqual(expectedMultimap.get("2"), collectedMultimap.get("2"));
+        Verify.assertListMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
@@ -12,7 +12,9 @@ package org.eclipse.collections.impl.multimap.list;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Bags;
@@ -78,106 +80,102 @@ public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
     @Test
     public void selectKeysValues()
     {
-        FastListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll("One", FastList.newListWith(1, 2, 3, 4, 2));
         mutableMultimap.putAll("Two", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableListMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<String, Integer> selectedMultimap = immutableMap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
-        FastListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4, 2));
         ImmutableListMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
     @Test
     public void rejectKeysValues()
     {
-        FastListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll("One", FastList.newListWith(1, 2, 3, 4, 1));
         mutableMultimap.putAll("Two", FastList.newListWith(2, 3, 4, 5, 1));
         ImmutableListMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<String, Integer> rejectedMultimap = immutableMap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
-        FastListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3, 1));
         ImmutableListMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get("One"), rejectedMultimap.get("One"));
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
     @Test
     public void selectKeysMultiValues()
     {
-        FastListMultimap<Integer, String> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<Integer, String> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll(1, FastList.newListWith("1", "3", "4"));
         mutableMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
         mutableMultimap.putAll(3, FastList.newListWith("2", "3", "4", "5", "2"));
         mutableMultimap.putAll(4, FastList.newListWith("1", "3", "4"));
         ImmutableListMultimap<Integer, String> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<Integer, String> selectedMultimap = immutableMap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
-        FastListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
         ImmutableListMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
     @Test
     public void rejectKeysMultiValues()
     {
-        FastListMultimap<Integer, String> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<Integer, String> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll(1, FastList.newListWith("1", "2", "3", "4", "1"));
         mutableMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "1"));
         mutableMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
         mutableMultimap.putAll(4, FastList.newListWith("1", "3", "4", "5"));
         ImmutableListMultimap<Integer, String> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<Integer, String> rejectedMultimap = immutableMap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
-        FastListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<Integer, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
         ImmutableListMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get(3), rejectedMultimap.get(3));
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
     @Test
     public void collectKeysValues()
     {
-        FastListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll("1", FastList.newListWith(1, 2, 3, 4, 1));
         mutableMultimap.putAll("2", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableListMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<Integer, String> collectedMultimap1 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(Integer.valueOf(key), value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap1 = expectedMultimap1.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap1, collectedMultimap1);
 
         ImmutableBagMultimap<Integer, String> collectedMultimap2 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap2 = expectedMultimap2.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap2, collectedMultimap2);
     }
 
     @Override
     @Test
     public void collectValues()
     {
-        FastListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, Integer> mutableMultimap = FastListMultimap.newMultimap();
         mutableMultimap.putAll("1", FastList.newListWith(1, 2, 3, 4, 1));
         mutableMultimap.putAll("2", FastList.newListWith(2, 3, 4, 5, 2));
         ImmutableListMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<String, String> collectedMultimap = immutableMap.collectValues(value -> value + "Value");
-        FastListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value", "2Value"));
         ImmutableListMultimap<String, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
@@ -78,8 +78,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableSetMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
         MutableSetMultimap<String, Integer> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSetsEqual(expectedMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertSetMultimapsEqual(expectedMultimap, selectedMultimap);
     }
 
     @Override
@@ -92,8 +91,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableSetMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
         MutableSetMultimap<String, Integer> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertSetsEqual(expectedMultimap.get("One"), rejectedMultimap.get("One"));
+        Verify.assertSetMultimapsEqual(expectedMultimap, rejectedMultimap);
     }
 
     @Override
@@ -110,8 +108,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableSetMultimap<Integer, String> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableSetMultimap<Integer, String> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSetsEqual(expectedMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertSetMultimapsEqual(expectedMultimap, selectedMultimap);
     }
 
     @Override
@@ -128,8 +125,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableSetMultimap<Integer, String> rejectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
         MutableSetMultimap<Integer, String> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertSetsEqual(expectedMultimap.get(3), rejectedMultimap.get(3));
+        Verify.assertSetMultimapsEqual(expectedMultimap, rejectedMultimap);
     }
 
     @Override
@@ -143,16 +139,13 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
-        Assert.assertEquals(expectedMultimap1.get(1), collectedMultimap1.get(1));
-        Assert.assertEquals(expectedMultimap1.get(2), collectedMultimap1.get(2));
+        Verify.assertBagMultimapsEqual(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
-        Assert.assertEquals(expectedMultimap2.get(1), collectedMultimap2.get(1));
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -166,8 +159,6 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableBagMultimap<String, String> expectedMultimap = HashBagMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
-        Assert.assertEquals(expectedMultimap.get("1"), collectedMultimap.get("1"));
-        Assert.assertEquals(expectedMultimap.get("2"), collectedMultimap.get("2"));
+        Verify.assertBagMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
@@ -22,6 +22,7 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.AbstractImmutableMultimapTestCase;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.Assert;
@@ -87,7 +88,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSetMultimap<String, Integer> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4));
         ImmutableSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
+        Verify.assertSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
@@ -102,7 +103,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSetMultimap<String, Integer> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3));
         ImmutableSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
+        Verify.assertSetMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
@@ -119,7 +120,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSetMultimap<Integer, String> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll(2, FastList.newListWith("2", "3", "4", "5", "2"));
         ImmutableSetMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
+        Verify.assertSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
     }
 
     @Override
@@ -136,7 +137,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSetMultimap<Integer, String> expectedMultimap = UnifiedSetMultimap.newMultimap();
         expectedMultimap.putAll(3, FastList.newListWith("2", "3", "4", "2"));
         ImmutableSetMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
+        Verify.assertSetMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
     }
 
     @Override
@@ -152,14 +153,14 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         expectedMultimap.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap.putAll(2, FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
 
         ImmutableBagMultimap<Integer, String> collectedMultimap2 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap2 = expectedMultimap2.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -175,6 +176,6 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         expectedMultimap.putAll("1", FastList.newListWith("1Value", "2Value", "3Value", "4Value"));
         expectedMultimap.putAll("2", FastList.newListWith("2Value", "3Value", "4Value", "5Value"));
         ImmutableBagMultimap<String, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
@@ -107,8 +107,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
         MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedSetsEqual(expectedMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -122,8 +121,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
         MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
-        Verify.assertSortedSetsEqual(expectedMultimap.get("One"), rejectedMultimap.get("One"));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap, rejectedMultimap);
         Assert.assertEquals(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
@@ -139,8 +137,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<Integer, Integer> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
         MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedSetsEqual(expectedMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -156,8 +153,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<Integer, Integer> selectedMultimap = multimap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 3));
         MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
-        Verify.assertSortedSetsEqual(expectedMultimap.get(3), selectedMultimap.get(3));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -172,13 +168,13 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<Integer, String> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
         MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -192,8 +188,6 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
-        Verify.assertListsEqual(expectedMultimap.get("1"), collectedMultimap.get("1"));
-        Verify.assertListsEqual(expectedMultimap.get("2"), collectedMultimap.get("2"));
+        Verify.assertListMultimapsEqual(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
@@ -14,9 +14,12 @@ import java.util.Collections;
 
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.multimap.set.UnsortedSetMultimap;
 import org.eclipse.collections.api.multimap.sortedset.ImmutableSortedSetMultimap;
+import org.eclipse.collections.api.multimap.sortedset.MutableSortedSetMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
@@ -121,16 +124,15 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     @Test
     public void selectKeysValues()
     {
-        TreeSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll("One", FastList.newListWith(4, 3, 2, 1, 1));
         mutableMultimap.putAll("Two", FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableSortedSetMultimap<String, Integer> selectedMultimap = immutableMap.selectKeysValues((key, value) -> ("Two".equals(key) && (value % 2 == 0)));
-        TreeSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2));
         ImmutableSortedSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get("Two"), selectedMultimap.get("Two"));
+        Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -138,35 +140,33 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     @Test
     public void rejectKeysValues()
     {
-        TreeSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll("One", FastList.newListWith(4, 3, 2, 1, 1));
         mutableMultimap.putAll("Two", FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableSortedSetMultimap<String, Integer> rejectedMultimap = immutableMap.rejectKeysValues((key, value) -> ("Two".equals(key) || (value % 2 == 0)));
-        TreeSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1));
         ImmutableSortedSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, rejectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get("One"), rejectedMultimap.get("One"));
-        Assert.assertEquals(expectedMultimap.comparator(), rejectedMultimap.comparator());
+        Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
+        Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
     @Override
     @Test
     public void selectKeysMultiValues()
     {
-        TreeSortedSetMultimap<Integer, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<Integer, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll(1, FastList.newListWith(4, 3, 1));
         mutableMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         mutableMultimap.putAll(3, FastList.newListWith(5, 4, 3, 2, 2));
         mutableMultimap.putAll(4, FastList.newListWith(4, 3, 1));
         ImmutableSortedSetMultimap<Integer, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableSortedSetMultimap<Integer, Integer> selectedMultimap = immutableMap.selectKeysMultiValues((key, values) -> (key % 2 == 0 && Iterate.sizeOf(values) > 3));
-        TreeSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<Integer, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get(2), selectedMultimap.get(2));
+        Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -174,18 +174,17 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     @Test
     public void rejectKeysMultiValues()
     {
-        TreeSortedSetMultimap<Integer, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<Integer, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll(1, FastList.newListWith(5, 4, 3, 2, 1));
         mutableMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         mutableMultimap.putAll(3, FastList.newListWith(5, 4, 2, 2));
         mutableMultimap.putAll(4, FastList.newListWith(4, 3, 1));
         ImmutableSortedSetMultimap<Integer, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableSortedSetMultimap<Integer, Integer> selectedMultimap = immutableMap.rejectKeysMultiValues((key, values) -> (key % 2 == 0 || Iterate.sizeOf(values) > 4));
-        TreeSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(5, 4, 2, 2));
         ImmutableSortedSetMultimap<Integer, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, selectedMultimap);
-        Verify.assertIterablesEqual(expectedImmutableMultimap.get(3), selectedMultimap.get(3));
+        Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
         Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
@@ -193,38 +192,38 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     @Test
     public void collectKeysValues()
     {
-        TreeSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll("1", FastList.newListWith(4, 3, 2, 1, 1));
         mutableMultimap.putAll("2", FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableBagMultimap<Integer, String> collectedMultimap1 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(Integer.valueOf(key), value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap1 = HashBagMultimap.newMultimap();
         expectedMultimap1.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap1.putAll(2, FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap1 = expectedMultimap1.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap1, collectedMultimap1);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap1, collectedMultimap1);
 
         ImmutableBagMultimap<Integer, String> collectedMultimap2 = immutableMap.collectKeysValues((key, value) -> Tuples.pair(1, value + "Value"));
-        HashBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
+        MutableBagMultimap<Integer, String> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.putAll(1, FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap2.putAll(1, FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
         ImmutableBagMultimap<Integer, String> expectedImmutableMultimap2 = expectedMultimap2.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap2, collectedMultimap2);
+        Verify.assertBagMultimapsEqual(expectedImmutableMultimap2, collectedMultimap2);
     }
 
     @Override
     @Test
     public void collectValues()
     {
-        TreeSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
+        MutableSortedSetMultimap<String, Integer> mutableMultimap = TreeSortedSetMultimap.newMultimap(Comparators.<Integer>reverseNaturalOrder());
         mutableMultimap.putAll("1", FastList.newListWith(4, 3, 2, 1, 1));
         mutableMultimap.putAll("2", FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<String, Integer> immutableMap = mutableMultimap.toImmutable();
         ImmutableListMultimap<String, String> collectedMultimap = immutableMap.collectValues(value -> value + "Value");
-        FastListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
+        MutableListMultimap<String, String> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("1", FastList.newListWith("4Value", "3Value", "2Value", "1Value"));
         expectedMultimap.putAll("2", FastList.newListWith("5Value", "4Value", "3Value", "2Value"));
         ImmutableListMultimap<String, String> expectedImmutableMultimap = expectedMultimap.toImmutable();
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        Verify.assertListMultimapsEqual(expectedImmutableMultimap, collectedMultimap);
     }
 }


### PR DESCRIPTION
Implement new methods that provide assertions for ListMultimaps, SetMultimaps and BagMultimaps.
This is a minor version change.