### PR TITLE
In <primitive>ArrayList.newWithNValues, replace loop with Arrays.fill

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -15,6 +15,7 @@ New Functionality
 Optimizations
 -------------
 
+* In <primitive>ArrayList.newWithNValues, replace loop with Arrays.fill.
 * Optimize MutableList.chunk() for RandomAccess lists to use the backing array instead of an iterator.
 
 Bug fixes

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -97,10 +97,8 @@ public class <name>ArrayList extends Abstract<name>Iterable
     public static <name>ArrayList newWithNValues(int size, <type> value)
     {
         <name>ArrayList newList = new <name>ArrayList(size);
-        for (int i = 0; i \< size; i++)
-        {
-            newList.add(value);
-        }
+        newList.size = size;
+        Arrays.fill(newList.items, value);
         return newList;
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
@@ -63,6 +63,15 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         <name>ArrayList newList = <name>ArrayList.newWithNValues(5, <(literal.(type))("42")>);
         Verify.assertSize(5, newList);
         Assert.assertEquals(<name>ArrayList.newListWith(<["42", "42", "42", "42", "42"]:(literal.(type))(); separator=", ">), newList);
+
+        <name>ArrayList newList2 = <name>ArrayList.newWithNValues(0, <(literal.(type))("2")>);
+        Verify.assertSize(0, newList2);
+    }
+
+    @Test(expected = NegativeArraySizeException.class)
+    public void newWithNValues_throws_negative_size()
+    {
+        <name>ArrayList newList = <name>ArrayList.newWithNValues(-5, <(literal.(type))("42")>);
     }
 
     @Test


### PR DESCRIPTION
As suggested by @motlin in the link below.
https://github.com/eclipse/eclipse-collections/pull/105
Add more tests for <primitive>ArrayList.newWithNValues.

Signed-off-by: guoci <zguoci@gmail.com>