### PR TITLE
Enable Maven JDeps plugin to find usages of JDK internal API.

### DIFF
--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -74,6 +74,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/eclipse-collections-code-generator-ant/pom.xml
+++ b/eclipse-collections-code-generator-ant/pom.xml
@@ -63,6 +63,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -71,6 +71,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -62,6 +62,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -76,6 +76,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -76,6 +76,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -80,6 +80,14 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+                <configuration>
+                    <failOnWarning>false</failOnWarning>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -157,6 +157,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -56,6 +56,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,20 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jdeps-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>jdkinternals</goal>
+                                <goal>test-jdkinternals</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.4.1</version>
                     <executions>

--- a/scala-unit-tests/pom.xml
+++ b/scala-unit-tests/pom.xml
@@ -94,6 +94,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/serialization-tests/pom.xml
+++ b/serialization-tests/pom.xml
@@ -81,6 +81,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -110,6 +110,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>

--- a/unit-tests/pom.xml
+++ b/unit-tests/pom.xml
@@ -110,6 +110,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
[Jdeps tool](https://wiki.openjdk.java.net/display/JDK8/Java+Dependency+Analysis+Tool) was added as a part of Java 8 to analyze JDK internal API usages. The changes are limited to the `pom.xml`s to enable the [Maven JDeps plugin](https://maven.apache.org/plugins/maven-jdeps-plugin/).

Eclipse Collections main library is dependent on `sun.misc.Unsafe`, if the Jdeps plugin is used in the default run mode, then the build will fail. The configuration is overriden to not fail only for the Main Library.
The config override is suggested [here](http://mail.openjdk.java.net/pipermail/jigsaw-dev/2015-April/004284.html).