### PR TITLE
Improve speed of AbstractImmutableList.chunk() by using sublists

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
@@ -21,6 +21,7 @@ import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
 
 import net.jcip.annotations.Immutable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -864,6 +865,36 @@ abstract class AbstractImmutableList<T>
     public ImmutableList<T> toImmutable()
     {
         return this;
+    }
+
+    @Override
+    public RichIterable<RichIterable<T>> chunk(int size)
+    {
+        if (size <= 0)
+        {
+            throw new IllegalArgumentException("Size for groups must be positive but was: " + size);
+        }
+
+        if (this.isEmpty())
+        {
+            return Lists.immutable.empty();
+        }
+        MutableList<RichIterable<T>> result = Lists.mutable.empty();
+        if (this.size() <= size)
+        {
+            result.add(this);
+        }
+        else
+        {
+            for (int startIndex = 0, endIndex = size;
+                 endIndex <= this.size() && startIndex < this.size(); startIndex += size, endIndex += Math
+                    .min(size, this.size() - endIndex))
+            {
+                result.add(new ImmutableSubList<>(this, startIndex, endIndex));
+            }
+        }
+
+        return result.toImmutable();
     }
 
     protected static class ImmutableSubList<T>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -1358,6 +1358,22 @@ public abstract class AbstractRichIterableTestCase
         Assert.assertEquals(FastList.newListWith(2, 2, 2, 1), sizes);
     }
 
+    @Test
+    public void chunk_empty()
+    {
+        RichIterable<String> collection = this.newWith();
+        RichIterable<RichIterable<String>> groups = collection.chunk(2);
+        Assert.assertEquals(groups.size(), 0);
+    }
+
+    @Test
+    public void chunk_single()
+    {
+        RichIterable<String> collection = this.newWith("1");
+        RichIterable<RichIterable<String>> groups = collection.chunk(2);
+        Assert.assertEquals(FastList.newListWith(1), groups.collect(RichIterable::size));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void chunk_zero_throws()
     {


### PR DESCRIPTION
Improve speed of AbstractImmutableList.chunk() by using sublists [Fixes #116]. AbstractMutableList.chunk() still needs to be discussed as mentioned in pull request #118.