### PR TITLE
Skip deployment of the junit-trait-runner maven module.

### DIFF
--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <prerequisites>
@@ -94,44 +96,4 @@
 
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Another try at getting the build to pass. I suspect that deployment to maven central is failing on this one module due to a mismatch between the groupId and the package name. At this point, I'd rather work on the fix on master, and get the 7.0.x branch deployed without this new, optional module.