### PR TITLE
Implement Iterate.toMultimap()

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutAllProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutAllProcedure.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+
+/**
+ * MultimapKeyValuePutAllProcedure uses an Functions to calculate the key and values for an object and puts the key with
+ * all values into the specified {@link MutableMultimap}.
+ */
+public class MultimapKeyValuePutAllProcedure<T, K, V> implements Procedure<T>
+{
+    private static final long serialVersionUID = 1L;
+
+    private final MutableMultimap<K, V> mutableMultimap;
+    private final Function<? super T, ? extends K> keyFunction;
+    private final Function<? super T, ? extends Iterable<V>> valueFunction;
+
+    public MultimapKeyValuePutAllProcedure(MutableMultimap<K, V> mutableMultimap, Function<? super T, ? extends K> keyFunction, Function<? super T, ? extends Iterable<V>> valueFunction)
+    {
+        this.mutableMultimap = mutableMultimap;
+        this.keyFunction = keyFunction;
+        this.valueFunction = valueFunction;
+    }
+
+    public void value(T each)
+    {
+        K key = this.keyFunction.valueOf(each);
+        Iterable<V> value = this.valueFunction.valueOf(each);
+        this.mutableMultimap.putAll(key, value);
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
@@ -72,6 +72,7 @@ import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.MapCollectProcedure;
 import org.eclipse.collections.impl.block.procedure.MaxComparatorProcedure;
 import org.eclipse.collections.impl.block.procedure.MinComparatorProcedure;
+import org.eclipse.collections.impl.block.procedure.MultimapKeyValuePutAllProcedure;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
@@ -2996,6 +2997,48 @@ public final class Iterate
     }
 
     /**
+     * Iterate over the specified collection applying the specified Functions to each element to calculate
+     * a key and values, add the results to {@code targetMultimap} and return the {@code targetMultimap}.
+     * <p>
+     * Example using a Java 8 lambda expression:
+     * <pre>
+     * MutableMultimap&lt;String, String&gt; multimap =
+     *      Iterate.<b>toMultimap</b>(integers, each -> "key:" + each, each -> Lists.mutable.of("value:" + each), FastListMultimap.newMultimap());
+     * </pre>
+     * <p>
+     * Example using an anonymous inner class:
+     * <pre>
+     * MutableMultimap&lt;String, String&gt; multimap =
+     *      Iterate.<b>groupByAndCollect</b>(integers,
+     *          new Function&lt;Integer, String&gt;()
+     *          {
+     *              public String valueOf(Integer each)
+     *              {
+     *                  return "key:" + each;
+     *              }
+     *          }, new Function&lt;Integer, Iterable&lt;String&gt;&gt;()
+     *          {
+     *              public Iterable&lt;String&gt; valueOf(Integer each)
+     *              {
+     *                  return Lists.mutable.of("value:" + each);
+     *              }
+     *          }, FastListMultimap.newMultimap());
+     * </pre>
+     *
+     * @see Iterate#groupBy(Iterable, Function) when only keys get transformed
+     * @see Iterate#groupByEach(Iterable, Function) when only keys get transformed and Function returns multiple keys
+     */
+    public static <T, K, V, R extends MutableMultimap<K, V>> R toMultimap(
+            Iterable<T> iterable,
+            Function<? super T, ? extends K> keyFunction,
+            Function<? super T, ? extends Iterable<V>> valuesFunction,
+            R targetMultimap)
+    {
+        Iterate.forEach(iterable, new MultimapKeyValuePutAllProcedure<T, K, V>(targetMultimap, keyFunction, valuesFunction));
+        return targetMultimap;
+    }
+
+    /**
      * Return the specified collection as a sorted List.
      */
     public static <T extends Comparable<? super T>> MutableList<T> toSortedList(Iterable<T> iterable)
@@ -3089,6 +3132,8 @@ public final class Iterate
 
     /**
      * @see RichIterable#groupBy(Function)
+     * @see Iterate#groupByEach(Iterable, Function) when function returns multiple keys
+     * @see Iterate#toMultimap(Iterable, Function, Function, MutableMultimap) when both keys and values get transformed
      */
     public static <T, V> MutableMultimap<V, T> groupBy(
             Iterable<T> iterable,
@@ -3119,6 +3164,8 @@ public final class Iterate
 
     /**
      * @see RichIterable#groupBy(Function, MutableMultimap)
+     * @see Iterate#groupByEach(Iterable, Function, MutableMultimap) when function returns multiple keys
+     * @see Iterate#toMultimap(Iterable, Function, Function, MutableMultimap) when both keys and values get transformed
      */
     public static <T, V, R extends MutableMultimap<V, T>> R groupBy(
             Iterable<T> iterable,
@@ -3202,6 +3249,8 @@ public final class Iterate
 
     /**
      * @see RichIterable#groupByEach(Function)
+     * @see Iterate#groupBy(Iterable, Function) when function returns single key
+     * @see Iterate#toMultimap(Iterable, Function, Function, MutableMultimap) when both keys and values get transformed
      */
     public static <T, V> MutableMultimap<V, T> groupByEach(
             Iterable<T> iterable,
@@ -3232,6 +3281,8 @@ public final class Iterate
 
     /**
      * @see RichIterable#groupByEach(Function, MutableMultimap)
+     * @see Iterate#groupBy(Iterable, Function, MutableMultimap) when function returns single key
+     * @see Iterate#toMultimap(Iterable, Function, Function, MutableMultimap) when both keys and values get transformed
      */
     public static <T, V, R extends MutableMultimap<V, T>> R groupByEach(
             Iterable<T> iterable,

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutAllProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutAllProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class MultimapKeyValuePutAllProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5NdWx0\n"
+                        + "aW1hcEtleVZhbHVlUHV0QWxsUHJvY2VkdXJlAAAAAAAAAAECAANMAAtrZXlGdW5jdGlvbnQANUxv\n"
+                        + "cmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvYmxvY2svZnVuY3Rpb24vRnVuY3Rpb247TAAPbXV0\n"
+                        + "YWJsZU11bHRpbWFwdAA2TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tdWx0aW1hcC9NdXRh\n"
+                        + "YmxlTXVsdGltYXA7TAANdmFsdWVGdW5jdGlvbnEAfgABeHBwcHA=",
+                new MultimapKeyValuePutAllProcedure<Object, Object, Object>(null, null, null));
+    }
+}


### PR DESCRIPTION
Adding `toMultimap()` on `RichIterable` is a major version change. It can be added in the static utility for a minor version.
There is a new [MultimapKeyValuePutProcedure](https://github.com/nikhilnanivadekar/eclipse-collections/blob/bc7c316629762b43d5d8b05e9a1e5956d7557501/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutProcedure.java) created, if this will be a major version change, I can inline the call for minor version change, and replace with the `Procedure` in major version.
I have only added the `targetMultimap` variant of `toMultimap()`, this is because I want users to control the output instead of deciding which type of `Multimap` is returned for a particular `Iterable`.