### PR TITLE
Implement LazyIterable.takeWhile(Predicate) and LazyIterable.dropWhile(Predicate).

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -19,6 +19,7 @@ Optimizations
 Bug fixes
 ---------
 
+* Fixed Interval.take(int count) when count is 0. Old behavior was to return an Interval of size 1. This is a behavior breaking change.
 * Changed AbstractSynchronizedRichIterable.groupByUniqueKey() to return MapIterable instead of MutableMap.
 * Changed AbstractMutableMapIterable.groupByUniqueKey() to return MutableMapIterable instead of MutableMap.
 * Changed MutableMapIterable.aggregateBy() to return MutableMap instead of MutableMapIterable.

--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -8,6 +8,7 @@ New Functionality
 * Implemented Bags.mutable.ofAll(Iterable<? extends T> items) and Bags.mutable.withAll(Iterable<? extends T> items).
 * Implemented Multimap.keySet() to return an unmodifiable SetIterable of keys.
 * Implemented MutableMultimap.putAllPairs(Iterable<Pair<K, V>> keyValuePairs).
+* Implemented LazyIterable.takeWhile(Predicate<? super T> predicate) and LazyIterable.dropWhile(Predicate<? super T> predicate).
 * Pull up into() from LazyIterable to RichIterable.
 * Made StackIterable implement OrderedIterable.
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/LazyIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/LazyIterable.java
@@ -25,6 +25,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.tuple.Pair;
 
 /**
@@ -78,6 +79,18 @@ public interface LazyIterable<T>
      * Creates a deferred drop iterable for the current iterable using the specified count as the limit.
      */
     LazyIterable<T> drop(int count);
+
+    /**
+     * @see OrderedIterable#takeWhile(Predicate)
+     * @since 8.0
+     */
+    LazyIterable<T> takeWhile(Predicate<? super T> predicate);
+
+    /**
+     * @see OrderedIterable#dropWhile(Predicate)
+     * @since 8.0
+     */
+    LazyIterable<T> dropWhile(Predicate<? super T> predicate);
 
     /**
      * Creates a deferred distinct iterable to get distinct elements from the current iterable.

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/DropWhileIterablePredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/DropWhileIterablePredicate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.predicate;
+
+import org.eclipse.collections.api.block.predicate.Predicate;
+
+/**
+ * @since 8.0
+ */
+public class DropWhileIterablePredicate<T> implements Predicate<T>
+{
+    private static final long serialVersionUID = 1L;
+
+    private final Predicate<? super T> predicate;
+    private boolean doneDroppingElements;
+
+    public DropWhileIterablePredicate(Predicate<? super T> predicate)
+    {
+        this.predicate = predicate;
+    }
+
+    public boolean accept(T each)
+    {
+        if (!this.doneDroppingElements && !this.predicate.accept(each))
+        {
+            this.doneDroppingElements = true;
+        }
+        return this.doneDroppingElements;
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/AbstractLazyIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/AbstractLazyIterable.java
@@ -233,6 +233,16 @@ public abstract class AbstractLazyIterable<T>
         return LazyIterate.drop(this, count);
     }
 
+    public LazyIterable<T> takeWhile(Predicate<? super T> predicate)
+    {
+        return LazyIterate.takeWhile(this, predicate);
+    }
+
+    public LazyIterable<T> dropWhile(Predicate<? super T> predicate)
+    {
+        return LazyIterate.dropWhile(this, predicate);
+    }
+
     public LazyIterable<T> distinct()
     {
         return LazyIterate.distinct(this);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropIterable.java
@@ -22,7 +22,7 @@ import org.eclipse.collections.impl.block.predicate.DropIterablePredicate;
 import org.eclipse.collections.impl.block.procedure.IfObjectIntProcedure;
 import org.eclipse.collections.impl.block.procedure.IfProcedure;
 import org.eclipse.collections.impl.block.procedure.IfProcedureWith;
-import org.eclipse.collections.impl.lazy.iterator.DropIterator;
+import org.eclipse.collections.impl.lazy.iterator.SelectIterator;
 import org.eclipse.collections.impl.utility.Iterate;
 
 /**
@@ -88,6 +88,6 @@ public class DropIterable<T> extends AbstractLazyIterable<T>
 
     public Iterator<T> iterator()
     {
-        return new DropIterator<T>(this.adapted, this.count);
+        return new SelectIterator<T>(this.adapted.iterator(), new DropIterablePredicate<T>(this.count));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropWhileIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropWhileIterable.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy;
+
+import java.util.Iterator;
+
+import net.jcip.annotations.Immutable;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.block.predicate.DropWhileIterablePredicate;
+import org.eclipse.collections.impl.block.procedure.IfObjectIntProcedure;
+import org.eclipse.collections.impl.block.procedure.IfProcedure;
+import org.eclipse.collections.impl.block.procedure.IfProcedureWith;
+import org.eclipse.collections.impl.lazy.iterator.SelectIterator;
+import org.eclipse.collections.impl.utility.Iterate;
+
+/**
+ * Iterates over the elements of the adapted Iterable skipping the first elements until the predicate returns false.
+ *
+ * @since 8.0
+ */
+@Immutable
+public class DropWhileIterable<T> extends AbstractLazyIterable<T>
+{
+    private final Iterable<T> adapted;
+    private final Predicate<? super T> predicate;
+
+    public DropWhileIterable(Iterable<T> newAdapted, Predicate<? super T> predicate)
+    {
+        if (predicate == null)
+        {
+            throw new IllegalStateException("Predicate cannot be null");
+        }
+        this.adapted = newAdapted;
+        this.predicate = predicate;
+    }
+
+    public void each(Procedure<? super T> procedure)
+    {
+        Iterate.forEach(this.adapted, new IfProcedure<T>(new DropWhileIterablePredicate<T>(this.predicate), procedure));
+    }
+
+    @Override
+    public void forEachWithIndex(ObjectIntProcedure<? super T> objectIntProcedure)
+    {
+        Iterate.forEach(this.adapted, new IfObjectIntProcedure<T>(new DropWhileIterablePredicate<T>(this.predicate), objectIntProcedure));
+    }
+
+    @Override
+    public <P> void forEachWith(Procedure2<? super T, ? super P> procedure, P parameter)
+    {
+        Iterate.forEachWith(this.adapted, new IfProcedureWith<T, P>(new DropWhileIterablePredicate<T>(this.predicate), procedure), parameter);
+    }
+
+    @Override
+    public boolean anySatisfy(Predicate<? super T> predicate)
+    {
+        return Iterate.anySatisfy(this.adapted, Predicates.and(new DropWhileIterablePredicate<T>(this.predicate), predicate));
+    }
+
+    @Override
+    public boolean allSatisfy(Predicate<? super T> predicate)
+    {
+        return Iterate.allSatisfy(this.adapted, Predicates.or(Predicates.not(new DropWhileIterablePredicate<T>(this.predicate)), predicate));
+    }
+
+    @Override
+    public boolean noneSatisfy(Predicate<? super T> predicate)
+    {
+        return Iterate.noneSatisfy(this.adapted, Predicates.and(new DropWhileIterablePredicate<T>(this.predicate), predicate));
+    }
+
+    @Override
+    public T detect(Predicate<? super T> predicate)
+    {
+        return Iterate.detect(this.adapted, Predicates.and(new DropWhileIterablePredicate<T>(this.predicate), predicate));
+    }
+
+    public Iterator<T> iterator()
+    {
+        return new SelectIterator<T>(this.adapted.iterator(), new DropWhileIterablePredicate<T>(this.predicate));
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/LazyIterableAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/LazyIterableAdapter.java
@@ -111,6 +111,18 @@ public class LazyIterableAdapter<T>
     }
 
     @Override
+    public LazyIterable<T> takeWhile(Predicate<? super T> predicate)
+    {
+        return LazyIterate.takeWhile(this.adapted, predicate);
+    }
+
+    @Override
+    public LazyIterable<T> dropWhile(Predicate<? super T> predicate)
+    {
+        return LazyIterate.dropWhile(this.adapted, predicate);
+    }
+
+    @Override
     public LazyIterable<T> distinct()
     {
         return LazyIterate.distinct(this.adapted);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/TakeWhileIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/TakeWhileIterable.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy;
+
+import java.util.Iterator;
+
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
+import org.eclipse.collections.impl.lazy.iterator.TakeWhileIterator;
+
+/**
+ * Iterates over the elements of the adapted Iterable until the predicate returns false.
+ *
+ * @since 8.0
+ */
+public class TakeWhileIterable<T> extends AbstractLazyIterable<T>
+{
+    private final Iterable<T> adapted;
+    private final Predicate<? super T> predicate;
+
+    public TakeWhileIterable(Iterable<T> newAdapted, Predicate<? super T> predicate)
+    {
+        if (predicate == null)
+        {
+            throw new IllegalStateException("Predicate cannot be null");
+        }
+        this.adapted = newAdapted;
+        this.predicate = predicate;
+    }
+
+    public void each(Procedure<? super T> procedure)
+    {
+        for (T each : this.adapted)
+        {
+            if (!this.predicate.accept(each))
+            {
+                return;
+            }
+            procedure.value(each);
+        }
+    }
+
+    @Override
+    public void forEachWithIndex(ObjectIntProcedure<? super T> procedure)
+    {
+        int i = 0;
+        for (T each : this.adapted)
+        {
+            if (!this.predicate.accept(each))
+            {
+                return;
+            }
+            procedure.value(each, i);
+            i++;
+        }
+    }
+
+    @Override
+    public <P> void forEachWith(Procedure2<? super T, ? super P> procedure, P parameter)
+    {
+        for (T each : this.adapted)
+        {
+            if (!this.predicate.accept(each))
+            {
+                return;
+            }
+            procedure.value(each, parameter);
+        }
+    }
+
+    public Iterator<T> iterator()
+    {
+        return new TakeWhileIterator<T>(this.adapted, this.predicate);
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/iterator/DropIterator.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/iterator/DropIterator.java
@@ -13,13 +13,17 @@ package org.eclipse.collections.impl.lazy.iterator;
 import java.util.Iterator;
 
 import net.jcip.annotations.Immutable;
+import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.impl.block.predicate.DropIterablePredicate;
 
 /**
  * Iterates over the elements of the iterator skipping the first count elements or the full iterator if the count is
  * non-positive.
+ *
+ * @deprecated in 8.0. Use {@link SelectIterator#SelectIterator(Iterable, Predicate)} with {@link DropIterablePredicate#DropIterablePredicate(int)} as a predicate instead.
  */
 @Immutable
+@Deprecated
 public final class DropIterator<T> implements Iterator<T>
 {
     private final Iterator<T> delegateIterator;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIterator.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIterator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.eclipse.collections.api.block.predicate.Predicate;
+
+/**
+ * Iterates over the elements of the iterator until predicate returns false.
+ *
+ * @since 8.0
+ */
+public final class TakeWhileIterator<T> implements Iterator<T>
+{
+    private static final Object NULL = new Object();
+    private final Iterator<T> iterator;
+    private final Predicate<? super T> predicate;
+
+    private boolean terminate;
+    private Object next = NULL;
+
+    public TakeWhileIterator(Iterable<T> iterable, Predicate<? super T> predicate)
+    {
+        this(iterable.iterator(), predicate);
+    }
+
+    public TakeWhileIterator(Iterator<T> iterator, Predicate<? super T> predicate)
+    {
+        this.iterator = iterator;
+        this.predicate = predicate;
+    }
+
+    public boolean hasNext()
+    {
+        if (this.next != NULL)
+        {
+            return true;
+        }
+        if (!this.terminate && this.iterator.hasNext())
+        {
+            T temp = this.iterator.next();
+            if (this.predicate.accept(temp))
+            {
+                this.next = temp;
+                return true;
+            }
+
+            this.terminate = true;
+            this.next = NULL;
+        }
+        return false;
+    }
+
+    public T next()
+    {
+        if (this.hasNext())
+        {
+            Object temp = this.next;
+            this.next = NULL;
+            return (T) temp;
+        }
+        throw new NoSuchElementException();
+    }
+
+    public void remove()
+    {
+        throw new UnsupportedOperationException("Cannot remove from a takeWhile iterator");
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
@@ -1052,7 +1052,7 @@ public final class Interval
     }
 
     @Override
-    public Interval take(int count)
+    public LazyIterable<Integer> take(int count)
     {
         if (count < 0)
         {
@@ -1063,7 +1063,7 @@ public final class Interval
         {
             return Interval.fromToBy(this.from, this.locationAfterN(count - 1), this.step);
         }
-        return Interval.fromToBy(this.from, this.from, this.step);
+        return Lists.immutable.<Integer>empty().asLazy();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
@@ -52,7 +52,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred rich iterable for the specified iterable
+     * Creates a deferred rich iterable for the specified iterable.
      */
     public static <T> LazyIterable<T> adapt(Iterable<T> iterable)
     {
@@ -60,7 +60,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred filtering iterable for the specified iterable
+     * Creates a deferred filtering iterable for the specified iterable.
      */
     public static <T> LazyIterable<T> select(Iterable<T> iterable, Predicate<? super T> predicate)
     {
@@ -68,7 +68,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred negative filtering iterable for the specified iterable
+     * Creates a deferred negative filtering iterable for the specified iterable.
      */
     public static <T> LazyIterable<T> reject(Iterable<T> iterable, Predicate<? super T> predicate)
     {
@@ -81,7 +81,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred transforming iterable for the specified iterable
+     * Creates a deferred transforming iterable for the specified iterable.
      */
     public static <T, V> LazyIterable<V> collect(
             Iterable<T> iterable,
@@ -91,7 +91,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred flattening iterable for the specified iterable
+     * Creates a deferred flattening iterable for the specified iterable.
      */
     public static <T, V> LazyIterable<V> flatCollect(
             Iterable<T> iterable,
@@ -101,7 +101,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred filtering and transforming iterable for the specified iterable
+     * Creates a deferred filtering and transforming iterable for the specified iterable.
      */
     public static <T, V> LazyIterable<V> collectIf(
             Iterable<T> iterable,
@@ -112,7 +112,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred take iterable for the specified iterable using the specified count as the limit
+     * Creates a deferred take iterable for the specified iterable using the specified count as the limit.
      */
     public static <T> LazyIterable<T> take(Iterable<T> iterable, int count)
     {
@@ -120,7 +120,7 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred drop iterable for the specified iterable using the specified count as the size to drop
+     * Creates a deferred drop iterable for the specified iterable using the specified count as the size to drop.
      */
     public static <T> LazyIterable<T> drop(Iterable<T> iterable, int count)
     {
@@ -160,7 +160,7 @@ public final class LazyIterate
     }
 
     /**
-     * Combines iterables into a deferred composite iterable
+     * Combines iterables into a deferred composite iterable.
      */
     public static <T> LazyIterable<T> concatenate(Iterable<T>... iterables)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
@@ -22,12 +22,14 @@ import org.eclipse.collections.impl.lazy.CollectIterable;
 import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.lazy.DistinctIterable;
 import org.eclipse.collections.impl.lazy.DropIterable;
+import org.eclipse.collections.impl.lazy.DropWhileIterable;
 import org.eclipse.collections.impl.lazy.FlatCollectIterable;
 import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
 import org.eclipse.collections.impl.lazy.RejectIterable;
 import org.eclipse.collections.impl.lazy.SelectInstancesOfIterable;
 import org.eclipse.collections.impl.lazy.SelectIterable;
 import org.eclipse.collections.impl.lazy.TakeIterable;
+import org.eclipse.collections.impl.lazy.TakeWhileIterable;
 import org.eclipse.collections.impl.lazy.TapIterable;
 import org.eclipse.collections.impl.lazy.ZipIterable;
 import org.eclipse.collections.impl.lazy.ZipWithIndexIterable;
@@ -126,7 +128,29 @@ public final class LazyIterate
     }
 
     /**
-     * Creates a deferred distinct iterable for the specified iterable
+     * Creates a deferred takeWhile iterable for the specified iterable using the specified predicate.
+     * Short circuits at the first element which does not satisfy the Predicate.
+     *
+     * @since 8.0
+     */
+    public static <T> LazyIterable<T> takeWhile(Iterable<T> iterable, Predicate<? super T> predicate)
+    {
+        return new TakeWhileIterable<T>(iterable, predicate);
+    }
+
+    /**
+     * Creates a deferred dropWhile iterable for the specified iterable using the specified count as the size to drop.
+     * Short circuits at the first element which satisfies the Predicate.
+     *
+     * @since 8.0
+     */
+    public static <T> LazyIterable<T> dropWhile(Iterable<T> iterable, Predicate<? super T> predicate)
+    {
+        return new DropWhileIterable<T>(iterable, predicate);
+    }
+
+    /**
+     * Creates a deferred distinct iterable for the specified iterable.
      *
      * @since 5.0
      */

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/predicate/DropWhileIterablePredicateSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/predicate/DropWhileIterablePredicateSerializationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.predicate;
+
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class DropWhileIterablePredicateSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByZWRpY2F0ZS5Ecm9w\n"
+                        + "V2hpbGVJdGVyYWJsZVByZWRpY2F0ZQAAAAAAAAABAgACWgAUZG9uZURyb3BwaW5nRWxlbWVudHNM\n"
+                        + "AAlwcmVkaWNhdGV0ADdMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL2Jsb2NrL3ByZWRpY2F0\n"
+                        + "ZS9QcmVkaWNhdGU7eHAAc3IAQG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwuYmxvY2suZmFj\n"
+                        + "dG9yeS5QcmVkaWNhdGVzJEFsd2F5c1RydWUAAAAAAAAAAQIAAHhyADVvcmcuZWNsaXBzZS5jb2xs\n"
+                        + "ZWN0aW9ucy5pbXBsLmJsb2NrLmZhY3RvcnkuUHJlZGljYXRlcwAAAAAAAAABAgAAeHA=",
+                new DropWhileIterablePredicate<Object>(Predicates.alwaysTrue()));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyIterableTestHelper.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyIterableTestHelper.java
@@ -240,6 +240,18 @@ public class LazyIterableTestHelper<T> implements LazyIterable<T>
     }
 
     @Override
+    public LazyIterable<T> takeWhile(Predicate<? super T> predicate)
+    {
+        return null;
+    }
+
+    @Override
+    public LazyIterable<T> dropWhile(Predicate<? super T> predicate)
+    {
+        return null;
+    }
+
+    @Override
     public LazyIterable<T> distinct()
     {
         return null;

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DropIterableNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DropIterableNoIteratorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.test.lazy;
+
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.lazy.DropIterable;
+import org.eclipse.collections.impl.test.junit.Java8Runner;
+import org.eclipse.collections.test.IterableTestCase;
+import org.eclipse.collections.test.LazyNoIteratorTestCase;
+import org.eclipse.collections.test.list.mutable.FastListNoIterator;
+import org.junit.runner.RunWith;
+
+@RunWith(Java8Runner.class)
+public class DropIterableNoIteratorTest implements LazyNoIteratorTestCase
+{
+    @Override
+    public <T> LazyIterable<T> newWith(T... elements)
+    {
+        MutableList<T> list = new FastListNoIterator<>();
+        list.add((T) new Object());
+        IterableTestCase.addAllTo(elements, list);
+        return new DropIterable<>(list, 1);
+    }
+}

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DropWhileIterableNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/DropWhileIterableNoIteratorTest.java
@@ -12,7 +12,8 @@ package org.eclipse.collections.test.lazy;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.lazy.DropIterable;
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.lazy.DropWhileIterable;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.LazyNoIteratorTestCase;
@@ -20,13 +21,15 @@ import org.eclipse.collections.test.list.mutable.FastListNoIterator;
 import org.junit.runner.RunWith;
 
 @RunWith(Java8Runner.class)
-public class DropIterableTestNoIteratorTest implements LazyNoIteratorTestCase
+public class DropWhileIterableNoIteratorTest implements LazyNoIteratorTestCase
 {
     @Override
     public <T> LazyIterable<T> newWith(T... elements)
     {
         MutableList<T> list = new FastListNoIterator<>();
+        T object = (T) new Object();
+        list.add(object);
         IterableTestCase.addAllTo(elements, list);
-        return new DropIterable<>(list, 0);
+        return new DropWhileIterable<>(list, each -> each == object);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
@@ -377,6 +377,41 @@ public abstract class AbstractLazyIterableTestCase
     }
 
     @Test
+    public void takeWhile()
+    {
+        LazyIterable<Integer> lazyIterable = this.lazyIterable;
+        Assert.assertEquals(FastList.newList(), lazyIterable.takeWhile(Predicates.alwaysFalse()).toList());
+        Assert.assertEquals(FastList.newListWith(1), lazyIterable.takeWhile(each -> each <= 1).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2), lazyIterable.takeWhile(each -> each <= 2).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), lazyIterable.takeWhile(each -> each <= lazyIterable.size() - 1).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(each -> each <= lazyIterable.size()).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(Predicates.alwaysTrue()).toList());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void takeWhile_null_throws()
+    {
+        this.lazyIterable.takeWhile(null);
+    }
+
+    @Test
+    public void dropWhile()
+    {
+        LazyIterable<Integer> lazyIterable = this.lazyIterable;
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.dropWhile(Predicates.alwaysFalse()).toList());
+        Assert.assertEquals(FastList.newListWith(3, 4, 5, 6, 7), lazyIterable.dropWhile(each -> each <= 2).toList());
+        Assert.assertEquals(FastList.newListWith(7), lazyIterable.dropWhile(each -> each <= lazyIterable.size() - 1).toList());
+        Assert.assertEquals(FastList.newList(), lazyIterable.dropWhile(each -> each <= lazyIterable.size()).toList());
+        Assert.assertEquals(FastList.newList(), lazyIterable.dropWhile(Predicates.alwaysTrue()).toList());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void dropWhile_null_throws()
+    {
+        this.lazyIterable.dropWhile(null);
+    }
+
+    @Test
     public void detect()
     {
         Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detect(Integer.valueOf(3)::equals));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy;
+
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.math.IntegerSum;
+import org.eclipse.collections.impl.math.Sum;
+import org.eclipse.collections.impl.math.SumProcedure;
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DropWhileIterableTest extends AbstractLazyIterableTestCase
+{
+    private DropWhileIterable<Integer> dropWhileIterable;
+    private DropWhileIterable<Integer> emptyListDropWhileIterable;
+    private DropWhileIterable<Integer> alwaysFalseDropWhileIterable;
+    private DropWhileIterable<Integer> mostlyFalseDropWhileIterable;
+    private DropWhileIterable<Integer> alwaysTrueDropWhileIterable;
+
+    @Before
+    public void setUp()
+    {
+        this.dropWhileIterable = new DropWhileIterable<>(Interval.oneTo(5), each -> each <= 2);
+        this.emptyListDropWhileIterable = new DropWhileIterable<>(FastList.<Integer>newList(), each -> each <= 2);
+        this.alwaysFalseDropWhileIterable = new DropWhileIterable<>(Interval.oneTo(5), Predicates.alwaysFalse());
+        this.mostlyFalseDropWhileIterable = new DropWhileIterable<>(Interval.oneTo(5), each -> each <= 4);
+        this.alwaysTrueDropWhileIterable = new DropWhileIterable<>(Interval.oneTo(5), Predicates.alwaysTrue());
+    }
+
+    @Test
+    public void basic()
+    {
+        Assert.assertEquals(3, this.dropWhileIterable.size());
+        Assert.assertEquals(FastList.newListWith(3, 4, 5), this.dropWhileIterable.toList());
+
+        Assert.assertEquals(0, this.emptyListDropWhileIterable.size());
+        Assert.assertEquals(5, this.alwaysFalseDropWhileIterable.size());
+        Assert.assertEquals(1, this.mostlyFalseDropWhileIterable.size());
+        Assert.assertEquals(0, this.alwaysTrueDropWhileIterable.size());
+    }
+
+    @Test
+    public void forEach()
+    {
+        Sum sum1 = new IntegerSum(0);
+        this.dropWhileIterable.forEach(new SumProcedure<>(sum1));
+        Assert.assertEquals(12, sum1.getValue().intValue());
+
+        Sum sum2 = new IntegerSum(0);
+        this.emptyListDropWhileIterable.forEach(new SumProcedure<>(sum2));
+        Assert.assertEquals(0, sum2.getValue().intValue());
+
+        Sum sum3 = new IntegerSum(0);
+        this.alwaysFalseDropWhileIterable.forEach(new SumProcedure<>(sum3));
+        Assert.assertEquals(15, sum3.getValue().intValue());
+
+        Sum sum5 = new IntegerSum(0);
+        this.mostlyFalseDropWhileIterable.forEach(new SumProcedure<>(sum5));
+        Assert.assertEquals(5, sum5.getValue().intValue());
+
+        Sum sum6 = new IntegerSum(0);
+        this.alwaysTrueDropWhileIterable.forEach(new SumProcedure<>(sum6));
+        Assert.assertEquals(0, sum6.getValue().intValue());
+    }
+
+    @Test
+    public void forEachWithIndex()
+    {
+        Sum sum = new IntegerSum(0);
+        FastList<Integer> indices = FastList.newList(5);
+        ObjectIntProcedure<Integer> indexRecordingAndSumProcedure = (each, index) -> {
+            indices.add(index);
+            sum.add(each);
+        };
+
+        this.dropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
+        Assert.assertEquals(FastList.newListWith(0, 1, 2), indices);
+        Assert.assertEquals(12, sum.getValue().intValue());
+
+        indices.clear();
+        sum.add(sum.getValue().intValue() * -1);
+        this.emptyListDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
+        Assert.assertEquals(0, indices.size());
+
+        indices.clear();
+        sum.add(sum.getValue().intValue() * -1);
+        this.alwaysFalseDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
+        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        Assert.assertEquals(15, sum.getValue().intValue());
+
+        indices.clear();
+        sum.add(sum.getValue().intValue() * -1);
+        this.mostlyFalseDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
+        Assert.assertEquals(FastList.newListWith(0), indices);
+        Assert.assertEquals(5, sum.getValue().intValue());
+
+        indices.clear();
+        sum.add(sum.getValue().intValue() * -1);
+        this.alwaysTrueDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
+        Assert.assertEquals(0, indices.size());
+    }
+
+    @Test
+    public void forEachWith()
+    {
+        Procedure2<Integer, Sum> sumAdditionProcedure = (each, sum) -> sum.add(each);
+
+        Sum sum1 = new IntegerSum(0);
+        this.dropWhileIterable.forEachWith(sumAdditionProcedure, sum1);
+        Assert.assertEquals(12, sum1.getValue().intValue());
+
+        Sum sum2 = new IntegerSum(0);
+        this.emptyListDropWhileIterable.forEachWith(sumAdditionProcedure, sum2);
+        Assert.assertEquals(0, sum2.getValue().intValue());
+
+        Sum sum3 = new IntegerSum(0);
+        this.alwaysFalseDropWhileIterable.forEachWith(sumAdditionProcedure, sum3);
+        Assert.assertEquals(15, sum3.getValue().intValue());
+
+        Sum sum5 = new IntegerSum(0);
+        this.mostlyFalseDropWhileIterable.forEachWith(sumAdditionProcedure, sum5);
+        Assert.assertEquals(5, sum5.getValue().intValue());
+
+        Sum sum6 = new IntegerSum(0);
+        this.alwaysTrueDropWhileIterable.forEachWith(sumAdditionProcedure, sum6);
+        Assert.assertEquals(0, sum6.getValue().intValue());
+    }
+
+    @Override
+    @Test
+    public void iterator()
+    {
+        Sum sum1 = new IntegerSum(0);
+        for (Integer each : this.dropWhileIterable)
+        {
+            sum1.add(each);
+        }
+        Assert.assertEquals(12, sum1.getValue().intValue());
+
+        Sum sum2 = new IntegerSum(0);
+        for (Integer each : this.emptyListDropWhileIterable)
+        {
+            sum2.add(each);
+        }
+        Assert.assertEquals(0, sum2.getValue().intValue());
+
+        Sum sum3 = new IntegerSum(0);
+        for (Integer each : this.alwaysFalseDropWhileIterable)
+        {
+            sum3.add(each);
+        }
+        Assert.assertEquals(15, sum3.getValue().intValue());
+
+        Sum sum5 = new IntegerSum(0);
+        for (Integer each : this.mostlyFalseDropWhileIterable)
+        {
+            sum5.add(each);
+        }
+        Assert.assertEquals(5, sum5.getValue().intValue());
+
+        Sum sum6 = new IntegerSum(0);
+        for (Integer each : this.alwaysTrueDropWhileIterable)
+        {
+            sum6.add(each);
+        }
+        Assert.assertEquals(0, sum6.getValue().intValue());
+    }
+
+    @Override
+    protected <T> LazyIterable<T> newWith(T... elements)
+    {
+        return LazyIterate.dropWhile(FastList.newListWith(elements), Predicates.alwaysFalse());
+    }
+
+    @Override
+    @Test
+    public void distinct()
+    {
+        super.distinct();
+        Assert.assertEquals(
+                FastList.newListWith(2, 3, 4, 5),
+                new DropWhileIterable<>(FastList.newListWith(1, 1, 2, 3, 3, 3, 4, 5), each -> each % 2 != 0).distinct().toList());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy;
+
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.block.procedure.CountProcedure;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.math.IntegerSum;
+import org.eclipse.collections.impl.math.Sum;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
+{
+    private TakeWhileIterable<Integer> takeWhileIterable;
+    private TakeWhileIterable<Integer> emptyListTakeWhileIterable;
+    private TakeWhileIterable<Integer> alwaysFalseTakeWhileIterable;
+    private TakeWhileIterable<Integer> alwaysTrueTakeWhileIterable;
+
+    @Before
+    public void setUp()
+    {
+        this.takeWhileIterable = new TakeWhileIterable<>(Interval.oneTo(5), each -> each <= 2);
+        this.emptyListTakeWhileIterable = new TakeWhileIterable<>(FastList.<Integer>newList(), each -> each <= 2);
+        this.alwaysFalseTakeWhileIterable = new TakeWhileIterable<>(Interval.oneTo(5), Predicates.alwaysFalse());
+        this.alwaysTrueTakeWhileIterable = new TakeWhileIterable<>(Interval.oneTo(5), Predicates.alwaysTrue());
+    }
+
+    @Test
+    public void basic()
+    {
+        Assert.assertEquals(2, this.takeWhileIterable.size());
+        Assert.assertEquals(FastList.newListWith(1, 2), this.takeWhileIterable.toList());
+
+        Assert.assertEquals(0, this.emptyListTakeWhileIterable.size());
+        Assert.assertEquals(0, this.alwaysFalseTakeWhileIterable.size());
+        Assert.assertEquals(5, this.alwaysTrueTakeWhileIterable.size());
+    }
+
+    @Test
+    public void forEach()
+    {
+        CountProcedure<Integer> cb1 = new CountProcedure<>();
+        this.takeWhileIterable.forEach(cb1);
+        Assert.assertEquals(2, cb1.getCount());
+
+        CountProcedure<Integer> cb2 = new CountProcedure<>();
+        this.emptyListTakeWhileIterable.forEach(cb2);
+        Assert.assertEquals(0, cb2.getCount());
+
+        CountProcedure<Integer> cb3 = new CountProcedure<>();
+        this.alwaysFalseTakeWhileIterable.forEach(cb3);
+        Assert.assertEquals(0, cb3.getCount());
+
+        CountProcedure<Integer> cb5 = new CountProcedure<>();
+        this.alwaysTrueTakeWhileIterable.forEach(cb5);
+        Assert.assertEquals(5, cb5.getCount());
+    }
+
+    @Test
+    public void forEachWithIndex()
+    {
+        FastList<Integer> indices = FastList.newList(5);
+        ObjectIntProcedure<Integer> indexRecordingProcedure = (each, index) -> indices.add(index);
+
+        this.takeWhileIterable.forEachWithIndex(indexRecordingProcedure);
+        Assert.assertEquals(FastList.newListWith(0, 1), indices);
+
+        indices.clear();
+        this.emptyListTakeWhileIterable.forEachWithIndex(indexRecordingProcedure);
+        Verify.assertSize(0, indices);
+
+        indices.clear();
+        this.alwaysFalseTakeWhileIterable.forEachWithIndex(indexRecordingProcedure);
+        Verify.assertSize(0, indices);
+
+        indices.clear();
+        this.alwaysTrueTakeWhileIterable.forEachWithIndex(indexRecordingProcedure);
+        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+    }
+
+    @Test
+    public void forEachWith()
+    {
+        Procedure2<Integer, Sum> sumAdditionProcedure = (each, sum) -> sum.add(each);
+
+        Sum sum1 = new IntegerSum(0);
+        this.takeWhileIterable.forEachWith(sumAdditionProcedure, sum1);
+        Assert.assertEquals(3, sum1.getValue().intValue());
+
+        Sum sum2 = new IntegerSum(0);
+        this.emptyListTakeWhileIterable.forEachWith(sumAdditionProcedure, sum2);
+        Assert.assertEquals(0, sum2.getValue().intValue());
+
+        Sum sum3 = new IntegerSum(0);
+        this.alwaysFalseTakeWhileIterable.forEachWith(sumAdditionProcedure, sum3);
+        Assert.assertEquals(0, sum3.getValue().intValue());
+
+        Sum sum5 = new IntegerSum(0);
+        this.alwaysTrueTakeWhileIterable.forEachWith(sumAdditionProcedure, sum5);
+        Assert.assertEquals(15, sum5.getValue().intValue());
+    }
+
+    @Override
+    @Test
+    public void iterator()
+    {
+        Sum sum1 = new IntegerSum(0);
+        for (Integer each : this.takeWhileIterable)
+        {
+            sum1.add(each);
+        }
+        Assert.assertEquals(3, sum1.getValue().intValue());
+
+        Sum sum2 = new IntegerSum(0);
+        for (Integer each : this.emptyListTakeWhileIterable)
+        {
+            sum2.add(each);
+        }
+        Assert.assertEquals(0, sum2.getValue().intValue());
+
+        Sum sum3 = new IntegerSum(0);
+        for (Integer each : this.alwaysFalseTakeWhileIterable)
+        {
+            sum3.add(each);
+        }
+        Assert.assertEquals(0, sum3.getValue().intValue());
+
+        Sum sum5 = new IntegerSum(0);
+        for (Integer each : this.alwaysTrueTakeWhileIterable)
+        {
+            sum5.add(each);
+        }
+        Assert.assertEquals(15, sum5.getValue().intValue());
+    }
+
+    @Override
+    protected <T> LazyIterable<T> newWith(T... elements)
+    {
+        return LazyIterate.takeWhile(FastList.newListWith(elements), Predicates.alwaysTrue());
+    }
+
+    @Override
+    @Test
+    public void distinct()
+    {
+        super.distinct();
+        Assert.assertEquals(
+                FastList.newListWith(3, 2, 4, 1),
+                new TakeWhileIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), each -> each < 5).distinct().toList());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * JUnit test for {@link DropIterator}.
+ */
+public class DropIteratorTest
+{
+    @Test
+    public void iterator()
+    {
+        Interval list = Interval.oneTo(5);
+
+        Iterator<Integer> iterator1 = new DropIterator<>(list.iterator(), 2);
+        assertElements(iterator1, 2, list.size());
+
+        Iterator<Integer> iterator2 = new DropIterator<>(list, 5);
+        assertElements(iterator2, 5, list.size());
+
+        Iterator<Integer> iterator3 = new DropIterator<>(list, 10);
+        assertElements(iterator3, 5, list.size());
+
+        Iterator<Integer> iterator4 = new DropIterator<>(list, 0);
+        assertElements(iterator4, 0, list.size());
+
+        Iterator<Integer> iterator5 = new DropIterator<>(Lists.fixedSize.of(), 0);
+        assertElements(iterator5, 0, Lists.fixedSize.<Integer>of().size());
+    }
+
+    private static void assertElements(Iterator<Integer> iterator, int count, int size)
+    {
+        for (int i = count; i < size; i++)
+        {
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertEquals(Integer.valueOf(i + 1), iterator.next());
+        }
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void remove()
+    {
+        Verify.assertThrows(UnsupportedOperationException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).remove());
+    }
+
+    @Test
+    public void noSuchElementException()
+    {
+        Verify.assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).next());
+
+        Verify.assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.of(1, 2, 3), 4).next());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.lazy.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.eclipse.collections.impl.block.factory.Predicates;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * JUnit test for {@link TakeWhileIterator}.
+ */
+public class TakeWhileIteratorTest
+{
+    @Test
+    public void iterator()
+    {
+        Interval list = Interval.oneTo(5);
+
+        Iterator<Integer> iterator1 = new TakeWhileIterator<>(list.iterator(), each -> each <= 2);
+        assertElements(iterator1, 2);
+
+        Iterator<Integer> iterator2 = new TakeWhileIterator<>(list, each -> each <= 5);
+        assertElements(iterator2, 5);
+
+        Iterator<Integer> iterator3 = new TakeWhileIterator<>(list, Predicates.alwaysTrue());
+        assertElements(iterator3, 5);
+
+        Iterator<Integer> iterator4 = new TakeWhileIterator<>(list, Predicates.alwaysFalse());
+        assertElements(iterator4, 0);
+
+        Iterator<Integer> iterator5 = new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysFalse());
+        assertElements(iterator5, 0);
+    }
+
+    private static void assertElements(Iterator<Integer> iterator, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertEquals(Integer.valueOf(i + 1), iterator.next());
+        }
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void hasNext()
+    {
+        Interval list = Interval.oneTo(5);
+
+        Iterator<Integer> iterator1 = new TakeWhileIterator<>(list.iterator(), each -> each <= 1);
+        Assert.assertTrue(iterator1.hasNext());
+        Assert.assertTrue(iterator1.hasNext());
+
+        iterator1.next();
+        Assert.assertFalse(iterator1.hasNext());
+    }
+
+    @Test
+    public void remove()
+    {
+        Verify.assertThrows(UnsupportedOperationException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).remove());
+    }
+
+    @Test
+    public void noSuchElementException()
+    {
+        Verify.assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).next());
+
+        Verify.assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.of(1, 2, 3), Predicates.alwaysFalse()).next());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -793,6 +793,7 @@ public class IntervalTest
     @Test
     public void take()
     {
+        Verify.assertIterableEmpty(Interval.fromTo(1, 3).take(0));
         Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).take(2));
         Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).take(3));
 
@@ -803,6 +804,7 @@ public class IntervalTest
     public void drop()
     {
         Assert.assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).drop(2));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).drop(0));
         Verify.assertIterableEmpty(Interval.fromTo(1, 2).drop(3));
 
         Verify.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(1, 3).drop(-1));
@@ -845,7 +847,8 @@ public class IntervalTest
         MutableList<Integer> tapResult = Lists.mutable.of();
         Interval interval = Interval.fromTo(10, -10).by(-5);
         LazyIterable<Integer> lazyTapIterable = interval.tap(tapResult::add);
-        lazyTapIterable.each(x -> { }); //force evaluation
+        lazyTapIterable.each(x -> {
+        }); //force evaluation
         Assert.assertEquals(interval, tapResult);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -811,6 +811,26 @@ public class IntervalTest
     }
 
     @Test
+    public void takeWhile()
+    {
+        Verify.assertIterableEmpty(Interval.fromTo(1, 3).takeWhile(Predicates.alwaysFalse()).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).takeWhile(each -> each <= 2).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).takeWhile(Predicates.alwaysTrue()).toList());
+
+        Verify.assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).takeWhile(null));
+    }
+
+    @Test
+    public void dropWhile()
+    {
+        Assert.assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).dropWhile(each -> each <= 2).toList());
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).dropWhile(Predicates.alwaysFalse()).toList());
+        Verify.assertIterableEmpty(Interval.fromTo(1, 2).dropWhile(Predicates.alwaysTrue()).toList());
+
+        Verify.assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).dropWhile(null));
+    }
+
+    @Test
     public void distinct()
     {
         LazyIterable<Integer> integers = Interval.oneTo(1000000000);


### PR DESCRIPTION
1) Implement LazyIterable.takeWhile(Predicate) and LazyIterable.dropWhile(Predicate).
2) Bug fix for Interval.take(0).
3) Fix warnings for Javadoc in LazyIterate where period was missing.