### PR TITLE
Change our functional interfaces to extend the JDK functional interfaces.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/SerializableComparator.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/SerializableComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.block;
 import java.io.Serializable;
 import java.util.Comparator;
 
+@FunctionalInterface
 public interface SerializableComparator<T>
         extends Comparator<T>, Serializable
 {

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -17,8 +17,15 @@ import java.io.Serializable;
  * passed to the valueOf() method.  This transformation can return the value of calling a getter, or perform
  * some more elaborate logic to calculate a value, of type {@code V}.
  */
+@FunctionalInterface
 public interface Function<T, V>
-        extends Serializable
+        extends java.util.function.Function<T, V>, Serializable
 {
-    V valueOf(T object);
+    V valueOf(T each);
+
+    @Override
+    default V apply(T each)
+    {
+        return this.valueOf(each);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function0.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,13 +11,21 @@
 package org.eclipse.collections.api.block.function;
 
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 /**
  * Function0 is a zero argument lambda.  It can be stored in a variable or passed as a parameter and executed
  * by calling the value method.
  */
+@FunctionalInterface
 public interface Function0<R>
-        extends Serializable
+        extends Supplier<R>, Serializable
 {
     R value();
+
+    @Override
+    default R get()
+    {
+        return this.value();
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function2.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.block.function;
 
 import java.io.Serializable;
+import java.util.function.BiFunction;
 
 /**
  * A Function2 is used by injectInto() methods. It takes the injected argument as the first argument, and the
@@ -19,8 +20,15 @@ import java.io.Serializable;
  *
  * @since 1.0
  */
+@FunctionalInterface
 public interface Function2<T1, T2, R>
-        extends Serializable
+        extends BiFunction<T1, T2, R>, Serializable
 {
     R value(T1 argument1, T2 argument2);
+
+    @Override
+    default R apply(T1 argument1, T2 argument2)
+    {
+        return this.value(argument1, argument2);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function3.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/function/Function3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -17,6 +17,7 @@ import java.io.Serializable;
  * argument as the first argument, the current item of the collection as the second argument, and the specified
  * parameter for the third argument. The result of each subsequent iteration is passed in as the first argument.
  */
+@FunctionalInterface
 public interface Function3<T1, T2, T3, R>
         extends Serializable
 {

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/predicate/Predicate.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/predicate/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,8 +16,15 @@ import java.io.Serializable;
  * A Predicate is a lambda or closure with a boolean result.  The method accept should be implemented to indicate the object
  * passed to the method meets the criteria of this Predicate.  A Predicate is also known as a Discriminator or Filter.
  */
+@FunctionalInterface
 public interface Predicate<T>
-        extends Serializable
+        extends java.util.function.Predicate<T>, Serializable
 {
     boolean accept(T each);
+
+    @Override
+    default boolean test(T each)
+    {
+        return this.accept(each);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/predicate/Predicate2.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/predicate/Predicate2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,14 +11,22 @@
 package org.eclipse.collections.api.block.predicate;
 
 import java.io.Serializable;
+import java.util.function.BiPredicate;
 
 /**
  * A Predicate2 is primarily used in methods like selectWith, detectWith, rejectWith.  The first argument
  * is the element of the collection being iterated over, and the second argument is a parameter passed into
  * the predicate from the calling method.
  */
+@FunctionalInterface
 public interface Predicate2<T1, T2>
-        extends Serializable
+        extends BiPredicate<T1, T2>, Serializable
 {
     boolean accept(T1 argument1, T2 argument2);
+
+    @Override
+    default boolean test(T1 t1, T2 t2)
+    {
+        return this.accept(t1, t2);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/ObjectIntProcedure.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/ObjectIntProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,6 +16,7 @@ package org.eclipse.collections.api.block.procedure;
  *
  * @deprecated since 3.0 use {@link org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure} instead.
  */
+@FunctionalInterface
 @Deprecated
 public interface ObjectIntProcedure<T> extends org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure<T>
 {

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/Procedure.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/Procedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,12 +11,20 @@
 package org.eclipse.collections.api.block.procedure;
 
 import java.io.Serializable;
+import java.util.function.Consumer;
 
 /**
  * A Procedure is a single argument lambda which has no return argument.
  */
+@FunctionalInterface
 public interface Procedure<T>
-        extends Serializable
+        extends Consumer<T>, Serializable
 {
     void value(T each);
+
+    @Override
+    default void accept(T each)
+    {
+        this.value(each);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/Procedure2.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/block/procedure/Procedure2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.block.procedure;
 
 import java.io.Serializable;
+import java.util.function.BiConsumer;
 
 /**
  * A Procedure2 is used by forEachWith() methods and for MapIterate.forEachKeyValue().  In the forEachKeyValue()
@@ -18,8 +19,15 @@ import java.io.Serializable;
  * the procedure takes the the element of the collection as the first argument, and the specified parameter as the
  * second argument.
  */
+@FunctionalInterface
 public interface Procedure2<T1, T2>
-        extends Serializable
+        extends BiConsumer<T1, T2>, Serializable
 {
     void value(T1 argument1, T2 argument2);
+
+    @Override
+    default void accept(T1 argument1, T2 argument2)
+    {
+        this.value(argument1, argument2);
+    }
 }

--- a/eclipse-collections-code-generator/src/main/java/org/eclipse/collections/codegenerator/model/Primitive.java
+++ b/eclipse-collections-code-generator/src/main/java/org/eclipse/collections/codegenerator/model/Primitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2016 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -79,5 +79,10 @@ public enum Primitive
     public boolean isDoublePrimitive()
     {
         return this == DOUBLE;
+    }
+
+    public boolean hasSpecializedStream()
+    {
+        return this == INT || this == LONG || this == DOUBLE;
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/api/block/predicate/primitivePredicate.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/block/predicate/primitivePredicate.stg
@@ -22,10 +22,19 @@ import java.io.Serializable;
  *
  * @since 3.0.
  */
+<if(primitive.specializedStream)>@FunctionalInterface<endif>
 public interface <name>Predicate
-        extends Serializable
+        extends <if(primitive.specializedStream)>java.util.function.<name>Predicate, <endif>Serializable
 {
     boolean accept(<type> value);
+<if(primitive.specializedStream)>
+
+    @Override
+    default boolean test(<type> value)
+    {
+        return this.accept(value);
+    }
+<endif>
 }
 
 >>

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicate.java
@@ -25,4 +25,23 @@ public abstract class MapEntryPredicate<T1, T2>
     {
         return this.accept(entry.getKey(), entry.getValue());
     }
+
+    @Override
+    public MapEntryPredicate<T1, T2> negate()
+    {
+        return new MapEntryPredicate<T1, T2>()
+        {
+            @Override
+            public boolean accept(Map.Entry<T1, T2> entry)
+            {
+                return !MapEntryPredicate.this.accept(entry);
+            }
+
+            @Override
+            public boolean accept(T1 argument1, T2 argument2)
+            {
+                return !MapEntryPredicate.this.accept(argument1, argument2);
+            }
+        };
+    }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/PairPredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/PairPredicate.java
@@ -24,4 +24,23 @@ public abstract class PairPredicate<T1, T2>
     {
         return this.accept(pair.getOne(), pair.getTwo());
     }
+
+    @Override
+    public PairPredicate<T1, T2> negate()
+    {
+        return new PairPredicate<T1, T2>()
+        {
+            @Override
+            public boolean accept(T1 argument1, T2 argument2)
+            {
+                return !PairPredicate.this.accept(argument1, argument2);
+            }
+
+            @Override
+            public boolean accept(Pair<T1, T2> pair)
+            {
+                return !PairPredicate.this.accept(pair);
+            }
+        };
+    }
 }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -363,6 +363,9 @@
             <Class name="org.eclipse.collections.api.block.procedure.ObjectIntProcedure" />
             <Class name="org.eclipse.collections.api.block.function.Function" />
             <Class name="org.eclipse.collections.api.block.predicate.Predicate" />
+            <Class name="org.eclipse.collections.api.block.predicate.primitive.IntPredicate" />
+            <Class name="org.eclipse.collections.api.block.predicate.primitive.LongPredicate" />
+            <Class name="org.eclipse.collections.api.block.predicate.primitive.DoublePredicate" />
         </Or>
     </Match>
 </FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -361,6 +361,8 @@
         <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
         <Or>
             <Class name="org.eclipse.collections.api.block.procedure.ObjectIntProcedure" />
+            <Class name="org.eclipse.collections.api.block.function.Function" />
+            <Class name="org.eclipse.collections.api.block.predicate.Predicate" />
         </Or>
     </Match>
 </FindBugsFilter>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
@@ -108,7 +108,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
         StubProcedure<Object> procedure = new StubProcedure<>();
         MutableMap<Object, Object> map = new EmptyMap<>();
 
-        map.forEach(procedure);
+        map.each(procedure);
         Assert.assertFalse(procedure.called);
 
         map.forEachKey(procedure);
@@ -237,7 +237,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
             implements Procedure<T>, Procedure2<T, T>, ObjectIntProcedure<T>
     {
         private static final long serialVersionUID = 1L;
-        private boolean called = false;
+        private boolean called;
 
         @Override
         public void value(T each)


### PR DESCRIPTION
The first commit changes the Object functional interfaces like Procedure to extend the JDK functional interfaces like Consumer.

The second commit handles primitive predicates. The work is not complete until we do all primitive functional interfaces but I'm hoping to get help with that effort.