### PR TITLE
Optimize MutableList.chunk() for RandomAccess lists

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -7,12 +7,12 @@ New Functionality
 * Changed MutableBagIterable.addOccurrences(T item, int occurrences) to return the updated number of occurrences instead of void.
 * Implemented Multimap.keySet() to return an unmodifiable SetIterable of keys.
 * Implemented MutableMultimap.putAllPairs(Iterable<Pair<K, V>> keyValuePairs).
-* Pull up into() from LazyIterable to RichIterable
+* Pull up into() from LazyIterable to RichIterable.
 
 Optimizations
 -------------
 
-* A Placeholder
+* Optimize MutableList.chunk() for RandomAccess lists to use the backing array instead of an iterator.
 
 Bug fixes
 ---------

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
@@ -22,6 +22,7 @@ import java.util.Random;
 import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
@@ -1114,6 +1115,35 @@ public abstract class AbstractMutableList<T>
     public int binarySearch(T key)
     {
         return Collections.binarySearch((List<? extends Comparable<? super T>>) this, key);
+    }
+
+    @Override
+    public RichIterable<RichIterable<T>> chunk(int size)
+    {
+        if (size <= 0)
+        {
+            throw new IllegalArgumentException("Size for groups must be positive but was: " + size);
+        }
+
+        if (this instanceof RandomAccess)
+        {
+            MutableList<RichIterable<T>> result = Lists.mutable.empty();
+            int i = 0;
+            while (i < this.size())
+            {
+                MutableList<T> batch = new FastList<T>(Math.min(size, this.size() - i));
+
+                for (int j = 0; j < size && i < this.size(); j++)
+                {
+                    batch.add(this.get(i));
+                    i++;
+                }
+                result.add(batch);
+            }
+            return result;
+        }
+
+        return super.chunk(size);
     }
 
     public MutableList<T> take(int count)


### PR DESCRIPTION
Current implementation of `MutableList.chunk()` uses an iterator. Optimize to use the backing array when the list is RandomAccess. 
Currently all implementations which extend `AbstractMutableList` are RandomAccess.