### PR TITLE
Simplify and optimize a few methods.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/AbstractBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/AbstractBag.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.MutableByteBag;
 import org.eclipse.collections.api.bag.primitive.MutableCharBag;
@@ -77,9 +78,9 @@ public abstract class AbstractBag<T>
     @Override
     public <R extends Collection<T>> R select(final Predicate<? super T> predicate, final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<T> targetBag = (MutableBag<T>) target;
+            final MutableBagIterable<T> targetBag = (MutableBagIterable<T>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -117,9 +118,9 @@ public abstract class AbstractBag<T>
             final P parameter,
             final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<T> targetBag = (MutableBag<T>) target;
+            final MutableBagIterable<T> targetBag = (MutableBagIterable<T>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -154,9 +155,9 @@ public abstract class AbstractBag<T>
     @Override
     public <R extends Collection<T>> R reject(final Predicate<? super T> predicate, final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<T> targetBag = (MutableBag<T>) target;
+            final MutableBagIterable<T> targetBag = (MutableBagIterable<T>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -194,9 +195,9 @@ public abstract class AbstractBag<T>
             final P parameter,
             final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<T> targetBag = (MutableBag<T>) target;
+            final MutableBagIterable<T> targetBag = (MutableBagIterable<T>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -248,9 +249,9 @@ public abstract class AbstractBag<T>
     @Override
     public <V, R extends Collection<V>> R collect(final Function<? super T, ? extends V> function, final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<V> targetBag = (MutableBag<V>) target;
+            final MutableBagIterable<V> targetBag = (MutableBagIterable<V>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -283,9 +284,9 @@ public abstract class AbstractBag<T>
             final P parameter,
             final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<V> targetBag = (MutableBag<V>) target;
+            final MutableBagIterable<V> targetBag = (MutableBagIterable<V>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -318,9 +319,9 @@ public abstract class AbstractBag<T>
             final Function<? super T, ? extends V> function,
             final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<V> targetBag = (MutableBag<V>) target;
+            final MutableBagIterable<V> targetBag = (MutableBagIterable<V>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {
@@ -356,9 +357,9 @@ public abstract class AbstractBag<T>
     @Override
     public <V, R extends Collection<V>> R flatCollect(final Function<? super T, ? extends Iterable<V>> function, final R target)
     {
-        if (target instanceof MutableBag<?>)
+        if (target instanceof MutableBagIterable<?>)
         {
-            final MutableBag<V> targetBag = (MutableBag<V>) target;
+            final MutableBagIterable<V> targetBag = (MutableBagIterable<V>) target;
 
             this.forEachWithOccurrences(new ObjectIntProcedure<T>()
             {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
@@ -36,7 +36,6 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.block.procedure.MultimapEachPutProcedure;
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Sets;
@@ -135,6 +134,7 @@ final class ImmutableSingletonBag<T>
         return HashBag.newBag(elements).with(this.value).toImmutable();
     }
 
+    @Override
     public ImmutableBag<T> newWithoutAll(Iterable<? extends T> elements)
     {
         return this.emptyIfMatchesOrThis(Predicates.in(elements));
@@ -224,13 +224,19 @@ final class ImmutableSingletonBag<T>
 
     public ImmutableBag<T> reject(Predicate<? super T> predicate)
     {
-        return this.select(Predicates.not(predicate));
+        return predicate.accept(this.value)
+                ? Bags.immutable.<T>empty()
+                : this;
     }
 
     @Override
     public <R extends Collection<T>> R reject(Predicate<? super T> predicate, R target)
     {
-        return this.select(Predicates.not(predicate), target);
+        if (!predicate.accept(this.value))
+        {
+            target.add(this.value);
+        }
+        return target;
     }
 
     @Override
@@ -239,7 +245,11 @@ final class ImmutableSingletonBag<T>
             P parameter,
             R target)
     {
-        return this.selectWith(Predicates2.not(predicate), parameter, target);
+        if (!predicate.accept(this.value, parameter))
+        {
+            target.add(this.value);
+        }
+        return target;
     }
 
     public <S> ImmutableBag<S> selectInstancesOf(Class<S> clazz)
@@ -361,6 +371,7 @@ final class ImmutableSingletonBag<T>
         return UnifiedMap.newWithKeysValues(this.value, 1);
     }
 
+    @Override
     public ImmutableBag<T> toImmutable()
     {
         return this;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -993,6 +993,25 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
                 procedure.value(this.nonSentinel(cur), (V) this.table[i + 1]);
             }
         }
+    }
+
+    @Override
+    public V getFirst()
+    {
+        for (int i = 0; i < this.table.length; i += 2)
+        {
+            Object cur = this.table[i];
+            if (cur == CHAINED_KEY)
+            {
+                Object[] chain = (Object[]) this.table[i + 1];
+                return (V) chain[1];
+            }
+            if (cur != null)
+            {
+                return (V) this.table[i + 1];
+            }
+        }
+        return null;
     }
 
     public <E> MutableMap<K, V> collectKeysAndValues(

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -1035,6 +1035,25 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
                 procedure.value(this.nonSentinel(cur), (V) this.table[i + 1]);
             }
         }
+    }
+
+    @Override
+    public V getFirst()
+    {
+        for (int i = 0; i < this.table.length; i += 2)
+        {
+            Object cur = this.table[i];
+            if (cur == CHAINED_KEY)
+            {
+                Object[] chain = (Object[]) this.table[i + 1];
+                return (V) chain[1];
+            }
+            if (cur != null)
+            {
+                return (V) this.table[i + 1];
+            }
+        }
+        return null;
     }
 
     public <E> MutableMap<K, V> collectKeysAndValues(

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -669,7 +669,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
 
     public <V extends Comparable<? super V>> T minBy(Function<? super T, ? extends V> function)
     {
-        return this.delegate.asReversed().toList().minBy(function);
+        return this.delegate.asReversed().minBy(function);
     }
 
     public String makeString()

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -57,8 +57,8 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     protected static final MutableList<Integer> MORE_COLLISIONS = FastList.newList(COLLISIONS)
             .with(COLLISION_6, COLLISION_7, COLLISION_8, COLLISION_9);
     protected static final String[] FREQUENT_COLLISIONS = {"\u9103\ufffe", "\u9104\uffdf",
-        "\u9105\uffc0", "\u9106\uffa1", "\u9107\uff82", "\u9108\uff63", "\u9109\uff44",
-        "\u910a\uff25", "\u910b\uff06", "\u910c\ufee7"};
+            "\u9105\uffc0", "\u9106\uffa1", "\u9107\uff82", "\u9108\uff63", "\u9109\uff44",
+            "\u910a\uff25", "\u910b\uff06", "\u910c\ufee7"};
 
     @Test
     public void valuesCollection_toArray()
@@ -850,6 +850,16 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         }
 
         Assert.assertArrayEquals(expected, map.keysView().toArray());
+    }
+
+    @Override
+    public void getFirst()
+    {
+        super.getFirst();
+
+        MutableMap<String, String> map = this.newMap();
+        map.collectKeysAndValues(Arrays.asList(FREQUENT_COLLISIONS), Functions.identity(), Functions.identity());
+        Assert.assertEquals(FREQUENT_COLLISIONS[0], map.getFirst());
     }
 
     private static final class NoInstanceOfInEquals


### PR DESCRIPTION
- Simplify and optimize a few methods in ImmutableSingletonBag.
- Fix performance problem in ArrayStack.minBy().
- Optimize UnifiedMap.getFirst() to not delegate to an iterator.
- Optimize AbstractBag for all MutableBagIterable targets, not just MutableBag targets.
