### PR TITLE
Extract MutableIterable and ImmutableIterable.

### DIFF
--- a/.idea/inspectionProfiles/Language_Migration.xml
+++ b/.idea/inspectionProfiles/Language_Migration.xml
@@ -1,0 +1,1915 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="Language Migration" />
+    <option name="myLocal" value="false" />
+    <inspection_tool class="AbstractBeanReferencesInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AbstractClassWithoutAbstractMethods" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="AbstractMethodOverridesAbstractMethod" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreJavaDoc" value="true" />
+    </inspection_tool>
+    <inspection_tool class="AccessStaticViaInstance" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AccessToNonThreadSafeStaticFieldFromInstance" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="nonThreadSafeClasses">
+        <value />
+      </option>
+      <option name="nonThreadSafeTypes" value="java.text.DateFormat,java.util.Calendar" />
+    </inspection_tool>
+    <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AccessorLikeMethodIsEmptyParen" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AccessorLikeMethodIsUnit" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Add Shebang line" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="AndroidDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Annotator" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AnonymousClassVariableHidesContainingMethodVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="AnonymousInnerClassMayBeStatic" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="AntDuplicateTargetsInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AntMissingPropertiesFileInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AntResolveInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ApparentRefinementOfResultType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AppliedTypeLambdaCanBeSimplified" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArchaicSystemPropertyAccess" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="ArgNamesErrorsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArgNamesWarningsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArithmeticOnVolatileField" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ArrayEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArrayHashCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArrayObjectsEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ArraySizeCall" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="ArraysAsListWithZeroOrOneArgument" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AssertEqualsBetweenInconvertibleTypes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AssertEqualsBetweenInconvertibleTypesTestNG" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AssertWithSideEffects" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AssignmentToLambdaParameter" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="AssignmentToMethodParameter" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreTransformationOfOriginalParameter" value="false" />
+    </inspection_tool>
+    <inspection_tool class="AtomicFieldUpdaterIssues" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AtomicFieldUpdaterNotStaticFinal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AutoBoxing" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoreAddedToCollection" value="false" />
+    </inspection_tool>
+    <inspection_tool class="AutoUnboxing" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="AutowiredDependenciesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BadExceptionCaught" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="exceptionsString" value="java.lang.NullPointerException,java.lang.IllegalMonitorStateException,java.lang.ArrayIndexOutOfBoundsException" />
+      <option name="exceptions">
+        <value />
+      </option>
+    </inspection_tool>
+    <inspection_tool class="BadExceptionDeclared" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="exceptionsString" value="java.lang.Throwable,java.lang.Exception,java.lang.Error,java.lang.RuntimeException,java.lang.NullPointerException,java.lang.ClassCastException,java.lang.ArrayIndexOutOfBoundsException" />
+      <option name="exceptions">
+        <value />
+      </option>
+      <option name="ignoreTestCases" value="false" />
+      <option name="ignoreLibraryOverrides" value="false" />
+    </inspection_tool>
+    <inspection_tool class="BadExpressionStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashAddShebang" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashBuiltInVariable" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashDuplicateFunction" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashEvaluateArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashEvaluateExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashFixShebang" enabled="false" level="WARNING" enabled_by_default="false">
+      <shebang>/bin/bash</shebang>
+      <shebang>/bin/sh</shebang>
+    </inspection_tool>
+    <inspection_tool class="BashFloatArithmetic" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="BashGlobalLocalVarDef" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashInternalCommandFunctionOverride" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashMissingInclude" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashReadOnlyVariable" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="BashRecursiveInclusion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashSimpleArrayUse" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="BashSimpleVarUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashUnknownFileDescriptor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashUnresolvedVariable" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashUnusedFunction" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashUnusedFunctionParams" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashWrapFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BigDecimalMethodWithoutRoundingCalled" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BooleanConstructor" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="BoundFieldAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BoxingBoxedValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BreakStatement" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="CStyleArrayDeclaration" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="CanBeFinal" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="REPORT_CLASSES" value="false" />
+      <option name="REPORT_METHODS" value="false" />
+      <option name="REPORT_FIELDS" value="true" />
+    </inspection_tool>
+    <inspection_tool class="CaseClassParam" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CastConflictsWithInstanceof" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="CastThatLosesPrecision" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoreIntegerCharCasts" value="false" />
+    </inspection_tool>
+    <inspection_tool class="CatchGenericClass" enabled="true" level="INFO" enabled_by_default="true" />
+    <inspection_tool class="CaughtExceptionImmediatelyRethrown" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ChainedPackage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ChannelResource" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="CheckDtdRefs" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="CheckEmptyScriptTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckImageSize" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckNodeTest" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckStyle" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckTagEmptyBody" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="CheckValidXmlInScriptTagBody" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckXmlFileWithXercesValidator" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ClashingTraitMethods" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ClassEscapesItsScope" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ClassInTopLevelPackage" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassInitializerMayBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ClassNamePrefixedWithPackageName" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ClassUnconnectedToPackage" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ClassWithoutToString" level="INFO" enabled="false" />
+    <inspection_tool class="CloneCallsSuperClone" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CloneDeclaresCloneNotSupported" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CodeBlock2Expr" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="CollectionAddedToSelf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CollectionContainsUrl" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ComparatorMethodParameterNotUsed" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="CompareToUsesNonFinalVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ComparingDiffCollectionKinds" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ComparingUnrelatedTypes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ComponentNotRegistered" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_ACTIONS" value="true" />
+      <option name="IGNORE_NON_PUBLIC" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComponentRegistrationProblems" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ConflictingExtensionProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConfusingElse" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="reportWhenNoStatementFollow" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ConfusingFloatingPointLiteral" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ConstantConditionalExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantConditionalExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantConditions" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ConstantIfStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantIfStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantNamingConvention" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="onlyCheckImmutables" value="false" />
+      <option name="m_regex" value="[A-Z_\d]*" />
+      <option name="m_minLength" value="2" />
+      <option name="m_maxLength" value="99" />
+    </inspection_tool>
+    <inspection_tool class="ConstantOnLHSOfComparison" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ConstantStringIntern" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstraintValidatorCreator" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Contract" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Convert to string" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="Convert2Diamond" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="Convert2Lambda" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="Convert2MethodRef" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="Convert2streamapi" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertExpressionToSAM" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConvertToStringTemplate" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ConvertibleToMethodValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CorrespondsUnsorted" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssInvalidElementInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="CssInvalidHtmlTagReferenceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssInvalidImportInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssInvalidShorthandPropertyValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssNegativeValueInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssNoGenericFontName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssOptimizeSimilarPropertiesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssOverwrittenProperties" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssRgbFunctionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssUnitlessNumber" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssUnknownProperty" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myCustomPropertiesEnabled" value="false" />
+      <option name="myIgnoreVendorSpecificProperties" value="false" />
+      <option name="myCustomPropertiesList">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="CssUnusedSymbolInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DangerousCatchAll" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DataProviderReturnType" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="DeclareParentsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DefaultAnnotationParam" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DefaultFileTemplate" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="CHECK_FILE_HEADER" value="true" />
+      <option name="CHECK_TRY_CATCH_SECTION" value="true" />
+      <option name="CHECK_METHOD_BODY" value="true" />
+    </inspection_tool>
+    <inspection_tool class="DelegatesTo" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Dependency" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedClassUsageInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DeprecatedViewBound" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Deprecation" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="DialogTitleCapitalization" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DontUsePairConstructor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DoubleCheckedLocking" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreOnVolatileVariables" value="false" />
+    </inspection_tool>
+    <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="DoubleNegation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DropTakeToSlice" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicateCaseLabelJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicateMnemonic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicatePropertyOnObjectJS" level="WARNING" enabled="false" />
+    <inspection_tool class="DuplicateThrows" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicatedBeanNamesInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="DuplicatedDataProviderNames" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="EjbDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EjbErrorInspection" level="INSPECTION" enabled="false" />
+    <inspection_tool class="EjbQlInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EjbWarningInspection" level="WARNING" enabled="false" />
+    <inspection_tool class="EmptyCatchBlock" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_includeComments" value="true" />
+      <option name="m_ignoreTestCases" value="true" />
+      <option name="m_ignoreIgnoreParameter" value="true" />
+    </inspection_tool>
+    <inspection_tool class="EmptyCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyClass" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignorableAnnotations">
+        <value />
+      </option>
+      <option name="ignoreClassWithParameterization" value="false" />
+      <option name="ignoreThrowables" value="true" />
+      <option name="commentsAreContent" value="true" />
+    </inspection_tool>
+    <inspection_tool class="EmptyFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyInitializer" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="EmptyMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="EmptyParenMethodAccessedAsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyParenMethodOverridenAsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyStatementBody" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportEmptyBlocks" value="true" />
+    </inspection_tool>
+    <inspection_tool class="EmptyStatementBodyJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportEmptyBlocks" value="false" />
+    </inspection_tool>
+    <inspection_tool class="EmptyTryBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyWebServiceClass" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnumeratedConstantNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z_\d]*" />
+      <option name="m_minLength" value="2" />
+      <option name="m_maxLength" value="99" />
+    </inspection_tool>
+    <inspection_tool class="EqualityToSameElements" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="EqualsOrHashCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EqualsUsesNonFinalVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="EqualsWithItself" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExceptionCaughtLocallyJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExceptionFromCatchWhichDoesntWrap" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreGetMessage" value="true" />
+      <option name="ignoreCantWrap" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ExistsEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExtendsAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExtendsObject" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExtendsThread" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ExtensionPointBeanClass" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExternalizableWithoutPublicNoArgConstructor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FacesModelInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FallthroughInSwitchStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FallthruInSwitchStatement" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="FeatureEnvy" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreTestCases" value="true" />
+    </inspection_tool>
+    <inspection_tool class="FieldAccessedSynchronizedAndUnsynchronized" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="countGettersAndSetters" value="false" />
+    </inspection_tool>
+    <inspection_tool class="FieldCanBeLocal" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FieldFromDelayedInit" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FieldHidesSuperclassField" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreInvisibleFields" value="true" />
+    </inspection_tool>
+    <inspection_tool class="FieldMayBeFinal" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FieldMayBeStatic" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FileEqualsUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FilterEmptyCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FilterHeadOption" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FilterOtherContains" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FilterSize" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FinalPrivateMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FinalStaticMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FinalizeCallsSuperFinalize" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreObjectSubclasses" value="false" />
+      <option name="ignoreTrivialFinalizers" value="true" />
+    </inspection_tool>
+    <inspection_tool class="FinallyBlockCannotCompleteNormally" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FindEmptyCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FloatLiteralEndingWithDecimalPoint" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FloatingPointEquality" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="FoldTrueAnd" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ForCanBeForeach" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_INDEXED_LOOP" value="true" />
+      <option name="ignoreUntypedCollections" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ForwardReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FunctionTupleSyntacticSugar" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GWTRemoteServiceAsyncCheck" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GWTStyleCheck" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GetGetOrElse" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GetOrElseNull" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrDeprecatedAPIUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrEqualsBetweenInconvertibleTypes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrFinalVariableAccess" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrMethodMayBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrPackage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrReassignedInClosureLocalVar" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrUnresolvedAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyAccessToStaticFieldLockedOnInstance" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyAccessibility" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyConditionalWithIdenticalBranches" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyConstantConditional" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyConstantIfStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyConstructorNamedArguments" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyDivideByZero" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyDocCheck" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="GroovyDoubleNegation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyDuplicateSwitchBranch" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyEmptyStatementBody" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyFallthrough" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyIfStatementWithIdenticalBranches" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyInArgumentCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyInfiniteLoopStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyInfiniteRecursion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyLabeledStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyMissingReturnStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyResultOfObjectAllocationIgnored" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovySillyAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovySingletonAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovySynchronizationOnNonFinalField" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovySynchronizationOnVariableInitializedWithLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyTrivialConditional" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyTrivialIf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUncheckedAssignmentOfMemberOfRawType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnnecessaryContinue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnnecessaryReturn" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnreachableStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnsynchronizedMethodOverridesSynchronizedMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnusedAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnusedCatchParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnusedDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyUnusedIncOrDec" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyVariableNotAssigned" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GtkPreferredJComboBoxRenderer" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GwtInconsistentI18nInterface" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GwtInconsistentSerializableClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GwtJavaScriptReferences" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GwtMethodWithParametersInConstantsInterface" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GwtServiceNotRegistered" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="GwtToHtmlReferences" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="HardwiredNamespacePrefix" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="HashCodeUsesVar" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="HeadOrLastOption" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HibernateConfigDomInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="HibernateMappingDatasourceDomInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="HibernateMappingDomInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="HibernateResource" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="HoconIncludeResolution" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlExtraClosingTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownAnchorTarget" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myValues">
+        <value>
+          <list size="5">
+            <item index="0" class="java.lang.String" itemvalue="type" />
+            <item index="1" class="java.lang.String" itemvalue="wmode" />
+            <item index="2" class="java.lang.String" itemvalue="src" />
+            <item index="3" class="java.lang.String" itemvalue="width" />
+            <item index="4" class="java.lang.String" itemvalue="height" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownBooleanAttribute" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownTag" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myValues">
+        <value>
+          <list size="5">
+            <item index="0" class="java.lang.String" itemvalue="embed" />
+            <item index="1" class="java.lang.String" itemvalue="nobr" />
+            <item index="2" class="java.lang.String" itemvalue="noembed" />
+            <item index="3" class="java.lang.String" itemvalue="comment" />
+            <item index="4" class="java.lang.String" itemvalue="script" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownTarget" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IOResource" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoredTypesString" value="java.io.ByteArrayOutputStream,java.io.ByteArrayInputStream,java.io.StringBufferInputStream,java.io.CharArrayWriter,java.io.CharArrayReader,java.io.StringWriter,java.io.StringReader" />
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="IfCanBeSwitch" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="minimumBranches" value="3" />
+      <option name="suggestIntSwitches" value="false" />
+      <option name="suggestEnumSwitches" value="false" />
+    </inspection_tool>
+    <inspection_tool class="IfElseToOption" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfNullToElvis" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfThenToElvis" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfThenToSafeAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="IgnoreCoverEntry" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IgnoreDuplicateEntry" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="IgnoreIncorrectEntry" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="IgnoreRelativeEntry" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="IgnoreResultOfCall" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportAllNonLibraryCalls" value="false" />
+      <option name="callCheckString" value="java.io.File,.*,java.io.InputStream,read|skip|available|markSupported,java.io.Reader,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Integer,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.UUID,.*,java.util.regex.Matcher,pattern|toMatchResult|start|end|group|groupCount|matches|find|lookingAt|quoteReplacement|replaceAll|replaceFirst|regionStart|regionEnd|hasTransparantBounds|hasAnchoringBounds|hitEnd|requireEnd,java.util.regex.Pattern,.*" />
+    </inspection_tool>
+    <inspection_tool class="IgnoreSyntaxEntry" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="IgnoreUnusedEntry" enabled="false" level="UNUSED ENTRY" enabled_by_default="false" />
+    <inspection_tool class="ImplicitArrayToString" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ImplicitNumericConversion" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoreWideningConversions" value="false" />
+      <option name="ignoreCharConversions" value="false" />
+      <option name="ignoreConstantConversions" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ImplicitTypeConversion" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="BITS" value="1720" />
+      <option name="FLAG_EXPLICIT_CONVERSION" value="true" />
+      <option name="IGNORE_NODESET_TO_BOOLEAN_VIA_STRING" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ImplicitlyExposedWebServiceMethods" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="IncompatibleMask" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IncompatibleMaskJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IncompleteProperty" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="InconsistentResourceBundle" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_MISSING_TRANSLATIONS" value="true" />
+      <option name="REPORT_INCONSISTENT_PROPERTIES" value="true" />
+      <option name="REPORT_DUPLICATED_PROPERTIES" value="true" />
+    </inspection_tool>
+    <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="IndexOfReplaceableByContains" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IndexZeroUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InfiniteLoopJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InfiniteLoopStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InfiniteRecursion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InfiniteRecursionJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InjectedReferences" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="InjectionNotApplicable" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="InjectionValueTypeInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="InnerClassMayBeStatic" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="InspectionDescriptionNotFoundInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InspectionMappingConsistency" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InspectionUsingGrayColors" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InstanceMethodNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="InstanceVariableNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="2" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="InstanceofIncompatibleInterface" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="InstanceofInterfaces" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="InstantiatingObjectToGetClassObject" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="IntegerDivisionInFloatingPointContext" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="IntegerMultiplicationImplicitCastToLong" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreNonOverflowingCompileTimeConstants" value="true" />
+    </inspection_tool>
+    <inspection_tool class="IntentionDescriptionNotFoundInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InterfaceMethodClashesWithObject" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IntroduceWhenSubject" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JDBCResource" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="JNDIResource" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="JSBitwiseOperatorUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSCheckFunctionSignatures" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSDeprecatedSymbols" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="JSDuplicatedDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSFieldCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSImplicitlyInternalDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSLastCommaInArrayLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSLastCommaInObjectLiteral" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSMismatchedCollectionQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="queries" value="trace,write" />
+      <option name="updates" value="pop,push,shift,splice,unshift" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidTargetOfIndexedPropertyAccess" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSPotentiallyInvalidUsageOfThis" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSReferencingMutableVariableFromClosure" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSShowOverridingMarkers" level="INFO" enabled="false" />
+    <inspection_tool class="JSUndeclaredVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="JSUnfilteredForInLoop" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnnecessarySemicolon" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnresolvedFunction" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="JSUnresolvedLibraryURL" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnresolvedVariable" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="JSUntypedDeclaration" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="JSUnusedAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnusedGlobalSymbols" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnusedLocalSymbols" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSValidateJSDoc" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSValidateJSON" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="JSValidateTypes" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="JUnit3StyleTestMethodInJUnit4Class" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="JUnit4AnnotatedMethodInJUnit3TestCase" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="JUnit4MethodNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="(?!test)[a-z][A-Za-z_\d]*" />
+      <option name="m_minLength" value="3" />
+      <option name="m_maxLength" value="99" />
+    </inspection_tool>
+    <inspection_tool class="JUnitAbstractTestClassNamingConvention" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z][A-Za-z\d]*TestCase" />
+      <option name="m_minLength" value="9" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="JUnitTestClassNamingConvention" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z][A-Za-z\d]*Test" />
+      <option name="m_minLength" value="5" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="Java8CollectionsApi" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaAccessorMethodCalledAsEmptyParen" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaAccessorMethodOverridenAsEmptyParen" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaDoc" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="TOP_LEVEL_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="INNER_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="METHOD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="FIELD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="IGNORE_DEPRECATED" value="false" />
+      <option name="IGNORE_JAVADOC_PERIOD" value="false" />
+      <option name="IGNORE_DUPLICATED_THROWS" value="false" />
+      <option name="IGNORE_POINT_TO_ITSELF" value="true" />
+      <option name="myAdditionalJavadocTags" value="ant.task" />
+    </inspection_tool>
+    <inspection_tool class="JavaFxDefaultTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaFxUnresolvedFxIdReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaFxUnusedImports" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaLangImport" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="JavaMutatorMethodAccessedAsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavaMutatorMethodOverridenAsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavacQuirks" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavadocReference" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="JavaeeApplicationDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaDataSourceORMDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaDataSourceORMInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaModelErrorInspection" level="INSPECTION" enabled="false" />
+    <inspection_tool class="JpaModelWarningInspection" level="WARNING" enabled="false" />
+    <inspection_tool class="JpaORMDomInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaQlInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JpaQueryApiInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JsonDuplicatePropertyKeys" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JsonStandardCompliance" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="KDocUnresolvedReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KeySetIterationMayUseEntrySet" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="KindProjectorSimplifyTypeProjection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KindProjectorUseCorrectLambdaKeyword" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinDeprecation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="KotlinInvalidBundleOrProperty" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="KotlinUnusedImport" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LanguageFeature" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LanguageMismatch" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_NON_ANNOTATED_REFERENCES" value="true" />
+    </inspection_tool>
+    <inspection_tool class="LastIndexToLast" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LengthOneStringInIndexOf" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="LimitedScopeInnerClass" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ListenerMayUseAdapter" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="checkForEmptyMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="LocalCanBeFinal" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_VARIABLES" value="false" />
+      <option name="REPORT_PARAMETERS" value="true" />
+    </inspection_tool>
+    <inspection_tool class="LocalVariableHidingMemberVariable" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_ignoreInvisibleFields" value="true" />
+      <option name="m_ignoreStaticMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="LocalVariableNamingConvention" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreForLoopParameters" value="false" />
+      <option name="m_ignoreCatchParameters" value="false" />
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="99" />
+    </inspection_tool>
+    <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="loggerClassName" value="org.slf4j.LoggerFactory" />
+      <option name="loggerFactoryMethodName" value="getLogger" />
+    </inspection_tool>
+    <inspection_tool class="LoggingConditionDisagreesWithLogStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="LongLiteralsEndingWithLowercaseL" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="LoopStatementThatDoesntLoopJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LoopStatementsThatDontLoop" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LoopVariableNotUpdated" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LossyEncoding" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MagicConstant" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MalformedFormatString" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MalformedRegex" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MalformedXPath" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ManualArrayCopy" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ManualArrayToCollectionCopy" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapFlatten" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapGetOrElseBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapKeys" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapToBooleanContains" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MapValues" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MatchToPartialFunction" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MathRandomCastToInt" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MavenDuplicateDependenciesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MavenDuplicatePluginInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MavenModelInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MavenRedundantGroupId" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MethodCanBeVariableArityMethod" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreByteAndShortArrayParameters" value="true" />
+      <option name="ignoreOverridingMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MethodMayBeStatic" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_onlyPrivateOrFinal" value="false" />
+      <option name="m_ignoreEmptyMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MethodNameSameAsClassName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreMethodsAccessedFromAnonymousClass" value="true" />
+      <option name="ignoreStaticMethodsFromNonStaticInnerClass" value="false" />
+      <option name="onlyReportStaticMethods" value="false" />
+    </inspection_tool>
+    <inspection_tool class="MethodOverloadsParentMethod" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="MethodOverridesPrivateMethod" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="MimeType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MismatchedArrayReadWrite" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="queryNames">
+        <value />
+      </option>
+      <option name="updateNames">
+        <value />
+      </option>
+    </inspection_tool>
+    <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MissingDeprecatedAnnotation" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="MissingFinalNewline" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="MissingMnemonic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="INSPECTION" enabled_by_default="true">
+      <option name="ignoreObjectMethods" value="false" />
+      <option name="ignoreAnonymousClassMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MissortedModifiers" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_requireAnnotationsFirst" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MisspelledHeader" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="MultipleArgListsInAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MultipleDeclaration" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreForLoopDeclarations" value="false" />
+    </inspection_tool>
+    <inspection_tool class="MultipleRepositoryUrls" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MutatorLikeMethodIsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NakedNotify" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="NameBooleanParameters" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NativeMethods" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="NegatedConditional" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreNegatedNullComparison" value="false" />
+    </inspection_tool>
+    <inspection_tool class="NegatedEqualityExpression" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NegatedIfElse" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreNegatedNullComparison" value="false" />
+      <option name="m_ignoreNegatedZeroComparison" value="false" />
+    </inspection_tool>
+    <inspection_tool class="NestedSwitchStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NestedSynchronizedStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NestedTryStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NestingDepth" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_limit" value="5" />
+    </inspection_tool>
+    <inspection_tool class="NewInstanceOfSingleton" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NewStringBufferWithCharArgument" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NoButtonGroup" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NoExplicitFinalizeCalls" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NoLabelFor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NoReturnTypeForImplicitDef" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NoScrollPane" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NonBooleanMethodNameMayNotStartWithQuestion" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="questionString" value="is,can,has,could,will,shall,check,contains,equals,startsWith,endsWith" />
+      <option name="ignoreBooleanMethods" value="false" />
+      <option name="onlyWarnOnBaseMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="NonExceptionNameEndsWithException" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonFinalFieldInImmutable" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonFinalFieldOfException" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonFinalGuard" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonFinalStaticVariableUsedInClassInitialization" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonJREEmulationClassesInClientCode" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonJaxWsWebServices" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NonProtectedConstructorInAbstractClass" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreNonPublicClasses" value="false" />
+    </inspection_tool>
+    <inspection_tool class="NonSerializableFieldInSerializableClass" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignorableAnnotations">
+        <value />
+      </option>
+      <option name="ignoreAnonymousInnerClasses" value="true" />
+      <option name="superClassString" value="java.awt.Component" />
+    </inspection_tool>
+    <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonSerializableServiceParameters" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonSerializableWithSerializationMethods" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonShortCircuitBoolean" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonStaticFinalLogger" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="loggerClassName" value="org.slf4j.Logger" />
+    </inspection_tool>
+    <inspection_tool class="NonSynchronizedMethodOverridesSynchronizedMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NonThreadSafeLazyInitialization" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NotImplementedCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NotifyCalledOnCondition" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NotifyNotInSynchronizedContext" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NotifyWithoutCorrespondingWait" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="NullArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NullableProblems" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOTNULL_PARAMETER_OVERRIDES_NULLABLE" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_PARAMETER_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_GETTER" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_SETTER_PARAMETER" value="true" />
+      <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true" />
+      <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
+    </inspection_tool>
+    <inspection_tool class="NumberEquality" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NumericOverflow" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ObjectEquality" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreEnums" value="true" />
+      <option name="m_ignoreClassObjects" value="true" />
+      <option name="m_ignorePrivateConstructors" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ObjectEqualsNull" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ObjectLiteralToLambda" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ObjectNotify" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ObsoleteCollection" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreRequiredObsoleteCollectionTypes" value="true" />
+    </inspection_tool>
+    <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="OctalLiteral" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="OnDemandImport" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="OneButtonGroup" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="OneWayWebMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="OptionEqualsSome" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="OptionalGetWithoutIsPresent" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="OptionalUsedAsFieldOrParameterType" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="OverlyStrongTypeCast" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoreInMatchingInstanceof" value="false" />
+    </inspection_tool>
+    <inspection_tool class="OverridingDeprecatedMember" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PackageDirectoryMismatch" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PackageVisibleField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ParameterCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ParameterHidingMemberVariable" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_ignoreInvisibleFields" value="true" />
+      <option name="m_ignoreStaticMethodParametersHidingInstanceFields" value="false" />
+      <option name="m_ignoreForConstructors" value="true" />
+      <option name="m_ignoreForPropertySetters" value="true" />
+      <option name="m_ignoreForAbstractMethods" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_ignoreSingleCharacterNames" value="false" />
+      <option name="m_ignoreOverridesOfLibraryMethods" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ParameterNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="ParameterlessMemberOverridenAsEmptyParen" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PatternNotApplicable" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="PatternOverriddenByNonAnnotatedMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PatternValidation" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_NON_CONSTANT_VALUES" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PluginXmlValidity" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="PointlessArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PointlessArithmeticExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PointlessBitwiseExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBooleanExpression" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBooleanExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PointlessIndexOfComparison" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="PointlessNullCheck" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="PostfixTemplateDescriptionNotFound" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ProtectedMemberInFinalClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="PublicConstructorInNonPublicClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="PublicField" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreEnums" value="false" />
+      <option name="ignorableAnnotations">
+        <value>
+          <item value="org.junit.Rule" />
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PublicFieldAccessedInSynchronizedContext" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="PublicStaticArrayField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="QuestionableName" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="nameString" value="aa,abc,bad,bar,bar2,baz,baz1,baz2,baz3,bb,blah,bogus,bool,cc,dd,defau1t,dummy,dummy2,ee,fa1se,ff,foo,foo1,foo2,foo3,foobar,four,fred,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,string,two,then,three,whi1e,var" />
+    </inspection_tool>
+    <inspection_tool class="RangeToIndices" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RawUseOfParameterizedType" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreObjectConstruction" value="false" />
+      <option name="ignoreUncompilable" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ReadObjectAndWriteObjectPrivate" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ReadObjectInitialization" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ReadResolveAndWriteReplaceProtected" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantArrayCreation" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantCast" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantCollectionConversion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantHeadOrLastOption" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantImplements" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreSerializable" value="false" />
+      <option name="ignoreCloneable" value="false" />
+    </inspection_tool>
+    <inspection_tool class="RedundantImport" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="RedundantMethodOverride" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantSamConstructor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantStringFormatCall" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantThrows" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantTypeArguments" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RedundantTypeConversion" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_ANY" value="false" />
+    </inspection_tool>
+    <inspection_tool class="RedundantVisibilityModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReferenceMustBePrefixed" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReferencesToClassesFromDefaultPackagesInJSPFile" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReflectionForUnavailableAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RefusedBequest" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreEmptySuperMethods" value="false" />
+      <option name="onlyReportWhenAnnotated" value="true" />
+    </inspection_tool>
+    <inspection_tool class="RemoveCurlyBracesFromTemplate" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveExplicitSuperQualifier" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveForLoopIndices" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RemoveRedundantReturn" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceAllDot" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreLazyOperators" value="true" />
+      <option name="ignoreObscureOperators" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ReplaceGetOrSet" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ReplaceToWithUntil" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReplaceWithOperatorAssignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RequiredAttributes" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myAdditionalRequiredHtmlAttributes" value="" />
+    </inspection_tool>
+    <inspection_tool class="ReservedWordUsedAsNameJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ReturnFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReturnFromFinallyBlockJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReturnOfDateField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ReturnThis" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ReuseOfLocalVariable" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ReverseIterator" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReverseMap" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ReverseTakeReverse" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RuntimeExec" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="RuntimeExecWithNonConstantString" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SSBasedInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <replaceConfiguration name="new ArrayList() to FastList.newList() (generified)" text="new ArrayList&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.&lt;$type$&gt;newList($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new ArrayList() to FastList.newList()" text="new ArrayList($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.newList($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new HashSet() to UnifiedSet.newSet() (generified)" text="new HashSet&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.&lt;$type$&gt;newSet($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new HashSet() to UnifiedSet.newSet()" text="new HashSet($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.newSet($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new HashMap() to UnifiedMap.newMap() (generified)" text="new HashMap&lt;$key$, $value$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.&lt;$key$, $value$&gt;newMap($expr$)">
+        <constraint name="key" within="" contains="" />
+        <constraint name="value" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new HashMap() to UnifiedMap.newMap()" text="new HashMap($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new FastList() to FastList.newList() (generified)" text="new FastList&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.&lt;$type$&gt;newList($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new FastList() to FastList.newList()" text="new FastList($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.newList($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedSet() to UnifiedSet.newSet() (generified)" text="new UnifiedSet&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.&lt;$type$&gt;newSet($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedSet() to UnifiedSet.newSet()" text="new UnifiedSet($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.newSet($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedMap() to UnifiedMap.newMap() (generified)" text="new UnifiedMap&lt;$key$, $value$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.&lt;$key$, $value$&gt;newMap($expr$)">
+        <constraint name="key" within="" contains="" />
+        <constraint name="value" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedMap() to UnifiedMap.newMap()" text="new UnifiedMap($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Collections.singletonList() to Lists.fixedSize.of()" text="Collections.singletonList($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.factory.Lists.fixedSize.of($expr$)">
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Collections.singleton() to Sets.fixedSize.of()" text="Collections.singleton($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.factory.Setss.fixedSize.of($expr$)">
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Collections.singletonMap() to Maps.fixedSize.of()" text="Collections.singletonMap($key$, $value$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.factory.Maps.fixedSize.of($key$, $value$)">
+        <constraint name="key" within="" contains="" />
+        <constraint name="value" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new FastList 3" text="new FastList&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.&lt;$type$&gt;newList($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new FastList 4" text="new FastList($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.newList($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedSet 3" text="new UnifiedSet&lt;$type$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.&lt;$type$&gt;newSet($expr$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedSet 4" text="new UnifiedSet($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.newSet($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedMap 3" text="new UnifiedMap&lt;$key$, $value$&gt;($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.&lt;$key$, $value$&gt;newMap($expr$)">
+        <constraint name="key" within="" contains="" />
+        <constraint name="value" within="" contains="" />
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="new UnifiedMap 4" text="new UnifiedMap($expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.map.mutable.UnifiedMap.newMap($expr$)">
+        <constraint name="expr" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="List to MutableList" text="java.util.List&lt;$type$&gt; $list$ = $mutableList$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.list.MutableList&lt;$type$&gt; $list$ = $mutableList$;">
+        <constraint name="type" within="" contains="" />
+        <constraint name="list" within="" contains="" />
+        <constraint name="mutableList" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Set to MutableSet" text="java.util.Set&lt;$type$&gt; $set$ = $mutableSet$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.set.MutableSet&lt;$type$&gt; $set$ = $mutableSet$;">
+        <constraint name="type" within="" contains="" />
+        <constraint name="set" within="" contains="" />
+        <constraint name="mutableSet" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Map to MutableMap" text="java.util.Map&lt;$key$, $value$&gt; $map$ = $mutableMap$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.map.MutableMap&lt;$key$, $value$&gt; $map$ = $mutableMap$;">
+        <constraint name="key" within="" contains="" />
+        <constraint name="value" within="" contains="" />
+        <constraint name="map" within="" contains="" />
+        <constraint name="mutableMap" nameOfExprType="MutableMap" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="List to MutableList 2" text="java.util.List $list$ = $mutableList$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.list.MutableList $list$ = $mutableList$;">
+        <constraint name="list" within="" contains="" />
+        <constraint name="mutableList" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Set to MutableSet 2" text="java.util.Set $set$ = $mutableSet$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.set.MutableSet $set$ = $mutableSet$;">
+        <constraint name="set" within="" contains="" />
+        <constraint name="mutableSet" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Map to MutableMap 2" text="java.util.Map $map$ = $mutableMap$;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.api.map.MutableMap $map$ = $mutableMap$;">
+        <constraint name="map" within="" contains="" />
+        <constraint name="mutableMap" nameOfExprType="MutableMap" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Iterate.notEmpty()" text="$collection$ != null &amp;&amp; !$collection$.isEmpty()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.notEmpty($collection$)">
+        <constraint name="collection" nameOfExprType="Collection" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Iterate.getFirst() 1" text="$collection$.iterator().next()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.getFirst($collection$)">
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Iterate.getFirst() 2" text="$collection$.listIterator().next()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.getFirst($collection$)">
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertTrue to assertFalse" text="Assert.assertTrue($string$, !$expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="junit.framework.Assert.assertFalse($string$, $expr$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Size of Collection 1" text="Assert.assertTrue($string$, $collection$.size() == $size$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Size of Collection 2" text="Assert.assertEquals($string$, $size$, $collection$.size())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Size of Collection 3" text="Assert.assertTrue($string$, $size$ == $collection$.size())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 1" text="Assert.assertEquals($string$, new ArrayList(), $collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 2" text="Assert.assertEquals($string$, $collection$, new ArrayList())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 3" text="Assert.assertEquals($string$, FastList.newList(), $collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 4" text="Assert.assertEquals($string$, $collection$, FastList.newList())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 5" text="Assert.assertEquals($string$, UnifiedSet.newSet(), $collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 6" text="Assert.assertEquals($string$, $collection$, UnifiedSet.newSet())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 7" text="Assert.assertEquals($string$, UnifiedMap.newMap(), $collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 8" text="Assert.assertEquals($string$, $collection$, UnifiedMap.newMap())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 9" text="Assert.assertTrue($string$, $collection$.isEmpty())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertEmpty 10" text="Verify.assertSize($string$, 0, $collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEmpty($string$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertInstanceOf" text="Assert.assertTrue($string$, $expr$ instanceof $class$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertInstanceOf($string$, $expr$, $class$.class)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+        <constraint name="class" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertContains" text="Assert.assertTrue($string$, $collection$.contains($obj$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertContains($string$, $obj$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+        <constraint name="obj" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="equals and hashCode 1" text="Assert.assertEquals($string$, $left$.hashCode(), $right$.hashCode())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEqualsAndHashCode($string$, $left$, $right$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="equals and hashCode 2" text="Assert.assertTrue($string$, $left$.hashCode() == $right$.hashCode())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertEqualsAndHashCode($string$, $left$, $right$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertNotEquals" text="Assert.assertFalse($string$, $left$.equals($right$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertNotEquals($string$, $left$, $right$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertNotContains" text="Assert.assertFalse($string$, $collection$.contains($obj$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertNotContains($string$, $obj$, $collection$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="collection" within="" contains="" />
+        <constraint name="obj" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertItemAtIndex 1" text="Assert.assertEquals($string$, $item$, $list$.get($index$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertItemAtIndex($string$, $item$, $index$, $list$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="item" within="" contains="" />
+        <constraint name="list" nameOfExprType="List" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="index" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertItemAtIndex 2" text="Assert.assertEquals($string$, $list$.get($index$), $item$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertItemAtIndex($string$, $item$, $index$, $list$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="list" nameOfExprType="List" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="index" within="" contains="" />
+        <constraint name="item" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertItemAtIndex 3" text="Assert.assertEquals($string$, $item$, $array$[$index$])" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertItemAtIndex($string$, $item$, $index$, $array$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="item" within="" contains="" />
+        <constraint name="array" nameOfExprType="Object\[\]" within="" contains="" />
+        <constraint name="index" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertItemAtIndex 4" text="Assert.assertEquals($string$, $array$[$index$], $item$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertItemAtIndex($string$, $item$, $index$, $array$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="array" nameOfExprType="Object\[\]" within="" contains="" />
+        <constraint name="index" within="" contains="" />
+        <constraint name="item" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertContainsAll 1" text="Assert.assertContains($string$, $expr1$, $coll$);&#10;assertContains($string$, $expr2$, $coll$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertContainsAll($string$, $coll$, $expr1$, $expr2$);">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="coll" nameOfExprType="Collection" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertContainsAll 2" text="Assert.assertContainsAll($string$, $coll$, $expr$);&#10;assertContains($string$, $expr2$, $coll$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertContainsAll($string$, $coll$, $expr$, $expr2$);">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="coll" nameOfExprType="Collection" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="expr" maxCount="2147483647" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 1" text="$left$ == null ? $right$ != null : !$left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="!org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 2" text="$left$ == null ? $right$ == null : $left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 3" text="$left$ == null ? $right$ == null : $left$ == $right$ || $left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 4" text="$left$ == $right$ || $left$ != null &amp;&amp; $left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 5" text="$right$ == $left$ || $left$ != null &amp;&amp; $left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="right" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="nullSafeEquals 6" text="$left$ == null || $right$ == null ? $left$ == $right$ : $left$.equals($right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Comparators.nullSafeEquals($left$, $right$)">
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 1" text="$Coll$&lt;$type$&gt; $coll$ = FastList.&lt;$type$&gt;newList();&#10;$coll$.add($expr$);&#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = FastList.&lt;$type$&gt;newListWith($expr$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 2" text="$Coll$&lt;$type$&gt; $coll$ = FastList.&lt;$type$&gt;newListWith($expr1$);&#10;$coll$.add($expr2$); &#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = FastList.&lt;$type$&gt;newListWith($expr1$, $expr2$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" maxCount="2147483647" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 3" text="$Coll$ $coll$ = FastList.newList();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = FastList.newListWith($expr$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 4" text="$Coll$ $coll$ = FastList.newListWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = FastList.newListWith($expr1$, $expr2$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" maxCount="2147483647" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 1" text="$Coll$&lt;$type$&gt; $coll$ = UnifiedSet.&lt;$type$&gt;newSet();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = UnifiedSet.&lt;$type$&gt;newSetWith($expr$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 2" text="$Coll$&lt;$type$&gt; $coll$ = UnifiedSet.&lt;$type$&gt;newSetWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = UnifiedSet.&lt;$type$&gt;newSetWith($expr1$, $expr2$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 3" text="$Coll$ $coll$ = UnifiedSet.newSet();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = UnifiedSet.newSetWith($expr$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 4" text="$Coll$ $coll$ = UnifiedSet.newSetWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = UnifiedSet.newSetWith($expr1$, $expr2$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 6" text="FastList.newList(Arrays.asList($expr$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.newListWith($expr$)">
+        <constraint name="expr" minCount="0" maxCount="2147483647" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 6" text="UnifiedSet.newSet(Arrays.asList($expr$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.set.mutable.UnifiedSet.newSetWith($expr$)">
+        <constraint name="expr" minCount="0" maxCount="2147483647" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="ArrayIterate.notEmpty()" text="$array$ != null &amp;&amp; $array$.length &gt; 0" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.ArrayIterate.notEmpty($array$)">
+        <constraint name="array" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="ArrayIterate.asList() to FastList.newListWith()" text="ArrayIterate.asList(new Object[]{$expr$})" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.list.mutable.FastList.newListWith($expr$)">
+        <constraint name="obj" within="" contains="" />
+        <constraint name="expr" minCount="0" maxCount="2147483647" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Iterate to ArrayIterate" text="Iterate.$method$(Arrays.asList($array$), $expr$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.ArrayIterate.$method$($array$, $expr$)">
+        <constraint name="list" within="" contains="" />
+        <constraint name="array" within="" contains="" />
+        <constraint name="expr" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="method" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertNotEquals 2" text="Assert.assertTrue($string$, $left$ != $right$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertNotEquals($string$, $left$, $right$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="assertInstanceOf 2" text="Assert.assertTrue($string$, $class$.class.isInstance($expr$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertInstanceOf($string$, $expr$, $class$.class)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+        <constraint name="class" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 7" text="$coll$ = FastList.newList();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = FastList.newListWith($expr$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 8" text="$coll$ = FastList.&lt;$type$&gt;newListWith($expr1$);&#10;$coll$.add($expr2$);&#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = FastList.&lt;$type$&gt;newListWith($expr1$, $expr2$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newListWith 9" text="$coll$ = FastList.newListWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="$coll$ = FastList.newListWith($expr1$, $expr2$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 7" text="$coll$ = UnifiedSet.newSet();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = UnifiedSet.newSetWith($expr$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 8" text="$coll$ = UnifiedSet.&lt;$type$&gt;newSetWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = UnifiedSet.&lt;$type$&gt;newSetWith($expr1$, $expr2$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newSetWith 9" text="$coll$ = UnifiedSet.newSetWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = UnifiedSet.newSetWith($expr1$, $expr2$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="size of array 1" text="Assert.assertTrue($string$, $array$.length == $size$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $array$)">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+        <constraint name="string" minCount="0" within="" contains="" />
+        <constraint name="array" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="size of array 2" text="Assert.assertEquals($string$, $size$, $array$.length)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $array$)">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+        <constraint name="string" minCount="0" within="" contains="" />
+        <constraint name="array" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="size of array 3" text="Assert.assertTrue($string$, $size$ == $array$.length)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertSize($string$, $size$, $array$)">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="expr1" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+        <constraint name="string" minCount="0" within="" contains="" />
+        <constraint name="array" within="" contains="" />
+        <constraint name="size" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="passThru selector" text="new Function&lt;$type$, $type$&gt;()&#10;{&#10;    public $type$ valueOf($type$ $object$)&#10;    {&#10;        return $object$;&#10;    }&#10;}" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.block.factory.Functions.&lt;$type$&gt;getPassThru()">
+        <constraint name="type" within="" contains="" />
+        <constraint name="object" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Iterate.isEmpty()" text="$collection$ == null || $collection$.isEmpty()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.isEmpty($collection$)">
+        <constraint name="collection" nameOfExprType="Collection" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Unmodifiable Collection" text="java.util.Collections.unmodifiableCollection($coll$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$.asUnmodifiable()">
+        <constraint name="coll" nameOfExprType="MutableCollection" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="UnmodifiableList" text="java.util.Collections.unmodifiableList($coll$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$.asUnmodifiable()">
+        <constraint name="coll" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Unmodifiable Set" text="java.util.Collections.unmodifiableSet($coll$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$.asUnmodifiable()">
+        <constraint name="coll" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Unmodifiable Map" text="java.util.Collections.unmodifiableMap($map$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$map$.asUnmodifiable()">
+        <constraint name="map" nameOfExprType="MutableMap" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Verify.assertNotNull" text="Assert.assertTrue($string$, $expr$ != null)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertNotNull($string$, $expr$)">
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+        <constraint name="left" within="" contains="" />
+        <constraint name="right" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="not Iterate.notEmpty()" text="!Iterate.notEmpty($iterable$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.isEmpty($iterable$)">
+        <constraint name="iterable" nameOfExprType="Iterable" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="!Iterate.isEmpty() to notEmpty()" text="!Iterate.isEmpty($iterable$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.Iterate.notEmpty($iterable$)">
+        <constraint name="iterable" nameOfExprType="Iterable" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="not MapIterate.notEmpty()" text="!MapIterate.notEmpty($map$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.MapIterate.isEmpty($map$)">
+        <constraint name="map" nameOfExprType="Map" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="!Map.isEmpty() to notEmpty()" text="!MapIterate.isEmpty($map$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.utility.MapIterate.notEmpty($map$)">
+        <constraint name="map" nameOfExprType="Map" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="!isEmpty() to notEmpty()" text="!$richIterable$.isEmpty()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$richIterable$.notEmpty()">
+        <constraint name="richIterable" script="&quot;&quot;" nameOfExprType="RichIterable" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="!notEmpty() to isEmpty()" text="!$richIterable$.notEmpty()" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$richIterable$.isEmpty()">
+        <constraint name="richIterable" script="&quot;&quot;" nameOfExprType="RichIterable" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Verify.assertThrows() 1" text="try&#10;{&#10;    $statements$;&#10;    Assert.fail($string$);&#10;}&#10;catch ($Exception$ e)&#10;{&#10;}" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="Verify.assertThrows($Exception$.class, new Runnable()&#10;{&#10;    public void run()&#10;    {&#10;        $statements$;&#10;    }&#10;});&#10;">
+        <constraint name="statements" maxCount="2147483647" within="" contains="" />
+        <constraint name="Exception" regexp="Exception" withinHierarchy="true" within="" contains="" />
+        <constraint name="string" nameOfExprType="String" minCount="0" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 1" text="$Coll$&lt;$type$&gt; $coll$ = HashBag.&lt;$type$&gt;newBag();&#10;$coll$.add($expr$);&#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = HashBag.&lt;$type$&gt;newBagWith($expr$);">
+        <constraint name="Coll" script="&quot;&quot;" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 2" text="$Coll$&lt;$type$&gt; $coll$ = HashBag.&lt;$type$&gt;newBagWith($expr1$);&#10;$coll$.add($expr2$); &#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$&lt;$type$&gt; $coll$ = HashBag.&lt;$type$&gt;newBagWith($expr1$, $expr2$);">
+        <constraint name="Coll" script="&quot;&quot;" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="type" script="&quot;&quot;" within="" contains="" />
+        <constraint name="coll" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr1" script="&quot;&quot;" maxCount="2147483647" within="" contains="" />
+        <constraint name="expr2" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 3" text="$Coll$ $coll$ = HashBag.newBag();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = HashBag.newBagWith($expr$);">
+        <constraint name="Coll" script="&quot;&quot;" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 4" text="$Coll$ $coll$ = HashBag.newBagWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$Coll$ $coll$ = HashBag.newBagWith($expr1$, $expr2$);">
+        <constraint name="Coll" regexp="Collection" withinHierarchy="true" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" maxCount="2147483647" within="" contains="" />
+        <constraint name="expr2" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 6" text="HashBag.newBag(Arrays.asList($expr$))" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.bag.mutable.HashBag.newBagWith($expr$)">
+        <constraint name="expr" minCount="0" maxCount="2147483647" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 7" text="$coll$ = HashBag.newBag();&#10;$coll$.add($expr$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = HashBag.newBagWith($expr$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 8" text="$coll$ = HashBag.&lt;$type$&gt;newBagWith($expr1$);&#10;$coll$.add($expr2$);&#10;" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = HashBag.&lt;$type$&gt;newBagWith($expr1$, $expr2$);">
+        <constraint name="coll" script="&quot;&quot;" within="" contains="" />
+        <constraint name="type" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr1" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr2" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="newBagWith 9" text="$coll$ = HashBag.newBagWith($expr1$);&#10;$coll$.add($expr2$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$coll$ = HashBag.newBagWith($expr1$, $expr2$);">
+        <constraint name="coll" within="" contains="" />
+        <constraint name="expr1" script="&quot;&quot;" within="" contains="" />
+        <constraint name="expr2" script="&quot;&quot;" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="synchronizedList() to asSynchronized()" text="Collections.synchronizedList($list$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$list$.asSynchronized()">
+        <constraint name="set" script="&quot;&quot;" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="list" script="&quot;&quot;" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="synchronizedSet() to asSynchronized()" text="Collections.synchronizedSet($set$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$set$.asSynchronized()">
+        <constraint name="set" script="&quot;&quot;" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="list" script="&quot;&quot;" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="synchronizedMap() to asSynchronized()" text="Collections.synchronizedMap($map$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$map$.asSynchronized()">
+        <constraint name="set" script="&quot;&quot;" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="list" script="&quot;&quot;" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="map" script="&quot;&quot;" nameOfExprType="MutableMap" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="synchronizedCollection() to asSynchronized()" text="Collections.synchronizedCollection($collection$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="$collection$.asSynchronized()">
+        <constraint name="set" script="&quot;&quot;" nameOfExprType="MutableSet" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="list" script="&quot;&quot;" nameOfExprType="MutableList" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="map" script="&quot;&quot;" nameOfExprType="MutableMap" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="collection" script="&quot;&quot;" nameOfExprType="MutableCollection" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Verify.assertCount()" text="Assert.assertEquals($expectedCount$, Iterate.count($iterable$, $discriminator$);" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="org.eclipse.collections.impl.test.Verify.assertCount($expectedCount$, $iterable$, $discriminator$);">
+        <constraint name="size" within="" contains="" />
+        <constraint name="iterable" within="" contains="" />
+        <constraint name="discriminator" within="" contains="" />
+        <constraint name="expectedCount" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="CollectionRemoveBlock.on()" text="new CollectionRemoveBlock&lt;$type$&gt;($coll$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="CollectionRemoveBlock.on($coll$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="CollectionAddBlock.on()" text="new CollectionAddBlock&lt;$type$&gt;($coll$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="true" replacement="CollectionAddBlock.on($coll$)">
+        <constraint name="type" within="" contains="" />
+        <constraint name="coll" within="" contains="" />
+      </replaceConfiguration>
+    </inspection_tool>
+    <inspection_tool class="SafeLock" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SafeVarargsDetector" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SameElementsToEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SamePackageImport" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SameParameterValue" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SameReturnValue" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SbtReplaceProjectWithProjectIn" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDefaultFileTemplateUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDeprecatedIdentifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDeprecation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocInlinedTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocMissingParameterDescription" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocUnbalancedHeader" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocUnclosedTagWithoutParser" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocUnknownParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaDocUnknownTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaFileName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaMalformedFormatString" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaPackageName" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaRedundantCast" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaRedundantConversion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaStyle" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaUnnecessaryParentheses" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaUnnecessarySemicolon" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaUnreachableCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaUnresolvedPropertyKey" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ScalaUnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaUselessExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScalaXmlUnmatchedTag" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="SecondUnsafeCall" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SelfIncludingJspFiles" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreAnonymousInnerClasses" value="true" />
+      <option name="superClassString" value="java.awt.Component" />
+    </inspection_tool>
+    <inspection_tool class="SerializableHasSerializationMethods" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="ignoreAnonymousInnerClasses" value="true" />
+      <option name="superClassString" value="java.awt.Component" />
+    </inspection_tool>
+    <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreAnonymousInnerClasses" value="true" />
+      <option name="superClassString" value="java.awt.Component" />
+    </inspection_tool>
+    <inspection_tool class="SerializableInnerClassWithNonSerializableOuterClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreAnonymousInnerClasses" value="true" />
+      <option name="superClassString" value="java.awt.Component" />
+    </inspection_tool>
+    <inspection_tool class="SetReplaceableByEnumSet" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SetupCallsSuperSetup" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SetupIsPublicVoidNoArg" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ShiftOutOfRange" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ShiftOutOfRangeJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SignalWithoutCorrespondingAwait" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SillyAssignment" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SillyAssignmentJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableAnnotation" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableConditionalExpression" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableEqualsExpression" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableFoldOrReduce" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableIfStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifiableJUnitAssertion" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SimplifyAssertNotNull" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SimplifyBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyBooleanWithConstants" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyFor" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="Since15" enabled="false" level="WARNING" enabled_by_default="false">
+      <effectiveLL value="JDK_1_6" />
+    </inspection_tool>
+    <inspection_tool class="SingleImport" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SizeToLength" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SleepWhileHoldingLock" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SocketResource" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="insideTryAllowed" value="false" />
+    </inspection_tool>
+    <inspection_tool class="SortFilter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SpringAopErrorsInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringAopWarningsInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanAutowiringInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanConstructorArgInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanDepedencyCheckInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanInstantiationInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanLookupMethodInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringBeanNameConventionInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringFactoryMethodInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringInjectionValueConsistencyInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringInjectionValueStyleInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringJamErrorInspection" level="INSPECTION" enabled="false" />
+    <inspection_tool class="SpringModelInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringReplacedMethodsInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SpringScopesInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StatefulEp" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StaticCallOnSubclass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StaticCollection" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreWeakCollections" value="false" />
+    </inspection_tool>
+    <inspection_tool class="StaticFieldReferenceOnSubclass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StaticGuardedByInstance" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StaticImport" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="allowedClasses">
+        <set>
+          <option value="org.eclipse.collections.impl.test.Verify" />
+          <option value="org.hamcrest.Matchers" />
+          <option value="org.junit.Assert" />
+        </set>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="StaticInheritance" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StaticInitializerReferencesSubClass" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StaticMethodNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StaticSuite" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StaticVariableInitialization" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignorePrimitives" value="false" />
+    </inspection_tool>
+    <inspection_tool class="StaticVariableOfConcreteClass" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="StaticVariableUninitializedUse" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignorePrimitives" value="false" />
+    </inspection_tool>
+    <inspection_tool class="StringBufferField" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="StringBufferReplaceableByString" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringBufferReplaceableByStringBuilder" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringBufferToStringInConcatenation" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringConcatenationArgumentToLogCall" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringConcatenationInLoops" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreUnlessAssigned" value="true" />
+    </inspection_tool>
+    <inspection_tool class="StringConcatenationInsideStringBufferAppend" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringConstructor" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreSubstringArguments" value="false" />
+    </inspection_tool>
+    <inspection_tool class="StringEquality" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringEqualsEmptyString" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringReplaceableByStringBuffer" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="onlyWarnOnLoop" value="true" />
+    </inspection_tool>
+    <inspection_tool class="StringToString" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StringTokenizerDelimiter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StrutsInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StrutsTilesInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StrutsValidatorFormInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="StrutsValidatorInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SubstringZero" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SubtractionInCompareTo" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SuppressionAnnotation" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="Suspicious Inferred Type" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="Suspicious New Line in Method Call" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousInferredType" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousMethodCalls" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="REPORT_CONVERTIBLE_METHOD_CALLS" value="false" />
+    </inspection_tool>
+    <inspection_tool class="SuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false">
+      <group names="x,width,left,right" />
+      <group names="y,height,top,bottom" />
+    </inspection_tool>
+    <inspection_tool class="SuspiciousSystemArraycopy" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousToArrayCall" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SwitchStatement" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
+    <inspection_tool class="SwitchStatementsWithoutDefault" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_ignoreFullyCoveredEnums" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SynchronizationOnLocalVariableOrMethodParameter" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="reportLocalVariables" value="true" />
+      <option name="reportMethodParameters" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SynchronizeOnLock" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SynchronizeOnNonFinalField" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SynchronizeOnThis" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SynchronizedMethod" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="m_includeNativeMethods" value="true" />
+      <option name="ignoreSynchronizedSuperMethods" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SynchronizedOnLiteralObject" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SyntaxError" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SystemExit" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SystemGC" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="SystemGetenv" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SystemRunFinalizersOnExit" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="SystemSetSecurityManager" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TailRecursion" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="TeardownIsPublicVoidNoArg" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TestCaseWithConstructor" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TestCaseWithNoTestMethods" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreSupers" value="true" />
+    </inspection_tool>
+    <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TestNGDataProvider" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TestOnlyProblems" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TextLabelInSwitchStatement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThisExpressionReferencesGlobalObjectJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadDeathRethrown" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadDumpStack" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadRun" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadStartInConstruction" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadStopSuspendResume" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThreadWithDefaultRunMethod" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThrowCaughtLocally" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreRethrownExceptions" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ThrowFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ThrowFromFinallyBlockJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThrowableInstanceNeverThrown" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ThrowablePrintedToSystemOut" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ThrowableResultOfMethodCallIgnored" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ThrownExceptionsPerMethod" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_limit" value="3" />
+    </inspection_tool>
+    <inspection_tool class="ThrowsRuntimeException" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="ToSetAndBack" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TodoComment" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="TooBroadScope" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_allowConstructorAsInitializer" value="true" />
+      <option name="m_onlyLookAtBlocks" value="false" />
+    </inspection_tool>
+    <inspection_tool class="TrailingSpacesInProperty" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TransientFieldInNonSerializableClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TrivialConditionalJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TrivialFunctionalExpressionUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TrivialIf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TrivialIfJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TrivialMethodReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TrivialStringConcatenation" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TypeAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TypeCheckCanBeMatch" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TypeCustomizer" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TypeMayBeWeakened" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
+      <option name="useParameterizedTypeForCollectionMethods" value="true" />
+      <option name="doNotWeakenToJavaLangObject" value="true" />
+      <option name="onlyWeakentoInterface" value="true" />
+    </inspection_tool>
+    <inspection_tool class="TypeParameterExtendsFinalClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TypeParameterExtendsObject" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TypeParameterHidesVisibleType" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="TypeParameterNamingConvention" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_regex" value="[A-Za-z\d]+" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="TypeParameterShadow" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UNCHECKED_WARNING" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="UNUSED_IMPORT" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UNUSED_SYMBOL" enabled="true" level="INSPECTION" enabled_by_default="true">
+      <option name="LOCAL_VARIABLE" value="true" />
+      <option name="FIELD" value="true" />
+      <option name="METHOD" value="true" />
+      <option name="CLASS" value="true" />
+      <option name="PARAMETER" value="true" />
+      <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnaryPlus" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnconditionalWait" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnconstructableTestCase" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UndesirableClassUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnitInMap" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnitMethodIsParameterless" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnknownGuard" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnknownLanguage" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="UnnecessarilyQualifiedStaticallyImportedElement" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryAnnotationParentheses" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryBlockStatement" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreSwitchBranches" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryBoxing" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryBreak" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryCallToStringValueOf" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryConditionalExpression" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryConstructor" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryContinue" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryContinueJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryEnumModifier" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryFinalOnLocalVariable" enabled="true" level="INSPECTION" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryFinalOnLocalVariableOrParameter" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryFinalOnParameter" enabled="true" level="INSPECTION" enabled_by_default="true">
+      <option name="onlyWarnOnAbstractMethods" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <scope name="No package-info.java" level="INSPECTION" enabled="true">
+        <option name="m_ignoreJavadoc" value="false" />
+      </scope>
+      <option name="m_ignoreJavadoc" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryInheritDoc" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryInitCause" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryInterfaceModifier" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryJavaDocLink" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreInlineLinkToSuper" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLabelJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLabelOnBreakStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLabelOnContinueStatement" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryParentheses" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreClarifyingParentheses" value="true" />
+      <option name="ignoreParenthesesOnConditionals" value="false" />
+      <option name="ignoreParenthesesOnLambdaParameter" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryQualifiedReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryQualifierForThis" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryReturn" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreInThenBranch" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryReturnJS" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessarySemicolon" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessarySuperConstructor" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessarySuperQualifier" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryTemporaryOnConversionFromString" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryTemporaryOnConversionToString" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryToStringCall" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryUnaryMinus" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryUnboxing" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreReferences" value="true" />
+      <option name="ignoreComplexLiterals" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnqualifiedFieldAccess" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnqualifiedMethodAccess" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UnqualifiedStaticUsage" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreStaticFieldAccesses" value="true" />
+      <option name="m_ignoreStaticMethodCalls" value="false" />
+      <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnreachableCodeJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnresolvedPropertyKey" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnresolvedReference" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="UnsafeReturnStatementVisitor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnsafeVfsRecursion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedAssignment" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="REPORT_PREFIX_EXPRESSIONS" value="false" />
+      <option name="REPORT_POSTFIX_EXPRESSIONS" value="true" />
+      <option name="REPORT_REDUNDANT_INITIALIZER" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnusedCatchParameter" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="m_ignoreCatchBlocksWithComments" value="true" />
+      <option name="m_ignoreTestCases" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnusedDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ADD_MAINS_TO_ENTRIES" value="true" />
+      <option name="ADD_APPLET_TO_ENTRIES" value="true" />
+      <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
+      <option name="ADD_NONJAVA_TO_ENTRIES" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnusedLabel" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedMessageFormatParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedParameters" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedReceiverParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseJBColor" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UseOfAWTPeerClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseOfJDBCDriverClass" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseOfObsoleteAssert" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseOfProcessBuilder" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseOfPropertiesAsHashtable" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UseOfSunClasses" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UsePrimitiveTypes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UsePropertyAccessSyntax" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UseVirtualFileEquals" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UtilSchemaInspection" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UtilityClassWithPublicConstructor" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="UtilityClassWithoutPrivateConstructor" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignorableAnnotations">
+        <value />
+      </option>
+      <option name="ignoreClassesWithOnlyMain" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ValidExternallyBoundObject" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="VarCouldBeVal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VariablePatternShadow" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VolatileArrayField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="VolatileLongOrDoubleField" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="VtlDirectiveArgsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VtlFileReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VtlInterpolationsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VtlReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="VtlTypesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WaitCalledOnCondition" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WaitNotInLoop" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WaitNotInSynchronizedContext" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WaitOrAwaitWithoutTimeout" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WaitWhileHoldingTwoLocks" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WaitWithoutCorrespondingNotify" enabled="false" level="INSPECTION" enabled_by_default="false" />
+    <inspection_tool class="WeakerAccess" enabled="false" level="INFO" enabled_by_default="false">
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="false" />
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="false" />
+      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="true" />
+    </inspection_tool>
+    <inspection_tool class="WebProperties" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WebWarnings" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WhileCanBeForeach" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WhileLoopSpinsOnField" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="ignoreNonEmtpyLoops" value="false" />
+    </inspection_tool>
+    <inspection_tool class="WrongPackageStatement" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="XmlDuplicatedId" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="XmlHighlighting" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="XmlInvalidId" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="XmlPathReference" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="XmlUnboundNsPrefix" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="XmlUnusedNamespaceDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="XmlWrongRootElement" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="XsltDeclarations" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="XsltTemplateInvocation" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="XsltUnusedDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="XsltVariableShadowing" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ZeroIndexToHead" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ZipWithIndex" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="dependsOnMethodTestNG" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="groupsTestNG" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="groups">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="unused" enabled="false" level="INSPECTION" enabled_by_default="false">
+      <option name="LOCAL_VARIABLE" value="true" />
+      <option name="FIELD" value="true" />
+      <option name="METHOD" value="true" />
+      <option name="CLASS" value="true" />
+      <option name="PARAMETER" value="true" />
+      <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="true" />
+      <option name="ADD_MAINS_TO_ENTRIES" value="true" />
+      <option name="ADD_APPLET_TO_ENTRIES" value="true" />
+      <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
+      <option name="ADD_NONJAVA_TO_ENTRIES" value="false" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ImmutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ImmutableIterable.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.ImmutableMapIterable;
+import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
+import org.eclipse.collections.api.multimap.ImmutableMultimap;
+import org.eclipse.collections.api.partition.PartitionImmutableIterable;
+import org.eclipse.collections.api.tuple.Pair;
+
+public interface ImmutableIterable<T> extends RichIterable<T>
+{
+    @Override
+    ImmutableIterable<T> tap(Procedure<? super T> procedure);
+
+    @Override
+    ImmutableIterable<T> select(Predicate<? super T> predicate);
+
+    @Override
+    <P> ImmutableIterable<T> selectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    ImmutableIterable<T> reject(Predicate<? super T> predicate);
+
+    @Override
+    <P> ImmutableIterable<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    PartitionImmutableIterable<T> partition(Predicate<? super T> predicate);
+
+    @Override
+    <P> PartitionImmutableIterable<T> partitionWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    <S> ImmutableIterable<S> selectInstancesOf(Class<S> clazz);
+
+    @Override
+    <V> ImmutableIterable<V> collect(Function<? super T, ? extends V> function);
+
+    /*
+    @Override
+    ImmutableBooleanIterable collectBoolean(BooleanFunction<? super T> booleanFunction);
+
+    @Override
+    ImmutableByteIterable collectByte(ByteFunction<? super T> byteFunction);
+
+    @Override
+    ImmutableCharIterable collectChar(CharFunction<? super T> charFunction);
+
+    @Override
+    ImmutableDoubleIterable collectDouble(DoubleFunction<? super T> doubleFunction);
+
+    @Override
+    ImmutableFloatIterable collectFloat(FloatFunction<? super T> floatFunction);
+
+    @Override
+    ImmutableIntIterable collectInt(IntFunction<? super T> intFunction);
+
+    @Override
+    ImmutableLongIterable collectLong(LongFunction<? super T> longFunction);
+
+    @Override
+    ImmutableShortIterable collectShort(ShortFunction<? super T> shortFunction);
+    */
+
+    @Override
+    <P, V> ImmutableIterable<V> collectWith(Function2<? super T, ? super P, ? extends V> function, P parameter);
+
+    @Override
+    <V> ImmutableIterable<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
+
+    @Override
+    <V> ImmutableIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
+
+    @Override
+    <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
+
+    @Override
+    <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
+
+    @Override
+    <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
+
+    @Override
+    <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
+
+    @Override
+    <V> ImmutableMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
+
+    @Override
+    <V> ImmutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
+
+    @Override
+    <V> ImmutableMapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+
+    @Override
+    <S> ImmutableIterable<Pair<T, S>> zip(Iterable<S> that);
+
+    @Override
+    ImmutableIterable<Pair<T, Integer>> zipWithIndex();
+
+    @Override
+    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator);
+
+    @Override
+    <K, V> ImmutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ImmutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/ImmutableIterable.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.ImmutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
@@ -121,13 +120,13 @@ public interface ImmutableIterable<T> extends RichIterable<T>
     ImmutableIterable<Pair<T, Integer>> zipWithIndex();
 
     @Override
-    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
+    <K, V> ImmutableMapIterable<K, V> aggregateInPlaceBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
             Procedure2<? super V, ? super T> mutatingAggregator);
 
     @Override
-    <K, V> ImmutableMap<K, V> aggregateBy(
+    <K, V> ImmutableMapIterable<K, V> aggregateBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
             Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/MutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/MutableIterable.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
+import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+import org.eclipse.collections.api.ordered.OrderedIterable;
+import org.eclipse.collections.api.partition.PartitionMutableIterable;
+import org.eclipse.collections.api.tuple.Pair;
+
+public interface MutableIterable<T> extends RichIterable<T>
+{
+    @Override
+    MutableIterable<T> tap(Procedure<? super T> procedure);
+
+    @Override
+    MutableIterable<T> select(Predicate<? super T> predicate);
+
+    @Override
+    <P> MutableIterable<T> selectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    MutableIterable<T> reject(Predicate<? super T> predicate);
+
+    @Override
+    <P> MutableIterable<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    PartitionMutableIterable<T> partition(Predicate<? super T> predicate);
+
+    @Override
+    <P> PartitionMutableIterable<T> partitionWith(Predicate2<? super T, ? super P> predicate, P parameter);
+
+    @Override
+    <S> MutableIterable<S> selectInstancesOf(Class<S> clazz);
+
+    @Override
+    <V> MutableIterable<V> collect(Function<? super T, ? extends V> function);
+
+    /*
+    @Override
+    MutableBooleanIterable collectBoolean(BooleanFunction<? super T> booleanFunction);
+
+    @Override
+    MutableByteIterable collectByte(ByteFunction<? super T> byteFunction);
+
+    @Override
+    MutableCharIterable collectChar(CharFunction<? super T> charFunction);
+
+    @Override
+    MutableDoubleIterable collectDouble(DoubleFunction<? super T> doubleFunction);
+
+    @Override
+    MutableFloatIterable collectFloat(FloatFunction<? super T> floatFunction);
+
+    @Override
+    MutableIntIterable collectInt(IntFunction<? super T> intFunction);
+
+    @Override
+    MutableLongIterable collectLong(LongFunction<? super T> longFunction);
+
+    @Override
+    MutableShortIterable collectShort(ShortFunction<? super T> shortFunction);
+    */
+
+    @Override
+    <P, V> MutableIterable<V> collectWith(Function2<? super T, ? super P, ? extends V> function, P parameter);
+
+    /**
+     * Returns a new MutableIterable with the results of applying the specified function to each element of the source
+     * iterable, but only for elements that evaluate to true for the specified predicate.
+     * <p>
+     * <pre>e.g.
+     * Lists.mutable.of().with(1, 2, 3).collectIf(Predicates.notNull(), Functions.getToString())
+     * </pre>
+     */
+    @Override
+    <V> MutableIterable<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
+
+    @Override
+    <V> MutableIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
+
+    /**
+     * Returns an unmodifiable view of this iterable.  This method allows modules to provide users with "read-only"
+     * access to internal iterables.  Query operations on the returned iterable "read through" to this iterable,
+     * and attempts to modify the returned iterable, whether direct or via its iterator, result in an
+     * <tt>UnsupportedOperationException</tt>.
+     * <p>
+     * The returned iterable does <i>not</i> pass the hashCode and equals operations through to the backing
+     * iterable, but relies on <tt>Object</tt>'s <tt>equals</tt> and <tt>hashCode</tt> methods.  This is necessary to
+     * preserve the contracts of these operations in the case that the backing iterable is a set or a list.<p>
+     * <p>
+     * The returned iterable will be serializable if this iterable is serializable.
+     *
+     * @return an unmodifiable view of this iterable.
+     * @since 1.0 on MutableCollection
+     * @since 8.0 on MutableIterable
+     */
+    MutableIterable<T> asUnmodifiable();
+
+    /**
+     * Returns a synchronized (thread-safe) iterable backed by this iterable.  In order to guarantee serial access,
+     * it is critical that <strong>all</strong> access to the backing iterable is accomplished through the returned
+     * iterable.
+     * <p>
+     * It is imperative that the user manually synchronize on the returned iterable when iterating over it using the
+     * standard JDK iterator or JDK 5 for loop.
+     * <pre>
+     *  MutableIterable iterable = myIterable.asSynchronized();
+     *     ...
+     *  synchronized(iterable)
+     *  {
+     *      Iterator i = c.iterator(); // Must be in the synchronized block
+     *      while (i.hasNext())
+     *         foo(i.next());
+     *  }
+     * </pre>
+     * Failure to follow this advice may result in non-deterministic behavior.
+     * <p>
+     * The preferred way of iterating over a synchronized iterable is to use the iterable.forEach() method which is
+     * properly synchronized internally.
+     * <pre>
+     *  MutableIterable iterable = myIterable.asSynchronized();
+     *     ...
+     *  iterable.forEach(new Procedure()
+     *  {
+     *      public void value(Object each)
+     *      {
+     *          ...
+     *      }
+     *  });
+     * </pre>
+     * <p>
+     * The returned iterable does <i>not</i> pass the <tt>hashCode</tt> and <tt>equals</tt> operations through to the
+     * backing iterable, but relies on <tt>Object</tt>'s equals and hashCode methods.  This is necessary to preserve
+     * the contracts of these operations in the case that the backing iterable is a set or a list.
+     * <p>
+     * The returned iterable will be serializable if this iterable is serializable.
+     *
+     * @return a synchronized view of this iterable.
+     * @since 1.0 on MutableCollection
+     * @since 8.0 on MutableIterable
+     */
+    MutableIterable<T> asSynchronized();
+
+    /**
+     * Converts this MutableIterable to an ImmutableIterable.
+     *
+     * @since 1.0 on MutableCollection
+     * @since 8.0 on MutableIterable
+     */
+    ImmutableIterable<T> toImmutable();
+
+    @Override
+    <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
+
+    @Override
+    <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
+
+    @Override
+    <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
+
+    @Override
+    <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
+
+    @Override
+    <V> MutableMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
+
+    @Override
+    <V> MutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
+
+    @Override
+    <V> MutableMapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+
+    /**
+     * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.
+     */
+    @Override
+    @Deprecated
+    <S> MutableIterable<Pair<T, S>> zip(Iterable<S> that);
+
+    /**
+     * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex()} instead.
+     */
+    @Override
+    @Deprecated
+    MutableIterable<Pair<T, Integer>> zipWithIndex();
+
+    @Override
+    <K, V> MutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator);
+
+    @Override
+    <K, V> MutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/MutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/MutableIterable.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
@@ -209,13 +208,13 @@ public interface MutableIterable<T> extends RichIterable<T>
     MutableIterable<Pair<T, Integer>> zipWithIndex();
 
     @Override
-    <K, V> MutableMap<K, V> aggregateInPlaceBy(
+    <K, V> MutableMapIterable<K, V> aggregateInPlaceBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
             Procedure2<? super V, ? super T> mutatingAggregator);
 
     @Override
-    <K, V> MutableMap<K, V> aggregateBy(
+    <K, V> MutableMapIterable<K, V> aggregateBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
             Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/Bag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/Bag.java
@@ -15,9 +15,7 @@ import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -167,6 +165,7 @@ public interface Bag<T>
     /**
      * @since 8.0
      */
+    @Override
     default IntSummaryStatistics summarizeInt(IntFunction<? super T> function)
     {
         IntSummaryStatistics stats = new IntSummaryStatistics();
@@ -184,6 +183,7 @@ public interface Bag<T>
     /**
      * @since 8.0
      */
+    @Override
     default DoubleSummaryStatistics summarizeFloat(FloatFunction<? super T> function)
     {
         DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
@@ -201,6 +201,7 @@ public interface Bag<T>
     /**
      * @since 8.0
      */
+    @Override
     default LongSummaryStatistics summarizeLong(LongFunction<? super T> function)
     {
         LongSummaryStatistics stats = new LongSummaryStatistics();
@@ -218,6 +219,7 @@ public interface Bag<T>
     /**
      * @since 8.0
      */
+    @Override
     default DoubleSummaryStatistics summarizeDouble(DoubleFunction<? super T> function)
     {
         DoubleSummaryStatistics stats = new DoubleSummaryStatistics();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.java
@@ -13,7 +13,6 @@ package org.eclipse.collections.api.bag.sorted;
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.bag.ImmutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -27,7 +26,6 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -37,7 +35,6 @@ import org.eclipse.collections.api.list.primitive.ImmutableFloatList;
 import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.ImmutableShortList;
-import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.sortedbag.ImmutableSortedBagMultimap;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionImmutableSortedBag;
@@ -144,22 +141,12 @@ public interface ImmutableSortedBag<T>
     <V> ImmutableSortedBagMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     /**
-     * Can return an ImmutableMap that's backed by a LinkedHashMap.
+     * TODO: aggregateBy can return an ImmutableMap that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 
     /**
-     * Can return an ImmutableMap that's backed by a LinkedHashMap.
+     * TODO: aggregateInPlaceBy can return an ImmutableMap that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator);
 
     @Override
     <S> ImmutableList<Pair<T, S>> zip(Iterable<S> that);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/MutableSortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/MutableSortedBag.java
@@ -12,7 +12,6 @@ package org.eclipse.collections.api.bag.sorted;
 
 import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -26,7 +25,6 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
@@ -36,7 +34,6 @@ import org.eclipse.collections.api.list.primitive.MutableFloatList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
-import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.sortedbag.MutableSortedBagMultimap;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionMutableSortedBag;
@@ -162,22 +159,12 @@ public interface MutableSortedBag<T>
     <V> MutableSortedBagMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     /**
-     * Can return an MutableMap that's backed by a LinkedHashMap.
+     * TODO: aggregateBy can return an MutableMap that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> MutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 
     /**
-     * Can return an MutableMap that's backed by a LinkedHashMap.
+     * TODO: aggregateInPlaceBy can return an MutableMap that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> MutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator);
 
     @Override
     <S> MutableList<Pair<T, S>> zip(Iterable<S> that);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/SortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/SortedBag.java
@@ -15,7 +15,6 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -29,7 +28,6 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.ByteList;
@@ -39,7 +37,6 @@ import org.eclipse.collections.api.list.primitive.FloatList;
 import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.list.primitive.LongList;
 import org.eclipse.collections.api.list.primitive.ShortList;
-import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.sorted.SortedMapIterable;
 import org.eclipse.collections.api.multimap.sortedbag.SortedBagMultimap;
 import org.eclipse.collections.api.ordered.ReversibleIterable;
@@ -170,22 +167,12 @@ public interface SortedBag<T>
     <V> SortedBagMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     /**
-     * Can return an MapIterable that's backed by a LinkedHashMap.
+     * TODO: aggregateBy can return an MapIterable that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> MapIterable<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 
     /**
-     * Can return an MapIterable that's backed by a LinkedHashMap.
+     * TODO: aggregateInPlaceBy can return an MapIterable that's backed by a LinkedHashMap.
      */
-    @Override
-    <K, V> MapIterable<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator);
 
     /**
      * Returns the comparator used to order the elements in this bag, or null if this bag uses the natural ordering of

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.collection;
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.ImmutableIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -25,6 +26,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableCharCollection;
@@ -33,6 +35,7 @@ import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection
 import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.partition.PartitionImmutableCollection;
 import org.eclipse.collections.api.tuple.Pair;
 
@@ -112,8 +115,23 @@ public interface ImmutableCollection<T>
     <V> ImmutableCollection<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
+    <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+
+    @Override
     <S> ImmutableCollection<Pair<T, S>> zip(Iterable<S> that);
 
     @Override
     ImmutableCollection<Pair<T, Integer>> zipWithIndex();
+
+    @Override
+    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator);
+
+    @Override
+    <K, V> ImmutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
@@ -11,9 +11,8 @@
 package org.eclipse.collections.api.collection;
 
 import net.jcip.annotations.Immutable;
-import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.ImmutableIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -26,7 +25,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableCharCollection;
@@ -35,10 +33,6 @@ import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection
 import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
-import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
-import org.eclipse.collections.api.multimap.ImmutableMultimap;
 import org.eclipse.collections.api.partition.PartitionImmutableCollection;
 import org.eclipse.collections.api.tuple.Pair;
 
@@ -47,7 +41,7 @@ import org.eclipse.collections.api.tuple.Pair;
  */
 @Immutable
 public interface ImmutableCollection<T>
-        extends RichIterable<T>
+        extends ImmutableIterable<T>
 {
     ImmutableCollection<T> newWith(T element);
 
@@ -118,41 +112,8 @@ public interface ImmutableCollection<T>
     <V> ImmutableCollection<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
-
-    @Override
-    <V> ImmutableMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
-
-    @Override
-    <V> ImmutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
-
-    @Override
-    <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
-
-    @Override
     <S> ImmutableCollection<Pair<T, S>> zip(Iterable<S> that);
 
     @Override
     ImmutableCollection<Pair<T, Integer>> zipWithIndex();
-
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator);
-
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.api.collection;
 
 import java.util.Collection;
 
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
@@ -28,7 +28,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -39,9 +38,6 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
-import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
 import org.eclipse.collections.api.tuple.Pair;
@@ -57,7 +53,7 @@ import org.eclipse.collections.api.tuple.Twin;
  * There are several extensions to MutableCollection, including MutableList, MutableSet, and MutableBag.
  */
 public interface MutableCollection<T>
-        extends Collection<T>, RichIterable<T>
+        extends Collection<T>, MutableIterable<T>
 {
     /**
      * This method allows mutable and fixed size collections the ability to add elements to their existing elements.
@@ -332,6 +328,7 @@ public interface MutableCollection<T>
      * @return an unmodifiable view of this collection.
      * @since 1.0
      */
+    @Override
     MutableCollection<T> asUnmodifiable();
 
     /**
@@ -376,6 +373,7 @@ public interface MutableCollection<T>
      * @return a synchronized view of this collection.
      * @since 1.0
      */
+    @Override
     MutableCollection<T> asSynchronized();
 
     /**
@@ -383,25 +381,8 @@ public interface MutableCollection<T>
      *
      * @since 1.0
      */
+    @Override
     ImmutableCollection<T> toImmutable();
-
-    @Override
-    <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
-
-    @Override
-    <V> MutableMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
-
-    @Override
-    <V> MutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
     <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
@@ -437,16 +418,4 @@ public interface MutableCollection<T>
      * @since 1.0
      */
     boolean retainAllIterable(Iterable<?> iterable);
-
-    @Override
-    <K, V> MutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator);
-
-    @Override
-    <K, V> MutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
@@ -28,6 +29,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
 import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
@@ -418,4 +420,16 @@ public interface MutableCollection<T>
      * @since 1.0
      */
     boolean retainAllIterable(Iterable<?> iterable);
+
+    @Override
+    <K, V> MutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator);
+
+    @Override
+    <K, V> MutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -34,7 +33,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -164,18 +162,6 @@ public interface ImmutableMap<K, V>
 
     @Override
     <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    @Override
-    <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator);
-
-    @Override
-    <K2, V2> ImmutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator);
 
     @Override
     ImmutableMap<V, K> flipUniqueValues();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMapIterable.java
@@ -12,19 +12,17 @@ package org.eclipse.collections.api.map;
 
 import java.util.Map;
 
-import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.ImmutableIterable;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.multimap.ImmutableMultimap;
 import org.eclipse.collections.api.partition.PartitionImmutableCollection;
 import org.eclipse.collections.api.tuple.Pair;
 
-public interface ImmutableMapIterable<K, V> extends MapIterable<K, V>
+public interface ImmutableMapIterable<K, V> extends MapIterable<K, V>, ImmutableIterable<V>
 {
     Map<K, V> castToMap();
 
@@ -81,23 +79,8 @@ public interface ImmutableMapIterable<K, V> extends MapIterable<K, V>
     <S> ImmutableCollection<S> selectInstancesOf(Class<S> clazz);
 
     @Override
-    <V1> ImmutableMultimap<V1, V> groupBy(Function<? super V, ? extends V1> function);
-
-    @Override
-    <V1> ImmutableMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
-
-    @Override
-    <V1> ImmutableMapIterable<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    @Override
     <S> ImmutableCollection<Pair<V, S>> zip(Iterable<S> that);
 
     @Override
     ImmutableCollection<Pair<V, Integer>> zipWithIndex();
-
-    @Override
-    <KK, VV> ImmutableMapIterable<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    @Override
-    <KK, VV> ImmutableMapIterable<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableOrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableOrderedMap.java
@@ -11,7 +11,6 @@
 package org.eclipse.collections.api.map;
 
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -24,7 +23,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -151,6 +149,7 @@ public interface ImmutableOrderedMap<K, V> extends OrderedMap<K, V>, ImmutableMa
     @Override
     <V1> ImmutableListMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
+    /*
     @Override
     <V1> ImmutableOrderedMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
 
@@ -159,4 +158,5 @@ public interface ImmutableOrderedMap<K, V> extends OrderedMap<K, V>, ImmutableMa
 
     @Override
     <KK, VV> ImmutableOrderedMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
+    */
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
@@ -20,7 +20,6 @@ import org.eclipse.collections.api.bag.primitive.MutableIntBag;
 import org.eclipse.collections.api.bag.primitive.MutableLongBag;
 import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -33,7 +32,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -167,18 +165,6 @@ public interface MutableMap<K, V>
 
     @Override
     <V1> MutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    @Override
-    <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator);
-
-    @Override
-    <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator);
 
     @Override
     MutableMap<V, K> flipUniqueValues();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
@@ -12,20 +12,14 @@ package org.eclipse.collections.api.map;
 
 import java.util.Map;
 
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.MutableCollection;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
 import org.eclipse.collections.api.tuple.Pair;
@@ -33,7 +27,7 @@ import org.eclipse.collections.api.tuple.Pair;
 /**
  * @since 6.0
  */
-public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
+public interface MutableMapIterable<K, V> extends MapIterable<K, V>, MutableIterable<V>, Map<K, V>
 {
     /**
      * This method allows mutable map the ability to add an element in the form of Pair<K,V>.
@@ -186,6 +180,7 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
      *
      * @return an unmodifiable view of this map.
      */
+    @Override
     MutableMapIterable<K, V> asUnmodifiable();
 
     /**
@@ -226,6 +221,7 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
      * <p>
      * The returned map will be serializable if the specified map is serializable.
      */
+    @Override
     MutableMapIterable<K, V> asSynchronized();
 
     /**
@@ -278,35 +274,8 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
     <S> MutableCollection<S> selectInstancesOf(Class<S> clazz);
 
     @Override
-    <V1> MutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function);
-
-    @Override
-    <V1> MutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function);
-
-    @Override
-    <V1> MutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function);
-
-    @Override
-    <V1> MutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function);
-
-    @Override
-    <V1> MutableMultimap<V1, V> groupBy(Function<? super V, ? extends V1> function);
-
-    @Override
-    <V1> MutableMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
-
-    @Override
-    <V1> MutableMapIterable<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
-
-    @Override
     <S> MutableCollection<Pair<V, S>> zip(Iterable<S> that);
 
     @Override
     MutableCollection<Pair<V, Integer>> zipWithIndex();
-
-    @Override
-    <KK, VV> MutableMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    @Override
-    <KK, VV> MutableMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableOrderedMap.java
@@ -149,6 +149,8 @@ public interface MutableOrderedMap<K, V> extends OrderedMap<K, V>, MutableMapIte
     @Override
     <V1> MutableListMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
+    /* TODO
     @Override
     <V1> MutableOrderedMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
+    */
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/OrderedMap.java
@@ -157,6 +157,8 @@ public interface OrderedMap<K, V>
     @Override
     <V1> ListMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
+    /* TODO
     @Override
     <V1> OrderedMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
+    */
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.map.primitive;
 
+import org.eclipse.collections.api.ImmutableIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
@@ -20,7 +21,6 @@ import org.eclipse.collections.api.bag.primitive.ImmutableIntBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableLongBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -32,7 +32,6 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -43,14 +42,8 @@ import org.eclipse.collections.api.tuple.Pair;
 /**
  * @since 8.0.
  */
-public interface ImmutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
+public interface ImmutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>, ImmutableIterable<V>
 {
-    @Override
-    <K, VV> ImmutableMap<K, VV> aggregateInPlaceBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    @Override
-    <K, VV> ImmutableMap<K, VV> aggregateBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
-
     @Override
     <VV> ImmutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
@@ -130,16 +123,4 @@ public interface ImmutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
     @Override
     @Deprecated
     ImmutableSet<Pair<V, Integer>> zipWithIndex();
-
-    @Override
-    <VV> ImmutableObjectLongMap<VV> sumByInt(Function<? super V, ? extends VV> groupBy, IntFunction<? super V> function);
-
-    @Override
-    <VV> ImmutableObjectDoubleMap<VV> sumByFloat(Function<? super V, ? extends VV> groupBy, FloatFunction<? super V> function);
-
-    @Override
-    <VV> ImmutableObjectLongMap<VV> sumByLong(Function<? super V, ? extends VV> groupBy, LongFunction<? super V> function);
-
-    @Override
-    <VV> ImmutableObjectDoubleMap<VV> sumByDouble(Function<? super V, ? extends VV> groupBy, DoubleFunction<? super V> function);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.bag.primitive.MutableIntBag;
 import org.eclipse.collections.api.bag.primitive.MutableLongBag;
 import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -32,6 +33,7 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -42,6 +44,12 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>, MutableIterable<V>
 {
     void clear();
+
+    @Override
+    <K, VV> MutableMap<K, VV> aggregateInPlaceBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
+
+    @Override
+    <K, VV> MutableMap<K, VV> aggregateBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 
     @Override
     <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.map.primitive;
 
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.MutableByteBag;
@@ -20,7 +21,6 @@ import org.eclipse.collections.api.bag.primitive.MutableIntBag;
 import org.eclipse.collections.api.bag.primitive.MutableLongBag;
 import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -32,7 +32,6 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -40,15 +39,9 @@ import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 
-public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
+public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>, MutableIterable<V>
 {
     void clear();
-
-    @Override
-    <K, VV> MutableMap<K, VV> aggregateInPlaceBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator);
-
-    @Override
-    <K, VV> MutableMap<K, VV> aggregateBy(Function<? super V, ? extends K> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator);
 
     @Override
     <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
@@ -129,16 +122,4 @@ public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
     @Override
     @Deprecated
     MutableSet<Pair<V, Integer>> zipWithIndex();
-
-    @Override
-    <VV> MutableObjectLongMap<VV> sumByInt(Function<? super V, ? extends VV> groupBy, IntFunction<? super V> function);
-
-    @Override
-    <VV> MutableObjectDoubleMap<VV> sumByFloat(Function<? super V, ? extends VV> groupBy, FloatFunction<? super V> function);
-
-    @Override
-    <VV> MutableObjectLongMap<VV> sumByLong(Function<? super V, ? extends VV> groupBy, LongFunction<? super V> function);
-
-    @Override
-    <VV> MutableObjectDoubleMap<VV> sumByDouble(Function<? super V, ? extends VV> groupBy, DoubleFunction<? super V> function);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
@@ -14,7 +14,6 @@ import java.util.SortedMap;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -27,7 +26,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -169,16 +167,4 @@ public interface ImmutableSortedMap<K, V>
 
     @Override
     <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
-
-    @Override
-    <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator);
-
-    @Override
-    <K2, V2> ImmutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionImmutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionImmutableCollection.java
@@ -17,7 +17,7 @@ import org.eclipse.collections.api.collection.ImmutableCollection;
  * on a Predicate.  The results that answer true for the Predicate will be returned from the getSelected() method and the
  * results that answer false for the predicate will be returned from the getRejected() method.
  */
-public interface PartitionImmutableCollection<T> extends PartitionIterable<T>
+public interface PartitionImmutableCollection<T> extends PartitionImmutableIterable<T>
 {
     @Override
     ImmutableCollection<T> getSelected();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionImmutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionImmutableIterable.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.partition;
+
+import org.eclipse.collections.api.ImmutableIterable;
+
+public interface PartitionImmutableIterable<T> extends PartitionIterable<T>
+{
+    @Override
+    ImmutableIterable<T> getSelected();
+
+    @Override
+    ImmutableIterable<T> getRejected();
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionMutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionMutableCollection.java
@@ -17,7 +17,7 @@ import org.eclipse.collections.api.collection.MutableCollection;
  * The results that answer true for the Predicate will be returned from the getSelected() method and the results that answer false
  * for the predicate will be returned from the getRejected() method.
  */
-public interface PartitionMutableCollection<T> extends PartitionIterable<T>
+public interface PartitionMutableCollection<T> extends PartitionMutableIterable<T>
 {
     @Override
     MutableCollection<T> getSelected();
@@ -25,5 +25,6 @@ public interface PartitionMutableCollection<T> extends PartitionIterable<T>
     @Override
     MutableCollection<T> getRejected();
 
+    @Override
     PartitionImmutableCollection<T> toImmutable();
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionMutableIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/PartitionMutableIterable.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.partition;
+
+import org.eclipse.collections.api.MutableIterable;
+
+public interface PartitionMutableIterable<T> extends PartitionIterable<T>
+{
+    @Override
+    MutableIterable<T> getSelected();
+
+    @Override
+    MutableIterable<T> getRejected();
+
+    PartitionImmutableIterable<T> toImmutable();
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionImmutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionImmutableStack.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.partition.stack;
 
+import org.eclipse.collections.api.partition.PartitionImmutableIterable;
 import org.eclipse.collections.api.stack.ImmutableStack;
 
 /**
@@ -17,7 +18,7 @@ import org.eclipse.collections.api.stack.ImmutableStack;
  * The results that answer true for the Predicate will be returned from the getSelected() method and the results that answer
  * false for the predicate will be returned from the getRejected() method.
  */
-public interface PartitionImmutableStack<T> extends PartitionStack<T>
+public interface PartitionImmutableStack<T> extends PartitionStack<T>, PartitionImmutableIterable<T>
 {
     @Override
     ImmutableStack<T> getSelected();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionMutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/partition/stack/PartitionMutableStack.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.partition.stack;
 
+import org.eclipse.collections.api.partition.PartitionMutableIterable;
 import org.eclipse.collections.api.stack.MutableStack;
 
 /**
@@ -17,7 +18,7 @@ import org.eclipse.collections.api.stack.MutableStack;
  * The results that answer true for the Predicate will be returned from the getSelected() method and the results
  * that answer false for the predicate will be returned from the getRejected() method.
  */
-public interface PartitionMutableStack<T> extends PartitionStack<T>
+public interface PartitionMutableStack<T> extends PartitionStack<T>, PartitionMutableIterable<T>
 {
     @Override
     MutableStack<T> getSelected();
@@ -25,6 +26,7 @@ public interface PartitionMutableStack<T> extends PartitionStack<T>
     @Override
     MutableStack<T> getRejected();
 
+    @Override
     PartitionImmutableStack<T> toImmutable();
 
     /**

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
@@ -10,8 +10,8 @@
 
 package org.eclipse.collections.api.stack;
 
+import org.eclipse.collections.api.ImmutableIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -25,10 +25,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
 import org.eclipse.collections.api.partition.stack.PartitionImmutableStack;
 import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
@@ -41,7 +38,7 @@ import org.eclipse.collections.api.stack.primitive.ImmutableLongStack;
 import org.eclipse.collections.api.stack.primitive.ImmutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 
-public interface ImmutableStack<T> extends StackIterable<T>
+public interface ImmutableStack<T> extends StackIterable<T>, ImmutableIterable<T>
 {
     ImmutableStack<T> push(T item);
 
@@ -138,24 +135,6 @@ public interface ImmutableStack<T> extends StackIterable<T>
 
     @Override
     ImmutableStack<Pair<T, Integer>> zipWithIndex();
-
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator);
-
-    @Override
-    <K, V> ImmutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
-
-    @Override
-    <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
-
-    @Override
-    <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
 
     /**
      * Size takes linear time on ImmutableStacks.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
@@ -12,8 +12,8 @@ package org.eclipse.collections.api.stack;
 
 import java.util.Collection;
 
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -27,11 +27,8 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.partition.stack.PartitionMutableStack;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
@@ -44,7 +41,7 @@ import org.eclipse.collections.api.stack.primitive.MutableLongStack;
 import org.eclipse.collections.api.stack.primitive.MutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 
-public interface MutableStack<T> extends StackIterable<T>
+public interface MutableStack<T> extends StackIterable<T>, MutableIterable<T>
 {
     /**
      * Adds an item to the top of the stack.
@@ -87,8 +84,10 @@ public interface MutableStack<T> extends StackIterable<T>
     @Override
     MutableStack<T> distinct();
 
+    @Override
     MutableStack<T> asUnmodifiable();
 
+    @Override
     MutableStack<T> asSynchronized();
 
     @Override
@@ -155,18 +154,6 @@ public interface MutableStack<T> extends StackIterable<T>
     <V> MutableStack<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
-
-    @Override
-    <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
-
-    @Override
     <V> MutableListMultimap<V, T> groupBy(Function<? super T, ? extends V> function);
 
     @Override
@@ -180,10 +167,4 @@ public interface MutableStack<T> extends StackIterable<T>
 
     @Override
     MutableStack<Pair<T, Integer>> zipWithIndex();
-
-    @Override
-    <K, V> MutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator);
-
-    @Override
-    <K, V> MutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator);
 }

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/abstractImmutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/abstractImmutablePrimitiveObjectMap.stg
@@ -23,22 +23,12 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
+import org.eclipse.collections.impl.AbstractRichIterable;
 import org.eclipse.collections.impl.block.procedure.checked.primitive.Checked<name>ObjectProcedure;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
+import org.eclipse.collections.impl.collection.immutable.AbstractImmutableIterable;
 import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
 
 /**
@@ -46,7 +36,9 @@ import org.eclipse.collections.impl.map.mutable.primitive.<name>ObjectHashMap;
  *
  * @since 4.0.
  */
-public abstract class AbstractImmutable<name>ObjectMap\<V> implements Immutable<name>ObjectMap\<V>
+public abstract class AbstractImmutable<name>ObjectMap\<V>
+        extends AbstractRichIterable\<V>
+        implements AbstractImmutableIterable\<V>, Immutable<name>ObjectMap\<V>
 {
     protected static class Immutable<name>ObjectMapSerializationProxy\<V> implements Externalizable
     {
@@ -107,30 +99,6 @@ public abstract class AbstractImmutable<name>ObjectMap\<V> implements Immutable<
         {
             return this.map.toImmutable();
         }
-    }
-
-    public \<V1> ImmutableObjectLongMap\<V1> sumByInt(Function\<? super V, ? extends V1> groupBy, IntFunction\<? super V> function)
-    {
-        MutableObjectLongMap\<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
-    }
-
-    public \<V1> ImmutableObjectDoubleMap\<V1> sumByFloat(Function\<? super V, ? extends V1> groupBy, FloatFunction\<? super V> function)
-    {
-        MutableObjectDoubleMap\<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
-    }
-
-    public \<V1> ImmutableObjectLongMap\<V1> sumByLong(Function\<? super V, ? extends V1> groupBy, LongFunction\<? super V> function)
-    {
-        MutableObjectLongMap\<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
-    }
-
-    public \<V1> ImmutableObjectDoubleMap\<V1> sumByDouble(Function\<? super V, ? extends V1> groupBy, DoubleFunction\<? super V> function)
-    {
-        MutableObjectDoubleMap\<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
@@ -675,14 +675,9 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
         return map.toImmutable();
     }
 
-    public void forEach(Procedure\<? super V> procedure)
-    {
-        this.each(procedure);
-    }
-
     public void each(Procedure\<? super V> procedure)
     {
-        this.delegate.forEach(procedure);
+        this.delegate.each(procedure);
     }
 
     public void forEachWithIndex(ObjectIntProcedure\<? super V> objectIntProcedure)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
@@ -842,11 +842,6 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
         return keys.contains(this.key1) ? (Immutable<name>ObjectMap\<V>) Immutable<name>ObjectEmptyMap.INSTANCE : this;
     }
 
-    public void forEach(Procedure\<? super V> procedure)
-    {
-        this.each(procedure);
-    }
-
     public void each(Procedure\<? super V> procedure)
     {
         procedure.value(this.value1);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -98,11 +98,7 @@ import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
-import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
@@ -114,6 +110,7 @@ import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
+import org.eclipse.collections.impl.AbstractRichIterable;
 import org.eclipse.collections.impl.SpreadFunctions;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
@@ -129,11 +126,8 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Functions0;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.MapCollectProcedure;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.PartitionProcedure;
 import org.eclipse.collections.impl.block.procedure.SelectInstancesOfProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectBooleanProcedure;
@@ -144,13 +138,12 @@ import org.eclipse.collections.impl.block.procedure.primitive.CollectFloatProced
 import org.eclipse.collections.impl.block.procedure.primitive.CollectIntProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectLongProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectShortProcedure;
+import org.eclipse.collections.impl.collection.mutable.AbstractMutableIterable;
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
 import org.eclipse.collections.impl.iterator.Unmodifiable<name>Iterator;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterable;
 import org.eclipse.collections.impl.lazy.primitive.AbstractLazy<name>Iterable;
@@ -176,7 +169,9 @@ import org.eclipse.collections.impl.utility.internal.IterableIterate;
  *
  * @since 3.0.
  */
-public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Externalizable
+public class <name>ObjectHashMap\<V>
+        extends AbstractRichIterable\<V>
+        implements AbstractMutableIterable\<V>, Mutable<name>ObjectMap\<V>, Externalizable
 {
     private static final long serialVersionUID = 1L;
     private static final int DEFAULT_INITIAL_CAPACITY = 8;
@@ -560,11 +555,6 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     {
         this.forEachValue(procedure);
         return this;
-    }
-
-    public void forEach(Procedure\<? super V> procedure)
-    {
-        this.each(procedure);
     }
 
     public void each(Procedure\<? super V> procedure)
@@ -1472,20 +1462,6 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return result;
     }
 
-    public \<K, VV> MutableMap\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
-    {
-        MutableMap\<K, VV> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure\<V, K, VV>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
-    }
-
-    public \<K, VV> MutableMap\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
-    {
-        MutableMap\<K, VV> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure\<V, K, VV>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
-    }
-
     public \<VV> MutableBagMultimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
     {
         return this.groupBy(function, HashBagMultimap.\<VV, V>newMultimap());
@@ -2036,30 +2012,6 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             }
         }
         return sum;
-    }
-
-    public \<V1> MutableObjectLongMap\<V1> sumByInt(Function\<? super V, ? extends V1> groupBy, IntFunction\<? super V> function)
-    {
-        MutableObjectLongMap\<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
-    }
-
-    public \<V1> MutableObjectDoubleMap\<V1> sumByFloat(Function\<? super V, ? extends V1> groupBy, FloatFunction\<? super V> function)
-    {
-        MutableObjectDoubleMap\<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
-    }
-
-    public \<V1> MutableObjectLongMap\<V1> sumByLong(Function\<? super V, ? extends V1> groupBy, LongFunction\<? super V> function)
-    {
-        MutableObjectLongMap\<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
-    }
-
-    public \<V1> MutableObjectDoubleMap\<V1> sumByDouble(Function\<? super V, ? extends V1> groupBy, DoubleFunction\<? super V> function)
-    {
-        MutableObjectDoubleMap\<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
     }
 
     public void clear()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/AbstractImmutableBagIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/AbstractImmutableBagIterable.java
@@ -11,114 +11,17 @@
 package org.eclipse.collections.impl.bag.immutable;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.bag.ImmutableBagIterable;
-import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
-import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
-import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.collection.MutableCollection;
-import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.impl.bag.AbstractBag;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
-import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.collection.immutable.AbstractImmutableIterable;
 
 @Immutable
 public abstract class AbstractImmutableBagIterable<T>
         extends AbstractBag<T>
-        implements ImmutableBagIterable<T>
+        implements ImmutableBagIterable<T>, AbstractImmutableIterable<T>
 {
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
-    }
-
-    protected void removeAllFrom(Iterable<? extends T> elements, MutableCollection<T> result)
-    {
-        if (elements instanceof Set)
-        {
-            result.removeAll((Set<?>) elements);
-        }
-        else if (elements instanceof List)
-        {
-            List<T> toBeRemoved = (List<T>) elements;
-            if (this.size() * toBeRemoved.size() > 10000)
-            {
-                result.removeAll(UnifiedSet.newSet(elements));
-            }
-            else
-            {
-                result.removeAll(toBeRemoved);
-            }
-        }
-        else
-        {
-            result.removeAll(UnifiedSet.newSet(elements));
-        }
-    }
-
     @Override
     public boolean add(T t)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
@@ -18,38 +18,26 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
-import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.bag.AbstractBag;
 import org.eclipse.collections.impl.block.factory.Predicates2;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.factory.Procedures2;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
+import org.eclipse.collections.impl.collection.mutable.AbstractMutableIterable;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
 
 public abstract class AbstractMutableBagIterable<T>
         extends AbstractBag<T>
-        implements MutableBagIterable<T>
+        implements MutableBagIterable<T>, AbstractMutableIterable<T>
 {
     protected abstract RichIterable<T> getKeysView();
 
@@ -230,56 +218,6 @@ public abstract class AbstractMutableBagIterable<T>
     public <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function)
     {
         return this.getKeysView().maxBy(function);
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/SynchronizedBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/SynchronizedBiMap.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.FloatIterable;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bimap.ImmutableBiMap;
@@ -222,7 +223,7 @@ public class SynchronizedBiMap<K, V> extends AbstractSynchronizedMapIterable<K, 
     }
 
     @Override
-    public <V1> RichIterable<V1> collect(Function<? super V, ? extends V1> function)
+    public <V1> MutableIterable<V1> collect(Function<? super V, ? extends V1> function)
     {
         synchronized (this.lock)
         {
@@ -303,7 +304,7 @@ public class SynchronizedBiMap<K, V> extends AbstractSynchronizedMapIterable<K, 
     }
 
     @Override
-    public <P, V1> RichIterable<V1> collectWith(Function2<? super V, ? super P, ? extends V1> function, P parameter)
+    public <P, V1> MutableIterable<V1> collectWith(Function2<? super V, ? super P, ? extends V1> function, P parameter)
     {
         synchronized (this.lock)
         {
@@ -312,7 +313,7 @@ public class SynchronizedBiMap<K, V> extends AbstractSynchronizedMapIterable<K, 
     }
 
     @Override
-    public <V1> RichIterable<V1> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends V1> function)
+    public <V1> MutableIterable<V1> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends V1> function)
     {
         synchronized (this.lock)
         {
@@ -321,7 +322,7 @@ public class SynchronizedBiMap<K, V> extends AbstractSynchronizedMapIterable<K, 
     }
 
     @Override
-    public <V1> RichIterable<V1> flatCollect(Function<? super V, ? extends Iterable<V1>> function)
+    public <V1> MutableIterable<V1> flatCollect(Function<? super V, ? extends Iterable<V1>> function)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 
 import net.jcip.annotations.GuardedBy;
 import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.MutableIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
@@ -48,8 +49,8 @@ import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.set.MutableSet;
@@ -59,7 +60,7 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.utility.LazyIterate;
 
-public abstract class AbstractSynchronizedRichIterable<T> implements RichIterable<T>
+public abstract class AbstractSynchronizedRichIterable<T> implements MutableIterable<T>
 {
     protected final Object lock;
     @GuardedBy("this.lock")
@@ -889,7 +890,7 @@ public abstract class AbstractSynchronizedRichIterable<T> implements RichIterabl
     }
 
     @Override
-    public <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    public <V> MutableMapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
@@ -19,6 +19,9 @@ import java.util.function.BinaryOperator;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
@@ -31,6 +34,24 @@ import org.eclipse.collections.impl.utility.Iterate;
 public abstract class AbstractImmutableCollection<T> extends AbstractRichIterable<T> implements ImmutableCollection<T>, Collection<T>, AbstractImmutableIterable<T>
 {
     protected abstract MutableCollection<T> newMutable(int size);
+
+    @Override
+    public <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator)
+    {
+        return AbstractImmutableIterable.super.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
+    }
+
+    @Override
+    public <K, V> ImmutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    {
+        return AbstractImmutableIterable.super.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
+    }
 
     @Override
     public Optional<T> reduce(BinaryOperator<T> accumulator)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
@@ -19,58 +19,18 @@ import java.util.function.BinaryOperator;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
-import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.impl.AbstractRichIterable;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.utility.Iterate;
 
-public abstract class AbstractImmutableCollection<T> extends AbstractRichIterable<T> implements ImmutableCollection<T>, Collection<T>
+public abstract class AbstractImmutableCollection<T> extends AbstractRichIterable<T> implements ImmutableCollection<T>, Collection<T>, AbstractImmutableIterable<T>
 {
     protected abstract MutableCollection<T> newMutable(int size);
-
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map.toImmutable();
-    }
 
     @Override
     public Optional<T> reduce(BinaryOperator<T> accumulator)
@@ -81,34 +41,6 @@ public abstract class AbstractImmutableCollection<T> extends AbstractRichIterabl
         }
         return Optional.of(this.injectInto(null, (result, each) ->
                 result == null ? each : accumulator.apply(result, each)));
-    }
-
-    @Override
-    public <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableIterable.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.collection.immutable;
+
+import org.eclipse.collections.api.ImmutableIterable;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
+import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
+import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
+import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
+import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
+import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+
+public interface AbstractImmutableIterable<T> extends ImmutableIterable<T>
+{
+    @Override
+    default <K, V> ImmutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    {
+        MutableMap<K, V> map = UnifiedMap.newMap();
+        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
+        return map.toImmutable();
+    }
+
+    @Override
+    default <K, V> ImmutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator)
+    {
+        MutableMap<K, V> map = UnifiedMap.newMap();
+        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
+        return map.toImmutable();
+    }
+
+    @Override
+    default <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
+    {
+        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
+    }
+
+    @Override
+    default <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
+    {
+        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
+    }
+
+    @Override
+    default <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
+    {
+        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
+    }
+
+    @Override
+    default <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
+    {
+        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
@@ -50,8 +50,6 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
@@ -63,13 +61,10 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
@@ -80,7 +75,7 @@ import org.eclipse.collections.impl.utility.internal.IterableIterate;
 import org.eclipse.collections.impl.utility.internal.MutableCollectionIterate;
 
 public abstract class AbstractCollectionAdapter<T>
-        implements MutableCollection<T>
+        implements MutableCollection<T>, AbstractMutableIterable<T>
 {
     protected abstract Collection<T> getDelegate();
 
@@ -269,34 +264,6 @@ public abstract class AbstractCollectionAdapter<T>
     public double sumOfDouble(DoubleFunction<? super T> function)
     {
         return Iterate.sumOfDouble(this.getDelegate(), function);
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        ObjectLongHashMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        ObjectDoubleHashMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        ObjectLongHashMap<V> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        ObjectDoubleHashMap<V> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMultiReaderMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMultiReaderMutableCollection.java
@@ -59,18 +59,15 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.Twin;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 
 /**
  * AbstractMultiReaderMutableCollection is a common abstraction that provides thread-safe collection behaviors.
  * Subclasses of this class must provide implementations of getDelegate() and getLock().
  */
-public abstract class AbstractMultiReaderMutableCollection<T> implements MutableCollection<T>
+public abstract class AbstractMultiReaderMutableCollection<T> implements MutableCollection<T>, AbstractMutableIterable<T>
 {
     protected abstract MutableCollection<T> getDelegate();
 
@@ -1110,29 +1107,57 @@ public abstract class AbstractMultiReaderMutableCollection<T> implements Mutable
     @Override
     public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().sumByInt(groupBy, function);
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().sumByFloat(groupBy, function);
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
     }
 
     @Override
     public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().sumByLong(groupBy, function);
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().sumByDouble(groupBy, function);
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
@@ -19,38 +19,22 @@ import java.util.function.BinaryOperator;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
-import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.AbstractRichIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.factory.Procedures2;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
 
 public abstract class AbstractMutableCollection<T>
-        extends AbstractRichIterable<T>
-        implements MutableCollection<T>
+        extends AbstractRichIterable<T> implements MutableCollection<T>, AbstractMutableIterable<T>
 {
     @Override
     public <P> Twin<MutableList<T>> selectAndRejectWith(
@@ -145,56 +129,6 @@ public abstract class AbstractMutableCollection<T>
             result.add(batch);
         }
         return result;
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateInPlaceBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateBy(
-            Function<? super T, ? extends K> groupBy,
-            Function0<? extends V> zeroValueFactory,
-            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
@@ -19,9 +19,12 @@ import java.util.function.BinaryOperator;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
@@ -129,6 +132,18 @@ public abstract class AbstractMutableCollection<T>
             result.add(batch);
         }
         return result;
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
+    {
+        return AbstractMutableIterable.super.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    {
+        return AbstractMutableIterable.super.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableIterable.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.collection.mutable;
+
+import org.eclipse.collections.api.MutableIterable;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
+import org.eclipse.collections.api.block.function.primitive.FloatFunction;
+import org.eclipse.collections.api.block.function.primitive.IntFunction;
+import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
+import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
+import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
+import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
+import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
+import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+
+public interface AbstractMutableIterable<T> extends MutableIterable<T>
+{
+    @Override
+    default <K, V> MutableMap<K, V> aggregateInPlaceBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator)
+    {
+        MutableMap<K, V> map = UnifiedMap.newMap();
+        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
+        return map;
+    }
+
+    @Override
+    default <K, V> MutableMap<K, V> aggregateBy(
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    {
+        MutableMap<K, V> map = UnifiedMap.newMap();
+        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
+        return map;
+    }
+
+    @Override
+    default <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
+    {
+        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
+    }
+
+    @Override
+    default <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
+    {
+        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
+    }
+
+    @Override
+    default <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
+    {
+        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
+    }
+
+    @Override
+    default <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
+    {
+        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
+        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractUnmodifiableMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractUnmodifiableMutableCollection.java
@@ -62,11 +62,8 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.utility.LazyIterate;
 
@@ -687,29 +684,25 @@ public class AbstractUnmodifiableMutableCollection<T> implements MutableCollecti
     @Override
     public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
+        return this.getMutableCollection().sumByInt(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
+        return this.getMutableCollection().sumByFloat(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
+        return this.getMutableCollection().sumByLong(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
+        return this.getMutableCollection().sumByDouble(groupBy, function);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
@@ -34,7 +34,6 @@ import org.eclipse.collections.api.bag.primitive.MutableIntBag;
 import org.eclipse.collections.api.bag.primitive.MutableLongBag;
 import org.eclipse.collections.api.bag.primitive.MutableShortBag;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -47,13 +46,8 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -73,9 +67,6 @@ import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
 import org.eclipse.collections.impl.bag.mutable.primitive.ShortHashBag;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.PartitionPredicate2Procedure;
 import org.eclipse.collections.impl.block.procedure.PartitionProcedure;
 import org.eclipse.collections.impl.block.procedure.SelectInstancesOfProcedure;
@@ -87,10 +78,9 @@ import org.eclipse.collections.impl.block.procedure.primitive.CollectFloatProced
 import org.eclipse.collections.impl.block.procedure.primitive.CollectIntProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectLongProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectShortProcedure;
+import org.eclipse.collections.impl.collection.immutable.AbstractImmutableIterable;
 import org.eclipse.collections.impl.map.AbstractMapIterable;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
@@ -100,7 +90,7 @@ import org.eclipse.collections.impl.utility.MapIterate;
 @Immutable
 public abstract class AbstractImmutableMap<K, V>
         extends AbstractMapIterable<K, V>
-        implements ImmutableMap<K, V>, Map<K, V>
+        implements ImmutableMap<K, V>, Map<K, V>, AbstractImmutableIterable<V>
 {
     @Override
     public Map<K, V> castToMap()
@@ -432,55 +422,5 @@ public abstract class AbstractImmutableMap<K, V>
     public <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
     {
         return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap()).toImmutable();
-    }
-
-    @Override
-    public <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <K2, V2> ImmutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
@@ -16,28 +16,17 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
-import org.eclipse.collections.api.block.function.primitive.FloatFunction;
-import org.eclipse.collections.api.block.function.primitive.IntFunction;
-import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.predicate.Predicate2;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
+import org.eclipse.collections.impl.collection.mutable.AbstractMutableIterable;
 import org.eclipse.collections.impl.map.AbstractMapIterable;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 import org.eclipse.collections.impl.tuple.AbstractImmutableEntry;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.MapIterate;
 
-public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterable<K, V> implements MutableMapIterable<K, V>
+public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterable<K, V> implements MutableMapIterable<K, V>, AbstractMutableIterable<V>
 {
     @Override
     public Iterator<V> iterator()
@@ -118,28 +107,6 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
     }
 
     @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
-    }
-
-    @Override
     public RichIterable<K> keysView()
     {
         return LazyIterate.adapt(this.keySet());
@@ -173,33 +140,5 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
     public Pair<K, V> detect(Predicate2<? super K, ? super V> predicate)
     {
         return MapIterate.detect(this, predicate);
-    }
-
-    @Override
-    public <V1> MutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
-    }
-
-    @Override
-    public <V1> MutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
-    }
-
-    @Override
-    public <V1> MutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
-    }
-
-    @Override
-    public <V1> MutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
@@ -17,7 +17,6 @@ import java.util.SortedMap;
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -30,7 +29,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
@@ -43,10 +41,6 @@ import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.ImmutableShortList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
@@ -58,9 +52,6 @@ import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.PartitionPredicate2Procedure;
 import org.eclipse.collections.impl.block.procedure.PartitionProcedure;
 import org.eclipse.collections.impl.block.procedure.SelectInstancesOfProcedure;
@@ -72,6 +63,7 @@ import org.eclipse.collections.impl.block.procedure.primitive.CollectFloatProced
 import org.eclipse.collections.impl.block.procedure.primitive.CollectIntProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectLongProcedure;
 import org.eclipse.collections.impl.block.procedure.primitive.CollectShortProcedure;
+import org.eclipse.collections.impl.collection.immutable.AbstractImmutableIterable;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
@@ -84,8 +76,6 @@ import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.map.AbstractMapIterable;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
-import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.partition.list.PartitionFastList;
@@ -94,7 +84,7 @@ import org.eclipse.collections.impl.utility.MapIterate;
 @Immutable
 public abstract class AbstractImmutableSortedMap<K, V>
         extends AbstractMapIterable<K, V>
-        implements ImmutableSortedMap<K, V>, SortedMap<K, V>
+        implements ImmutableSortedMap<K, V>, SortedMap<K, V>, AbstractImmutableIterable<V>
 {
     @Override
     public SortedMap<K, V> castToMap()
@@ -442,56 +432,6 @@ public abstract class AbstractImmutableSortedMap<K, V>
     public <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
     {
         return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap()).toImmutable();
-    }
-
-    @Override
-    public <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <K2, V2> ImmutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
-    {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function)
-    {
-        MutableObjectLongMap<V1> result = ObjectLongHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function)).toImmutable();
-    }
-
-    @Override
-    public <V1> ImmutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function)
-    {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleHashMap.newMap();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function)).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMap.java
@@ -73,14 +73,8 @@ import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollection;
 import org.eclipse.collections.impl.factory.SortedMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnmodifiableMutableSet;
 import org.eclipse.collections.impl.tuple.AbstractImmutableEntry;
 import org.eclipse.collections.impl.utility.LazyIterate;
@@ -807,31 +801,27 @@ public class UnmodifiableTreeMap<K, V>
     }
 
     @Override
-    public <V1> MutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function)
+    public <VV> MutableObjectLongMap<VV> sumByInt(Function<? super V, ? extends VV> groupBy, IntFunction<? super V> function)
     {
-        MutableObjectLongMap<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
+        return this.getMutableSortedMap().sumByInt(groupBy, function);
     }
 
     @Override
-    public <V1> MutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function)
+    public <VV> MutableObjectDoubleMap<VV> sumByFloat(Function<? super V, ? extends VV> groupBy, FloatFunction<? super V> function)
     {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
+        return this.getMutableSortedMap().sumByFloat(groupBy, function);
     }
 
     @Override
-    public <V1> MutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function)
+    public <VV> MutableObjectLongMap<VV> sumByLong(Function<? super V, ? extends VV> groupBy, LongFunction<? super V> function)
     {
-        MutableObjectLongMap<V1> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
+        return this.getMutableSortedMap().sumByLong(groupBy, function);
     }
 
     @Override
-    public <V1> MutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function)
+    public <VV> MutableObjectDoubleMap<VV> sumByDouble(Function<? super V, ? extends VV> groupBy, DoubleFunction<? super V> function)
     {
-        MutableObjectDoubleMap<V1> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
+        return this.getMutableSortedMap().sumByDouble(groupBy, function);
     }
 
     @Override
@@ -1141,25 +1131,15 @@ public class UnmodifiableTreeMap<K, V>
     }
 
     @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Procedure2<? super V2, ? super V> mutatingAggregator)
+    public <KK, VV> MutableMap<KK, VV> aggregateBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Function2<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
+        return this.getMutableSortedMap().aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
     }
 
     @Override
-    public <K2, V2> MutableMap<K2, V2> aggregateBy(
-            Function<? super V, ? extends K2> groupBy,
-            Function0<? extends V2> zeroValueFactory,
-            Function2<? super V2, ? super V, ? extends V2> nonMutatingAggregator)
+    public <KK, VV> MutableMap<KK, VV> aggregateInPlaceBy(Function<? super V, ? extends KK> groupBy, Function0<? extends VV> zeroValueFactory, Procedure2<? super VV, ? super V> mutatingAggregator)
     {
-        MutableMap<K2, V2> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
+        return this.getMutableSortedMap().aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -58,8 +58,6 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
@@ -81,9 +79,8 @@ import org.eclipse.collections.api.stack.primitive.ImmutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.checked.CheckedProcedure;
+import org.eclipse.collections.impl.collection.immutable.AbstractImmutableIterable;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
@@ -105,7 +102,7 @@ import org.eclipse.collections.impl.utility.LazyIterate;
  * The immutable equivalent of ArrayStack. Wraps a FastList.
  */
 @Immutable
-final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
+final class ImmutableArrayStack<T> implements ImmutableStack<T>, AbstractImmutableIterable<T>, Serializable
 {
     private static final long serialVersionUID = 1L;
     private final FastList<T> delegate;
@@ -780,30 +777,6 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     }
 
     @Override
-    public <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        return this.delegate.asReversed().sumByInt(groupBy, function).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        return this.delegate.asReversed().sumByFloat(groupBy, function).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        return this.delegate.asReversed().sumByLong(groupBy, function).toImmutable();
-    }
-
-    @Override
-    public <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        return this.delegate.asReversed().sumByDouble(groupBy, function).toImmutable();
-    }
-
-    @Override
     public String makeString()
     {
         return this.delegate.asReversed().makeString();
@@ -912,22 +885,6 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     public RichIterable<RichIterable<T>> chunk(int size)
     {
         return this.delegate.asReversed().chunk(size);
-    }
-
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map.toImmutable();
-    }
-
-    @Override
-    public <K, V> ImmutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -55,8 +55,6 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
-import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
@@ -78,8 +76,7 @@ import org.eclipse.collections.api.stack.primitive.MutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
-import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
+import org.eclipse.collections.impl.collection.mutable.AbstractMutableIterable;
 import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -102,7 +99,7 @@ import org.eclipse.collections.impl.utility.LazyIterate;
  * FastList.add(). The backing data structure grows and shrinks by 50% at a time, and size is constant. ArrayStack does
  * not extend Vector, as does the Java Stack, which was one of the reasons to create this data structure.
  */
-public class ArrayStack<T> implements MutableStack<T>, Externalizable
+public class ArrayStack<T> implements MutableStack<T>, AbstractMutableIterable<T>, Externalizable
 {
     private static final long serialVersionUID = 1L;
     private FastList<T> delegate;
@@ -703,30 +700,6 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
     }
 
     @Override
-    public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
-    {
-        return (MutableObjectLongMap<V>) this.delegate.asReversed().sumByInt(groupBy, function);
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
-    {
-        return (MutableObjectDoubleMap<V>) this.delegate.asReversed().sumByFloat(groupBy, function);
-    }
-
-    @Override
-    public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
-    {
-        return (MutableObjectLongMap<V>) this.delegate.asReversed().sumByLong(groupBy, function);
-    }
-
-    @Override
-    public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
-    {
-        return (MutableObjectDoubleMap<V>) this.delegate.asReversed().sumByDouble(groupBy, function);
-    }
-
-    @Override
     public T max()
     {
         return this.delegate.asReversed().max();
@@ -1107,22 +1080,6 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
         {
             throw new IllegalArgumentException("Count must be positive but was " + count);
         }
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateInPlaceBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new MutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, mutatingAggregator));
-        return map;
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> aggregateBy(Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
-    {
-        MutableMap<K, V> map = UnifiedMap.newMap();
-        this.forEach(new NonMutatingAggregationProcedure<>(map, groupBy, zeroValueFactory, nonMutatingAggregator));
-        return map;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
@@ -72,9 +72,6 @@ import org.eclipse.collections.api.stack.primitive.MutableLongStack;
 import org.eclipse.collections.api.stack.primitive.MutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.UnmodifiableIteratorAdapter;
-import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
-import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
-import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
 
 public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
 {
@@ -711,29 +708,25 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
     @Override
     public <V> MutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByIntFunction(groupBy, function));
+        return this.mutableStack.sumByInt(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByFloatFunction(groupBy, function));
+        return this.mutableStack.sumByFloat(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
     {
-        MutableObjectLongMap<V> result = ObjectLongMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByLongFunction(groupBy, function));
+        return this.mutableStack.sumByLong(groupBy, function);
     }
 
     @Override
     public <V> MutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
     {
-        MutableObjectDoubleMap<V> result = ObjectDoubleMaps.mutable.empty();
-        return this.injectInto(result, PrimitiveFunctions.sumByDoubleFunction(groupBy, function));
+        return this.mutableStack.sumByDouble(groupBy, function);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -25,8 +25,8 @@ public class Collectors2Test
 {
     public static final Interval SMALL_INTERVAL = Interval.oneTo(5);
     public static final Interval LARGE_INTERVAL = Interval.oneTo(20000);
-    private final List<Integer> smallData = new ArrayList<Integer>(SMALL_INTERVAL);
-    private final List<Integer> bigData = new ArrayList<Integer>(LARGE_INTERVAL);
+    private final List<Integer> smallData = new ArrayList<>(SMALL_INTERVAL);
+    private final List<Integer> bigData = new ArrayList<>(LARGE_INTERVAL);
 
     @Test
     public void makeString0()


### PR DESCRIPTION
We already have `MutableCollection` and `ImmutableCollection`, but lots of types with mutable and immutable subclasses are not Collections. Some examples are Stacks, MapIterables, and BiMaps. This change extracts some of the common API between all mutable and immutable types.