### PR TITLE
Add .maven folder to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.maven


### PR DESCRIPTION
This is added so that Hudson maven build can commit updated pom files as part of release build, without committing local maven repository under the workspace.

FYI attaching POC release build console: https://hudson.eclipse.org/collections/job/eclipse-collections-release/5/consoleFull 