### PR TITLE
Fix several type signature problems due to missing overrides, incorrect return types, and generics problems.

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -9,6 +9,7 @@ New Functionality
 * Implemented Multimap.keySet() to return an unmodifiable SetIterable of keys.
 * Implemented MutableMultimap.putAllPairs(Iterable<Pair<K, V>> keyValuePairs).
 * Pull up into() from LazyIterable to RichIterable.
+* Made StackIterable implement OrderedIterable.
 
 Optimizations
 -------------
@@ -18,7 +19,14 @@ Optimizations
 Bug fixes
 ---------
 
-* A Placeholder
+* Changed AbstractSynchronizedRichIterable.groupByUniqueKey() to return MapIterable instead of MutableMap.
+* Changed AbstractMutableMapIterable.groupByUniqueKey() to return MutableMapIterable instead of MutableMap.
+* Changed MutableMapIterable.aggregateBy() to return MutableMap instead of MutableMapIterable.
+* Fixed return types on MapIterable.collect(Function2) overrides.
+* Fixed return type of UnifiedSetWithHashingStrategy.groupByEach() method to preserve hashing strategy.
+* Fixed generics on Multimap.forEachKeyValue().
+* Fixed generics on Multimap.forEachKeyMultiValues().
+* Made primitive-object maps more bag-like. Change the filtering and transformation methods to return bags since they contain duplicates and no meaningful order.
 
 Acquiring Eclipse Collections
 -----------------------------

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/UnsortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/UnsortedBag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -31,6 +31,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.multimap.bag.UnsortedBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.bag.PartitionUnsortedBag;
@@ -39,6 +40,8 @@ import org.eclipse.collections.api.tuple.Pair;
 
 public interface UnsortedBag<T> extends Bag<T>
 {
+    UnsortedBag<T> tap(Procedure<? super T> procedure);
+
     UnsortedBag<T> selectByOccurrences(IntPredicate predicate);
 
     UnsortedBag<T> select(Predicate<? super T> predicate);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/FixedSizeCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/FixedSizeCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,6 +14,7 @@ import java.util.Collection;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 
 /**
  * A FixedSizeCollection is a collection that may be mutated, but cannot grow or shrink in size.  It is up to
@@ -145,4 +146,6 @@ public interface FixedSizeCollection<T>
      * @throws UnsupportedOperationException
      */
     void clear();
+
+    FixedSizeCollection<T> tap(Procedure<? super T> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.list;
 
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.FixedSizeCollection;
 
 /**
@@ -21,4 +22,6 @@ public interface FixedSizeList<T>
         extends MutableList<T>, FixedSizeCollection<T>
 {
     FixedSizeList<T> toReversed();
+
+    FixedSizeList<T> tap(Procedure<? super T> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ListIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ListIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -30,6 +30,7 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.ByteList;
 import org.eclipse.collections.api.list.primitive.CharList;
@@ -103,6 +104,8 @@ public interface ListIterable<T>
      * @since 5.0
      */
     ImmutableList<T> toImmutable();
+
+    ListIterable<T> tap(Procedure<? super T> procedure);
 
     ListIterable<T> select(Predicate<? super T> predicate);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ConcurrentMutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ConcurrentMutableMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -12,10 +12,13 @@ package org.eclipse.collections.api.map;
 
 import java.util.concurrent.ConcurrentMap;
 
+import org.eclipse.collections.api.block.procedure.Procedure;
+
 /**
  * A ConcurrentMutableMap provides an api which combines and supports both MutableMap and ConcurrentMap.
  */
 public interface ConcurrentMutableMap<K, V>
         extends MutableMap<K, V>, ConcurrentMap<K, V>
 {
+    ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/FixedSizeMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/FixedSizeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,6 +11,8 @@
 package org.eclipse.collections.api.map;
 
 import java.util.Map;
+
+import org.eclipse.collections.api.block.procedure.Procedure;
 
 /**
  * A FixedSizeMap is a map that may be mutated, but cannot grow or shrink in size.
@@ -42,4 +44,6 @@ public interface FixedSizeMap<K, V>
      * @throws UnsupportedOperationException
      */
     V removeKey(K key);
+
+    FixedSizeMap<K, V> tap(Procedure<? super V> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableOrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableOrderedMap.java
@@ -100,6 +100,8 @@ public interface ImmutableOrderedMap<K, V> extends OrderedMap<K, V>, ImmutableMa
 
     ImmutableList<Pair<V, Integer>> zipWithIndex();
 
+    <VV> ImmutableList<VV> collect(Function<? super V, ? extends VV> function);
+
     <P, V1> ImmutableList<V1> collectWith(Function2<? super V, ? super P, ? extends V1> function, P parameter);
 
     <V1> ImmutableList<V1> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends V1> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
@@ -267,7 +267,7 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
 
     MutableCollection<Pair<V, Integer>> zipWithIndex();
 
-    <KK, VV> MutableMapIterable<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
+    <KK, VV> MutableMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
 
-    <KK, VV> MutableMapIterable<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
+    <KK, VV> MutableMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
@@ -98,6 +98,8 @@ public interface MutableOrderedMap<K, V> extends OrderedMap<K, V>, MutableMapIte
 
     MutableList<Pair<V, Integer>> zipWithIndex();
 
+    <VV> MutableList<VV> collect(Function<? super V, ? extends VV> function);
+
     <P, V1> MutableList<V1> collectWith(Function2<? super V, ? super P, ? extends V1> function, P parameter);
 
     <V1> MutableList<V1> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends V1> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
@@ -11,7 +11,6 @@
 package org.eclipse.collections.api.map;
 
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -24,7 +23,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
@@ -113,8 +111,4 @@ public interface MutableOrderedMap<K, V> extends OrderedMap<K, V>, MutableMapIte
     <V1> MutableListMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
     <V1> MutableOrderedMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    <KK, VV> MutableOrderedMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    <KK, VV> MutableOrderedMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
@@ -11,7 +11,6 @@
 package org.eclipse.collections.api.map;
 
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -24,7 +23,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.ByteList;
@@ -120,8 +118,4 @@ public interface OrderedMap<K, V>
     <V1> ListMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
     <V1> OrderedMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    <KK, VV> OrderedMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    <KK, VV> OrderedMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
@@ -105,6 +105,8 @@ public interface OrderedMap<K, V>
 
     ListIterable<Pair<V, Integer>> zipWithIndex();
 
+    <VV> ListIterable<VV> collect(Function<? super V, ? extends VV> function);
+
     <P, V1> ListIterable<V1> collectWith(Function2<? super V, ? super P, ? extends V1> function, P parameter);
 
     <V1> ListIterable<V1> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends V1> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/UnsortedMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/UnsortedMapIterable.java
@@ -69,6 +69,8 @@ public interface UnsortedMapIterable<K, V>
 
     PartitionBag<V> partition(Predicate<? super V> predicate);
 
+    <P> PartitionBag<V> partitionWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
     <S> Bag<S> selectInstancesOf(Class<S> clazz);
 
     <V1> Bag<V1> collect(Function<? super V, ? extends V1> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.map.primitive;
+
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableCharBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
+import org.eclipse.collections.api.block.function.primitive.ByteFunction;
+import org.eclipse.collections.api.block.function.primitive.CharFunction;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ShortFunction;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
+import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.tuple.Pair;
+
+/**
+ * @since 8.0.
+ */
+public interface ImmutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
+{
+    <K, VV> ImmutableMap<K, VV> aggregateInPlaceBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
+
+    <K, VV> ImmutableMap<K, VV> aggregateBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
+
+    <VV> ImmutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
+
+    <VV> ImmutableBagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function);
+
+    <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+
+    <VV> ImmutableBag<VV> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends VV> function);
+
+    <VV> ImmutableBag<VV> collect(Function<? super V, ? extends VV> function);
+
+    <VV> ImmutableBag<VV> flatCollect(Function<? super V, ? extends Iterable<VV>> function);
+
+    ImmutableBooleanBag collectBoolean(BooleanFunction<? super V> booleanFunction);
+
+    ImmutableByteBag collectByte(ByteFunction<? super V> byteFunction);
+
+    ImmutableCharBag collectChar(CharFunction<? super V> charFunction);
+
+    ImmutableDoubleBag collectDouble(DoubleFunction<? super V> doubleFunction);
+
+    ImmutableFloatBag collectFloat(FloatFunction<? super V> floatFunction);
+
+    ImmutableIntBag collectInt(IntFunction<? super V> intFunction);
+
+    ImmutableLongBag collectLong(LongFunction<? super V> longFunction);
+
+    ImmutableShortBag collectShort(ShortFunction<? super V> shortFunction);
+
+    <P, VV> ImmutableBag<VV> collectWith(Function2<? super V, ? super P, ? extends VV> function, P parameter);
+
+    <S> ImmutableBag<S> selectInstancesOf(Class<S> clazz);
+
+    ImmutableBag<V> select(Predicate<? super V> predicate);
+
+    <P> ImmutableBag<V> selectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    ImmutableBag<V> reject(Predicate<? super V> predicate);
+
+    <P> ImmutableBag<V> rejectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    PartitionImmutableBag<V> partition(Predicate<? super V> predicate);
+
+    <P> PartitionImmutableBag<V> partitionWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    /**
+     * @deprecated in 7.0. Use {@link OrderedIterable#zip(Iterable)} instead.
+     */
+    @Deprecated
+    <S> ImmutableBag<Pair<V, S>> zip(Iterable<S> that);
+
+    /**
+     * @deprecated in 7.0. Use {@link OrderedIterable#zipWithIndex()} instead.
+     */
+    @Deprecated
+    ImmutableSet<Pair<V, Integer>> zipWithIndex();
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,6 +11,14 @@
 package org.eclipse.collections.api.map.primitive;
 
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.MutableByteBag;
+import org.eclipse.collections.api.bag.primitive.MutableCharBag;
+import org.eclipse.collections.api.bag.primitive.MutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.MutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.bag.primitive.MutableLongBag;
+import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
@@ -25,15 +33,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.collection.MutableCollection;
-import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
-import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
-import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
-import org.eclipse.collections.api.collection.primitive.MutableDoubleCollection;
-import org.eclipse.collections.api.collection.primitive.MutableFloatCollection;
-import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
-import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
-import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -41,7 +40,7 @@ import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 
-public interface MutablePrimitiveObjectMap<V>
+public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
 {
     void clear();
 
@@ -57,35 +56,37 @@ public interface MutablePrimitiveObjectMap<V>
 
     <VV> MutableBag<VV> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends VV> function);
 
-    <VV> MutableCollection<VV> collect(Function<? super V, ? extends VV> function);
+    <VV> MutableBag<VV> collect(Function<? super V, ? extends VV> function);
 
-    MutableBooleanCollection collectBoolean(BooleanFunction<? super V> booleanFunction);
+    MutableBooleanBag collectBoolean(BooleanFunction<? super V> booleanFunction);
 
-    MutableByteCollection collectByte(ByteFunction<? super V> byteFunction);
+    MutableByteBag collectByte(ByteFunction<? super V> byteFunction);
 
-    MutableCharCollection collectChar(CharFunction<? super V> charFunction);
+    MutableCharBag collectChar(CharFunction<? super V> charFunction);
 
-    MutableDoubleCollection collectDouble(DoubleFunction<? super V> doubleFunction);
+    MutableDoubleBag collectDouble(DoubleFunction<? super V> doubleFunction);
 
-    MutableFloatCollection collectFloat(FloatFunction<? super V> floatFunction);
+    MutableFloatBag collectFloat(FloatFunction<? super V> floatFunction);
 
-    MutableIntCollection collectInt(IntFunction<? super V> intFunction);
+    MutableIntBag collectInt(IntFunction<? super V> intFunction);
 
-    MutableLongCollection collectLong(LongFunction<? super V> longFunction);
+    MutableLongBag collectLong(LongFunction<? super V> longFunction);
 
-    MutableShortCollection collectShort(ShortFunction<? super V> shortFunction);
+    MutableShortBag collectShort(ShortFunction<? super V> shortFunction);
 
-    <P, VV> MutableCollection<VV> collectWith(Function2<? super V, ? super P, ? extends VV> function, P parameter);
+    <P, VV> MutableBag<VV> collectWith(Function2<? super V, ? super P, ? extends VV> function, P parameter);
+
+    <VV> MutableBag<VV> flatCollect(Function<? super V, ? extends Iterable<VV>> function);
 
     <S> MutableBag<S> selectInstancesOf(Class<S> clazz);
 
-    MutableCollection<V> select(Predicate<? super V> predicate);
+    MutableBag<V> select(Predicate<? super V> predicate);
 
-    <P> MutableCollection<V> selectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+    <P> MutableBag<V> selectWith(Predicate2<? super V, ? super P> predicate, P parameter);
 
-    MutableCollection<V> reject(Predicate<? super V> predicate);
+    MutableBag<V> reject(Predicate<? super V> predicate);
 
-    <P> MutableCollection<V> rejectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+    <P> MutableBag<V> rejectWith(Predicate2<? super V, ? super P> predicate, P parameter);
 
     PartitionMutableBag<V> partition(Predicate<? super V> predicate);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/PrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/PrimitiveObjectMap.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.map.primitive;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.primitive.BooleanBag;
+import org.eclipse.collections.api.bag.primitive.ByteBag;
+import org.eclipse.collections.api.bag.primitive.CharBag;
+import org.eclipse.collections.api.bag.primitive.DoubleBag;
+import org.eclipse.collections.api.bag.primitive.FloatBag;
+import org.eclipse.collections.api.bag.primitive.IntBag;
+import org.eclipse.collections.api.bag.primitive.LongBag;
+import org.eclipse.collections.api.bag.primitive.ShortBag;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
+import org.eclipse.collections.api.block.function.primitive.ByteFunction;
+import org.eclipse.collections.api.block.function.primitive.CharFunction;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ShortFunction;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.map.UnsortedMapIterable;
+import org.eclipse.collections.api.multimap.bag.BagMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
+import org.eclipse.collections.api.partition.bag.PartitionBag;
+import org.eclipse.collections.api.set.UnsortedSetIterable;
+import org.eclipse.collections.api.tuple.Pair;
+
+/**
+ * @since 8.0.
+ */
+public interface PrimitiveObjectMap<V> extends RichIterable<V>
+{
+    boolean containsValue(Object value);
+
+    void forEachValue(Procedure<? super V> procedure);
+
+    /**
+     * Follows the same general contract as {@link Map#equals(Object)}.
+     */
+    @Override
+    boolean equals(Object o);
+
+    /**
+     * Follows the same general contract as {@link Map#hashCode()}.
+     */
+    @Override
+    int hashCode();
+
+    /**
+     * Returns a string representation of this PrimitiveObjectMap. The string representation consists of a list of the
+     * map's key-value pairs in the order they are returned by its iterator. The key and value in each key-value pair are separated
+     * by a colon (<tt>":"</tt>) and each pair is enclosed in square brackets (<tt>"[]"</tt>). Adjacent key-value pairs
+     * are separated by the characters <tt>", "</tt> (comma and space). Keys and values are converted to strings as by
+     * String#valueOf().
+     *
+     * @return a string representation of this PrimitiveObjectMap
+     */
+    String toString();
+
+    Collection<V> values();
+
+    Bag<V> select(Predicate<? super V> predicate);
+
+    <P> Bag<V> selectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    Bag<V> reject(Predicate<? super V> predicate);
+
+    <P> Bag<V> rejectWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    PartitionBag<V> partition(Predicate<? super V> predicate);
+
+    <P> PartitionBag<V> partitionWith(Predicate2<? super V, ? super P> predicate, P parameter);
+
+    <S> Bag<S> selectInstancesOf(Class<S> clazz);
+
+    <VV> Bag<VV> collect(Function<? super V, ? extends VV> function);
+
+    BooleanBag collectBoolean(BooleanFunction<? super V> booleanFunction);
+
+    ByteBag collectByte(ByteFunction<? super V> byteFunction);
+
+    CharBag collectChar(CharFunction<? super V> charFunction);
+
+    DoubleBag collectDouble(DoubleFunction<? super V> doubleFunction);
+
+    FloatBag collectFloat(FloatFunction<? super V> floatFunction);
+
+    IntBag collectInt(IntFunction<? super V> intFunction);
+
+    LongBag collectLong(LongFunction<? super V> longFunction);
+
+    ShortBag collectShort(ShortFunction<? super V> shortFunction);
+
+    <P, VV> Bag<VV> collectWith(Function2<? super V, ? super P, ? extends VV> function, P parameter);
+
+    <VV> Bag<VV> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends VV> function);
+
+    <VV> Bag<VV> flatCollect(Function<? super V, ? extends Iterable<VV>> function);
+
+    <VV> BagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function);
+
+    <VV> BagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
+
+    <VV> UnsortedMapIterable<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+
+    /**
+     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.
+     */
+    @Deprecated
+    <S> Bag<Pair<V, S>> zip(Iterable<S> that);
+
+    /**
+     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex()} instead.
+     */
+    @Deprecated
+    UnsortedSetIterable<Pair<V, Integer>> zipWithIndex();
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
@@ -13,7 +13,6 @@ package org.eclipse.collections.api.map.sorted;
 import java.util.SortedMap;
 
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -26,7 +25,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
@@ -172,16 +170,6 @@ public interface MutableSortedMap<K, V>
     <VV> MutableListMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
     <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
-
-    <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator);
-
-    <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator);
 
     // TODO: When we have implementations of linked hash maps
     // MutableOrderedMap<V, K> flipUniqueValues();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/SortedMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/SortedMapIterable.java
@@ -35,6 +35,7 @@ import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.list.primitive.LongList;
 import org.eclipse.collections.api.list.primitive.ShortList;
 import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.UnsortedMapIterable;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.api.multimap.sortedset.SortedSetMultimap;
 import org.eclipse.collections.api.ordered.ReversibleIterable;
@@ -58,6 +59,8 @@ public interface SortedMapIterable<K, V>
     SortedMapIterable<K, V> select(Predicate2<? super K, ? super V> predicate);
 
     SortedMapIterable<K, V> reject(Predicate2<? super K, ? super V> predicate);
+
+    <K2, V2> UnsortedMapIterable<K2, V2> collect(Function2<? super K, ? super V, Pair<K2, V2>> function);
 
     <R> SortedMapIterable<K, R> collectValues(Function2<? super K, ? super V, ? extends R> function);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
@@ -117,8 +117,9 @@ public interface Multimap<K, V>
      * {@code [ ["key1", {@link RichIterable["val1", "val2", "val2"]}], ["key2", {@link RichIterable["val3"]}] ]}
      *
      * @since 6.0
+     * @param procedure
      */
-    void forEachKeyMultiValues(Procedure2<K, ? super Iterable<V>> procedure);
+    void forEachKeyMultiValues(Procedure2<? super K, ? super Iterable<V>> procedure);
 
     /**
      * Returns the number of key-value entry pairs.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -101,8 +101,9 @@ public interface Multimap<K, V>
      * The given procedure would be invoked with the parameters:
      * <p>
      * {@code [ ["key1", "val1"], ["key1", "val2"], ["key1", "val2"], ["key2", "val3"] ]}
+     * @param procedure
      */
-    void forEachKeyValue(Procedure2<K, V> procedure);
+    void forEachKeyValue(Procedure2<? super K, ? super V> procedure);
 
     /**
      * Calls the {@code procedure} with each <em>key-Iterable[value]</em>.
@@ -221,6 +222,7 @@ public interface Multimap<K, V>
      * <p>
      * Any two empty Multimaps are equal, because they both have empty {@link #toMap} views.
      */
+    @Override
     boolean equals(Object obj);
 
     /**
@@ -228,6 +230,7 @@ public interface Multimap<K, V>
      * <p>
      * The hash code of a Multimap is defined as the hash code of the map view, as returned by {@link #toMap}.
      */
+    @Override
     int hashCode();
 
     /**

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/OrderedIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/OrderedIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -72,6 +72,8 @@ public interface OrderedIterable<T> extends RichIterable<T>
      * see if the iterable is empty to validate that a null result was not due to the container being empty.
      */
     T getLast();
+
+    OrderedIterable<T> tap(Procedure<? super T> procedure);
 
     /**
      * Returns the initial elements that satisfy the Predicate. Short circuits at the first element which does not

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/ReversibleIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/ReversibleIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -116,6 +116,8 @@ public interface ReversibleIterable<T> extends OrderedIterable<T>
     PartitionReversibleIterable<T> partitionWhile(Predicate<? super T> predicate);
 
     ReversibleIterable<T> distinct();
+
+    ReversibleIterable<T> tap(Procedure<? super T> procedure);
 
     ReversibleIterable<T> select(Predicate<? super T> predicate);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/SortedIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ordered/SortedIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,6 +16,7 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.ordered.SortedIterableMultimap;
 import org.eclipse.collections.api.partition.ordered.PartitionSortedIterable;
@@ -37,6 +38,8 @@ public interface SortedIterable<T> extends OrderedIterable<T>
      * ordering of its elements.
      */
     Comparator<? super T> comparator();
+
+    SortedIterable<T> tap(Procedure<? super T> procedure);
 
     /**
      * Returns the initial elements that satisfy the Predicate. Short circuits at the first element which does not

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionStack.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.collections.api.partition.stack;
 
-import org.eclipse.collections.api.partition.PartitionIterable;
+import org.eclipse.collections.api.partition.ordered.PartitionOrderedIterable;
 import org.eclipse.collections.api.stack.StackIterable;
 
 /**
@@ -18,7 +18,7 @@ import org.eclipse.collections.api.stack.StackIterable;
  * The results that answer true for the Predicate will be returned from the getSelected() method and the results
  * that answer false for the predicate will be returned from the getRejected() method.
  */
-public interface PartitionStack<T> extends PartitionIterable<T>
+public interface PartitionStack<T> extends PartitionOrderedIterable<T>
 {
     StackIterable<T> getSelected();
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/FixedSizeSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/FixedSizeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.set;
 
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.FixedSizeCollection;
 
 /**
@@ -18,4 +19,5 @@ import org.eclipse.collections.api.collection.FixedSizeCollection;
 public interface FixedSizeSet<T>
         extends MutableSet<T>, FixedSizeCollection<T>
 {
+    FixedSizeSet<T> tap(Procedure<? super T> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/SetIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/SetIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.annotation.Beta;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.set.PartitionSet;
 import org.eclipse.collections.api.tuple.Pair;
@@ -91,6 +92,8 @@ public interface SetIterable<T> extends RichIterable<T>
      */
     <B> LazyIterable<Pair<T, B>> cartesianProduct(SetIterable<B> set);
 
+    SetIterable<T> tap(Procedure<? super T> procedure);
+
     SetIterable<T> select(Predicate<? super T> predicate);
 
     <P> SetIterable<T> selectWith(Predicate2<? super T, ? super P> predicate, P parameter);
@@ -122,11 +125,13 @@ public interface SetIterable<T> extends RichIterable<T>
     /**
      * Follows the same general contract as {@link Set#equals(Object)}.
      */
+    @Override
     boolean equals(Object o);
 
     /**
      * Follows the same general contract as {@link Set#hashCode()}.
      */
+    @Override
     int hashCode();
 
     ImmutableSetIterable<T> toImmutable();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/UnsortedSetIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/UnsortedSetIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -24,6 +24,7 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.multimap.set.UnsortedSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.set.primitive.BooleanSet;
@@ -47,6 +48,8 @@ public interface UnsortedSetIterable<T>
      * [[], [1], [2], [1, 2]].
      */
     UnsortedSetIterable<UnsortedSetIterable<T>> powerSet();
+
+    UnsortedSetIterable<T> tap(Procedure<? super T> procedure);
 
     <V> UnsortedSetIterable<V> collect(Function<? super T, ? extends V> function);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/SortedSetIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/SortedSetIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -26,6 +26,7 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.ByteList;
@@ -85,6 +86,8 @@ public interface SortedSetIterable<T>
      * [[], [1], [2], [1, 2]].
      */
     SortedSetIterable<SortedSetIterable<T>> powerSet();
+
+    SortedSetIterable<T> tap(Procedure<? super T> procedure);
 
     SortedSetIterable<T> select(Predicate<? super T> predicate);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.stack;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -19,10 +20,12 @@ import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
 import org.eclipse.collections.api.partition.stack.PartitionImmutableStack;
@@ -44,6 +47,14 @@ public interface ImmutableStack<T> extends StackIterable<T>
 
     ImmutableStack<T> pop(int count);
 
+    ImmutableStack<T> takeWhile(Predicate<? super T> predicate);
+
+    ImmutableStack<T> dropWhile(Predicate<? super T> predicate);
+
+    PartitionImmutableStack<T> partitionWhile(Predicate<? super T> predicate);
+
+    ImmutableStack<T> distinct();
+
     ImmutableStack<T> tap(Procedure<? super T> procedure);
 
     ImmutableStack<T> select(Predicate<? super T> predicate);
@@ -53,6 +64,8 @@ public interface ImmutableStack<T> extends StackIterable<T>
     ImmutableStack<T> reject(Predicate<? super T> predicate);
 
     <P> ImmutableStack<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    <S> ImmutableStack<S> selectInstancesOf(Class<S> clazz);
 
     PartitionImmutableStack<T> partition(Predicate<? super T> predicate);
 
@@ -80,6 +93,8 @@ public interface ImmutableStack<T> extends StackIterable<T>
 
     <V> ImmutableStack<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
 
+    <V> ImmutableStack<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function);
+
     <V> ImmutableStack<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     <V> ImmutableListMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
@@ -91,6 +106,10 @@ public interface ImmutableStack<T> extends StackIterable<T>
     <S> ImmutableStack<Pair<T, S>> zip(Iterable<S> that);
 
     ImmutableStack<Pair<T, Integer>> zipWithIndex();
+
+    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator);
+
+    <K, V> ImmutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 
     /**
      * Size takes linear time on ImmutableStacks.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.stack;
 import java.util.Collection;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -21,10 +22,12 @@ import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
@@ -70,6 +73,14 @@ public interface MutableStack<T> extends StackIterable<T>
 
     void clear();
 
+    MutableStack<T> takeWhile(Predicate<? super T> predicate);
+
+    MutableStack<T> dropWhile(Predicate<? super T> predicate);
+
+    PartitionMutableStack<T> partitionWhile(Predicate<? super T> predicate);
+
+    MutableStack<T> distinct();
+
     MutableStack<T> asUnmodifiable();
 
     MutableStack<T> asSynchronized();
@@ -83,6 +94,8 @@ public interface MutableStack<T> extends StackIterable<T>
     MutableStack<T> reject(Predicate<? super T> predicate);
 
     <P> MutableStack<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    <S> MutableStack<S> selectInstancesOf(Class<S> clazz);
 
     PartitionMutableStack<T> partition(Predicate<? super T> predicate);
 
@@ -110,6 +123,8 @@ public interface MutableStack<T> extends StackIterable<T>
 
     <V> MutableStack<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
 
+    <V> MutableStack<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function);
+
     <V> MutableStack<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     <V> MutableListMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
@@ -121,4 +136,8 @@ public interface MutableStack<T> extends StackIterable<T>
     <S> MutableStack<Pair<T, S>> zip(Iterable<S> that);
 
     MutableStack<Pair<T, Integer>> zipWithIndex();
+
+    <K, V> MutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator);
+
+    <K, V> MutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/StackIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/StackIterable.java
@@ -13,7 +13,6 @@ package org.eclipse.collections.api.stack;
 import java.util.AbstractCollection;
 import java.util.List;
 
-import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
@@ -23,12 +22,14 @@ import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.stack.PartitionStack;
 import org.eclipse.collections.api.stack.primitive.BooleanStack;
 import org.eclipse.collections.api.stack.primitive.ByteStack;
@@ -53,7 +54,7 @@ import org.eclipse.collections.api.tuple.Pair;
  * {@link #toString()} follows the same rules as {@link AbstractCollection#toString()} except it processes the elements
  * in the same order as {@code forEach()}.
  */
-public interface StackIterable<T> extends RichIterable<T>
+public interface StackIterable<T> extends OrderedIterable<T>
 {
     /**
      * @return the top of the stack.
@@ -90,12 +91,22 @@ public interface StackIterable<T> extends RichIterable<T>
     /**
      * Follows the same general contract as {@link List#equals(Object)}, but for Stacks.
      */
+    @Override
     boolean equals(Object o);
 
     /**
      * Follows the same general contract as {@link List#hashCode()}, but for Stacks.
      */
+    @Override
     int hashCode();
+
+    StackIterable<T> takeWhile(Predicate<? super T> predicate);
+
+    StackIterable<T> dropWhile(Predicate<? super T> predicate);
+
+    PartitionStack<T> partitionWhile(Predicate<? super T> predicate);
+
+    StackIterable<T> distinct();
 
     /**
      * Converts the stack to a MutableStack implementation.
@@ -113,6 +124,8 @@ public interface StackIterable<T> extends RichIterable<T>
     StackIterable<T> reject(Predicate<? super T> predicate);
 
     <P> StackIterable<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    <S> StackIterable<S> selectInstancesOf(Class<S> clazz);
 
     PartitionStack<T> partition(Predicate<? super T> predicate);
 
@@ -139,6 +152,8 @@ public interface StackIterable<T> extends RichIterable<T>
     <P, V> StackIterable<V> collectWith(Function2<? super T, ? super P, ? extends V> function, P parameter);
 
     <V> StackIterable<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
+
+    <V> StackIterable<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function);
 
     <V> StackIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitiveObjectMap.stg
@@ -45,39 +45,13 @@ import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection
  *
  * @since 3.0.
  */
-public interface Immutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>
+public interface Immutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, ImmutablePrimitiveObjectMap\<V>
 {
     Immutable<name>ObjectMap\<V> tap(Procedure\<? super V> procedure);
 
     Immutable<name>ObjectMap\<V> select(<name>ObjectPredicate\<? super V> predicate);
 
     Immutable<name>ObjectMap\<V> reject(<name>ObjectPredicate\<? super V> predicate);
-
-    ImmutableCollection\<V> select(Predicate\<? super V> predicate);
-
-    \<P> ImmutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter);
-
-    ImmutableCollection\<V> reject(Predicate\<? super V> predicate);
-
-    \<VV> ImmutableCollection\<VV> collect(Function\<? super V, ? extends VV> function);
-
-    ImmutableBooleanCollection collectBoolean(BooleanFunction\<? super V> booleanFunction);
-
-    ImmutableByteCollection collectByte(ByteFunction\<? super V> byteFunction);
-
-    ImmutableCharCollection collectChar(CharFunction\<? super V> charFunction);
-
-    ImmutableDoubleCollection collectDouble(DoubleFunction\<? super V> doubleFunction);
-
-    ImmutableFloatCollection collectFloat(FloatFunction\<? super V> floatFunction);
-
-    ImmutableIntCollection collectInt(IntFunction\<? super V> intFunction);
-
-    ImmutableLongCollection collectLong(LongFunction\<? super V> longFunction);
-
-    ImmutableShortCollection collectShort(ShortFunction\<? super V> shortFunction);
-
-    \<P, VV> ImmutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter);
 
     Immutable<name>ObjectMap\<V> newWithKeyValue(<type> key, V value);
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitivePrimitiveMap.stg
@@ -18,11 +18,11 @@ body(type1, type2, name1, name2) ::= <<
 package org.eclipse.collections.api.map.primitive;
 
 import org.eclipse.collections.api.<name1>Iterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.primitive.Immutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name2>Predicate;
 import org.eclipse.collections.api.block.predicate.primitive.<name1><name2>Predicate;
-import org.eclipse.collections.api.collection.ImmutableCollection;
-import org.eclipse.collections.api.collection.primitive.Immutable<name2>Collection;
 
 /**
  * This file was automatically generated from template file immutablePrimitivePrimitiveMap.stg.
@@ -35,11 +35,11 @@ public interface Immutable<name1><name2>Map extends <name1><name2>Map
 
     Immutable<name1><name2>Map reject(<name1><name2>Predicate predicate);
 
-    Immutable<name2>Collection select(<name2>Predicate predicate);
+    Immutable<name2>Bag select(<name2>Predicate predicate);
 
-    Immutable<name2>Collection reject(<name2>Predicate predicate);
+    Immutable<name2>Bag reject(<name2>Predicate predicate);
 
-    \<V> ImmutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function);
+    \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function);
 
     Immutable<name1><name2>Map newWithKeyValue(<type1> key, <type2> value);
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>ObjectPredicate;
+import org.eclipse.collections.api.block.procedure.Procedure;
 
 /**
  * This file was automatically generated from template file mutablePrimitiveObjectMap.stg.
@@ -59,6 +60,8 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
      * passed to the function.
      */
     \<P> V updateValueWith(<type> key, Function0\<? extends V> factory, Function2\<? super V, ? super P, ? extends V> function, P parameter);
+
+    Mutable<name>ObjectMap\<V> tap(Procedure\<? super V> procedure);
 
     Mutable<name>ObjectMap\<V> select(<name>ObjectPredicate\<? super V> predicate);
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveValuesMap.stg
@@ -16,10 +16,10 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.api.map.primitive;
 
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
-import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
-import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 
 /**
@@ -29,11 +29,11 @@ import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
  */
 public interface Mutable<name>ValuesMap extends <name>ValuesMap
 {
-    Mutable<name>Collection select(<name>Predicate predicate);
+    Mutable<name>Bag select(<name>Predicate predicate);
 
-    Mutable<name>Collection reject(<name>Predicate predicate);
+    Mutable<name>Bag reject(<name>Predicate predicate);
 
-    \<V> MutableCollection\<V> collect(<name>ToObjectFunction\<? extends V> function);
+    \<V> MutableBag\<V> collect(<name>ToObjectFunction\<? extends V> function);
 
     void clear();
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveObjectMap.stg
@@ -33,7 +33,7 @@ import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
  *
  * @since 3.0.
  */
-public interface <name>ObjectMap\<V> extends RichIterable\<V>
+public interface <name>ObjectMap\<V> extends PrimitiveObjectMap\<V>
 {
     V get(<type> key);
 
@@ -41,11 +41,7 @@ public interface <name>ObjectMap\<V> extends RichIterable\<V>
 
     boolean containsKey(<type> key);
 
-    boolean containsValue(Object value);
-
     <name>ObjectMap\<V> tap(Procedure\<? super V> procedure);
-
-    void forEachValue(Procedure\<? super V> procedure);
 
     void forEachKey(<name>Procedure procedure);
 
@@ -55,34 +51,9 @@ public interface <name>ObjectMap\<V> extends RichIterable\<V>
 
     <name>ObjectMap\<V> reject(<name>ObjectPredicate\<? super V> predicate);
 
-    /**
-     * Follows the same general contract as {@link Map#equals(Object)}.
-     */
-    @Override
-    boolean equals(Object o);
-
-    /**
-     * Follows the same general contract as {@link Map#hashCode()}.
-     */
-    @Override
-    int hashCode();
-
-    /**
-     * Returns a string representation of this <name>ObjectMap. The string representation consists of a list of the
-     * map's key-value pairs in the order they are returned by its iterator. The key and value in each key-value pair are separated
-     * by a colon (\<tt>":"\</tt>) and each pair is enclosed in square brackets (\<tt>"[]"\</tt>). Adjacent key-value pairs
-     * are separated by the characters \<tt>", "\</tt> (comma and space). Keys and values are converted to strings as by
-     * String#valueOf().
-     *
-     * @return a string representation of this <name>ObjectMap
-     */
-    String toString();
-
     Immutable<name>ObjectMap\<V> toImmutable();
 
     Mutable<name>Set keySet();
-
-    Collection\<V> values();
 
     /**
      * @since 5.0

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
@@ -17,6 +17,11 @@ body(type, name) ::= <<
 package org.eclipse.collections.api.map.primitive;
 
 import org.eclipse.collections.api.<name>Iterable;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.primitive.<name>Bag;
+import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
+import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
 
@@ -32,6 +37,12 @@ public interface <name>ValuesMap extends <name>Iterable
     void forEachValue(<name>Procedure procedure);
 
     Mutable<name>Collection values();
+
+    <name>Bag select(<name>Predicate predicate);
+
+    <name>Bag reject(<name>Predicate predicate);
+
+    \<V> Bag\<V> collect(<name>ToObjectFunction\<? extends V> function);
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/api/stack/primitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/stack/primitiveStack.stg
@@ -16,10 +16,10 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.api.stack.primitive;
 
-import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.list.primitive.<name>List;
+import org.eclipse.collections.api.ordered.primitive.Ordered<name>Iterable;
 import org.eclipse.collections.api.stack.StackIterable;
 
 /**
@@ -27,7 +27,7 @@ import org.eclipse.collections.api.stack.StackIterable;
  *
  * @since 3.0.
  */
-public interface <name>Stack extends <name>Iterable
+public interface <name>Stack extends Ordered<name>Iterable
 {
     /**
      * Returns the top of the stack.

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveValuesMap.stg
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
@@ -35,13 +36,13 @@ import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ValuesMap;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.collection.mutable.primitive.Synchronized<name>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name>Collection;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.primitive.Abstract<name>Iterable;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
-import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
+import org.eclipse.collections.impl.primitive.Abstract<name>Iterable;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 
 /**
@@ -243,18 +244,18 @@ public abstract class AbstractMutable<name>ValuesMap extends Abstract<name>Itera
         return array;
     }
 
-    public Mutable<name>Collection select(<name>Predicate predicate)
+    public Mutable<name>Bag select(<name>Predicate predicate)
     {
-        <name>ArrayList result = new <name>ArrayList();
+        Mutable<name>Bag result = new <name>HashBag();
 
         <forEachValueSatisfying(template = {result.add(<value>)})>
 
         return result;
     }
 
-    public Mutable<name>Collection reject(<name>Predicate predicate)
+    public Mutable<name>Bag reject(<name>Predicate predicate)
     {
-        <name>ArrayList result = new <name>ArrayList();
+        Mutable<name>Bag result = new <name>HashBag();
         if (this.getSentinelValues() != null)
         {
             if (this.getSentinelValues().containsZeroKey && !predicate.accept(this.getSentinelValues().zeroValue))
@@ -276,9 +277,9 @@ public abstract class AbstractMutable<name>ValuesMap extends Abstract<name>Itera
         return result;
     }
 
-    public \<V> MutableCollection\<V> collect(<name>ToObjectFunction\<? extends V> function)
+    public \<V> MutableBag\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        FastList\<V> target = FastList.newList(this.size());
+        MutableBag\<V> target = HashBag.newBag(this.size());
         if (this.getSentinelValues() != null)
         {
             if (this.getSentinelValues().containsZeroKey)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectEmptyMap.stg
@@ -14,9 +14,9 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Immutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Immutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
-    return <name>Lists.immutable.with();
+    return <name>Bags.immutable.empty();
 }
 
 public \<R extends Mutable<name>Collection> R collect<name>(<name>Function\<? super V> <type>Function, R target)
@@ -38,12 +38,20 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name>Iterable;
-import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
+import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableCharBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
-import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
@@ -59,7 +67,6 @@ import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFuncti
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.<name>ObjectPredicate;
@@ -68,57 +75,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.api.collection.ImmutableCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableByteCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableCharCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableDoubleCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MapIterable;
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ObjectLongMap;
-import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
-import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
-import org.eclipse.collections.api.map.sorted.MutableSortedMap;
-import org.eclipse.collections.api.multimap.Multimap;
-import org.eclipse.collections.api.multimap.MutableMultimap;
-import org.eclipse.collections.api.partition.PartitionIterable;
-import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
-import org.eclipse.collections.api.set.sorted.MutableSortedSet;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
-import org.eclipse.collections.impl.factory.Bags;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.factory.SortedMaps;
-import org.eclipse.collections.impl.factory.SortedSets;
-import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.eclipse.collections.impl.factory.primitive.ByteLists;
-import org.eclipse.collections.impl.factory.primitive.CharLists;
-import org.eclipse.collections.impl.factory.primitive.DoubleLists;
-import org.eclipse.collections.impl.factory.primitive.FloatLists;
-import org.eclipse.collections.impl.factory.primitive.IntLists;
-import org.eclipse.collections.impl.factory.primitive.LongLists;
-import org.eclipse.collections.impl.factory.primitive.ShortLists;
-import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
-import org.eclipse.collections.impl.multimap.list.FastListMultimap;
-import org.eclipse.collections.impl.partition.list.PartitionFastList;
-import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
-import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name>Set;
-import org.eclipse.collections.impl.utility.LazyIterate;
-import org.eclipse.collections.impl.utility.primitive.Lazy<name>Iterate;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -127,6 +83,50 @@ import org.eclipse.collections.api.collection.primitive.MutableFloatCollection;
 import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
+import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
+import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ObjectLongMap;
+import org.eclipse.collections.api.map.sorted.MutableSortedMap;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.api.set.sorted.MutableSortedSet;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
+import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
+import org.eclipse.collections.impl.block.factory.Comparators;
+import org.eclipse.collections.impl.factory.Bags;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.factory.Multimaps;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.factory.SortedMaps;
+import org.eclipse.collections.impl.factory.SortedSets;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
+import org.eclipse.collections.impl.factory.primitive.ByteBags;
+import org.eclipse.collections.impl.factory.primitive.CharBags;
+import org.eclipse.collections.impl.factory.primitive.DoubleBags;
+import org.eclipse.collections.impl.factory.primitive.FloatBags;
+import org.eclipse.collections.impl.factory.primitive.IntBags;
+import org.eclipse.collections.impl.factory.primitive.LongBags;
+import org.eclipse.collections.impl.factory.primitive.ShortBags;
+import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
+import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
+import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
+import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name>Set;
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.eclipse.collections.impl.utility.primitive.Lazy<name>Iterate;
 
 /**
  * Immutable<name>ObjectEmptyMap is an optimization for {@link Immutable<name>ObjectMap} of size 0.
@@ -242,9 +242,24 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return elements.length == 0;
     }
 
-    public ImmutableCollection\<V> select(Predicate\<? super V> predicate)
+    public ImmutableBag\<V> select(Predicate\<? super V> predicate)
     {
-        return Lists.immutable.with();
+        return Bags.immutable.empty();
+    }
+
+    public \<P> ImmutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    {
+        return Bags.immutable.empty();
+    }
+
+    public ImmutableBag\<V> reject(Predicate\<? super V> predicate)
+    {
+        return Bags.immutable.empty();
+    }
+
+    public \<P> ImmutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    {
+        return Bags.immutable.empty();
     }
 
     public \<R extends Collection\<V>\> R select(Predicate\<? super V> predicate, R target)
@@ -252,19 +267,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<P> ImmutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P, R extends Collection\<V>\> R selectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R target)
     {
-        return Lists.immutable.with();
-    }
-
-    public \<P, R extends Collection\<V>\> R selectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
-    {
-        return targetCollection;
-    }
-
-    public ImmutableCollection\<V> reject(Predicate\<? super V> predicate)
-    {
-        return Lists.immutable.with();
+        return target;
     }
 
     public \<R extends Collection\<V>\> R reject(Predicate\<? super V> predicate, R target)
@@ -272,34 +277,39 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<P> ImmutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P, R extends Collection\<V>\> R rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R target)
     {
-        return Lists.immutable.with();
+        return target;
     }
 
-    public \<P, R extends Collection\<V>\> R rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
+    public PartitionImmutableBag\<V> partition(Predicate\<? super V> predicate)
     {
-        return targetCollection;
+        return new PartitionHashBag\<V>().toImmutable();
     }
 
-    public PartitionIterable\<V> partition(Predicate\<? super V> predicate)
+    public \<P> PartitionImmutableBag\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
-        return new PartitionFastList\<V>();
+        return new PartitionHashBag\<V>().toImmutable();
     }
 
-    public \<P> PartitionIterable\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<S> ImmutableBag\<S> selectInstancesOf(Class\<S> clazz)
     {
-        return new PartitionFastList\<V>();
+        return Bags.immutable.empty();
     }
 
-    public \<S> RichIterable\<S> selectInstancesOf(Class\<S> clazz)
+    public \<VV> ImmutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
-        return Lists.mutable.with();
+        return Bags.immutable.empty();
     }
 
-    public \<VV> ImmutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<P, VV> ImmutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
-        return Lists.immutable.with();
+        return Bags.immutable.empty();
+    }
+
+    public \<VV> ImmutableBag\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
+    {
+        return Bags.immutable.empty();
     }
 
     <collectPrimitive("Boolean", "boolean")>
@@ -318,14 +328,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
 
     <collectPrimitive("Short", "short")>
 
-    public \<VV> RichIterable\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return Lists.mutable.with();
-    }
-
-    public \<VV> RichIterable\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
-    {
-        return Lists.mutable.with();
+        return Bags.immutable.empty();
     }
 
     public V detect(Predicate\<? super V> predicate)
@@ -641,9 +646,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         }
     }
 
-    public \<VV> Multimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
     {
-        return FastListMultimap.newMultimap();
+        return Multimaps.immutable.bag.empty();
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupBy(Function\<? super V, ? extends VV> function, R target)
@@ -651,9 +656,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<VV> Multimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return FastListMultimap.newMultimap();
+        return Multimaps.immutable.bag.empty();
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function, R target)
@@ -661,9 +666,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<VV> MapIterable\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableMap\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
     {
-        return UnifiedMap.newMap();
+        return Maps.immutable.empty();
     }
 
     public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
@@ -671,9 +676,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<S> RichIterable\<Pair\<V, S>\> zip(Iterable\<S> that)
+    public \<S> ImmutableBag\<Pair\<V, S>\> zip(Iterable\<S> that)
     {
-        return Lists.immutable.of();
+        return Bags.immutable.empty();
     }
 
     public \<S, R extends Collection\<Pair\<V, S>\>> R zip(Iterable\<S> that, R target)
@@ -681,9 +686,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public RichIterable\<Pair\<V, Integer>\> zipWithIndex()
+    public ImmutableSet\<Pair\<V, Integer>\> zipWithIndex()
     {
-        return Lists.immutable.of();
+        return Sets.immutable.empty();
     }
 
     public \<R extends Collection\<Pair\<V, Integer>\>> R zipWithIndex(R target)
@@ -696,14 +701,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return Lists.immutable.of();
     }
 
-    public \<K, VV> MapIterable\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
     {
-        return Maps.immutable.with();
-    }
-
-    public \<K, VV> MapIterable\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
-    {
-        return Maps.immutable.with();
+        return Maps.immutable.empty();
     }
 
     public \<VV extends Comparable\<? super VV>\> V maxBy(Function\<? super V, ? extends VV> function)
@@ -736,9 +736,9 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
         return target;
     }
 
-    public \<P, VV> ImmutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
-        return Lists.immutable.with();
+        return Maps.immutable.empty();
     }
 
     public \<P, VV, R extends Collection\<VV>\> R collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter, R targetCollection)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
@@ -1,4 +1,5 @@
 import "copyright.stg"
+import "copyright.stg"
 import "primitiveEquals.stg"
 import "primitiveHashCode.stg"
 import "primitiveLiteral.stg"
@@ -14,7 +15,7 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Immutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Immutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
     return this.delegate.collect<name>(<type>Function).toImmutable();
 }
@@ -40,7 +41,16 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableCharBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
@@ -65,15 +75,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.api.collection.ImmutableCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableByteCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableCharCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableDoubleCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -84,15 +85,16 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
-import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
-import org.eclipse.collections.api.partition.PartitionIterable;
+import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
+import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
@@ -220,7 +222,7 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.containsAllArguments(elements);
     }
 
-    public ImmutableCollection\<V> select(Predicate\<? super V> predicate)
+    public ImmutableBag\<V> select(Predicate\<? super V> predicate)
     {
         return this.delegate.select(predicate).toImmutable();
     }
@@ -230,17 +232,17 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.select(predicate, target);
     }
 
-    public \<P> ImmutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> ImmutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.delegate.selectWith(predicate, parameter).toImmutable();
     }
 
-    public \<P, R extends Collection\<V>\> R selectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
+    public \<P, R extends Collection\<V>\> R selectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R target)
     {
-        return this.delegate.selectWith(predicate, parameter, targetCollection);
+        return this.delegate.selectWith(predicate, parameter, target);
     }
 
-    public ImmutableCollection\<V> reject(Predicate\<? super V> predicate)
+    public ImmutableBag\<V> reject(Predicate\<? super V> predicate)
     {
         return this.delegate.reject(predicate).toImmutable();
     }
@@ -250,32 +252,32 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.reject(predicate, target);
     }
 
-    public \<P> ImmutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> ImmutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.delegate.rejectWith(predicate, parameter).toImmutable();
     }
 
-    public \<P, R extends Collection\<V>\> R rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
+    public \<P, R extends Collection\<V>\> R rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R target)
     {
-        return this.delegate.rejectWith(predicate, parameter, targetCollection);
+        return this.delegate.rejectWith(predicate, parameter, target);
     }
 
-    public PartitionIterable\<V> partition(Predicate\<? super V> predicate)
+    public PartitionImmutableBag\<V> partition(Predicate\<? super V> predicate)
     {
-        return this.delegate.partition(predicate);
+        return this.delegate.partition(predicate).toImmutable();
     }
 
-    public \<P> PartitionIterable\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> PartitionImmutableBag\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
-        return this.delegate.partitionWith(predicate, parameter);
+        return this.delegate.partitionWith(predicate, parameter).toImmutable();
     }
 
-    public \<S> RichIterable\<S> selectInstancesOf(Class\<S> clazz)
+    public \<S> ImmutableBag\<S> selectInstancesOf(Class\<S> clazz)
     {
-        return this.delegate.selectInstancesOf(clazz);
+        return this.delegate.selectInstancesOf(clazz).toImmutable();
     }
 
-    public \<VV> ImmutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
         return this.delegate.collect(function).toImmutable();
     }
@@ -288,19 +290,19 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     <collectPrimitive("Int", "int")>
     <collectPrimitive("Long", "long")>
     <collectPrimitive("Short", "short")>
-    public \<P, VV> ImmutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<P, VV> ImmutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
         return this.delegate.collectWith(function, parameter).toImmutable();
     }
 
-    public \<VV> RichIterable\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBag\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.collectIf(predicate, function);
+        return this.delegate.collectIf(predicate, function).toImmutable();
     }
 
-    public \<VV> RichIterable\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> ImmutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return this.delegate.flatCollect(function);
+        return this.delegate.flatCollect(function).toImmutable();
     }
 
     public V detect(Predicate\<? super V> predicate)
@@ -543,9 +545,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         this.delegate.appendString(appendable, start, separator, end);
     }
 
-    public \<VV> Multimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.groupBy(function);
+        return this.delegate.groupBy(function).toImmutable();
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupBy(Function\<? super V, ? extends VV> function, R target)
@@ -553,9 +555,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.groupBy(function, target);
     }
 
-    public \<VV> Multimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return this.delegate.groupByEach(function);
+        return this.delegate.groupByEach(function).toImmutable();
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function, R target)
@@ -563,9 +565,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.groupByEach(function, target);
     }
 
-    public \<VV> MapIterable\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableMap\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.groupByUniqueKey(function);
+        return this.delegate.groupByUniqueKey(function).toImmutable();
     }
 
     public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
@@ -573,9 +575,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.groupByUniqueKey(function, target);
     }
 
-    public \<S> RichIterable\<Pair\<V, S>\> zip(Iterable\<S> that)
+    public \<S> ImmutableBag\<Pair\<V, S>\> zip(Iterable\<S> that)
     {
-        return this.delegate.zip(that);
+        return this.delegate.zip(that).toImmutable();
     }
 
     public \<S, R extends Collection\<Pair\<V, S>\>> R zip(Iterable\<S> that, R target)
@@ -583,9 +585,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.zip(that, target);
     }
 
-    public RichIterable\<Pair\<V, Integer>\> zipWithIndex()
+    public ImmutableSet\<Pair\<V, Integer>\> zipWithIndex()
     {
-        return this.delegate.zipWithIndex();
+        return this.delegate.zipWithIndex().toImmutable();
     }
 
     public \<R extends Collection\<Pair\<V, Integer>\>> R zipWithIndex(R target)
@@ -598,14 +600,14 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.chunk(size);
     }
 
-    public \<K, VV> MapIterable\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
     {
-        return this.delegate.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
+        return this.delegate.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator).toImmutable();
     }
 
-    public \<K, VV> MapIterable\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
-        return this.delegate.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
+        return this.delegate.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator).toImmutable();
     }
 
     public \<VV extends Comparable\<? super VV>\> V maxBy(Function\<? super V, ? extends VV> function)
@@ -718,19 +720,16 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return this.delegate.keyValuesView();
     }
 
-    @Override
     public boolean equals(Object obj)
     {
         return this.delegate.equals(obj);
     }
 
-    @Override
     public int hashCode()
     {
         return this.delegate.hashCode();
     }
 
-    @Override
     public String toString()
     {
         return this.delegate.toString();

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
@@ -14,9 +14,9 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Immutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Immutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
-    return <name>Lists.immutable.with(<type>Function.<type>ValueOf(this.value1));
+    return <name>Bags.immutable.with(<type>Function.<type>ValueOf(this.value1));
 }
 
 public \<R extends Mutable<name>Collection> R collect<name>(<name>Function\<? super V> <type>Function, R target)
@@ -42,7 +42,16 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.<name>Iterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableCharBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
+import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -68,15 +77,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
-import org.eclipse.collections.api.collection.ImmutableCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableByteCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableCharCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableDoubleCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
-import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -86,21 +86,25 @@ import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
-import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
-import org.eclipse.collections.api.partition.PartitionIterable;
-import org.eclipse.collections.api.partition.list.PartitionMutableList;
+import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.partition.PartitionMutableCollection;
+import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
+import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
+import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
@@ -109,26 +113,28 @@ import org.eclipse.collections.impl.block.procedure.PartitionPredicate2Procedure
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.factory.Multimaps;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.factory.SortedSets;
-import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.eclipse.collections.impl.factory.primitive.ByteLists;
-import org.eclipse.collections.impl.factory.primitive.CharLists;
-import org.eclipse.collections.impl.factory.primitive.DoubleLists;
-import org.eclipse.collections.impl.factory.primitive.FloatLists;
-import org.eclipse.collections.impl.factory.primitive.IntLists;
-import org.eclipse.collections.impl.factory.primitive.LongLists;
-import org.eclipse.collections.impl.factory.primitive.ShortLists;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
+import org.eclipse.collections.impl.factory.primitive.ByteBags;
+import org.eclipse.collections.impl.factory.primitive.CharBags;
+import org.eclipse.collections.impl.factory.primitive.DoubleBags;
+import org.eclipse.collections.impl.factory.primitive.FloatBags;
+import org.eclipse.collections.impl.factory.primitive.IntBags;
+import org.eclipse.collections.impl.factory.primitive.LongBags;
+import org.eclipse.collections.impl.factory.primitive.ShortBags;
+import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
-import org.eclipse.collections.impl.multimap.list.FastListMultimap;
-import org.eclipse.collections.impl.partition.list.PartitionFastList;
+import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
+import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name>Set;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
@@ -335,9 +341,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return true;
     }
 
-    public ImmutableCollection\<V> select(Predicate\<? super V> predicate)
+    public ImmutableBag\<V> select(Predicate\<? super V> predicate)
     {
-        return predicate.accept(this.value1) ? Lists.immutable.with(this.value1) : Lists.immutable.\<V>with();
+        return predicate.accept(this.value1) ? Bags.immutable.with(this.value1) : Bags.immutable.\<V>with();
     }
 
     public \<R extends Collection\<V>\> R select(Predicate\<? super V> predicate, R target)
@@ -349,9 +355,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<P> ImmutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> ImmutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
-        return predicate.accept(this.value1, parameter) ? Lists.immutable.with(this.value1) : Lists.immutable.\<V>with();
+        return predicate.accept(this.value1, parameter) ? Bags.immutable.with(this.value1) : Bags.immutable.\<V>with();
     }
 
     public \<P, R extends Collection\<V>\> R selectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
@@ -363,9 +369,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return targetCollection;
     }
 
-    public ImmutableCollection\<V> reject(Predicate\<? super V> predicate)
+    public ImmutableBag\<V> reject(Predicate\<? super V> predicate)
     {
-        return predicate.accept(this.value1) ? Lists.immutable.\<V>with() : Lists.immutable.with(this.value1);
+        return predicate.accept(this.value1) ? Bags.immutable.\<V>with() : Bags.immutable.with(this.value1);
     }
 
     public \<R extends Collection\<V>\> R reject(Predicate\<? super V> predicate, R target)
@@ -377,9 +383,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<P> ImmutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> ImmutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
-        return predicate.accept(this.value1, parameter) ? Lists.immutable.\<V>with() : Lists.immutable.with(this.value1);
+        return predicate.accept(this.value1, parameter) ? Bags.immutable.\<V>with() : Bags.immutable.with(this.value1);
     }
 
     public \<P, R extends Collection\<V>\> R rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter, R targetCollection)
@@ -391,28 +397,28 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return targetCollection;
     }
 
-    public PartitionIterable\<V> partition(Predicate\<? super V> predicate)
+    public PartitionImmutableBag\<V> partition(Predicate\<? super V> predicate)
     {
-        PartitionMutableList\<V> partitionMutableList = new PartitionFastList\<V>();
-        this.forEach(new PartitionProcedure\<V>(predicate, partitionMutableList));
-        return partitionMutableList;
+        PartitionMutableBag\<V> partitionMutableBag = new PartitionHashBag\<V>();
+        this.forEach(new PartitionProcedure\<V>(predicate, partitionMutableBag));
+        return partitionMutableBag.toImmutable();
     }
 
-    public \<P> PartitionIterable\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> PartitionImmutableBag\<V> partitionWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
-        PartitionMutableList\<V> partitionMutableList = new PartitionFastList\<V>();
-        this.forEach(new PartitionPredicate2Procedure\<V, P>(predicate, parameter, partitionMutableList));
-        return partitionMutableList;
+        PartitionMutableBag\<V> partitionMutableBag = new PartitionHashBag\<V>();
+        this.forEach(new PartitionPredicate2Procedure\<V, P>(predicate, parameter, partitionMutableBag));
+        return partitionMutableBag.toImmutable();
     }
 
-    public \<S> RichIterable\<S> selectInstancesOf(Class\<S> clazz)
+    public \<S> ImmutableBag\<S> selectInstancesOf(Class\<S> clazz)
     {
-        return clazz.isInstance(this.value1) ? Lists.immutable.with(clazz.cast(this.value1)) : Lists.immutable.\<S>with();
+        return clazz.isInstance(this.value1) ? Bags.immutable.with(clazz.cast(this.value1)) : Bags.immutable.\<S>with();
     }
 
-    public \<VV> ImmutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
-        return Lists.immutable.with(function.valueOf(this.value1));
+        return Bags.immutable.with(function.valueOf(this.value1));
     }
 
     <collectPrimitive("Boolean", "boolean")>
@@ -423,14 +429,14 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
     <collectPrimitive("Int", "int")>
     <collectPrimitive("Long", "long")>
     <collectPrimitive("Short", "short")>
-    public \<VV> RichIterable\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBag\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
     {
-        return predicate.accept(this.value1) ? Lists.immutable.with(function.valueOf(this.value1)) : Lists.immutable.\<VV>with();
+        return predicate.accept(this.value1) ? Bags.immutable.with(function.valueOf(this.value1)) : Bags.immutable.\<VV>with();
     }
 
-    public \<VV> RichIterable\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> ImmutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return Lists.immutable.withAll(function.valueOf(this.value1));
+        return Bags.immutable.withAll(function.valueOf(this.value1));
     }
 
     public V detect(Predicate\<? super V> predicate)
@@ -684,9 +690,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         }
     }
 
-    public \<VV> Multimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
     {
-        return new FastListMultimap\<VV, V>(Tuples.pair(function.valueOf(this.value1), this.value1));
+        return Multimaps.immutable.bag.with(function.valueOf(this.value1), this.value1);
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupBy(Function\<? super V, ? extends VV> function, R target)
@@ -695,14 +701,14 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<VV> Multimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> ImmutableBagMultimap\<VV, V> groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return this.groupByEach(function, FastListMultimap.\<VV, V>newMultimap());
+        return this.groupByEach(function, HashBagMultimap.\<VV, V>newMultimap()).toImmutable();
     }
 
     public \<VV, R extends MutableMultimap\<VV, V>\> R groupByEach(Function\<? super V, ? extends Iterable\<VV>\> function, R target)
     {
-        Iterable\<VV> iterable  = function.valueOf(this.value1);
+        Iterable\<VV> iterable = function.valueOf(this.value1);
         for (VV key : iterable)
         {
             target.put(key, this.value1);
@@ -710,9 +716,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<VV> MapIterable\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
+    public \<VV> ImmutableMap\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
     {
-        return new UnifiedMap(Tuples.pair(function.valueOf(this.value1), this.value1));
+        return Maps.immutable.with(function.valueOf(this.value1), this.value1);
     }
 
     public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
@@ -724,9 +730,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<S> RichIterable\<Pair\<V, S>\> zip(Iterable\<S> that)
+    public \<S> ImmutableBag\<Pair\<V, S>\> zip(Iterable\<S> that)
     {
-        return this.zip(that, FastList.\<Pair\<V, S>\>newList());
+        return this.zip(that, HashBag.\<Pair\<V, S>\>newBag()).toImmutable();
     }
 
     public \<S, R extends Collection\<Pair\<V, S>\>> R zip(Iterable\<S> that, R target)
@@ -734,9 +740,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return IterableIterate.zip(this, that, target);
     }
 
-    public RichIterable\<Pair\<V, Integer>\> zipWithIndex()
+    public ImmutableSet\<Pair\<V, Integer>\> zipWithIndex()
     {
-        return this.zipWithIndex(FastList.\<Pair\<V, Integer>\>newList());
+        return this.zipWithIndex(UnifiedSet.\<Pair\<V, Integer>\>newSet()).toImmutable();
     }
 
     public \<R extends Collection\<Pair\<V, Integer>\>> R zipWithIndex(R target)
@@ -755,18 +761,18 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return result;
     }
 
-    public \<K, VV> MapIterable\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
     {
         MutableMap\<K, VV> map = UnifiedMap.newMap();
         this.forEach(new MutatingAggregationProcedure\<V, K, VV>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
+        return map.toImmutable();
     }
 
-    public \<K, VV> MapIterable\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
+    public \<K, VV> ImmutableMap\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
         MutableMap\<K, VV> map = UnifiedMap.newMap();
         this.forEach(new NonMutatingAggregationProcedure\<V, K, VV>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
+        return map.toImmutable();
     }
 
     public \<VV extends Comparable\<? super VV>\> V maxBy(Function\<? super V, ? extends VV> function)
@@ -804,9 +810,9 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return target;
     }
 
-    public \<P, VV> ImmutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<P, VV> ImmutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
-        return Lists.immutable.with(function.value(this.value1, parameter));
+        return Bags.immutable.with(function.value(this.value1, parameter));
     }
 
     public \<P, VV, R extends Collection\<VV>\> R collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter, R targetCollection)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
@@ -29,6 +29,8 @@ import org.eclipse.collections.api.<name1>Iterable;
 import org.eclipse.collections.api.Lazy<name1>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name2>Iterable;<endif>
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.primitive.Immutable<name2>Bag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name2>ToObjectFunction;
@@ -37,7 +39,6 @@ import org.eclipse.collections.api.block.predicate.primitive.<name2>Predicate;
 import org.eclipse.collections.api.block.procedure.primitive.<name1>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name1><name2>Procedure;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.block.procedure.primitive.<name2>Procedure;<endif>
-import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.primitive.Immutable<name2>Collection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
@@ -49,8 +50,8 @@ import org.eclipse.collections.api.set.primitive.Mutable<name2>Set;
 import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name2>HashBag;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.primitive.<name2>Lists;
+import org.eclipse.collections.impl.factory.Bags;
+import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.iterator.ImmutableEmpty<name2>Iterator;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name2>IterableAdapter;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
@@ -177,24 +178,24 @@ final class Immutable<name1><name2>EmptyMap implements Immutable<name1><name2>Ma
         return true;
     }
 
-    public Immutable<name2>Collection select(<name2>Predicate predicate)
+    public Immutable<name2>Bag select(<name2>Predicate predicate)
     {
-        return <name2>Lists.immutable.with();
+        return <name2>Bags.immutable.empty();
     }
 
-    public Immutable<name2>Collection reject(<name2>Predicate predicate)
+    public Immutable<name2>Bag reject(<name2>Predicate predicate)
     {
-        return <name2>Lists.immutable.with();
+        return <name2>Bags.immutable.empty();
+    }
+
+    public \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
+    {
+        return Bags.immutable.empty();
     }
 
     public <type2> detectIfNone(<name2>Predicate predicate, <type2> ifNone)
     {
         return ifNone;
-    }
-
-    public \<V> ImmutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function)
-    {
-        return Lists.immutable.of();
     }
 
     public \<T> T injectInto(T injectedValue, Object<name2>ToObjectFunction\<? super T, ? extends T> function)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
@@ -31,7 +31,9 @@ import org.eclipse.collections.api.<name1>Iterable;
 import org.eclipse.collections.api.Lazy<name1>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name2>Iterable;<endif>
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
+import org.eclipse.collections.api.bag.primitive.Immutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name2>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name1><name2>Predicate;
@@ -181,24 +183,24 @@ final class Immutable<name1><name2>HashMap implements Immutable<name1><name2>Map
         return this.delegate.noneSatisfy(predicate);
     }
 
-    public Immutable<name2>Collection select(<name2>Predicate predicate)
+    public Immutable<name2>Bag select(<name2>Predicate predicate)
     {
         return this.delegate.select(predicate).toImmutable();
     }
 
-    public Immutable<name2>Collection reject(<name2>Predicate predicate)
+    public Immutable<name2>Bag reject(<name2>Predicate predicate)
     {
         return this.delegate.reject(predicate).toImmutable();
+    }
+
+    public \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
+    {
+        return this.delegate.collect(function).toImmutable();
     }
 
     public <type2> detectIfNone(<name2>Predicate predicate, <type2> ifNone)
     {
         return this.delegate.detectIfNone(predicate, ifNone);
-    }
-
-    public \<V> ImmutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function)
-    {
-        return this.delegate.collect(function).toImmutable();
     }
 
     <(arithmeticMethods.(type2))()>

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
@@ -23,11 +23,14 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.eclipse.collections.api.<name1>Iterable;
 import org.eclipse.collections.api.<name2>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.<name1>Iterable;<endif>
 import org.eclipse.collections.api.Lazy<name2>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name1>Iterable;<endif>
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.primitive.Immutable<name2>Bag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name2>ToObjectFunction;
@@ -36,7 +39,6 @@ import org.eclipse.collections.api.block.predicate.primitive.<name1><name2>Predi
 import org.eclipse.collections.api.block.procedure.primitive.<name2>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name1><name2>Procedure;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.block.procedure.primitive.<name1>Procedure;<endif>
-import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.primitive.Immutable<name2>Collection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
@@ -48,9 +50,11 @@ import org.eclipse.collections.api.set.primitive.Mutable<name2>Set;
 import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name2>HashBag;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
+import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.factory.primitive.<name1>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.iterator.Unmodifiable<name2>Iterator;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name2>IterableAdapter;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
@@ -63,6 +67,7 @@ import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 /**
  * Immutable<name1><name2>SingletonMap is an optimization for {@link Immutable<name1><name2>Map} of size 1.
  * This file was automatically generated from template file immutablePrimitivePrimitiveSingletonMap.stg.
+ *
  * @since 4.0.
  */
 final class Immutable<name1><name2>SingletonMap implements Immutable<name1><name2>Map, Serializable
@@ -193,24 +198,24 @@ final class Immutable<name1><name2>SingletonMap implements Immutable<name1><name
         return !predicate.accept(this.value1);
     }
 
-    public Immutable<name2>Collection select(<name2>Predicate predicate)
+    public Immutable<name2>Bag select(<name2>Predicate predicate)
     {
-        return predicate.accept(this.value1) ? <name2>ArrayList.newListWith(this.value1).toImmutable() : new <name2>ArrayList().toImmutable();
+        return predicate.accept(this.value1) ? <name2>HashBag.newBagWith(this.value1).toImmutable() : <name2>Bags.immutable.empty();
     }
 
-    public Immutable<name2>Collection reject(<name2>Predicate predicate)
+    public Immutable<name2>Bag reject(<name2>Predicate predicate)
     {
-        return predicate.accept(this.value1) ? new <name2>ArrayList().toImmutable() : <name2>ArrayList.newListWith(this.value1).toImmutable();
+        return predicate.accept(this.value1) ? <name2>Bags.immutable.empty() : <name2>HashBag.newBagWith(this.value1).toImmutable();
+    }
+
+    public \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
+    {
+        return Bags.immutable.of(function.valueOf(this.value1));
     }
 
     public <type2> detectIfNone(<name2>Predicate predicate, <type2> ifNone)
     {
         return predicate.accept(this.value1) ? this.value1 : ifNone;
-    }
-
-    public \<V> ImmutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function)
-    {
-        return Lists.immutable.of(function.valueOf(this.value1));
     }
 
     public <type2>[] toArray()

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -14,9 +14,9 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Mutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Mutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
-    return this.collect<name>(<type>Function, new <name>ArrayList(this.size()));
+    return this.collect<name>(<type>Function, new <name>HashBag());
 }
 
 public \<R extends Mutable<name>Collection> R collect<name>(<name>Function\<? super V> <type>Function, R target)
@@ -24,6 +24,7 @@ public \<R extends Mutable<name>Collection> R collect<name>(<name>Function\<? su
     this.forEach(new Collect<name>Procedure\<V>(<type>Function, target));
     return target;
 }
+
 >>
 
 body(type, name) ::= <<
@@ -47,13 +48,20 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.MutableByteBag;
+import org.eclipse.collections.api.bag.primitive.MutableCharBag;
+import org.eclipse.collections.api.bag.primitive.MutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.MutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.bag.primitive.MutableLongBag;
+import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
-import org.eclipse.collections.impl.bag.mutable.HashBag;
-import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
-import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
 import org.eclipse.collections.api.block.function.primitive.CharFunction;
@@ -63,8 +71,6 @@ import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatObjectToFloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
-import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
-import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
@@ -72,12 +78,11 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.<name>ObjectPredicate;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
-import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
-import org.eclipse.collections.api.collection.MutableCollection;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -91,17 +96,15 @@ import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
+import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
-import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
-import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.api.set.primitive.<name>Set;
@@ -110,13 +113,22 @@ import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.SpreadFunctions;
-import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ByteHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.CharHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.DoubleHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.FloatHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ShortHashBag;
+import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.eclipse.collections.impl.block.factory.Functions0;
 import org.eclipse.collections.impl.block.factory.Functions;
+import org.eclipse.collections.impl.block.factory.Functions0;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
+import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.MapCollectProcedure;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
@@ -133,25 +145,18 @@ import org.eclipse.collections.impl.block.procedure.primitive.CollectShortProced
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.iterator.Unmodifiable<name>Iterator;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterable;
 import org.eclipse.collections.impl.lazy.primitive.AbstractLazy<name>Iterable;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.FloatArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
+import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
-import org.eclipse.collections.impl.multimap.list.FastListMultimap;
-import org.eclipse.collections.impl.partition.list.PartitionFastList;
+import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
+import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.Synchronized<name>Set;
@@ -161,7 +166,6 @@ import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
-import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 
 /**
  * This file was automatically generated from template file primitiveObjectHashMap.stg.
@@ -725,9 +729,9 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return result;
     }
 
-    public MutableCollection\<V> select(Predicate\<? super V> predicate)
+    public MutableBag\<V> select(Predicate\<? super V> predicate)
     {
-        MutableList\<V> result = FastList.newList();
+        MutableBag\<V> result = new HashBag\<V>();
         if (this.sentinelValues != null)
         {
             if (this.sentinelValues.containsZeroKey && predicate.accept(this.sentinelValues.zeroValue))
@@ -772,7 +776,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return target;
     }
 
-    public \<P> MutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.select(Predicates.bind(predicate, parameter));
     }
@@ -800,9 +804,9 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return targetCollection;
     }
 
-    public MutableCollection\<V> reject(Predicate\<? super V> predicate)
+    public MutableBag\<V> reject(Predicate\<? super V> predicate)
     {
-        MutableList\<V> result = FastList.newList();
+        MutableBag\<V> result = new HashBag\<V>();
         if (this.sentinelValues != null)
         {
             if (this.sentinelValues.containsZeroKey && !predicate.accept(this.sentinelValues.zeroValue))
@@ -847,7 +851,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return target;
     }
 
-    public \<P> MutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.reject(Predicates.bind(predicate, parameter));
     }
@@ -896,28 +900,21 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return result;
     }
 
-    public \<VV> MutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<VV> MutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
-        return this.collect(function, FastList.\<VV>newList(this.size()));
+        return this.collect(function, new HashBag\<VV>());
     }
 
     <collectPrimitive("Boolean", "boolean")>
-
     <collectPrimitive("Byte", "byte")>
-
     <collectPrimitive("Char", "char")>
-
     <collectPrimitive("Double", "double")>
-
     <collectPrimitive("Float", "float")>
-
     <collectPrimitive("Int", "int")>
-
     <collectPrimitive("Long", "long")>
-
     <collectPrimitive("Short", "short")>
 
-    public \<P, VV> MutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<P, VV> MutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
         return this.collect(Functions.bind(function, parameter));
     }
@@ -996,9 +993,9 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return target;
     }
 
-    public \<VV> MutableList\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> MutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
-        return this.flatCollect(function, FastList.\<VV>newList());
+        return this.flatCollect(function, new HashBag\<VV>());
     }
 
     public \<VV, R extends Collection\<VV>\> R flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function, R target)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitiveObjectMap.stg
@@ -14,7 +14,7 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Mutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Mutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
     synchronized (this.lock)
     {
@@ -29,6 +29,7 @@ public \<R extends Mutable<name>Collection> R collect<name>(<name>Function\<? su
         return this.map.collect<name>(<type>Function, target);
     }
 }
+
 >>
 
 body(type, name) ::= <<
@@ -42,16 +43,25 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 
+import net.jcip.annotations.GuardedBy;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.MutableByteBag;
+import org.eclipse.collections.api.bag.primitive.MutableCharBag;
+import org.eclipse.collections.api.bag.primitive.MutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.MutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.bag.primitive.MutableLongBag;
+import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
-import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
 import org.eclipse.collections.api.block.function.primitive.CharFunction;
@@ -61,7 +71,6 @@ import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatObjectToFloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
-import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
@@ -73,7 +82,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -85,18 +93,18 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
+import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
-import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
-import org.eclipse.collections.api.partition.PartitionMutableCollection;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
-import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.SynchronizedRichIterable;
@@ -105,8 +113,6 @@ import org.eclipse.collections.impl.collection.mutable.SynchronizedMutableCollec
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.primitive.Synchronized<name>Iterable;
 import org.eclipse.collections.impl.set.mutable.primitive.Synchronized<name>Set;
-import org.eclipse.collections.impl.bag.mutable.HashBag;
-import net.jcip.annotations.GuardedBy;
 
 /**
  * A synchronized view of a {@link Mutable<name>ObjectMap}. It is imperative that the user manually synchronize on the collection when iterating over it using the
@@ -376,7 +382,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public MutableCollection\<V> select(Predicate\<? super V> predicate)
+    public MutableBag\<V> select(Predicate\<? super V> predicate)
     {
         synchronized (this.lock)
         {
@@ -392,7 +398,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public \<P> MutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         synchronized (this.lock)
         {
@@ -476,7 +482,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public MutableCollection\<V> reject(Predicate\<? super V> predicate)
+    public MutableBag\<V> reject(Predicate\<? super V> predicate)
     {
         synchronized (this.lock)
         {
@@ -492,7 +498,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public \<P> MutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         synchronized (this.lock)
         {
@@ -516,7 +522,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public \<VV> MutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<VV> MutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
         synchronized (this.lock)
         {
@@ -525,22 +531,15 @@ public final class Synchronized<name>ObjectMap\<V>
     }
 
     <collectPrimitive("Boolean", "boolean")>
-
     <collectPrimitive("Byte", "byte")>
-
     <collectPrimitive("Char", "char")>
-
     <collectPrimitive("Double", "double")>
-
     <collectPrimitive("Float", "float")>
-
     <collectPrimitive("Int", "int")>
-
     <collectPrimitive("Long", "long")>
-
     <collectPrimitive("Short", "short")>
 
-    public \<P, VV> MutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<P, VV> MutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
         synchronized (this.lock)
         {
@@ -580,7 +579,7 @@ public final class Synchronized<name>ObjectMap\<V>
         }
     }
 
-    public \<VV> RichIterable\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> MutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.<name2>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name2>Iterable;<endif>
 import org.eclipse.collections.api.Lazy<name1>Iterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>Function;
 import org.eclipse.collections.api.block.function.primitive.<name2>Function0;
@@ -41,7 +42,6 @@ import org.eclipse.collections.api.block.predicate.primitive.<name1><name2>Predi
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.block.procedure.primitive.<name2>Procedure;<endif>
 import org.eclipse.collections.api.block.procedure.primitive.<name1><name2>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name1>Procedure;
-import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.Mutable<name2>Iterator;
 import org.eclipse.collections.api.list.primitive.Mutable<name2>List;
@@ -327,7 +327,7 @@ public final class Synchronized<name1><name2>Map
         }
     }
 
-    public Mutable<name2>Collection select(<name2>Predicate predicate)
+    public Mutable<name2>Bag select(<name2>Predicate predicate)
     {
         synchronized (this.lock)
         {
@@ -335,11 +335,19 @@ public final class Synchronized<name1><name2>Map
         }
     }
 
-    public Mutable<name2>Collection reject(<name2>Predicate predicate)
+    public Mutable<name2>Bag reject(<name2>Predicate predicate)
     {
         synchronized (this.lock)
         {
             return this.map.reject(predicate);
+        }
+    }
+
+    public \<V> MutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.map.collect(function);
         }
     }
 
@@ -348,14 +356,6 @@ public final class Synchronized<name1><name2>Map
         synchronized (this.lock)
         {
             return this.map.detectIfNone(predicate, ifNone);
-        }
-    }
-
-    public \<V> MutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function)
-    {
-        synchronized (this.lock)
-        {
-            return this.map.collect(function);
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitiveObjectMap.stg
@@ -14,7 +14,7 @@ class(primitive) ::= <<
 >>
 
 collectPrimitive(name, type) ::= <<
-public Mutable<name>Collection collect<name>(<name>Function\<? super V> <type>Function)
+public Mutable<name>Bag collect<name>(<name>Function\<? super V> <type>Function)
 {
     return this.map.collect<name>(<type>Function);
 }
@@ -42,11 +42,19 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
-import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.MutableByteBag;
+import org.eclipse.collections.api.bag.primitive.MutableCharBag;
+import org.eclipse.collections.api.bag.primitive.MutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.MutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.bag.primitive.MutableLongBag;
+import org.eclipse.collections.api.bag.primitive.MutableShortBag;
+import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
+import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
 import org.eclipse.collections.api.block.function.primitive.CharFunction;
@@ -56,7 +64,6 @@ import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatObjectToFloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
-import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
@@ -68,7 +75,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -79,21 +85,19 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
-import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
+import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
-import org.eclipse.collections.api.map.sorted.MutableSortedMap;
-import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
-import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
-import org.eclipse.collections.api.partition.PartitionMutableCollection;
+import org.eclipse.collections.api.map.sorted.MutableSortedMap;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
-import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
@@ -277,7 +281,7 @@ public final class Unmodifiable<name>ObjectMap\<V>
         return this.map.containsAllArguments(elements);
     }
 
-    public MutableCollection\<V> select(Predicate\<? super V> predicate)
+    public MutableBag\<V> select(Predicate\<? super V> predicate)
     {
         return this.map.select(predicate);
     }
@@ -287,7 +291,7 @@ public final class Unmodifiable<name>ObjectMap\<V>
         return this.map.select(predicate, target);
     }
 
-    public \<P> MutableCollection\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> selectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.map.selectWith(predicate, parameter);
     }
@@ -341,7 +345,7 @@ public final class Unmodifiable<name>ObjectMap\<V>
         return this.map.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
     }
 
-    public MutableCollection\<V> reject(Predicate\<? super V> predicate)
+    public MutableBag\<V> reject(Predicate\<? super V> predicate)
     {
         return this.map.reject(predicate);
     }
@@ -351,7 +355,7 @@ public final class Unmodifiable<name>ObjectMap\<V>
         return this.map.reject(predicate, target);
     }
 
-    public \<P> MutableCollection\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
+    public \<P> MutableBag\<V> rejectWith(Predicate2\<? super V, ? super P> predicate, P parameter)
     {
         return this.map.rejectWith(predicate, parameter);
     }
@@ -366,28 +370,21 @@ public final class Unmodifiable<name>ObjectMap\<V>
         throw new UnsupportedOperationException("Cannot call clear() on " + this.getClass().getSimpleName());
     }
 
-    public \<VV> MutableCollection\<VV> collect(Function\<? super V, ? extends VV> function)
+    public \<VV> MutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
         return this.map.collect(function);
     }
 
     <collectPrimitive("Boolean", "boolean")>
-
     <collectPrimitive("Byte", "byte")>
-
     <collectPrimitive("Char", "char")>
-
     <collectPrimitive("Double", "double")>
-
     <collectPrimitive("Float", "float")>
-
     <collectPrimitive("Int", "int")>
-
     <collectPrimitive("Long", "long")>
-
     <collectPrimitive("Short", "short")>
 
-    public \<P, VV> MutableCollection\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
+    public \<P, VV> MutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
         return this.map.collectWith(function, parameter);
     }
@@ -412,7 +409,7 @@ public final class Unmodifiable<name>ObjectMap\<V>
         return this.map.collectIf(predicate, function, target);
     }
 
-    public \<VV> RichIterable\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
+    public \<VV> MutableBag\<VV> flatCollect(Function\<? super V, ? extends Iterable\<VV>\> function)
     {
         return this.map.flatCollect(function);
     }

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitivePrimitiveMap.stg
@@ -27,6 +27,7 @@ import org.eclipse.collections.api.<name2>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name2>Iterable;<endif>
 import org.eclipse.collections.api.Lazy<name1>Iterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>Function;
 import org.eclipse.collections.api.block.function.primitive.<name2>Function0;
@@ -39,7 +40,6 @@ import org.eclipse.collections.api.block.predicate.primitive.<name1><name2>Predi
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.block.procedure.primitive.<name2>Procedure;<endif>
 import org.eclipse.collections.api.block.procedure.primitive.<name1><name2>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name1>Procedure;
-import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.Mutable<name2>Iterator;
 import org.eclipse.collections.api.list.primitive.Mutable<name2>List;
@@ -49,10 +49,10 @@ import org.eclipse.collections.api.map.primitive.Mutable<name1><name2>Map;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.set.primitive.Mutable<name1>Set;<endif>
 import org.eclipse.collections.api.set.primitive.Mutable<name2>Set;
 import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
+import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.iterator.Unmodifiable<name2>Iterator;
 import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name1>Set;
-import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
 
 /**
  * This file was automatically generated from template file unmodifiablePrimitivePrimitiveMap.stg.
@@ -251,24 +251,24 @@ public final class Unmodifiable<name1><name2>Map
         return this.map.noneSatisfy(predicate);
     }
 
-    public Mutable<name2>Collection select(<name2>Predicate predicate)
+    public Mutable<name2>Bag select(<name2>Predicate predicate)
     {
         return this.map.select(predicate);
     }
 
-    public Mutable<name2>Collection reject(<name2>Predicate predicate)
+    public Mutable<name2>Bag reject(<name2>Predicate predicate)
     {
         return this.map.reject(predicate);
+    }
+
+    public \<V> MutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
+    {
+        return this.map.collect(function);
     }
 
     public <type2> detectIfNone(<name2>Predicate predicate, <type2> ifNone)
     {
         return this.map.detectIfNone(predicate, ifNone);
-    }
-
-    public \<V> MutableCollection\<V> collect(<name2>ToObjectFunction\<? extends V> function)
-    {
-        return this.map.collect(function);
     }
 
     <(arithmeticMethods.(type2))(name2, type2)>

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveArrayStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveArrayStack.stg
@@ -27,7 +27,9 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -376,6 +378,26 @@ final class Immutable<name>ArrayStack
     public void appendString(Appendable appendable, String start, String separator, String end)
     {
         this.delegate.asReversed().appendString(appendable, start, separator, end);
+    }
+
+    public <type> getFirst()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".getFirst() not implemented yet");
+    }
+
+    public int indexOf(<type> value)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".injectIntoWithIndex() not implemented yet");
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
     }
 
     private void checkSizeLessThanCount(int count)

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
@@ -23,8 +23,10 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -289,6 +291,26 @@ final class Immutable<name>EmptyStack implements Immutable<name>Stack, Serializa
         {
             throw new RuntimeException(e);
         }
+    }
+
+    public <type> getFirst()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".getFirst() not implemented yet");
+    }
+
+    public int indexOf(<type> value)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".injectIntoWithIndex() not implemented yet");
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
@@ -23,8 +23,10 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -257,6 +259,26 @@ final class Immutable<name>SingletonStack implements Immutable<name>Stack, Seria
     public \<T> T injectInto(T injectedValue, Object<name>ToObjectFunction\<? super T, ? extends T> function)
     {
         return function.valueOf(injectedValue, this.element1);
+    }
+
+    public <type> getFirst()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".getFirst() not implemented yet");
+    }
+
+    public int indexOf(<type> value)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".injectIntoWithIndex() not implemented yet");
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/primitiveArrayStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/primitiveArrayStack.stg
@@ -26,8 +26,10 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -394,6 +396,26 @@ public final class <name>ArrayStack
     public Mutable<name>Bag toBag()
     {
         return <name>HashBag.newBag(this);
+    }
+
+    public <type> getFirst()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".getFirst() not implemented yet");
+    }
+
+    public int indexOf(<type> value)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".injectIntoWithIndex() not implemented yet");
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
     }
 
     public Lazy<name>Iterable asLazy()

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
@@ -25,7 +25,9 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -402,6 +404,38 @@ public final class Synchronized<name>Stack
         synchronized (this.lock)
         {
             return this.stack.injectInto(injectedValue, function);
+        }
+    }
+
+    public <type> getFirst()
+    {
+        synchronized (this.lock)
+        {
+            return this.stack.getFirst();
+        }
+    }
+
+    public int indexOf(<type> value)
+    {
+        synchronized (this.lock)
+        {
+            return this.stack.indexOf(value);
+        }
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.stack.injectIntoWithIndex(injectedValue, function);
+        }
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        synchronized (this.lock)
+        {
+            this.stack.forEachWithIndex(procedure);
         }
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
@@ -23,7 +23,9 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
+import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.<name>List;
@@ -274,6 +276,26 @@ public final class Unmodifiable<name>Stack
     public \<T> T injectInto(T injectedValue, Object<name>ToObjectFunction\<? super T, ? extends T> function)
     {
         return this.stack.injectInto(injectedValue, function);
+    }
+
+    public <type> getFirst()
+    {
+        return this.stack.getFirst();
+    }
+
+    public int indexOf(<type> value)
+    {
+        return this.stack.indexOf(value);
+    }
+
+    public \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function)
+    {
+        return this.stack.injectIntoWithIndex(injectedValue, function);
+    }
+
+    public void forEachWithIndex(<name>IntProcedure procedure)
+    {
+        this.stack.forEachWithIndex(procedure);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapTestCase.stg
@@ -37,6 +37,7 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.factory.Bags;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
@@ -468,9 +469,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         BooleanIterable actual1 = map.select(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true), actual1);
+        Assert.assertEquals(BooleanBags.immutable.with(true, true), actual1);
         BooleanIterable actual2 = map.select(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanArrayList.newListWith(false, false), actual2);
+        Assert.assertEquals(BooleanBags.immutable.with(false, false), actual2);
     }
 
     @Test
@@ -478,9 +479,9 @@ public abstract class Abstract<name>BooleanMapTestCase
     {
         <name>BooleanMap map = this.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         BooleanIterable actual1 = map.reject(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanArrayList.newListWith(false, false), actual1);
+        Assert.assertEquals(BooleanBags.immutable.with(false, false), actual1);
         BooleanIterable actual2 = map.reject(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true), actual2);
+        Assert.assertEquals(BooleanBags.immutable.with(true, true), actual2);
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
@@ -41,6 +41,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.<name>ObjectPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
@@ -51,6 +52,14 @@ import org.eclipse.collections.api.partition.PartitionIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ByteHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.CharHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.DoubleHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.FloatHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ShortHashBag;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions;
@@ -63,14 +72,7 @@ import org.eclipse.collections.impl.block.factory.StringPredicates;
 import org.eclipse.collections.impl.block.factory.StringPredicates2;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.FloatArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
+import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMapTest;
@@ -146,17 +148,17 @@ public abstract class Abstract<name>ObjectMapTestCase
             map1.select((<type> value, String object) -> object.endsWith("ne")));
 
         RichIterable\<String> actual1 = map1.select(StringPredicates.endsWith("ne"));
-        Assert.assertTrue(FastList.newListWith("one", "nine").equals(actual1) || FastList.newListWith("nine", "one").equals(actual1));
+        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
 
-        Assert.assertEquals(FastList.newListWith("nine"), map1.select(Predicates.equal("nine")));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine")));
 
-        Assert.assertEquals(FastList.newListWith("zero"), map1.select(StringPredicates.endsWith("o")));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o")));
 
-        Assert.assertEquals(FastList.newListWith("nine"), map1.select(Predicates.equal("nine"), FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.select(Predicates.equal("nine"), HashBag.\<String>newBag()));
 
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.select(StringPredicates.endsWith("ne"), FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.select(StringPredicates.endsWith("ne"), HashBag.\<String>newBag()));
 
-        Assert.assertEquals(FastList.newListWith("zero"), map1.select(StringPredicates.endsWith("o"), FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.select(StringPredicates.endsWith("o"), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -164,11 +166,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne"));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne"));
 
-        Assert.assertEquals(FastList.newListWith("nine"), map1.selectWith(Object::equals, "nine"));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine"));
 
-        Assert.assertEquals(FastList.newListWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o"));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o"));
     }
 
     @Test
@@ -176,11 +178,11 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne", FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.selectWith(StringPredicates2.endsWith(), "ne", HashBag.\<String>newBag()));
 
-        Assert.assertEquals(FastList.newListWith("nine"), map1.selectWith(Object::equals, "nine", FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.selectWith(Object::equals, "nine", HashBag.\<String>newBag()));
 
-        Assert.assertEquals(FastList.newListWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o", FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.selectWith(StringPredicates2.endsWith(), "o", HashBag.\<String>newBag()));
     }
 
     @Test
@@ -197,8 +199,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase()));
-        Assert.assertEquals(FastList.newListWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase(), FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase()));
+        Assert.assertEquals(HashBag.newBagWith("ZERO", "ONE", "NINE"), map1.collect(StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -206,16 +208,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "true", <(literal.(type))("1")>, "false", <(literal.(type))("2")>, "nah");
 
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, false), map1.collectBoolean(StringFunctions.toPrimitiveBoolean()));
+        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), map1.collectBoolean(StringFunctions.toPrimitiveBoolean()));
     }
 
     @Test
     public void collectBoolean_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "true", <(literal.(type))("1")>, "false", <(literal.(type))("2")>, "nah");
-        BooleanArrayList target = new BooleanArrayList();
+        BooleanHashBag target = new BooleanHashBag();
         Assert.assertSame(target, map1.collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, false), target);
+        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, false), target);
     }
 
     @Test
@@ -223,16 +225,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 0, (byte) 1, (byte) 9), map1.collectByte(Byte::parseByte));
+        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), map1.collectByte(Byte::parseByte));
     }
 
     @Test
     public void collectByte_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        ByteArrayList target = new ByteArrayList();
+        ByteHashBag target = new ByteHashBag();
         Assert.assertSame(target, map1.collectByte(Byte::parseByte, target));
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 0, (byte) 1, (byte) 9), target);
+        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 9), target);
     }
 
     @Test
@@ -240,16 +242,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(CharArrayList.newListWith((char) 0, (char) 1, (char) 9), map1.collectChar(StringFunctions.toPrimitiveChar()));
+        Assert.assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), map1.collectChar(StringFunctions.toPrimitiveChar()));
     }
 
     @Test
     public void collectChar_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        CharArrayList target = new CharArrayList();
+        CharHashBag target = new CharHashBag();
         Assert.assertSame(target, map1.collectChar(StringFunctions.toPrimitiveChar(), target));
-        Assert.assertEquals(CharArrayList.newListWith((char) 0, (char) 1, (char) 9), target);
+        Assert.assertEquals(CharHashBag.newBagWith((char) 0, (char) 1, (char) 9), target);
     }
 
     @Test
@@ -257,16 +259,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(DoubleArrayList.newListWith(0.0d, 1.0d, 9.0d), map1.collectDouble(Double::parseDouble));
+        Assert.assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), map1.collectDouble(Double::parseDouble));
     }
 
     @Test
     public void collectDouble_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        DoubleArrayList target = new DoubleArrayList();
+        DoubleHashBag target = new DoubleHashBag();
         Assert.assertSame(target, map1.collectDouble(Double::parseDouble, target));
-        Assert.assertEquals(DoubleArrayList.newListWith(0.0d, 1.0d, 9.0d), target);
+        Assert.assertEquals(DoubleHashBag.newBagWith(0.0d, 1.0d, 9.0d), target);
     }
 
     @Test
@@ -274,16 +276,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(FloatArrayList.newListWith(0.0f, 1.0f, 9.0f), map1.collectFloat(Float::parseFloat));
+        Assert.assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), map1.collectFloat(Float::parseFloat));
     }
 
     @Test
     public void collectFloat_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        FloatArrayList target = new FloatArrayList();
+        FloatHashBag target = new FloatHashBag();
         Assert.assertSame(target, map1.collectFloat(Float::parseFloat, target));
-        Assert.assertEquals(FloatArrayList.newListWith(0.0f, 1.0f, 9.0f), target);
+        Assert.assertEquals(FloatHashBag.newBagWith(0.0f, 1.0f, 9.0f), target);
     }
 
     @Test
@@ -291,16 +293,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(IntArrayList.newListWith(0, 1, 9), map1.collectInt(Integer::parseInt));
+        Assert.assertEquals(IntHashBag.newBagWith(0, 1, 9), map1.collectInt(Integer::parseInt));
     }
 
     @Test
     public void collectInt_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        IntArrayList target = new IntArrayList();
+        IntHashBag target = new IntHashBag();
         Assert.assertSame(target, map1.collectInt(Integer::parseInt, target));
-        Assert.assertEquals(IntArrayList.newListWith(0, 1, 9), target);
+        Assert.assertEquals(IntHashBag.newBagWith(0, 1, 9), target);
     }
 
     @Test
@@ -308,16 +310,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(LongArrayList.newListWith(0L, 1L, 9L), map1.collectLong(Long::parseLong));
+        Assert.assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), map1.collectLong(Long::parseLong));
     }
 
     @Test
     public void collectLong_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        LongArrayList target = new LongArrayList();
+        LongHashBag target = new LongHashBag();
         Assert.assertSame(target, map1.collectLong(Long::parseLong, target));
-        Assert.assertEquals(LongArrayList.newListWith(0L, 1L, 9L), target);
+        Assert.assertEquals(LongHashBag.newBagWith(0L, 1L, 9L), target);
     }
 
     @Test
@@ -325,16 +327,16 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
 
-        Assert.assertEquals(ShortArrayList.newListWith((short) 0, (short) 1, (short) 9), map1.collectShort(Short::parseShort));
+        Assert.assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), map1.collectShort(Short::parseShort));
     }
 
     @Test
     public void collectShort_withTarget()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "0", <(literal.(type))("1")>, "1", <(literal.(type))("2")>, "9");
-        ShortArrayList target = new ShortArrayList();
+        ShortHashBag target = new ShortHashBag();
         Assert.assertSame(target, map1.collectShort(Short::parseShort, target));
-        Assert.assertEquals(ShortArrayList.newListWith((short) 0, (short) 1, (short) 9), target);
+        Assert.assertEquals(ShortHashBag.newBagWith((short) 0, (short) 1, (short) 9), target);
     }
 
     @Test
@@ -342,7 +344,7 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("ZERO!", "ONE!", "NINE!"),
+        Assert.assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
             map1.collectWith((String argument1, String argument2) -> argument1.toUpperCase() + argument2, "!"));
     }
 
@@ -351,8 +353,8 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("ZERO!", "ONE!", "NINE!"),
-            map1.collectWith((String argument1, String argument2) -> argument1.toUpperCase() + argument2, "!", FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("ZERO!", "ONE!", "NINE!"),
+            map1.collectWith((String argument1, String argument2) -> argument1.toUpperCase() + argument2, "!", HashBag.\<String>newBag()));
     }
 
     @Test
@@ -362,7 +364,7 @@ public abstract class Abstract<name>ObjectMapTestCase
 
         Assert.assertEquals(HashBag.newBagWith("ONE", "NINE"), map1.collectIf(StringPredicates.endsWith("ne"), StringFunctions.toUpperCase()));
         Assert.assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase()));
-        Assert.assertEquals(FastList.newListWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase(), FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("ZERO"), map1.collectIf(StringPredicates.endsWith("o"), StringFunctions.toUpperCase(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -372,9 +374,9 @@ public abstract class Abstract<name>ObjectMapTestCase
         <name>ObjectMap\<String> map2 = this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
         <name>ObjectMap\<String> map3 = this.newWithKeysValues(<(literal.(type))("5")>, "five", <(literal.(type))("9")>, "nine");
 
-        Function\<String, FastList\<Character>\> toChars = (String object) ->
+        Function\<String, MutableList\<Character>\> toChars = (String object) ->
             {
-                FastList\<Character> list = FastList.newList();
+                MutableList\<Character> list = FastList.newList();
                 char[] chars = object.toCharArray();
                 for (char aChar : chars)
                 {
@@ -923,12 +925,12 @@ public abstract class Abstract<name>ObjectMapTestCase
             map1.reject((<type> value, String object) -> !object.endsWith("ne")));
 
         RichIterable\<String> actual1 = map1.reject(StringPredicates.endsWith("ne").not());
-        Assert.assertTrue(FastList.newListWith("one", "nine").equals(actual1) || FastList.newListWith("nine", "one").equals(actual1));
-        Assert.assertEquals(FastList.newListWith("nine"), map1.reject(Predicates.equal("nine").not()));
-        Assert.assertEquals(FastList.newListWith("zero"), map1.reject(StringPredicates.endsWith("o").not()));
-        Assert.assertEquals(FastList.newListWith("nine"), map1.reject(Predicates.equal("nine").not(), FastList.\<String>newList()));
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.reject(StringPredicates.endsWith("ne").not(), FastList.\<String>newList()));
-        Assert.assertEquals(FastList.newListWith("zero"), map1.reject(StringPredicates.endsWith("o").not(), FastList.\<String>newList()));
+        Assert.assertTrue(HashBag.newBagWith("one", "nine").equals(actual1));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not()));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not()));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.reject(Predicates.equal("nine").not(), HashBag.\<String>newBag()));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.reject(StringPredicates.endsWith("ne").not(), HashBag.\<String>newBag()));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.reject(StringPredicates.endsWith("o").not(), HashBag.\<String>newBag()));
     }
 
     @Test
@@ -936,9 +938,9 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne"));
-        Assert.assertEquals(FastList.newListWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine"));
-        Assert.assertEquals(FastList.newListWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o"));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne"));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine"));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o"));
     }
 
     @Test
@@ -946,9 +948,9 @@ public abstract class Abstract<name>ObjectMapTestCase
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one", <(literal.(type))("9")>, "nine");
 
-        Assert.assertEquals(FastList.newListWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne", FastList.\<String>newList()));
-        Assert.assertEquals(FastList.newListWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine", FastList.\<String>newList()));
-        Assert.assertEquals(FastList.newListWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o", FastList.\<String>newList()));
+        Assert.assertEquals(HashBag.newBagWith("one", "nine"), map1.rejectWith(StringPredicates2.notEndsWith(), "ne", HashBag.\<String>newBag()));
+        Assert.assertEquals(HashBag.newBagWith("nine"), map1.rejectWith(Predicates2.notEqual(), "nine", HashBag.\<String>newBag()));
+        Assert.assertEquals(HashBag.newBagWith("zero"), map1.rejectWith(StringPredicates2.notEndsWith(), "o", HashBag.\<String>newBag()));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -27,7 +27,6 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name2>Iterable;
 import org.eclipse.collections.api.Lazy<name2>Iterable;
-import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
@@ -35,11 +34,10 @@ import org.eclipse.collections.api.map.primitive.<name1><name2>Map;
 import org.eclipse.collections.api.map.primitive.Immutable<name1><name2>Map;
 import org.eclipse.collections.api.set.primitive.Mutable<name2>Set;
 import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
-import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name2>HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.<name2>Predicates;
 import org.eclipse.collections.impl.factory.Bags;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;<endif>
@@ -579,13 +577,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name2>Iterable actual1 = map.select(<name2>Predicates.greaterThan(<(literal.(type2))("1")>));
-        Assert.assertTrue(
-                <name2>ArrayList.newListWith(<(literal.(type2))("2")>, <(literal.(type2))("3")>).equals(actual1)
-                        || <name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>).equals(actual1));
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
         <name2>Iterable actual2 = map.select(<name2>Predicates.lessThan(<(literal.(type2))("2")>));
-        Assert.assertTrue(
-                <name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("1")>).equals(actual2)
-                        || <name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("0")>).equals(actual2));
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
     }
 
     @Test
@@ -593,13 +587,9 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
         <name2>Iterable actual1 = map.reject(<name2>Predicates.lessThan(<(literal.(type2))("2")>));
-        Assert.assertTrue(
-                <name2>ArrayList.newListWith(<(literal.(type2))("2")>, <(literal.(type2))("3")>).equals(actual1)
-                        || <name2>ArrayList.newListWith(<(literal.(type2))("3")>, <(literal.(type2))("2")>).equals(actual1));
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("2")>, <(literal.(type2))("3")>), actual1);
         <name2>Iterable actual2 = map.reject(<name2>Predicates.greaterThan(<(literal.(type2))("1")>));
-        Assert.assertTrue(
-                <name2>ArrayList.newListWith(<(literal.(type2))("0")>, <(literal.(type2))("1")>).equals(actual2)
-                        || <name2>ArrayList.newListWith(<(literal.(type2))("1")>, <(literal.(type2))("0")>).equals(actual2));
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>, <(literal.(type2))("1")>), actual2);
     }
 
     @Test
@@ -607,12 +597,10 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
 
-        <name2>ToObjectFunction\<<primitive2.wrapperName>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter + 1")>;
-        RichIterable\<<primitive2.wrapperName>\> objects = map.collect(function);
-
-        Assert.assertEquals(HashBag.newBagWith(<["1", "2", "3", "4"]:(literal.(type2))(); separator=", ">), objects.toBag());
-        Assert.assertEquals(Lists.immutable.with(), this.getEmptyMap().collect(function));
-        Assert.assertEquals(Lists.immutable.with(<(literal.(type2))("2")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).collect(function));
+        <name2>ToObjectFunction\<<primitive2.wrapperName>\> function = (parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter + 1")>;
+        Assert.assertEquals(Bags.immutable.with(<["1", "2", "3", "4"]:(literal.(type2))(); separator=", ">), map.collect(function));
+        Assert.assertEquals(Bags.immutable.empty(), this.getEmptyMap().collect(function));
+        Assert.assertEquals(Bags.immutable.with(<(literal.(type2))("2")>), this.newWithKeysValues(<["1"]:keyValue(); separator=", ">).collect(function));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanEmptyMapTest.stg
@@ -25,9 +25,10 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.map.primitive.Immutable<name>BooleanMap;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
-import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
+import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
@@ -204,31 +205,31 @@ public class Immutable<name>BooleanEmptyMapTest extends AbstractImmutable<name>B
     @Override
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((<type> value1, boolean value2) -> true));
+        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((key, value) -> true));
     }
 
     @Override
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((<type> value1, boolean value2) -> false));
+        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((key, value) -> false));
     }
 
     @Override
     public void select_value()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().select((boolean value) -> true));
+        Assert.assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().select(value -> true));
     }
 
     @Override
     public void reject_value()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().reject((boolean value) -> false));
+        Assert.assertEquals(BooleanBags.immutable.empty(), this.classUnderTest().reject(value -> false));
     }
 
     @Override
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count((boolean value) -> true));
+        Assert.assertEquals(0, this.classUnderTest().count(value -> true));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveBooleanSingletonMapTest.stg
@@ -27,9 +27,10 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.map.primitive.<name>BooleanMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>BooleanMap;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.<name>BooleanMaps;
-import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
+import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>BooleanHashMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -230,10 +231,10 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void select_value()
     {
         BooleanIterable actual1 = this.classUnderTest().select(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanArrayList.newListWith(), actual1);
+        Assert.assertEquals(BooleanBags.immutable.empty(), actual1);
 
         BooleanIterable actual2 = this.classUnderTest().select(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), actual2);
+        Assert.assertEquals(BooleanBags.immutable.with(true), actual2);
     }
 
     @Override
@@ -241,10 +242,10 @@ public class Immutable<name>BooleanSingletonMapTest extends AbstractImmutable<na
     public void reject_value()
     {
         BooleanIterable actual1 = this.classUnderTest().reject(BooleanPredicates.isTrue());
-        Assert.assertEquals(BooleanArrayList.newListWith(), actual1);
+        Assert.assertEquals(BooleanBags.immutable.empty(), actual1);
 
         BooleanIterable actual2 = this.classUnderTest().reject(BooleanPredicates.isFalse());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), actual2);
+        Assert.assertEquals(BooleanBags.immutable.with(true), actual2);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectSingletonMapTest.stg
@@ -23,11 +23,28 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.bag.primitive.MutableByteBag;
+import org.eclipse.collections.api.bag.primitive.MutableCharBag;
+import org.eclipse.collections.api.bag.primitive.MutableDoubleBag;
+import org.eclipse.collections.api.bag.primitive.MutableFloatBag;
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.bag.primitive.MutableLongBag;
+import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.partition.PartitionIterable;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ByteHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.CharHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.DoubleHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.FloatHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
+import org.eclipse.collections.impl.bag.mutable.primitive.ShortHashBag;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions0;
@@ -37,16 +54,7 @@ import org.eclipse.collections.impl.block.factory.StringFunctions;
 import org.eclipse.collections.impl.block.factory.StringPredicates;
 import org.eclipse.collections.impl.block.factory.StringPredicates2;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.FloatArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
-import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
-import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
 import org.junit.Assert;
@@ -281,29 +289,29 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
 
         Verify.assertIterableEmpty(this.classUnderTest().select((<type> value, String object) -> value != 0));
 
-        Assert.assertEquals(FastList.newListWith("zero"), this.classUnderTest().select(Predicates.equal("zero")));
+        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().select(Predicates.equal("zero")));
         Verify.assertIterableEmpty(this.classUnderTest().select(Predicates.equal("one")));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().select(Predicates.equal("zero"), target));
-        Assert.assertEquals(FastList.newListWith("zero"), target);
+        Assert.assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     public void selectWith()
     {
-        Assert.assertEquals(FastList.newListWith("zero"), this.classUnderTest().selectWith(Object::equals, "zero"));
+        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectWith(Object::equals, "zero"));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().selectWith(Object::equals, "zero", target));
-        Assert.assertEquals(FastList.newListWith("zero"), target);
+        Assert.assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(FastList.newListWith("zero"), this.classUnderTest().selectInstancesOf(String.class));
+        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().selectInstancesOf(String.class));
         Verify.assertIterableEmpty(this.classUnderTest().selectInstancesOf(Integer.class));
     }
 
@@ -317,24 +325,24 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
 
         Verify.assertIterableEmpty(this.classUnderTest().reject((value, object) -> value == 0));
 
-        Assert.assertEquals(FastList.newListWith("zero"), this.classUnderTest().reject(Predicates.equal("one")));
+        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().reject(Predicates.equal("one")));
         Verify.assertIterableEmpty(this.classUnderTest().reject(Predicates.equal("zero")));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().reject(Predicates.equal("one"), target));
-        Assert.assertEquals(FastList.newListWith("zero"), target);
+        Assert.assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(FastList.newListWith("zero"), this.classUnderTest().rejectWith(Object::equals, "one"));
+        Assert.assertEquals(HashBag.newBagWith("zero"), this.classUnderTest().rejectWith(Object::equals, "one"));
         Verify.assertIterableEmpty(this.classUnderTest().rejectWith(Object::equals, "zero"));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().rejectWith(Object::equals, "one", target));
-        Assert.assertEquals(FastList.newListWith("zero"), target);
+        Assert.assertEquals(HashBag.newBagWith("zero"), target);
     }
 
     @Override
@@ -439,7 +447,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     {
         PartitionIterable\<String> result = this.classUnderTest().partition(StringPredicates.endsWith("ne"));
         Verify.assertIterableEmpty(result.getSelected());
-        Assert.assertEquals(FastList.newListWith("zero"), result.getRejected());
+        Assert.assertEquals(HashBag.newBagWith("zero"), result.getRejected());
     }
 
     @Override
@@ -447,7 +455,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void partitionWith()
     {
         PartitionIterable\<String> result = this.classUnderTest().partitionWith(StringPredicates2.endsWith(), "ro");
-        Assert.assertEquals(FastList.newListWith("zero"), result.getSelected());
+        Assert.assertEquals(HashBag.newBagWith("zero"), result.getSelected());
         Verify.assertIterableEmpty(result.getRejected());
     }
 
@@ -495,28 +503,28 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void sumOfInt()
     {
-        Assert.assertEquals(4L, this.classUnderTest().sumOfInt((String value) -> value.length()));
+        Assert.assertEquals(4L, this.classUnderTest().sumOfInt(String::length));
     }
 
     @Override
     @Test
     public void sumOfFloat()
     {
-        Assert.assertEquals(4.0d, this.classUnderTest().sumOfFloat((String value) -> (float) value.length()), 0.0d);
+        Assert.assertEquals(4.0d, this.classUnderTest().sumOfFloat(value -> (float) value.length()), 0.0d);
     }
 
     @Override
     @Test
     public void sumOfLong()
     {
-        Assert.assertEquals(4L, this.classUnderTest().sumOfLong((String value) -> (long) value.length()));
+        Assert.assertEquals(4L, this.classUnderTest().sumOfLong(value -> (long) value.length()));
     }
 
     @Override
     @Test
     public void sumOfDouble()
     {
-        Assert.assertEquals(4.0d, this.classUnderTest().sumOfDouble((String value) -> (double) value.length()), 0.0d);
+        Assert.assertEquals(4.0d, this.classUnderTest().sumOfDouble(value -> (double) value.length()), 0.0d);
     }
 
     @Override
@@ -524,36 +532,35 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectIf()
     {
         Assert.assertEquals(
-                FastList.newListWith("ZERO"),
+                HashBag.newBagWith("ZERO"),
                 this.classUnderTest().collectIf(StringPredicates.endsWith("ro"), StringFunctions.toUpperCase()));
         Verify.assertIterableEmpty(this.classUnderTest().collectIf(StringPredicates.endsWith("ne"), StringFunctions.toUpperCase()));
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(
                 target,
                 this.classUnderTest().collectIf(StringPredicates.endsWith("ro"), StringFunctions.toUpperCase(), target));
-        Assert.assertEquals(FastList.newListWith("ZERO"), target);
+        Assert.assertEquals(HashBag.newBagWith("ZERO"), target);
     }
 
     @Override
     @Test
     public void flatCollect()
     {
-        Function\<String, Iterable\<Character>\> function = (String value) -> StringIterate.toSet(value);
-        Verify.assertListsEqual(FastList.newListWith('e', 'o', 'r', 'z'), this.classUnderTest().flatCollect(function).toSortedList());
-        UnifiedSet\<Character> target = UnifiedSet.newSet();
-        Assert.assertSame(target, this.classUnderTest().flatCollect(function, target));
-        Verify.assertSetsEqual(UnifiedSet.newSetWith('z', 'e', 'r', 'o'), target);
+        Verify.assertBagsEqual(HashBag.newBagWith('z', 'e', 'r', 'o'), this.classUnderTest().flatCollect(StringIterate::toSet));
+        MutableBag\<Character> target = HashBag.newBag();
+        Assert.assertSame(target, this.classUnderTest().flatCollect(StringIterate::toSet, target));
+        Verify.assertBagsEqual(HashBag.newBagWith('z', 'e', 'r', 'o'), target);
     }
 
     @Override
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith("ZERO"), this.classUnderTest().collect(StringFunctions.toUpperCase()));
+        Assert.assertEquals(HashBag.newBagWith("ZERO"), this.classUnderTest().collect(StringFunctions.toUpperCase()));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().collect(StringFunctions.toUpperCase(), target));
-        Assert.assertEquals(FastList.newListWith("ZERO"), target);
+        Assert.assertEquals(HashBag.newBagWith("ZERO"), target);
     }
 
     @Override
@@ -561,11 +568,11 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectWith()
     {
         Function2\<String, String, String> function = (String each, String param) -> each.toUpperCase() + param;
-        Assert.assertEquals(FastList.newListWith("ZERO!"), this.classUnderTest().collectWith(function, "!"));
+        Assert.assertEquals(HashBag.newBagWith("ZERO!"), this.classUnderTest().collectWith(function, "!"));
 
-        FastList\<String> target = FastList.newList();
+        MutableBag\<String> target = HashBag.newBag();
         Assert.assertSame(target, this.classUnderTest().collectWith(function, "!", target));
-        Assert.assertEquals(FastList.newListWith("ZERO!"), target);
+        Assert.assertEquals(HashBag.newBagWith("ZERO!"), target);
     }
 
     @Override
@@ -573,7 +580,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectBoolean()
     {
         Assert.assertEquals(
-                BooleanArrayList.newListWith(true),
+                BooleanHashBag.newBagWith(true),
                 this.newWithKeysValues(<(literal.(type))("0")>, "true").collectBoolean(StringFunctions.toPrimitiveBoolean()));
     }
 
@@ -581,9 +588,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectBoolean_withTarget()
     {
-        BooleanArrayList target = new BooleanArrayList();
+        MutableBooleanBag target = new BooleanHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "true").collectBoolean(StringFunctions.toPrimitiveBoolean(), target));
-        Assert.assertEquals(BooleanArrayList.newListWith(true), target);
+        Assert.assertEquals(BooleanHashBag.newBagWith(true), target);
     }
 
     @Override
@@ -591,7 +598,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectByte()
     {
         Assert.assertEquals(
-                ByteArrayList.newListWith((byte) 0),
+                ByteHashBag.newBagWith((byte) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectByte(Byte::parseByte));
     }
 
@@ -599,9 +606,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectByte_withTarget()
     {
-        ByteArrayList target = new ByteArrayList();
+        MutableByteBag target = new ByteHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectByte(Byte::parseByte, target));
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 0), target);
+        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0), target);
     }
 
     @Override
@@ -609,7 +616,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectChar()
     {
         Assert.assertEquals(
-                CharArrayList.newListWith((char) 0),
+                CharHashBag.newBagWith((char) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectChar(StringFunctions.toPrimitiveChar()));
     }
 
@@ -617,9 +624,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectChar_withTarget()
     {
-        CharArrayList target = new CharArrayList();
+        MutableCharBag target = new CharHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectChar(StringFunctions.toPrimitiveChar(), target));
-        Assert.assertEquals(CharArrayList.newListWith((char) 0), target);
+        Assert.assertEquals(CharHashBag.newBagWith((char) 0), target);
     }
 
     @Override
@@ -627,7 +634,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectDouble()
     {
         Assert.assertEquals(
-                DoubleArrayList.newListWith((double) 0),
+                DoubleHashBag.newBagWith((double) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectDouble(Double::parseDouble));
     }
 
@@ -635,9 +642,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectDouble_withTarget()
     {
-        DoubleArrayList target = new DoubleArrayList();
+        MutableDoubleBag target = new DoubleHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectDouble(Double::parseDouble, target));
-        Assert.assertEquals(DoubleArrayList.newListWith((double) 0), target);
+        Assert.assertEquals(DoubleHashBag.newBagWith((double) 0), target);
     }
 
     @Override
@@ -645,7 +652,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectFloat()
     {
         Assert.assertEquals(
-                FloatArrayList.newListWith((float) 0),
+                FloatHashBag.newBagWith((float) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectFloat(Float::parseFloat));
     }
 
@@ -653,9 +660,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectFloat_withTarget()
     {
-        FloatArrayList target = new FloatArrayList();
+        MutableFloatBag target = new FloatHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectFloat(Float::parseFloat, target));
-        Assert.assertEquals(FloatArrayList.newListWith((float) 0), target);
+        Assert.assertEquals(FloatHashBag.newBagWith((float) 0), target);
     }
 
     @Override
@@ -663,7 +670,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectInt()
     {
         Assert.assertEquals(
-                IntArrayList.newListWith((int) 0),
+                IntHashBag.newBagWith((int) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectInt(Integer::parseInt));
     }
 
@@ -671,9 +678,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectInt_withTarget()
     {
-        IntArrayList target = new IntArrayList();
+        MutableIntBag target = new IntHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectInt(Integer::parseInt, target));
-        Assert.assertEquals(IntArrayList.newListWith((int) 0), target);
+        Assert.assertEquals(IntHashBag.newBagWith((int) 0), target);
     }
 
     @Override
@@ -681,7 +688,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectLong()
     {
         Assert.assertEquals(
-                LongArrayList.newListWith(0L),
+                LongHashBag.newBagWith(0L),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectLong(Long::parseLong));
     }
 
@@ -689,9 +696,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectLong_withTarget()
     {
-        LongArrayList target = new LongArrayList();
+        MutableLongBag target = new LongHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectLong(Long::parseLong, target));
-        Assert.assertEquals(LongArrayList.newListWith(0L), target);
+        Assert.assertEquals(LongHashBag.newBagWith(0L), target);
     }
 
     @Override
@@ -699,7 +706,7 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     public void collectShort()
     {
         Assert.assertEquals(
-                ShortArrayList.newListWith((short) 0),
+                ShortHashBag.newBagWith((short) 0),
                 this.newWithKeysValues(<(literal.(type))("0")>, "0").collectShort(Short::parseShort));
     }
 
@@ -707,9 +714,9 @@ public class Immutable<name>ObjectSingletonMapTest extends AbstractImmutable<nam
     @Test
     public void collectShort_withTarget()
     {
-        ShortArrayList target = new ShortArrayList();
+        MutableShortBag target = new ShortHashBag();
         Assert.assertSame(target, this.newWithKeysValues(<(literal.(type))("0")>, "0").collectShort(Short::parseShort, target));
-        Assert.assertEquals(ShortArrayList.newListWith((short) 0), target);
+        Assert.assertEquals(ShortHashBag.newBagWith((short) 0), target);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveEmptyMapTest.stg
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.iterator.<name2>Iterator;
 import org.eclipse.collections.api.map.primitive.Immutable<name1><name2>Map;
+import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;<endif>
@@ -206,14 +207,14 @@ public class Immutable<name1><name2>EmptyMapTest extends AbstractImmutable<name1
     @Test
     public void select_value()
     {
-        Assert.assertEquals(<name2>ArrayList.newListWith(), this.classUnderTest().select((<type2> value) -> true));
+        Assert.assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().select(value -> true));
     }
 
     @Override
     @Test
     public void reject_value()
     {
-        Assert.assertEquals(new <name2>ArrayList(), this.classUnderTest().reject((<type2> value) -> false));
+        Assert.assertEquals(<name2>Bags.immutable.empty(), this.classUnderTest().reject(value -> false));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitivePrimitiveSingletonMapTest.stg
@@ -31,6 +31,7 @@ import org.eclipse.collections.api.map.primitive.<name1><name2>Map;
 import org.eclipse.collections.api.map.primitive.Immutable<name1><name2>Map;
 import org.eclipse.collections.impl.block.factory.primitive.<name2>Predicates;
 import org.eclipse.collections.impl.factory.primitive.<name1><name2>Maps;
+import org.eclipse.collections.impl.factory.primitive.<name2>Bags;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;<endif>
 import org.eclipse.collections.impl.map.mutable.primitive.<name1><name2>HashMap;
@@ -219,10 +220,10 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void select_value()
     {
         <name2>Iterable actual1 = this.classUnderTest().select(<name2>Predicates.equal(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>ArrayList.newListWith(), actual1);
+        Assert.assertEquals(<name2>Bags.immutable.empty(), actual1);
 
         <name2>Iterable actual2 = this.classUnderTest().select(<name2>Predicates.equal(<(literal.(type2))("0")>));
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), actual2);
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
     }
 
     @Override
@@ -230,10 +231,10 @@ public class Immutable<name1><name2>SingletonMapTest extends AbstractImmutable<n
     public void reject_value()
     {
         <name2>Iterable actual1 = this.classUnderTest().reject(<name2>Predicates.equal(<(literal.(type2))("0")>));
-        Assert.assertEquals(<name2>ArrayList.newListWith(), actual1);
+        Assert.assertEquals(<name2>Bags.immutable.empty(), actual1);
 
         <name2>Iterable actual2 = this.classUnderTest().reject(<name2>Predicates.equal(<(literal.(type2))("1")>));
-        Assert.assertEquals(<name2>ArrayList.newListWith(<(literal.(type2))("0")>), actual2);
+        Assert.assertEquals(<name2>Bags.immutable.with(<(literal.(type2))("0")>), actual2);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
@@ -23,15 +23,15 @@ package org.eclipse.collections.impl.map.mutable.primitive;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.iterator.BooleanIterator;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableBooleanCollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -67,9 +67,9 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     }
 
     @Override
-    protected MutableList\<Object> newObjectCollectionWith(Object... elements)
+    protected MutableBag\<Object> newObjectCollectionWith(Object... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
@@ -25,16 +25,16 @@ package org.eclipse.collections.impl.map.mutable.primitive;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name2>Iterable;
+import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.<name2>Predicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable<name2>CollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.Synchronized<name2>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
 <if(primitive2.floatingPoint)>import org.eclipse.collections.impl.list.Interval;<endif>
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -70,9 +70,9 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     }
 
     @Override
-    protected MutableList\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
+    protected Bag\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
@@ -21,14 +21,14 @@ body(type, name) ::= <<
 package org.eclipse.collections.impl.map.mutable.primitive;
 
 import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableBooleanCollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -64,9 +64,9 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    protected MutableList\<Object> newObjectCollectionWith(Object... elements)
+    protected MutableBag\<Object> newObjectCollectionWith(Object... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
@@ -25,16 +25,16 @@ package org.eclipse.collections.impl.map.mutable.primitive;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name2>Iterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.<name2>Predicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable<name2>CollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.Synchronized<name2>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
 <if(primitive2.floatingPoint)>import org.eclipse.collections.impl.list.Interval;<endif>
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -70,9 +70,9 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    protected MutableList\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
+    protected MutableBag\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
@@ -23,16 +23,16 @@ package org.eclipse.collections.impl.map.mutable.primitive;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableBooleanCollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -68,9 +68,9 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    protected MutableList\<Object> newObjectCollectionWith(Object... elements)
+    protected MutableBag\<Object> newObjectCollectionWith(Object... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
@@ -25,17 +25,17 @@ package org.eclipse.collections.impl.map.mutable.primitive;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.<name2>Iterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
 import org.eclipse.collections.api.collection.primitive.Mutable<name2>Collection;
 import org.eclipse.collections.api.iterator.<name2>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name2>Iterator;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.primitive.<name2>Predicates;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable<name2>CollectionTestCase;
 import org.eclipse.collections.impl.collection.mutable.primitive.Synchronized<name2>Collection;
 import org.eclipse.collections.impl.collection.mutable.primitive.Unmodifiable<name2>Collection;
-<if(primitive2.floatingPoint)>import org.eclipse.collections.impl.list.Interval;<endif>
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.primitive.<name2>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -71,9 +71,9 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    protected MutableList\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
+    protected MutableBag\<<wrapperName2>\> newObjectCollectionWith(<wrapperName2>... elements)
     {
-        return FastList.newListWith(elements);
+        return HashBag.newBagWith(elements);
     }
 
     @Override
@@ -173,18 +173,10 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
     public void remove()
     {
-        <name1><name2>HashMap map = <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">);
-        Mutable<name2>Collection collection = map.values();
-        Assert.assertTrue(collection.remove(<(literal.(type2))("3")>));
-        Assert.assertFalse(collection.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(collection.contains(<(literal.(type2))("2")>));
-        Assert.assertFalse(map.contains(<(literal.(type2))("3")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("1")>));
-        Assert.assertTrue(map.contains(<(literal.(type2))("2")>));
+        this.classUnderTest().remove(<(literal.(type2))("0")>);
     }
 
     @Override
@@ -272,6 +264,8 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void collect()
     {
+        super.collect();
+
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
         Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
@@ -48,6 +48,7 @@ import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
@@ -837,7 +838,7 @@ public abstract class AbstractSynchronizedRichIterable<T> implements RichIterabl
         }
     }
 
-    public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    public <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedMutableCollection.java
@@ -154,6 +154,15 @@ public abstract class AbstractSynchronizedMutableCollection<T> extends AbstractS
         }
     }
 
+    @Override
+    public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().groupByUniqueKey(function);
+        }
+    }
+
     public <K, V> MutableMap<K, V> aggregateInPlaceBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -98,33 +98,15 @@ public class CollectIterable<T, V>
     }
 
     @Override
-    public <P> boolean anySatisfyWith(Predicate2<? super V, ? super P> predicate, P parameter)
-    {
-        return this.anySatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean allSatisfy(Predicate<? super V> predicate)
     {
         return Iterate.allSatisfy(this.adapted, Predicates.attributePredicate(this.function, predicate));
     }
 
     @Override
-    public <P> boolean allSatisfyWith(Predicate2<? super V, ? super P> predicate, P parameter)
-    {
-        return this.allSatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean noneSatisfy(Predicate<? super V> predicate)
     {
         return Iterate.noneSatisfy(this.adapted, Predicates.attributePredicate(this.function, predicate));
-    }
-
-    @Override
-    public <P> boolean noneSatisfyWith(Predicate2<? super V, ? super P> predicate, P parameter)
-    {
-        return this.noneSatisfy(Predicates.bind(predicate, parameter));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/RejectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/RejectIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.Iterator;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
@@ -73,33 +72,15 @@ public class RejectIterable<T>
     }
 
     @Override
-    public <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.anySatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean allSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.allSatisfy(this.adapted, new AllSatisfyPredicate<T>(this.predicate, predicate));
     }
 
     @Override
-    public <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.allSatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean noneSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.noneSatisfy(this.adapted, new AllSatisfyPredicate<T>(this.predicate, predicate));
-    }
-
-    @Override
-    public <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.noneSatisfy(Predicates.bind(predicate, parameter));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.Iterator;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
@@ -71,33 +70,15 @@ public class SelectInstancesOfIterable<T>
     }
 
     @Override
-    public <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.anySatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean allSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.allSatisfy((Iterable<T>) this.adapted, new AllSatisfyPredicate<T>(Predicates.instanceOf(this.clazz), predicate));
     }
 
     @Override
-    public <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.allSatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean noneSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.noneSatisfy((Iterable<T>) this.adapted, new AllSatisfyPredicate<T>(Predicates.instanceOf(this.clazz), predicate));
-    }
-
-    @Override
-    public <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.noneSatisfy(Predicates.bind(predicate, parameter));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.Iterator;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
@@ -70,33 +69,15 @@ public class SelectIterable<T>
     }
 
     @Override
-    public <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.anySatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean allSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.allSatisfy(this.adapted, new AllSatisfyPredicate<T>(this.predicate, predicate));
     }
 
     @Override
-    public <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.allSatisfy(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public boolean noneSatisfy(Predicate<? super T> predicate)
     {
         return Iterate.noneSatisfy(this.adapted, new AllSatisfyPredicate<T>(this.predicate, predicate));
-    }
-
-    @Override
-    public <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return this.noneSatisfy(Predicates.bind(predicate, parameter));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/list/ListIterableParallelIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/list/ListIterableParallelIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -85,12 +85,6 @@ public final class ListIterableParallelIterable<T> extends AbstractParallelListI
     }
 
     @Override
-    public <V> ParallelListIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function)
-    {
-        return new ParallelFlatCollectListIterable<T, V>(this, function);
-    }
-
-    @Override
     public Object[] toArray()
     {
         // TODO: Implement in parallel
@@ -125,6 +119,7 @@ public final class ListIterableParallelIterable<T> extends AbstractParallelListI
         return this.delegate.groupByUniqueKey(function);
     }
 
+    @Override
     public int getBatchSize()
     {
         return this.batchSize;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectIterable.java
@@ -13,7 +13,6 @@ package org.eclipse.collections.impl.lazy.parallel.set;
 import java.util.concurrent.ExecutorService;
 
 import org.eclipse.collections.api.LazyIterable;
-import org.eclipse.collections.api.ParallelIterable;
 import org.eclipse.collections.api.annotation.Beta;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -81,12 +80,6 @@ public class ParallelCollectIterable<T, V> extends AbstractParallelIterableImpl<
     {
         T resultItem = this.delegate.detect(Predicates.attributePredicate(this.function, predicate));
         return resultItem == null ? null : this.function.valueOf(resultItem);
-    }
-
-    @Override
-    public <V1> ParallelIterable<V1> flatCollect(Function<? super V, ? extends Iterable<V1>> function)
-    {
-        return new ParallelFlatCollectIterable<V, V1>(this, function);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,6 +16,7 @@ import java.util.RandomAccess;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.FixedSizeList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
@@ -30,6 +31,13 @@ public abstract class AbstractMemoryEfficientMutableList<T>
     public FixedSizeList<T> clone()
     {
         return (FixedSizeList<T>) super.clone();
+    }
+
+    @Override
+    public FixedSizeList<T> tap(Procedure<? super T> procedure)
+    {
+        this.each(procedure);
+        return this;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/ArrayAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/ArrayAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -20,6 +20,7 @@ import java.util.Comparator;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.FixedSizeList;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -176,6 +177,13 @@ public final class ArrayAdapter<T>
         {
             Arrays.sort(this.items, 0, this.size(), comparator);
         }
+        return this;
+    }
+
+    @Override
+    public FixedSizeList<T> tap(Procedure<? super T> procedure)
+    {
+        this.each(procedure);
         return this;
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractSynchronizedMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractSynchronizedMapIterable.java
@@ -238,6 +238,31 @@ public abstract class AbstractSynchronizedMapIterable<K, V>
         }
     }
 
+    @Override
+    public <VV> MutableMapIterable<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().groupByUniqueKey(function);
+        }
+    }
+
+    public <KK, VV> MutableMapIterable<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
+        }
+    }
+
+    public <KK, VV> MutableMapIterable<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
+        }
+    }
+
     public RichIterable<Pair<K, V>> keyValuesView()
     {
         synchronized (this.lock)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractSynchronizedMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractSynchronizedMapIterable.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.collection.AbstractSynchronizedRichIterable;
@@ -247,7 +248,7 @@ public abstract class AbstractSynchronizedMapIterable<K, V>
         }
     }
 
-    public <KK, VV> MutableMapIterable<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator)
+    public <KK, VV> MutableMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator)
     {
         synchronized (this.lock)
         {
@@ -255,7 +256,7 @@ public abstract class AbstractSynchronizedMapIterable<K, V>
         }
     }
 
-    public <KK, VV> MutableMapIterable<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
+    public <KK, VV> MutableMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
@@ -74,6 +74,7 @@ import org.eclipse.collections.impl.utility.MapIterate;
 public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterable<K, V>
         implements MutableMap<K, V>
 {
+    @Override
     @SuppressWarnings("AbstractMethodOverridesAbstractMethod")
     public abstract MutableMap<K, V> clone();
 
@@ -318,5 +319,11 @@ public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterabl
     public <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function)
     {
         return this.groupByEach(function, HashBagMultimap.<VV, V>newMultimap());
+    }
+
+    @Override
+    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, UnifiedMap.<VV, V>newMap());
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
@@ -94,9 +94,9 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
         return newValue;
     }
 
-    public <V1> MutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
+    public <VV> MutableMapIterable<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.<VV, V>newMap());
     }
 
     public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -1932,6 +1932,13 @@ public final class ConcurrentHashMap<K, V>
     public MutableMap<K, V> newEmpty()
     {
         return ConcurrentHashMap.newMap();
+    }
+
+    @Override
+    public ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure)
+    {
+        this.each(procedure);
+        return this;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -2053,6 +2053,13 @@ public class ConcurrentHashMapUnsafe<K, V>
     public MutableMap<K, V> newEmpty()
     {
         return ConcurrentHashMapUnsafe.newMap();
+    }
+
+    @Override
+    public ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure)
+    {
+        this.each(procedure);
+        return this;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -191,6 +191,13 @@ public final class ConcurrentMutableHashMap<K, V>
     public MutableMap<K, V> newEmpty()
     {
         return ConcurrentMutableHashMap.newMap();
+    }
+
+    @Override
+    public ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure)
+    {
+        this.each(procedure);
+        return this;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
@@ -27,7 +27,6 @@ import org.eclipse.collections.api.bag.primitive.MutableIntBag;
 import org.eclipse.collections.api.bag.primitive.MutableLongBag;
 import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -40,7 +39,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
@@ -428,30 +426,6 @@ public class SynchronizedMutableMap<K, V>
         synchronized (this.lock)
         {
             return this.getDelegate().groupByUniqueKey(function);
-        }
-    }
-
-    @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
-    {
-        synchronized (this.lock)
-        {
-            return this.getDelegate().aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
-        }
-    }
-
-    @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
-    {
-        synchronized (this.lock)
-        {
-            return this.getDelegate().aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
@@ -422,6 +422,16 @@ public class SynchronizedMutableMap<K, V>
         }
     }
 
+    @Override
+    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().groupByUniqueKey(function);
+        }
+    }
+
+    @Override
     public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
             Function<? super V, ? extends K2> groupBy,
             Function0<? extends V2> zeroValueFactory,
@@ -433,6 +443,7 @@ public class SynchronizedMutableMap<K, V>
         }
     }
 
+    @Override
     public <K2, V2> MutableMap<K2, V2> aggregateBy(
             Function<? super V, ? extends K2> groupBy,
             Function0<? extends V2> zeroValueFactory,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableBooleanValuesMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableBooleanValuesMap.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.LazyBooleanIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ObjectBooleanToObjectFunction;
@@ -26,11 +27,12 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.map.primitive.MutableBooleanValuesMap;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.collection.mutable.primitive.SynchronizedBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBooleanCollection;
+import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.lazy.primitive.LazyBooleanIterableAdapter;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.primitive.AbstractBooleanIterable;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 
@@ -229,9 +231,9 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
         }
     }
 
-    public MutableBooleanCollection select(BooleanPredicate predicate)
+    public MutableBooleanBag select(BooleanPredicate predicate)
     {
-        MutableBooleanList result = BooleanLists.mutable.empty();
+        MutableBooleanBag result = BooleanBags.mutable.empty();
 
         if (this.getSentinelValues() != null)
         {
@@ -255,9 +257,9 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
         return result;
     }
 
-    public MutableBooleanCollection reject(BooleanPredicate predicate)
+    public MutableBooleanBag reject(BooleanPredicate predicate)
     {
-        MutableBooleanList result = BooleanLists.mutable.empty();
+        MutableBooleanBag result = BooleanBags.mutable.empty();
         if (this.getSentinelValues() != null)
         {
             if (this.getSentinelValues().containsZeroKey && !predicate.accept(this.getSentinelValues().zeroValue))
@@ -277,6 +279,30 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
             }
         }
         return result;
+    }
+
+    public <V> MutableBag<V> collect(BooleanToObjectFunction<? extends V> function)
+    {
+        MutableBag<V> target = HashBag.newBag(this.size());
+        if (this.getSentinelValues() != null)
+        {
+            if (this.getSentinelValues().containsZeroKey)
+            {
+                target.add(function.valueOf(this.getSentinelValues().zeroValue));
+            }
+            if (this.getSentinelValues().containsOneKey)
+            {
+                target.add(function.valueOf(this.getSentinelValues().oneValue));
+            }
+        }
+        for (int i = 0; i < this.getTableSize(); i++)
+        {
+            if (this.isNonSentinelAtIndex(i))
+            {
+                target.add(function.valueOf(this.getValueAtIndex(i)));
+            }
+        }
+        return target;
     }
 
     public boolean detectIfNone(BooleanPredicate predicate, boolean value)
@@ -300,30 +326,6 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
             }
         }
         return value;
-    }
-
-    public <V> MutableCollection<V> collect(BooleanToObjectFunction<? extends V> function)
-    {
-        FastList<V> target = FastList.newList(this.size());
-        if (this.getSentinelValues() != null)
-        {
-            if (this.getSentinelValues().containsZeroKey)
-            {
-                target.add(function.valueOf(this.getSentinelValues().zeroValue));
-            }
-            if (this.getSentinelValues().containsOneKey)
-            {
-                target.add(function.valueOf(this.getSentinelValues().oneValue));
-            }
-        }
-        for (int i = 0; i < this.getTableSize(); i++)
-        {
-            if (this.isNonSentinelAtIndex(i))
-            {
-                target.add(function.valueOf(this.getValueAtIndex(i)));
-            }
-        }
-        return target;
     }
 
     public int count(BooleanPredicate predicate)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/AbstractMutableSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/AbstractMutableSortedMap.java
@@ -34,6 +34,7 @@ import org.eclipse.collections.api.list.primitive.MutableFloatList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
@@ -68,6 +69,7 @@ import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.map.mutable.AbstractMutableMapIterable;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.partition.list.PartitionFastList;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -309,6 +311,12 @@ public abstract class AbstractMutableSortedMap<K, V> extends AbstractMutableMapI
     public <VV> MutableListMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function)
     {
         return this.groupByEach(function, FastListMultimap.<VV, V>newMultimap());
+    }
+
+    @Override
+    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, UnifiedMap.<VV, V>newMap());
     }
 
     public void reverseForEach(Procedure<? super V> procedure)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
@@ -434,6 +434,16 @@ public class SynchronizedSortedMap<K, V>
         }
     }
 
+    @Override
+    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().groupByUniqueKey(function);
+        }
+    }
+
+    @Override
     public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
             Function<? super V, ? extends K2> groupBy,
             Function0<? extends V2> zeroValueFactory,
@@ -445,6 +455,7 @@ public class SynchronizedSortedMap<K, V>
         }
     }
 
+    @Override
     public <K2, V2> MutableMap<K2, V2> aggregateBy(
             Function<? super V, ? extends K2> groupBy,
             Function0<? extends V2> zeroValueFactory,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
@@ -17,7 +17,6 @@ import java.util.SortedMap;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -30,7 +29,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
@@ -440,30 +438,6 @@ public class SynchronizedSortedMap<K, V>
         synchronized (this.lock)
         {
             return this.getDelegate().groupByUniqueKey(function);
-        }
-    }
-
-    @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
-    {
-        synchronized (this.getLock())
-        {
-            return this.getDelegate().aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
-        }
-    }
-
-    @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
-    {
-        synchronized (this.getLock())
-        {
-            return this.getDelegate().aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -207,7 +207,7 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
         this.getMap().forEachKey(procedure);
     }
 
-    public void forEachKeyValue(final Procedure2<K, V> procedure)
+    public void forEachKeyValue(final Procedure2<? super K, ? super V> procedure)
     {
         final Procedure2<V, K> innerProcedure = new Procedure2<V, K>()
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
@@ -226,7 +226,7 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
         });
     }
 
-    public void forEachKeyMultiValues(Procedure2<K, ? super Iterable<V>> procedure)
+    public void forEachKeyMultiValues(Procedure2<? super K, ? super Iterable<V>> procedure)
     {
         this.getMap().forEachKeyValue(procedure);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
@@ -49,7 +49,6 @@ import org.eclipse.collections.impl.AbstractRichIterable;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.set.mutable.SynchronizedMutableSet;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
@@ -314,12 +313,6 @@ public abstract class AbstractUnifiedSet<T>
     public boolean retainAll(Collection<?> collection)
     {
         return this.retainAllIterable(collection);
-    }
-
-    public <V> UnifiedSetMultimap<V, T> groupByEach(
-            Function<? super T, ? extends Iterable<V>> function)
-    {
-        return this.groupByEach(function, UnifiedSetMultimap.<V, T>newMultimap());
     }
 
     public <V> MutableMap<V, T> groupByUniqueKey(

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.set.FixedSizeSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
@@ -107,6 +108,13 @@ abstract class AbstractMemoryEfficientMutableSet<T>
             return this;
         }
         return Sets.fixedSize.ofAll(this.toList().withoutAll(elements));
+    }
+
+    @Override
+    public FixedSizeSet<T> tap(Procedure<? super T> procedure)
+    {
+        this.each(procedure);
+        return this;
     }
 
     protected abstract class MemoryEfficientSetIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
@@ -1859,6 +1859,11 @@ public class UnifiedSet<T>
         return this.groupBy(function, UnifiedSetMultimap.<V, T>newMultimap());
     }
 
+    public <V> UnifiedSetMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
+    {
+        return this.groupByEach(function, new UnifiedSetMultimap<V, T>());
+    }
+
     public T get(T key)
     {
         int index = this.index(key);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -54,7 +54,6 @@ import org.eclipse.collections.impl.lazy.parallel.set.AbstractParallelUnsortedSe
 import org.eclipse.collections.impl.lazy.parallel.set.RootUnsortedSetBatch;
 import org.eclipse.collections.impl.lazy.parallel.set.SelectUnsortedSetBatch;
 import org.eclipse.collections.impl.lazy.parallel.set.UnsortedSetBatch;
-import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.multimap.set.strategy.UnifiedSetWithHashingStrategyMultimap;
 import org.eclipse.collections.impl.partition.set.strategy.PartitionUnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.set.AbstractUnifiedSet;
@@ -1897,10 +1896,9 @@ public class UnifiedSetWithHashingStrategy<T>
         return this.groupBy(function, UnifiedSetWithHashingStrategyMultimap.<V, T>newMultimap(this.hashingStrategy));
     }
 
-    public <V> UnifiedSetMultimap<V, T> groupByEach(
-            Function<? super T, ? extends Iterable<V>> function)
+    public <V> UnifiedSetWithHashingStrategyMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
     {
-        return this.groupByEach(function, UnifiedSetMultimap.<V, T>newMultimap());
+        return this.groupByEach(function, UnifiedSetWithHashingStrategyMultimap.<V, T>newMultimap(this.hashingStrategy));
     }
 
     public T get(T key)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -39,6 +39,7 @@ import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -56,13 +57,13 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.stack.PartitionImmutableStack;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
@@ -329,7 +330,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
         return partitionMutableStack.toImmutable();
     }
 
-    public <S> RichIterable<S> selectInstancesOf(Class<S> clazz)
+    public <S> ImmutableStack<S> selectInstancesOf(Class<S> clazz)
     {
         return ImmutableArrayStack.newStackFromTopToBottom(this.delegate.asReversed().selectInstancesOf(clazz).toList());
     }
@@ -797,18 +798,18 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
         return this.delegate.asReversed().chunk(size);
     }
 
-    public <K, V> MapIterable<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
+    public <K, V> ImmutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
     {
         MutableMap<K, V> map = UnifiedMap.newMap();
         this.forEach(new MutatingAggregationProcedure<T, K, V>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
+        return map.toImmutable();
     }
 
-    public <K, V> MapIterable<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    public <K, V> ImmutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
     {
         MutableMap<K, V> map = UnifiedMap.newMap();
         this.forEach(new NonMutatingAggregationProcedure<T, K, V>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
+        return map.toImmutable();
     }
 
     public int size()
@@ -850,6 +851,61 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     public <P> void forEachWith(Procedure2<? super T, ? super P> procedure, P parameter)
     {
         this.delegate.asReversed().forEachWith(procedure, parameter);
+    }
+
+    public ImmutableStack<T> takeWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".takeWhile() not implemented yet");
+    }
+
+    public ImmutableStack<T> dropWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".dropWhile() not implemented yet");
+    }
+
+    public PartitionImmutableStack<T> partitionWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".partitionWhile() not implemented yet");
+    }
+
+    public ImmutableStack<T> distinct()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".distinct() not implemented yet");
+    }
+
+    public int indexOf(Object object)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public <S> boolean corresponds(OrderedIterable<S> other, Predicate2<? super T, ? super S> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".corresponds() not implemented yet");
+    }
+
+    public boolean hasSameElements(OrderedIterable<T> other)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".hasSameElements() not implemented yet");
+    }
+
+    public void forEach(int startIndex, int endIndex, Procedure<? super T> procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEach() not implemented yet");
+    }
+
+    public void forEachWithIndex(int fromIndex, int toIndex, ObjectIntProcedure<? super T> objectIntProcedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
+    }
+
+    public <V> ImmutableStack<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".collectWithIndex() not implemented yet");
+    }
+
+    public int detectIndex(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".detectIndex() not implemented yet");
     }
 
     public Iterator<T> iterator()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -37,6 +37,7 @@ import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -59,6 +60,7 @@ import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.stack.PartitionMutableStack;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
@@ -987,5 +989,60 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
         MutableMap<K, V> map = UnifiedMap.newMap();
         this.forEach(new NonMutatingAggregationProcedure<T, K, V>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
         return map;
+    }
+
+    public MutableStack<T> takeWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".takeWhile() not implemented yet");
+    }
+
+    public MutableStack<T> dropWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".dropWhile() not implemented yet");
+    }
+
+    public PartitionMutableStack<T> partitionWhile(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".partitionWhile() not implemented yet");
+    }
+
+    public MutableStack<T> distinct()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".distinct() not implemented yet");
+    }
+
+    public int indexOf(Object object)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public <S> boolean corresponds(OrderedIterable<S> other, Predicate2<? super T, ? super S> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".corresponds() not implemented yet");
+    }
+
+    public boolean hasSameElements(OrderedIterable<T> other)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".hasSameElements() not implemented yet");
+    }
+
+    public void forEach(int startIndex, int endIndex, Procedure<? super T> procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEach() not implemented yet");
+    }
+
+    public void forEachWithIndex(int fromIndex, int toIndex, ObjectIntProcedure<? super T> objectIntProcedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
+    }
+
+    public <V> MutableStack<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".collectWithIndex() not implemented yet");
+    }
+
+    public int detectIndex(Predicate<? super T> predicate)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".detectIndex() not implemented yet");
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
@@ -33,6 +33,7 @@ import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.IntObjectToIntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.LongObjectToLongFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -55,6 +56,7 @@ import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.stack.PartitionMutableStack;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
@@ -71,9 +73,6 @@ import org.eclipse.collections.api.stack.primitive.MutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
 import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 
@@ -162,7 +161,7 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
         return this.mutableStack.partitionWith(predicate, parameter);
     }
 
-    public <S> RichIterable<S> selectInstancesOf(Class<S> clazz)
+    public <S> MutableStack<S> selectInstancesOf(Class<S> clazz)
     {
         return this.mutableStack.selectInstancesOf(clazz);
     }
@@ -572,6 +571,11 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
         return this.mutableStack.max();
     }
 
+    public int detectIndex(Predicate<? super T> predicate)
+    {
+        return this.mutableStack.detectIndex(predicate);
+    }
+
     public <V extends Comparable<? super V>> T minBy(Function<? super T, ? extends V> function)
     {
         return this.mutableStack.minBy(function);
@@ -743,6 +747,16 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
         this.mutableStack.forEachWithIndex(objectIntProcedure);
     }
 
+    public void forEachWithIndex(int fromIndex, int toIndex, ObjectIntProcedure<? super T> objectIntProcedure)
+    {
+        this.mutableStack.forEachWithIndex(fromIndex, toIndex, objectIntProcedure);
+    }
+
+    public <V> MutableStack<V> collectWithIndex(ObjectIntToObjectFunction<? super T, ? extends V> function)
+    {
+        return this.mutableStack.collectWithIndex(function);
+    }
+
     public <P> void forEachWith(Procedure2<? super T, ? super P> procedure, P parameter)
     {
         this.mutableStack.forEachWith(procedure, parameter);
@@ -775,9 +789,7 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
             Function0<? extends V> zeroValueFactory,
             Procedure2<? super V, ? super T> mutatingAggregator)
     {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<T, K, V>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
+        return this.mutableStack.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
     }
 
     public <K, V> MutableMap<K, V> aggregateBy(
@@ -785,8 +797,41 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
             Function0<? extends V> zeroValueFactory,
             Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
     {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<T, K, V>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
+        return this.mutableStack.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
+    }
+
+    public int indexOf(Object object)
+    {
+        return this.mutableStack.indexOf(object);
+    }
+
+    public <S> boolean corresponds(OrderedIterable<S> other, Predicate2<? super T, ? super S> predicate)
+    {
+        return this.mutableStack.corresponds(other, predicate);
+    }
+
+    public void forEach(int startIndex, int endIndex, Procedure<? super T> procedure)
+    {
+        this.mutableStack.forEach(startIndex, endIndex, procedure);
+    }
+
+    public MutableStack<T> takeWhile(Predicate<? super T> predicate)
+    {
+        return this.mutableStack.takeWhile(predicate);
+    }
+
+    public MutableStack<T> dropWhile(Predicate<? super T> predicate)
+    {
+        return this.mutableStack.dropWhile(predicate);
+    }
+
+    public PartitionMutableStack<T> partitionWhile(Predicate<? super T> predicate)
+    {
+        return this.mutableStack.partitionWhile(predicate);
+    }
+
+    public MutableStack<T> distinct()
+    {
+        return this.mutableStack.distinct();
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStack.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.LazyBooleanIterable;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
+import org.eclipse.collections.api.block.function.primitive.ObjectBooleanIntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.ObjectBooleanToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
+import org.eclipse.collections.api.block.procedure.primitive.BooleanIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.BooleanProcedure;
 import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
@@ -149,12 +151,12 @@ public final class BooleanArrayStack implements MutableBooleanStack, Externaliza
 
     public MutableBooleanStack select(BooleanPredicate predicate)
     {
-        return newStackFromTopToBottom(this.delegate.asReversed().select(predicate));
+        return BooleanArrayStack.newStackFromTopToBottom(this.delegate.asReversed().select(predicate));
     }
 
     public MutableBooleanStack reject(BooleanPredicate predicate)
     {
-        return newStackFromTopToBottom(this.delegate.asReversed().reject(predicate));
+        return BooleanArrayStack.newStackFromTopToBottom(this.delegate.asReversed().reject(predicate));
     }
 
     public MutableBooleanStack asUnmodifiable()
@@ -378,6 +380,26 @@ public final class BooleanArrayStack implements MutableBooleanStack, Externaliza
             String end)
     {
         this.delegate.asReversed().appendString(appendable, start, separator, end);
+    }
+
+    public boolean getFirst()
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".getFirst() not implemented yet");
+    }
+
+    public int indexOf(boolean value)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".indexOf() not implemented yet");
+    }
+
+    public <T> T injectIntoWithIndex(T injectedValue, ObjectBooleanIntToObjectFunction<? super T, ? extends T> function)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".injectIntoWithIndex() not implemented yet");
+    }
+
+    public void forEachWithIndex(BooleanIntProcedure procedure)
+    {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
     }
 
     public MutableBooleanList toList()


### PR DESCRIPTION
- Remove unnecessary overrides of anySatisfyWith, allSatisfyWith, and noneSatisfyWith from AbstractRichIterable.
- Remove unnecessary overrides of ParallelIterable.flatCollect().
- Change AbstractSynchronizedRichIterable.groupByUniqueKey() to return MapIterable instead of MutableMap.
- Change AbstractMutableMapIterable.groupByUniqueKey() to return MutableMapIterable instead of MutableMap.
- Change MutableMapIterable.aggregateBy() to return MutableMap instead of MutableMapIterable.
- Fix return types on MapIterable.collect(Function2) overrides.
- Fix return type of UnifiedSetWithHashingStrategy.groupByEach() method to preserve hashing strategy.
- Fix generics on Multimap.forEachKeyValue().
- Fix generics on Multimap.forEachKeyMultiValues().
- Add missing overrides for collect() in OrderedMaps.
- Add missing override UnsortedMapIterable.partitionWith().
- Add missing overrides of RichIterable.tap().
- Make StackIterable implement OrderedIterable.
- Make primitive-object maps more bag-like. Change the filtering and transformation methods to return bags since they contain duplicates and no meaningful order.
