### PR TITLE
Add Collector implementations to Collectors2 for additional API methods available on RichIterable

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
@@ -27,13 +27,25 @@ import org.eclipse.collections.api.bimap.ImmutableBiMap;
 import org.eclipse.collections.api.bimap.MutableBiMap;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
+import org.eclipse.collections.api.block.function.primitive.ByteFunction;
+import org.eclipse.collections.api.block.function.primitive.CharFunction;
 import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.collection.MutableCollection;
+import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
+import org.eclipse.collections.api.collection.primitive.MutableByteCollection;
+import org.eclipse.collections.api.collection.primitive.MutableCharCollection;
+import org.eclipse.collections.api.collection.primitive.MutableDoubleCollection;
+import org.eclipse.collections.api.collection.primitive.MutableFloatCollection;
+import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
+import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
+import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
@@ -762,6 +774,118 @@ public final class Collectors2
                 supplier,
                 (collection, each) -> collection.add(function.value(each, parameter)),
                 Collectors2.mergeCollections(),
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableBooleanCollection> Collector<T, ?, R> collectBoolean(
+            BooleanFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.booleanValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableByteCollection> Collector<T, ?, R> collectByte(
+            ByteFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.byteValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableCharCollection> Collector<T, ?, R> collectChar(
+            CharFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.charValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableShortCollection> Collector<T, ?, R> collectShort(
+            ShortFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.shortValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableIntCollection> Collector<T, ?, R> collectInt(
+            IntFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.intValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableFloatCollection> Collector<T, ?, R> collectFloat(
+            FloatFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.floatValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableLongCollection> Collector<T, ?, R> collectLong(
+            LongFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.longValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends MutableDoubleCollection> Collector<T, ?, R> collectDouble(
+            DoubleFunction<? super T> function, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) -> collection.add(function.doubleValueOf(each)),
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
                 EMPTY_CHARACTERISTICS);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.impl.collector;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.StringJoiner;
@@ -29,6 +30,9 @@ import org.eclipse.collections.api.block.function.primitive.DoubleFunction;
 import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
@@ -43,6 +47,7 @@ import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
+import org.eclipse.collections.api.partition.PartitionMutableCollection;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
@@ -637,6 +642,130 @@ public final class Collectors2
                     return map1;
                 },
                 Collector.Characteristics.UNORDERED);
+    }
+
+    public static <T, R extends Collection<T>> Collector<T, ?, R> select(Predicate<? super T> predicate, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) ->
+                {
+                    if (predicate.accept(each))
+                    {
+                        collection.add(each);
+                    }
+                },
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, P, R extends Collection<T>> Collector<T, ?, R> selectWith(
+            Predicate2<? super T, ? super P> predicate,
+            P parameter,
+            Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) ->
+                {
+                    if (predicate.accept(each, parameter))
+                    {
+                        collection.add(each);
+                    }
+                },
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends Collection<T>> Collector<T, ?, R> reject(Predicate<? super T> predicate, Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) ->
+                {
+                    if (!predicate.accept(each))
+                    {
+                        collection.add(each);
+                    }
+                },
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, P, R extends Collection<T>> Collector<T, ?, R> rejectWith(
+            Predicate2<? super T, ? super P> predicate,
+            P parameter,
+            Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (collection, each) ->
+                {
+                    if (!predicate.accept(each, parameter))
+                    {
+                        collection.add(each);
+                    }
+                },
+                (collection1, collection2) ->
+                {
+                    collection1.addAll(collection2);
+                    return collection1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, R extends PartitionMutableCollection<T>> Collector<T, ?, R> partition(
+            Predicate<? super T> predicate,
+            Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (partition, each) ->
+                {
+                    MutableCollection<T> bucket = predicate.accept(each) ? partition.getSelected() : partition.getRejected();
+                    bucket.add(each);
+                },
+                (partition1, partition2) ->
+                {
+                    partition1.getSelected().addAll(partition2.getSelected());
+                    partition1.getRejected().addAll(partition2.getRejected());
+                    return partition1;
+                },
+                EMPTY_CHARACTERISTICS);
+    }
+
+    public static <T, P, R extends PartitionMutableCollection<T>> Collector<T, ?, R> partitionWith(
+            Predicate2<? super T, ? super P> predicate,
+            P parameter,
+            Supplier<R> supplier)
+    {
+        return Collector.of(
+                supplier,
+                (partition, each) ->
+                {
+                    MutableCollection<T> bucket =
+                            predicate.accept(each, parameter) ? partition.getSelected() : partition.getRejected();
+                    bucket.add(each);
+                },
+                (partition1, partition2) ->
+                {
+                    partition1.getSelected().addAll(partition2.getSelected());
+                    partition1.getRejected().addAll(partition2.getRejected());
+                    return partition1;
+                },
+                EMPTY_CHARACTERISTICS);
     }
 }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -16,9 +16,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
+import org.eclipse.collections.api.partition.list.PartitionMutableList;
+import org.eclipse.collections.api.partition.set.PartitionMutableSet;
+import org.eclipse.collections.impl.block.factory.IntegerPredicates;
+import org.eclipse.collections.impl.block.factory.Predicates2;
+import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.BiMaps;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
+import org.eclipse.collections.impl.partition.list.PartitionFastList;
+import org.eclipse.collections.impl.partition.set.PartitionUnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.junit.Assert;
@@ -28,6 +39,7 @@ public class Collectors2Test
 {
     public static final Interval SMALL_INTERVAL = Interval.oneTo(5);
     public static final Interval LARGE_INTERVAL = Interval.oneTo(20000);
+    public static final int HALF_SIZE = LARGE_INTERVAL.size() / 2;
     private final List<Integer> smallData = new ArrayList<Integer>(SMALL_INTERVAL);
     private final List<Integer> bigData = new ArrayList<Integer>(LARGE_INTERVAL);
 
@@ -1184,5 +1196,233 @@ public class Collectors2Test
                 largeLongs.sumByDouble(each -> Double.valueOf(each % 2), Double::doubleValue),
                 largeLongs.parallelStream().collect(Collectors2.sumByDouble(each -> Double.valueOf(each % 2), Double::doubleValue))
         );
+    }
+
+    @Test
+    public void select()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().select(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().select(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().select(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void selectParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().select(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().select(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().select(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void selectWith()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void selectWithParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().selectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void reject()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().reject(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().reject(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().reject(IntegerPredicates.isEven()),
+                this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void rejectParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().reject(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().reject(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().reject(IntegerPredicates.isEven()),
+                this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void rejectWith()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.stream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void rejectWithParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void partition()
+    {
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partition(IntegerPredicates.isEven());
+        PartitionMutableList<Integer> actualList = this.bigData.stream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionFastList::new));
+        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
+        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partition(IntegerPredicates.isEven());
+        PartitionMutableSet<Integer> actualSet = this.bigData.stream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionUnifiedSet::new));
+        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partition(IntegerPredicates.isEven());
+        PartitionMutableBag<Integer> actualBag = this.bigData.stream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionHashBag::new));
+        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+    }
+
+    @Test
+    public void partitionParallel()
+    {
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partition(IntegerPredicates.isEven());
+        PartitionMutableList<Integer> actualList = this.bigData.parallelStream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionFastList::new));
+        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
+        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partition(IntegerPredicates.isEven());
+        PartitionMutableSet<Integer> actualSet = this.bigData.parallelStream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionUnifiedSet::new));
+        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partition(IntegerPredicates.isEven());
+        PartitionMutableBag<Integer> actualBag = this.bigData.parallelStream()
+                .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionHashBag::new));
+        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+    }
+
+    @Test
+    public void partitionWith()
+    {
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableList<Integer> actualList = this.bigData.stream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
+        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
+        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableSet<Integer> actualSet = this.bigData.stream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
+        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableBag<Integer> actualBag = this.bigData.stream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
+        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+    }
+
+    @Test
+    public void partitionWithParallel()
+    {
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableList<Integer> actualList = this.bigData.parallelStream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
+        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
+        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableSet<Integer> actualSet = this.bigData.parallelStream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
+        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableBag<Integer> actualBag = this.bigData.parallelStream()
+                .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
+        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -16,6 +16,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.list.primitive.BooleanList;
+import org.eclipse.collections.api.list.primitive.ByteList;
+import org.eclipse.collections.api.list.primitive.CharList;
+import org.eclipse.collections.api.list.primitive.DoubleList;
+import org.eclipse.collections.api.list.primitive.FloatList;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.api.list.primitive.LongList;
+import org.eclipse.collections.api.list.primitive.ShortList;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
@@ -27,6 +35,14 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.Stacks;
+import org.eclipse.collections.impl.factory.primitive.BooleanLists;
+import org.eclipse.collections.impl.factory.primitive.ByteLists;
+import org.eclipse.collections.impl.factory.primitive.CharLists;
+import org.eclipse.collections.impl.factory.primitive.DoubleLists;
+import org.eclipse.collections.impl.factory.primitive.FloatLists;
+import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.LongLists;
+import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.partition.list.PartitionFastList;
@@ -1505,5 +1521,165 @@ public class Collectors2Test
                 this.bigData.parallelStream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Bags.mutable::empty))
         );
+    }
+
+    @Test
+    public void collectBoolean()
+    {
+        BooleanList expected =
+                SMALL_INTERVAL.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable.empty());
+        BooleanList actual =
+                this.smallData.stream().collect(Collectors2.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectBooleanParallel()
+    {
+        BooleanList expected =
+                LARGE_INTERVAL.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable.empty());
+        BooleanList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectByte()
+    {
+        ByteList expected =
+                SMALL_INTERVAL.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable.empty());
+        ByteList actual =
+                this.smallData.stream().collect(Collectors2.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectByteParallel()
+    {
+        ByteList expected =
+                LARGE_INTERVAL.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable.empty());
+        ByteList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectChar()
+    {
+        CharList expected =
+                SMALL_INTERVAL.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable.empty());
+        CharList actual =
+                this.smallData.stream().collect(Collectors2.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectCharParallel()
+    {
+        CharList expected =
+                LARGE_INTERVAL.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable.empty());
+        CharList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectShort()
+    {
+        ShortList expected =
+                SMALL_INTERVAL.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable.empty());
+        ShortList actual =
+                this.smallData.stream().collect(Collectors2.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectShortParallel()
+    {
+        ShortList expected =
+                LARGE_INTERVAL.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable.empty());
+        ShortList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectInt()
+    {
+        IntList expected =
+                SMALL_INTERVAL.collectInt(each -> each, IntLists.mutable.empty());
+        IntList actual =
+                this.smallData.stream().collect(Collectors2.collectInt(each -> each, IntLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectIntParallel()
+    {
+        IntList expected =
+                LARGE_INTERVAL.collectInt(each -> each, IntLists.mutable.empty());
+        IntList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectInt(each -> each, IntLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectFloat()
+    {
+        FloatList expected =
+                SMALL_INTERVAL.collectFloat(each -> (float) each, FloatLists.mutable.empty());
+        FloatList actual =
+                this.smallData.stream().collect(Collectors2.collectFloat(each -> (float) each, FloatLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectFloatParallel()
+    {
+        FloatList expected =
+                LARGE_INTERVAL.collectFloat(each -> (float) each, FloatLists.mutable.empty());
+        FloatList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectFloat(each -> (float) each, FloatLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectLong()
+    {
+        LongList expected =
+                SMALL_INTERVAL.collectLong(each -> (long) each, LongLists.mutable.empty());
+        LongList actual =
+                this.smallData.stream().collect(Collectors2.collectLong(each -> (long) each, LongLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectLongParallel()
+    {
+        LongList expected =
+                LARGE_INTERVAL.collectLong(each -> (long) each, LongLists.mutable.empty());
+        LongList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectLong(each -> (long) each, LongLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectDouble()
+    {
+        DoubleList expected =
+                SMALL_INTERVAL.collectDouble(each -> (double) each, DoubleLists.mutable.empty());
+        DoubleList actual =
+                this.smallData.stream().collect(Collectors2.collectDouble(each -> (double) each, DoubleLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectDoubleParallel()
+    {
+        DoubleList expected =
+                LARGE_INTERVAL.collectDouble(each -> (double) each, DoubleLists.mutable.empty());
+        DoubleList actual =
+                this.bigData.parallelStream().collect(Collectors2.collectDouble(each -> (double) each, DoubleLists.mutable::empty));
+        Assert.assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
+import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Bags;
@@ -39,7 +40,7 @@ public class Collectors2Test
 {
     public static final Interval SMALL_INTERVAL = Interval.oneTo(5);
     public static final Interval LARGE_INTERVAL = Interval.oneTo(20000);
-    public static final int HALF_SIZE = LARGE_INTERVAL.size() / 2;
+    public static final Integer HALF_SIZE = Integer.valueOf(LARGE_INTERVAL.size() / 2);
     private final List<Integer> smallData = new ArrayList<Integer>(SMALL_INTERVAL);
     private final List<Integer> bigData = new ArrayList<Integer>(LARGE_INTERVAL);
 
@@ -1389,17 +1390,20 @@ public class Collectors2Test
     @Test
     public void partitionWith()
     {
-        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableList<Integer> actualList = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
         Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
         Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
-        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableSet<Integer> actualSet = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
         Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
         Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
-        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableBag<Integer> actualBag = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
         Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
@@ -1409,20 +1413,97 @@ public class Collectors2Test
     @Test
     public void partitionWithParallel()
     {
-        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableList<Integer> actualList = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
         Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
         Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
-        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableSet<Integer> actualSet = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
         Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
         Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
-        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partitionWith(Predicates2.greaterThan(), HALF_SIZE);
+        PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag()
+                .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableBag<Integer> actualBag = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
         Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
         Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+    }
+
+    @Test
+    public void collect()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().collect(Functions.getToString()),
+                this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().collect(Functions.getToString()),
+                this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().collect(Functions.getToString()),
+                this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void collectParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().collect(Functions.getToString()),
+                this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().collect(Functions.getToString()),
+                this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().collect(Functions.getToString()),
+                this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void collectWith()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.stream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.stream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.stream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Bags.mutable::empty))
+        );
+    }
+
+    @Test
+    public void collectWithParallel()
+    {
+        Assert.assertEquals(
+                LARGE_INTERVAL.toList().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Lists.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toSet().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Sets.mutable::empty))
+        );
+        Assert.assertEquals(
+                LARGE_INTERVAL.toBag().collectWith(Integer::sum, Integer.valueOf(10)),
+                this.bigData.parallelStream()
+                        .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Bags.mutable::empty))
+        );
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -73,6 +73,7 @@ import org.eclipse.collections.impl.block.function.MaxSizeFunction;
 import org.eclipse.collections.impl.block.function.MinSizeFunction;
 import org.eclipse.collections.impl.block.predicate.PairPredicate;
 import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
+import org.eclipse.collections.impl.collector.Collectors2;
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -279,41 +280,63 @@ public class IterateTest
     public void fromToDoit()
     {
         MutableList<Integer> list = Lists.mutable.of();
-        Interval.fromTo(6, 10).forEach(Procedures.cast(list::add));
+        Interval.fromTo(6, 10).each(list::add);
         Verify.assertContainsAll(list, 6, 10);
+    }
+
+    @Test
+    public void reduceInPlaceCollector()
+    {
+        this.iterables.each(each -> Assert.assertEquals(
+                Iterate.toSortedList(each),
+                Iterate.reduceInPlace(each, Collectors2.toSortedList())));
+        this.iterables.each(each -> Assert.assertEquals(
+                Iterate.sumByInt(each, value -> value % 2, value -> value),
+                Iterate.reduceInPlace(each, Collectors2.sumByInt(value -> value % 2, value -> value))));
+        this.iterables.each(each -> Assert.assertEquals(
+                Iterate.groupBy(each, value -> value % 2, Multimaps.mutable.bag.empty()),
+                Iterate.reduceInPlace(each, Collectors2.toBagMultimap(value -> value % 2))));
+    }
+
+    @Test
+    public void reduceInPlace()
+    {
+        this.iterables.each(each -> Assert.assertEquals(
+                Iterate.toSortedList(each),
+                Iterate.reduceInPlace(each, FastList::new, FastList::add).sortThis()));
     }
 
     @Test
     public void injectInto()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertEquals(Integer.valueOf(15), Iterate.injectInto(0, each, AddFunction.INTEGER))));
+        this.iterables.each(each -> Assert.assertEquals(Integer.valueOf(15), Iterate.injectInto(0, each, AddFunction.INTEGER)));
     }
 
     @Test
     public void injectIntoInt()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertEquals(15, Iterate.injectInto(0, each, AddFunction.INTEGER_TO_INT))));
+        this.iterables.each(each -> Assert.assertEquals(15, Iterate.injectInto(0, each, AddFunction.INTEGER_TO_INT)));
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0, null, AddFunction.INTEGER_TO_INT));
     }
 
     @Test
     public void injectIntoLong()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertEquals(15L, Iterate.injectInto(0L, each, AddFunction.INTEGER_TO_LONG))));
+        this.iterables.each(each -> Assert.assertEquals(15L, Iterate.injectInto(0L, each, AddFunction.INTEGER_TO_LONG)));
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0L, null, AddFunction.INTEGER_TO_LONG));
     }
 
     @Test
     public void injectIntoDouble()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0d, each, AddFunction.INTEGER_TO_DOUBLE), 0.001)));
+        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0d, each, AddFunction.INTEGER_TO_DOUBLE), 0.001));
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0d, null, AddFunction.INTEGER_TO_DOUBLE));
     }
 
     @Test
     public void injectIntoFloat()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0f, each, AddFunction.INTEGER_TO_FLOAT), 0.001)));
+        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0f, each, AddFunction.INTEGER_TO_FLOAT), 0.001));
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0f, null, AddFunction.INTEGER_TO_FLOAT));
     }
 
@@ -890,11 +913,11 @@ public class IterateTest
     @Test
     public void forEachWithIndex()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             UnifiedSet<Integer> set = UnifiedSet.newSet();
             Iterate.forEachWithIndex(each, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(set)));
             Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
-        }));
+        });
     }
 
     @Test
@@ -917,10 +940,10 @@ public class IterateTest
     @Test
     public void detect()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Integer result = Iterate.detect(each, Predicates.instanceOf(Integer.class));
             Assert.assertTrue(UnifiedSet.newSet(each).contains(result));
-        }));
+        });
     }
 
     @Test
@@ -975,80 +998,80 @@ public class IterateTest
     @Test
     public void detectWithIfNone()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Integer result = Iterate.detectWithIfNone(each, Predicates2.instanceOf(), Integer.class, 5);
             Verify.assertContains(result, UnifiedSet.newSet(each));
-        }));
+        });
     }
 
     @Test
     public void selectWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.selectWith(each, Predicates2.greaterThan(), 3);
             Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null));
     }
 
     @Test
     public void selectWithWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.selectWith(each, Predicates2.greaterThan(), 3, FastList.newList());
             Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null, null));
     }
 
     @Test
     public void rejectWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.rejectWith(each, Predicates2.greaterThan(), 3);
             Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null));
     }
 
     @Test
     public void rejectWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.rejectWith(each, Predicates2.greaterThan(), 3, FastList.newList());
             Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null, null));
     }
 
     @Test
     public void selectAndRejectWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Twin<MutableList<Integer>> result = Iterate.selectAndRejectWith(each, Predicates2.greaterThan(), 3);
             Assert.assertEquals(iBag(4, 5), result.getOne().toBag());
             Assert.assertEquals(iBag(1, 2, 3), result.getTwo().toBag());
-        }));
+        });
     }
 
     @Test
     public void partition()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             PartitionIterable<Integer> result = Iterate.partition(each, Predicates.greaterThan(3));
             Assert.assertEquals(iBag(4, 5), result.getSelected().toBag());
             Assert.assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
-        }));
+        });
     }
 
     @Test
     public void partitionWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             PartitionIterable<Integer> result = Iterate.partitionWith(each, Predicates2.greaterThan(), 3);
             Assert.assertEquals(iBag(4, 5), result.getSelected().toBag());
             Assert.assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
-        }));
+        });
     }
 
     @Test
@@ -1086,37 +1109,37 @@ public class IterateTest
     @Test
     public void anySatisfy()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.anySatisfy(each, Integer.class::isInstance))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.anySatisfy(each, Integer.class::isInstance)));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.anySatisfyWith(each, Predicates2.instanceOf(), Integer.class))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.anySatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
     }
 
     @Test
     public void allSatisfy()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.allSatisfy(each, Integer.class::isInstance))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.allSatisfy(each, Integer.class::isInstance)));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.allSatisfyWith(each, Predicates2.instanceOf(), Integer.class))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.allSatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.noneSatisfy(each, String.class::isInstance))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.noneSatisfy(each, String.class::isInstance)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> Assert.assertTrue(Iterate.noneSatisfyWith(each, Predicates2.instanceOf(), String.class))));
+        this.iterables.each(each -> Assert.assertTrue(Iterate.noneSatisfyWith(each, Predicates2.instanceOf(), String.class)));
     }
 
     @Test
@@ -1192,216 +1215,216 @@ public class IterateTest
     @Test
     public void forEach()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             UnifiedSet<Integer> set = UnifiedSet.newSet();
             Iterate.forEach(each, Procedures.cast(set::add));
             Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
-        }));
+        });
     }
 
     @Test
     public void collectIf()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collectIf(each, Predicates.greaterThan(3), String::valueOf);
             Assert.assertTrue(result.containsAll(FastList.newListWith("4", "5")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null));
     }
 
     @Test
     public void collectIfTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collectIf(each, Predicates.greaterThan(3), String::valueOf, FastList.newList());
             Assert.assertTrue(result.containsAll(FastList.newListWith("4", "5")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null, null));
     }
 
     @Test
     public void collect()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collect(each, String::valueOf);
             Assert.assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a));
     }
 
     @Test
     public void collectBoolean()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableBooleanCollection result = Iterate.collectBoolean(each, PrimitiveFunctions.integerIsPositive());
             Assert.assertTrue(result.containsAll(true, true, true, true, true));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
     }
 
     @Test
     public void collectBooleanWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableBooleanCollection expected = new BooleanArrayList();
             MutableBooleanCollection actual = Iterate.collectBoolean(each, PrimitiveFunctions.integerIsPositive(), expected);
             Assert.assertTrue(expected.containsAll(true, true, true, true, true));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
     }
 
     @Test
     public void collectByte()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableByteCollection result = Iterate.collectByte(each, PrimitiveFunctions.unboxIntegerToByte());
             Assert.assertTrue(result.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Test
     public void collectByteWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableByteCollection expected = new ByteArrayList();
             MutableByteCollection actual = Iterate.collectByte(each, PrimitiveFunctions.unboxIntegerToByte(), expected);
             Assert.assertTrue(actual.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
     }
 
     @Test
     public void collectChar()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableCharCollection result = Iterate.collectChar(each, PrimitiveFunctions.unboxIntegerToChar());
             Assert.assertTrue(result.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
     }
 
     @Test
     public void collectCharWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableCharCollection expected = new CharArrayList();
             MutableCharCollection actual = Iterate.collectChar(each, PrimitiveFunctions.unboxIntegerToChar(), expected);
             Assert.assertTrue(actual.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
     }
 
     @Test
     public void collectDouble()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableDoubleCollection result = Iterate.collectDouble(each, PrimitiveFunctions.unboxIntegerToDouble());
             Assert.assertTrue(result.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Test
     public void collectDoubleWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableDoubleCollection expected = new DoubleArrayList();
             MutableDoubleCollection actual = Iterate.collectDouble(each, PrimitiveFunctions.unboxIntegerToDouble(), expected);
             Assert.assertTrue(actual.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
     }
 
     @Test
     public void collectFloat()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableFloatCollection result = Iterate.collectFloat(each, PrimitiveFunctions.unboxIntegerToFloat());
             Assert.assertTrue(result.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Test
     public void collectFloatWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableFloatCollection expected = new FloatArrayList();
             MutableFloatCollection actual = Iterate.collectFloat(each, PrimitiveFunctions.unboxIntegerToFloat(), expected);
             Assert.assertTrue(actual.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
     }
 
     @Test
     public void collectInt()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableIntCollection result = Iterate.collectInt(each, PrimitiveFunctions.unboxIntegerToInt());
             Assert.assertTrue(result.containsAll(1, 2, 3, 4, 5));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Test
     public void collectIntWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableIntCollection expected = new IntArrayList();
             MutableIntCollection actual = Iterate.collectInt(each, PrimitiveFunctions.unboxIntegerToInt(), expected);
             Assert.assertTrue(actual.containsAll(1, 2, 3, 4, 5));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
     }
 
     @Test
     public void collectLong()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableLongCollection result = Iterate.collectLong(each, PrimitiveFunctions.unboxIntegerToLong());
             Assert.assertTrue(result.containsAll(1L, 2L, 3L, 4L, 5L));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Test
     public void collectLongWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableLongCollection expected = new LongArrayList();
             MutableLongCollection actual = Iterate.collectLong(each, PrimitiveFunctions.unboxIntegerToLong(), expected);
             Assert.assertTrue(actual.containsAll(1L, 2L, 3L, 4L, 5L));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
     }
 
     @Test
     public void collectShort()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableShortCollection result = Iterate.collectShort(each, PrimitiveFunctions.unboxIntegerToShort());
             Assert.assertTrue(result.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
     }
 
     @Test
     public void collectShortWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             MutableShortCollection expected = new ShortArrayList();
             MutableShortCollection actual = Iterate.collectShort(each, PrimitiveFunctions.unboxIntegerToShort(), expected);
             Assert.assertTrue(actual.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
             Assert.assertSame("Target list sent as parameter not returned", expected, actual);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
     }
 
@@ -1501,30 +1524,30 @@ public class IterateTest
     @Test
     public void collectTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collect(each, String::valueOf, UnifiedSet.newSet());
             Assert.assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a, null));
     }
 
     @Test
     public void collectWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collectWith(each, (each1, parm) -> each1 + parm, " ");
             Assert.assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null));
     }
 
     @Test
     public void collectWithWithTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<String> result = Iterate.collectWith(each, (each1, parm) -> each1 + parm, " ", UnifiedSet.newSet());
             Assert.assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null, null));
     }
 
@@ -1725,40 +1748,40 @@ public class IterateTest
     @Test
     public void select()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.select(each, Predicates.greaterThan(3));
             Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null));
     }
 
     @Test
     public void selectTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.select(each, Predicates.greaterThan(3), FastList.newList());
             Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null, null));
     }
 
     @Test
     public void reject()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.reject(each, Predicates.greaterThan(3));
             Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null));
     }
 
     @Test
     public void rejectTarget()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.reject(each, Predicates.greaterThan(3), FastList.newList());
             Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null, null));
     }
 
@@ -1775,10 +1798,10 @@ public class IterateTest
     @Test
     public void count()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             int result = Iterate.count(each, Predicates.greaterThan(3));
             Assert.assertEquals(2, result);
-        }));
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1790,10 +1813,10 @@ public class IterateTest
     @Test
     public void countWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             int result = Iterate.countWith(each, Predicates2.greaterThan(), 3);
             Assert.assertEquals(2, result);
-        }));
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1839,11 +1862,11 @@ public class IterateTest
     @Test
     public void forEachWith()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Sum result = new IntegerSum(0);
             Iterate.forEachWith(each, (integer, parm) -> result.add(integer.intValue() * parm.intValue()), 2);
             Assert.assertEquals(30, result.getValue().intValue());
-        }));
+        });
     }
 
     @Test
@@ -1921,10 +1944,10 @@ public class IterateTest
         MutableSet<Integer> set2 = UnifiedSet.newSet();
         Verify.assertEmpty(Iterate.take(set2, 2));
 
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.take(each, 2);
             Verify.assertSize(2, result);
-        }));
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1954,10 +1977,10 @@ public class IterateTest
         MutableSet<Integer> set2 = UnifiedSet.newSet();
         Verify.assertEmpty(Iterate.drop(set2, 2));
 
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             Collection<Integer> result = Iterate.drop(each, 2);
             Verify.assertSize(3, result);
-        }));
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2095,22 +2118,22 @@ public class IterateTest
     @Test
     public void makeString()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             String result = Iterate.makeString(each);
             Assert.assertEquals("1, 2, 3, 4, 5", result);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.makeString(null));
     }
 
     @Test
     public void appendString()
     {
-        this.iterables.forEach(Procedures.cast(each -> {
+        this.iterables.each(each -> {
             StringBuilder stringBuilder = new StringBuilder();
             Iterate.appendString(each, stringBuilder);
             String result = stringBuilder.toString();
             Assert.assertEquals("1, 2, 3, 4, 5", result);
-        }));
+        });
         Verify.assertThrows(IllegalArgumentException.class, () -> Iterate.appendString(null, new StringBuilder()));
     }
 


### PR DESCRIPTION
- chunk, zip, zipWithIndex, sumBy{Int, Long, Float, Double}
- select{With}, reject{With}, collect{With}, partition{With}
- collect{Boolean, Byte, Char, Short, Int, Long, Float, Double}
- add reduceInPlace methods to Iterate and remove unnecessary Procedures.cast() calls