### PR TITLE
Change MutableBagIterable.addOccurrences(T item, int occurrences) to return the updated number of occurrences instead of void.

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -4,6 +4,7 @@
 New Functionality
 -----------------
 
+* Changed MutableBagIterable.addOccurrences(T item, int occurrences) to return the updated number of occurrences instead of void.
 * Implemented Multimap.keySet() to return an unmodifiable SetIterable of keys.
 
 Optimizations

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MutableBagIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MutableBagIterable.java
@@ -26,7 +26,20 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 
 public interface MutableBagIterable<T> extends Bag<T>, MutableCollection<T>
 {
-    void addOccurrences(T item, int occurrences);
+    /**
+     * Add number of {@code occurrences} for an {@code item}. If the {@code item} does not exist, then the {@code item} is added to the bag.
+     *
+     * <p>
+     *  For Example:
+     *  <pre>
+     * MutableBagIterable&lt;String&gt; names = Bags.mutable.of("A", "B", "B");
+     * Assert.assertEquals(4, names.<b>addOccurrences</b>("A", 3));
+     * </pre>
+     *
+     * @return updated number of occurrences.
+     * @throws  IllegalArgumentException if {@code occurrences} are less than 0.
+     */
+    int addOccurrences(T item, int occurrences);
 
     boolean removeOccurrences(Object item, int occurrences);
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractHashBag.java
@@ -58,7 +58,7 @@ public abstract class AbstractHashBag<T> extends AbstractMutableBag<T>
         return source.notEmpty();
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         if (occurrences < 0)
         {
@@ -66,9 +66,11 @@ public abstract class AbstractHashBag<T> extends AbstractMutableBag<T>
         }
         if (occurrences > 0)
         {
-            this.items.updateValue(item, 0, IntToIntFunctions.add(occurrences));
+            int updatedOccurrences = this.items.updateValue(item, 0, IntToIntFunctions.add(occurrences));
             this.size += occurrences;
+            return updatedOccurrences;
         }
+        return this.occurrencesOf(item);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
@@ -217,12 +217,12 @@ public final class MultiReaderHashBag<T>
         }
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         this.acquireWriteLock();
         try
         {
-            this.delegate.addOccurrences(item, occurrences);
+            return this.delegate.addOccurrences(item, occurrences);
         }
         finally
         {
@@ -860,9 +860,9 @@ public final class MultiReaderHashBag<T>
             return iterator;
         }
 
-        public void addOccurrences(T item, int occurrences)
+        public int addOccurrences(T item, int occurrences)
         {
-            this.getDelegate().addOccurrences(item, occurrences);
+            return this.getDelegate().addOccurrences(item, occurrences);
         }
 
         public boolean removeOccurrences(Object item, int occurrences)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBag.java
@@ -127,11 +127,11 @@ public class SynchronizedBag<T>
         return new SynchronizedCollectionSerializationProxy<T>(this.getDelegate());
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         synchronized (this.getLock())
         {
-            this.getDelegate().addOccurrences(item, occurrences);
+            return this.getDelegate().addOccurrences(item, occurrences);
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBag.java
@@ -275,7 +275,7 @@ public class UnmodifiableBag<T>
         return this.getMutableBag().groupByEach(function);
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         throw new UnsupportedOperationException("Cannot call addOccurrences() on " + this.getClass().getSimpleName());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBag.java
@@ -161,11 +161,11 @@ public class SynchronizedSortedBag<T>
         return new SynchronizedCollectionSerializationProxy<T>(this.getDelegate());
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         synchronized (this.getLock())
         {
-            this.getDelegate().addOccurrences(item, occurrences);
+            return this.getDelegate().addOccurrences(item, occurrences);
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.java
@@ -444,7 +444,7 @@ public class TreeBag<T>
         return new InternalIterator();
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         if (occurrences < 0)
         {
@@ -452,9 +452,12 @@ public class TreeBag<T>
         }
         if (occurrences > 0)
         {
-            this.items.getIfAbsentPut(item, NEW_COUNTER_BLOCK).add(occurrences);
+            Counter counter = this.items.getIfAbsentPut(item, NEW_COUNTER_BLOCK);
+            counter.add(occurrences);
             this.size += occurrences;
+            return counter.getCount();
         }
+        return this.occurrencesOf(item);
     }
 
     public boolean removeOccurrences(Object item, int occurrences)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBag.java
@@ -127,7 +127,7 @@ public class UnmodifiableSortedBag<T>
         return this.getSortedBag().newEmpty();
     }
 
-    public void addOccurrences(T item, int occurrences)
+    public int addOccurrences(T item, int occurrences)
     {
         throw new UnsupportedOperationException("Cannot call addOccurrences() on " + this.getClass().getSimpleName());
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
@@ -45,9 +45,9 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
     default void MutableBagIterable_addOccurrences()
     {
         MutableBagIterable<Integer> mutableBag = this.newWith(1, 2, 2, 3, 3, 3);
-        mutableBag.addOccurrences(4, 4);
+        assertEquals(4, mutableBag.addOccurrences(4, 4));
         assertEquals(Bags.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
-        mutableBag.addOccurrences(1, 2);
+        assertEquals(3, mutableBag.addOccurrences(1, 2));
         assertEquals(Bags.immutable.with(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
@@ -55,11 +55,11 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
     default void MutableBagIterable_addOccurrences()
     {
         MutableSortedBag<Integer> mutableSortedBag = this.newWith(1, 2, 2, 3, 3, 3);
-        mutableSortedBag.addOccurrences(4, 4);
+        assertEquals(4, mutableSortedBag.addOccurrences(4, 4));
         assertEquals(TreeBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
-        mutableSortedBag.addOccurrences(1, 2);
+        assertEquals(3, mutableSortedBag.addOccurrences(1, 2));
         assertEquals(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
-        mutableSortedBag.addOccurrences(1, 0);
+        assertEquals(3, mutableSortedBag.addOccurrences(1, 0));
         assertEquals(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
@@ -30,11 +30,11 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
     default void MutableBagIterable_addOccurrences()
     {
         MutableSortedBag<Integer> mutableSortedBag = this.newWith(3, 3, 3, 2, 2, 1);
-        mutableSortedBag.addOccurrences(4, 4);
+        assertEquals(4, mutableSortedBag.addOccurrences(4, 4));
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1), mutableSortedBag);
-        mutableSortedBag.addOccurrences(1, 2);
+        assertEquals(3, mutableSortedBag.addOccurrences(1, 2));
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
-        mutableSortedBag.addOccurrences(1, 0);
+        assertEquals(3, mutableSortedBag.addOccurrences(1, 0));
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
@@ -39,9 +39,12 @@ public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollection
     @Test
     public void addOccurrences()
     {
-        MutableBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1);
-        bag.addOccurrences(1, 2);
+        MutableBag<Integer> bag = this.newWith(1, 1);
+        Assert.assertEquals(4, bag.addOccurrences(1, 2));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1), bag);
+        Assert.assertEquals(0, bag.addOccurrences(2, 0));
+        Assert.assertEquals(2, bag.addOccurrences(2, 2));
+        MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2), bag);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
@@ -90,10 +90,14 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void addOccurrences()
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2, 3);
-        bag.addOccurrences(1, 2);
-        bag.addOccurrences(4, 2);
-        bag.addOccurrences(2, 1);
+        Assert.assertEquals(2, bag.addOccurrences(1, 0));
+        Assert.assertEquals(4, bag.addOccurrences(1, 2));
+        Assert.assertEquals(0, bag.addOccurrences(4, 0));
+        Assert.assertEquals(2, bag.addOccurrences(4, 2));
+        Assert.assertEquals(2, bag.addOccurrences(2, 1));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3, 4, 4), bag);
+        Assert.assertEquals(3, bag.addOccurrences(2, 1));
+        MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 4, 4), bag);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
@@ -229,9 +229,16 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     @Test
     public void addOccurrences()
     {
-        MutableBagIterable<Object> bag = this.newWith();
-        bag.addOccurrences(new Object(), 0);
-        MutableBagTestCase.assertBagsEqual(HashBag.newBag(), bag);
+        MutableBagIterable<String> bag = this.newWith();
+        Assert.assertEquals(0, bag.addOccurrences("0", 0));
+        Assert.assertEquals(1, bag.addOccurrences("1", 1));
+        Assert.assertEquals(1, bag.addOccurrences("1", 0));
+        Assert.assertEquals(2, bag.addOccurrences("2", 2));
+        MutableBagTestCase.assertBagsEqual(HashBag.newBagWith("1", "2", "2"), bag);
+        Assert.assertEquals(1, bag.addOccurrences("1", 0));
+        Assert.assertEquals(6, bag.addOccurrences("2", 4));
+        Assert.assertEquals(1, bag.addOccurrences("3", 1));
+        MutableBagTestCase.assertBagsEqual(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2", "3"), bag);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
@@ -136,9 +136,12 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     public void addOccurrences()
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(0, integers.occurrencesOf(5));
-        integers.addOccurrences(5, 5);
-        Assert.assertEquals(5, integers.occurrencesOf(5));
+        Assert.assertEquals(6, integers.addOccurrences(1, 2));
+        Verify.assertBagsEqual(this.newWith(1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4), integers);
+        Assert.assertEquals(0, integers.addOccurrences(5, 0));
+        Assert.assertEquals(2, integers.addOccurrences(5, 2));
+        Assert.assertEquals(3, integers.addOccurrences(3, 1));
+        Verify.assertBagsEqual(this.newWith(1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 5, 5), integers);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
@@ -888,20 +888,20 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.addOccurrences();
 
         MutableSortedBag<Integer> bag = this.newWith();
-        bag.addOccurrences(0, 3);
-        bag.addOccurrences(2, 0);
-        bag.addOccurrences(1, 2);
+        Assert.assertEquals(3, bag.addOccurrences(0, 3));
+        Assert.assertEquals(0, bag.addOccurrences(2, 0));
+        Assert.assertEquals(2, bag.addOccurrences(1, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(0, 0, 0, 1, 1), bag);
-        bag.addOccurrences(0, 3);
-        bag.addOccurrences(1, 2);
+        Assert.assertEquals(6, bag.addOccurrences(0, 3));
+        Assert.assertEquals(4, bag.addOccurrences(1, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(0, 0, 0, 0, 0, 0, 1, 1, 1, 1), bag);
 
         MutableSortedBag<Integer> revBag = this.newWith(Collections.<Integer>reverseOrder());
-        revBag.addOccurrences(2, 3);
-        revBag.addOccurrences(3, 2);
+        Assert.assertEquals(3, revBag.addOccurrences(2, 3));
+        Assert.assertEquals(2, revBag.addOccurrences(3, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 3, 2, 2, 2), revBag);
-        revBag.addOccurrences(2, 3);
-        revBag.addOccurrences(3, 2);
+        Assert.assertEquals(6, revBag.addOccurrences(2, 3));
+        Assert.assertEquals(4, revBag.addOccurrences(3, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 3, 3, 3, 2, 2, 2, 2, 2, 2), revBag);
     }
 


### PR DESCRIPTION
Fixes #27.