### PR TITLE
Enforce maven version to 3.1.0+ and add supplimentary information to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Contact us
 
 Build
 -----
+The Eclipse Collections build requires below as dependencies.
+
+- Java 1.8
+- Maven 3.1.0+
 
 The Eclipse Collections build performs code generation to create primitive collections. Run the full build once before opening your IDE.
 
@@ -63,7 +67,7 @@ Coding Style
 Eclipse Collections follows a coding style that is similar to [Google's Style Guide for Java][style-guide], but with curly braces on their own lines. Many aspects of the style guide are enforced by CheckStyle, but not all, so please take care.
 
 ```bash
-$ mvn clean install checkstyle:check findbugs:check -DskipTests=true
+$ mvn clean install checkstyle:check findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests' -DskipTests=true
 ```
 
 Avoid changing whitespace on lines that are unrelated to your pull request. This helps preserve the accuracy of the git blame view, and makes code reviews easier.

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
                                         <version>1.8.0</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
-                                        <version>3.0.2</version>
+                                        <version>3.1.0</version>
                                     </requireMavenVersion>
                                     <requirePluginVersions>
                                         <unCheckedPluginList>


### PR DESCRIPTION
Reflect couple of feedback from contributors.
- It is reported that build fails with maven 3.0.x. Explicitly mention minimum working version 3.1.0.
- It is reported that findbugs build fails following the instruction. Made it sync with Travis CI findbugs build option.