### PR TITLE
Add instructions for commit sign-off to contribution guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,8 @@ If this is your first time contributing to an Eclipse Foundation project, you'll
 - [Create an account](https://dev.eclipse.org/site_login/createaccount.php) on dev.eclipse.org
 - Open your [Account Settings tab](https://dev.eclipse.org/site_login/myaccount.php#open_tab_accountsettings), enter your GitHub ID and click Update Account
 - Read and [sign the CLA](https://projects.eclipse.org/user/sign/cla)
-- Your git commits must use the same email address as your Eclipse account
-- Your git commits must be signed-off by the same user as your Eclipse account
-- [Sign your commits](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit)
+- Your git commits must be [signed off](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit)
+- Use the exact same email address for your Eclipse account, your commit author, and your commit sign-off.
 
 Issues
 ------
@@ -70,11 +69,8 @@ Commit messages
 
 - [Use the imperative mood][imperative-mood] as in "Fix bug" or "Add feature" rather than "Fixed bug" or "Added feature"
 - [Mention the GitHub issue][github-issue] when relevant
-- Sign-off your commits
-```bash
-$ git commit -s
-```
 - It's a good idea to follow the [advice in Pro Git](https://git-scm.com/book/ch5-2.html)
+- Sign-off your commits using `git commit --signoff` or `git commit -s` for short
 
 Pull requests
 -------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ If this is your first time contributing to an Eclipse Foundation project, you'll
 - Open your [Account Settings tab](https://dev.eclipse.org/site_login/myaccount.php#open_tab_accountsettings), enter your GitHub ID and click Update Account
 - Read and [sign the CLA](https://projects.eclipse.org/user/sign/cla)
 - Your git commits must use the same email address as your Eclipse account
+- Your git commits must be signed-off by the same user as your Eclipse account
 - [Sign your commits](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit)
 
 Issues
@@ -69,6 +70,10 @@ Commit messages
 
 - [Use the imperative mood][imperative-mood] as in "Fix bug" or "Add feature" rather than "Fixed bug" or "Added feature"
 - [Mention the GitHub issue][github-issue] when relevant
+- Sign-off your commits
+```bash
+$ git commit -s
+```
 - It's a good idea to follow the [advice in Pro Git](https://git-scm.com/book/ch5-2.html)
 
 Pull requests


### PR DESCRIPTION
The ip-validation by Eclipse requires all commits to be signed-off. This pull request add the instructions to sign-off the commits.