### PR TITLE
Skip deployment of the junit-trait-runner maven module.

### DIFF
--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <prerequisites>


### PR DESCRIPTION
Cherry picked to address `deploy` build failure. 

I'll manually tag the latest commit to 7.1.0 once this is merged. 