### PR TITLE
Fix GenerateMojo Deprecated Syntax Warnings

### DIFF
--- a/eclipse-collections-code-generator-maven-plugin/src/main/java/org/eclipse/collections/codegenerator/maven/GenerateMojo.java
+++ b/eclipse-collections-code-generator-maven-plugin/src/main/java/org/eclipse/collections/codegenerator/maven/GenerateMojo.java
@@ -31,12 +31,12 @@ public class GenerateMojo extends AbstractMojo
     /**
      * Skips code generation if true.
      *
-     * @parameter expression="${skipCodeGen}"
+     * @parameter property="skipCodeGen"
      */
     private boolean skipCodeGen;
 
     /**
-     * @parameter expression="${project.build.directory}/generated-sources"
+     * @parameter default-value="${project.build.directory}/generated-sources"
      * @required
      */
     private String templateDirectory;
@@ -44,7 +44,7 @@ public class GenerateMojo extends AbstractMojo
     /**
      * The Maven project to act upon.
      *
-     * @parameter expression="${project}"
+     * @parameter property="project"
      * @required
      */
     private MavenProject project;


### PR DESCRIPTION
The GenerateMojo uses the deprecated expression syntax which results in
deprecation warnings during the build.

Switch to the property or default value syntax that is recommended by
Maven.

Signed-off-by: Philippe Marschall <philippe.marschall@gmail.com>