### PR TITLE
Replace forkMode with forkCount

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
                         </includes>
                         <argLine>-XX:-OmitStackTraceInFastThrow</argLine>
                         <runOrder>random</runOrder>
-                        <forkMode>never</forkMode>
+                        <forkCount>0</forkCount>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
forkMode has been deprecated since surefire version 2.14 and been
replaced with forkCount and reuseForks.

Signed-off-by: Philippe Marschall <philippe.marschall@gmail.com>