### PR TITLE
Improve the Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ matrix:
   include:
     - jdk: oraclejdk8
       env:
+        - DESC="acceptance tests"
+        - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all --batch-mode --show-version --errors"
+
+    - jdk: oraclejdk8
+      env:
         - DESC="findbugs"
         - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
@@ -22,11 +27,6 @@ matrix:
       env:
         - DESC="unit tests"
         - CMD="mvn install --batch-mode --show-version --errors"
-
-    - jdk: oraclejdk8
-      env:
-        - DESC="acceptance tests"
-        - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ matrix:
 
     - jdk: oraclejdk8
       env:
-        - DESC="compile all modules"
-        - CMD="mvn install --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - DESC="compile jmh-tests and performance-tests"
+        - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ParallelMapIteratePutAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ParallelMapIteratePutAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -27,9 +27,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ParallelMapIteratePutAcceptanceTest
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelMapIteratePutAcceptanceTest.class);
     private static final long SEED = 0x12345678ABCDL;
 
     private static final long PUT_REPEAT = 100;
@@ -90,7 +93,7 @@ public class ParallelMapIteratePutAcceptanceTest
 
     private void runPutTest1(int threadCount, Integer[] contents, Integer[] constContents, ExecutorService executorService, boolean warmup)
     {
-        long ops = (warmup ? 1000000 / contents.length : 1000000 * PUT_REPEAT / contents.length) + 1;
+        long ops = ((warmup ? 1000000 : 1000000 * PUT_REPEAT) / contents.length) + 1;
         Future<?>[] futures = new Future<?>[threadCount];
         for (int i = 0; i < ops; i++)
         {
@@ -173,6 +176,7 @@ public class ParallelMapIteratePutAcceptanceTest
                         }
                     }
                 }
+                LOGGER.info("Processed chunk ending at: {}", end);
             }
             if (this.total < 0)
             {

--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ParallelUnsafeMapIteratePutAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ParallelUnsafeMapIteratePutAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -27,9 +27,13 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ParallelUnsafeMapIteratePutAcceptanceTest
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelUnsafeMapIteratePutAcceptanceTest.class);
+
     private static final long SEED = 0x12345678ABCDL;
 
     private static final long PUT_REPEAT = 100;
@@ -90,7 +94,7 @@ public class ParallelUnsafeMapIteratePutAcceptanceTest
 
     private void runPutTest1(int threadCount, Integer[] contents, Integer[] constContents, ExecutorService executorService, boolean warmup)
     {
-        long ops = (warmup ? 1000000 / contents.length : 1000000 * PUT_REPEAT / contents.length) + 1;
+        long ops = ((warmup ? 1000000 : 1000000 * PUT_REPEAT) / contents.length) + 1;
         Future<?>[] futures = new Future<?>[threadCount];
         for (int i = 0; i < ops; i++)
         {
@@ -173,6 +177,7 @@ public class ParallelUnsafeMapIteratePutAcceptanceTest
                         }
                     }
                 }
+                LOGGER.info("Processed chunk ending at: {}", end);
             }
             if (this.total < 0)
             {

--- a/pom.xml
+++ b/pom.xml
@@ -136,15 +136,15 @@
 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
+                <artifactId>slf4j-nop</artifactId>
                 <version>${slf4j.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
+                <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Add periodic logging to the parallel map acceptance tests to prevent timeouts.
* Set up a Travis job to compile, but not run, jmh-tests and performance-tests.
  * This replaces the build which compiled all modules with a much faster one that compiles the ones not included in other jobs.
* Move the slowest Travis job to run first.