### PR TITLE
Implement Iterate.groupByAndCollect().

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutProcedure.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+
+/**
+ * MultimapKeyValuePutProcedure uses an Functions to calculate the key and value for an object and puts the key and value
+ * into the specified {@link MutableMultimap}.
+ */
+public class MultimapKeyValuePutProcedure<T, K, V> implements Procedure<T>
+{
+    private static final long serialVersionUID = 1L;
+
+    private final MutableMultimap<K, V> mutableMultimap;
+    private final Function<? super T, ? extends K> keyFunction;
+    private final Function<? super T, ? extends V> valueFunction;
+
+    public MultimapKeyValuePutProcedure(MutableMultimap<K, V> mutableMultimap, Function<? super T, ? extends K> keyFunction, Function<? super T, ? extends V> valueFunction)
+    {
+        this.mutableMultimap = mutableMultimap;
+        this.keyFunction = keyFunction;
+        this.valueFunction = valueFunction;
+    }
+
+    public void value(T each)
+    {
+        K key = this.keyFunction.valueOf(each);
+        V value = this.valueFunction.valueOf(each);
+        this.mutableMultimap.put(key, value);
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MultimapKeyValuePutProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class MultimapKeyValuePutProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAElvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5NdWx0\n"
+                        + "aW1hcEtleVZhbHVlUHV0UHJvY2VkdXJlAAAAAAAAAAECAANMAAtrZXlGdW5jdGlvbnQANUxvcmcv\n"
+                        + "ZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvYmxvY2svZnVuY3Rpb24vRnVuY3Rpb247TAAPbXV0YWJs\n"
+                        + "ZU11bHRpbWFwdAA2TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tdWx0aW1hcC9NdXRhYmxl\n"
+                        + "TXVsdGltYXA7TAANdmFsdWVGdW5jdGlvbnEAfgABeHBwcHA=",
+                new MultimapKeyValuePutProcedure<Object, Object, Object>(null, null, null));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -549,6 +549,53 @@ public class IterateTest
     }
 
     @Test
+    public void groupByAndCollect()
+    {
+        MutableList<Integer> list = Lists.mutable.of(1, 2, 2, 3, 3, 3);
+
+        Pair[] expectedPairs = {Tuples.pair("Key1", "1"),
+                Tuples.pair("Key2", "2"),
+                Tuples.pair("Key2", "2"),
+                Tuples.pair("Key3", "3"),
+                Tuples.pair("Key3", "3"),
+                Tuples.pair("Key3", "3")};
+        Function<Integer, String> keyFunction = each -> "Key" + each;
+        Function<Integer, String> valueFunction = String::valueOf;
+        MutableListMultimap<String, String> actualMultimap1 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.list.empty());
+        Verify.assertListMultimapsEqual(FastListMultimap.newMultimap(expectedPairs), actualMultimap1);
+
+        MutableSetMultimap<String, String> actualMultimap2 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.set.empty());
+        Verify.assertSetMultimapsEqual(UnifiedSetMultimap.newMultimap(expectedPairs), actualMultimap2);
+
+        MutableBagMultimap<String, String> actualMultimap3 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.bag.empty());
+        Verify.assertBagMultimapsEqual(HashBagMultimap.newMultimap(expectedPairs), actualMultimap3);
+
+        MutableSortedSetMultimap<String, String> expectedMultimap4 = TreeSortedSetMultimap.newMultimap(Comparators.naturalOrder());
+        expectedMultimap4.putAllPairs(expectedPairs);
+        MutableSortedSetMultimap<String, String> actualMultimap4 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.sortedSet.with(Comparators.naturalOrder()));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap4, actualMultimap4);
+        Assert.assertSame(expectedMultimap4.comparator(), actualMultimap4.comparator());
+
+        MutableSortedSetMultimap<String, String> expectedMultimap5 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        expectedMultimap5.putAllPairs(expectedPairs);
+        MutableSortedSetMultimap<String, String> actualMultimap5 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.sortedSet.with(Comparators.reverseNaturalOrder()));
+        Verify.assertSortedSetMultimapsEqual(expectedMultimap5, actualMultimap5);
+        Assert.assertSame(expectedMultimap5.comparator(), actualMultimap5.comparator());
+
+        MutableSortedBagMultimap<String, String> expectedMultimap6 = TreeBagMultimap.newMultimap(Comparators.naturalOrder());
+        expectedMultimap6.putAllPairs(expectedPairs);
+        MutableSortedBagMultimap<String, String> actualMultimap6 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, TreeBagMultimap.newMultimap(Comparators.naturalOrder()));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap6, actualMultimap6);
+        Assert.assertSame(expectedMultimap6.comparator(), actualMultimap6.comparator());
+
+        MutableSortedBagMultimap<String, String> expectedMultimap7 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
+        expectedMultimap7.putAllPairs(expectedPairs);
+        MutableSortedBagMultimap<String, String> actualMultimap7 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder()));
+        Verify.assertSortedBagMultimapsEqual(expectedMultimap7, actualMultimap7);
+        Assert.assertSame(expectedMultimap7.comparator(), actualMultimap7.comparator());
+    }
+
+    @Test
     public void toList()
     {
         Assert.assertEquals(FastList.newListWith(1, 2, 3), FastList.newList(Interval.oneTo(3)));


### PR DESCRIPTION
Iteration pattern similar to `Iterate.toMultimap()` where both keys and values need to be transformed.