### PR TITLE
Make detectOptional methods throw NullPointerException when detecting null value.

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -10,6 +10,7 @@ New Functionality
 * Implemented selectByOccurrences on primitive Bags.
 * Implemented top/bottomOccurrences on primitive Bags.
 * Changed primitive functional interfaces to extend the corresponding JDK functional interfaces.
+* Made detectOptional methods throw NullPointerException when detecting null value.
 
 Optimizations
 -------------

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -1224,6 +1224,7 @@ public interface RichIterable<T>
      * </pre>
      * <p>
      *
+     * @throws NullPointerException if the element selected is null
      * @since 8.0
      */
     Optional<T> detectOptional(Predicate<? super T> predicate);
@@ -1238,6 +1239,7 @@ public interface RichIterable<T>
      * </pre>
      * <p>
      *
+     * @throws NullPointerException if the element selected is null
      * @since 8.0
      */
     <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/AbstractRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/AbstractRichIterable.java
@@ -427,13 +427,13 @@ public abstract class AbstractRichIterable<T> implements RichIterable<T>
     @Override
     public Optional<T> detectOptional(Predicate<? super T> predicate)
     {
-        return Optional.ofNullable(this.detect(predicate));
+        return IterableIterate.detectOptional(this, predicate);
     }
 
     @Override
     public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        return Optional.ofNullable(this.detectWith(predicate, parameter));
+        return this.detectOptional(Predicates.bind(predicate, parameter));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBag.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
@@ -398,6 +399,18 @@ public class ImmutableArrayBag<T>
     public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
         return ArrayIterate.detectWith(this.keys, predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return ArrayIterate.detectOptional(this.keys, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return ArrayIterate.detectWithOptional(this.keys, predicate, parameter);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBag.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.LazyIterable;
@@ -390,6 +391,18 @@ final class ImmutableEmptyBag<T>
     public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
         return null;
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.bag.Bag;
@@ -413,6 +414,18 @@ public class ImmutableHashBag<T>
     public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
         return this.delegate.detectWith(predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return this.delegate.detectOptional(predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return this.delegate.detectWithOptional(predicate, parameter);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
@@ -322,6 +323,14 @@ final class ImmutableSingletonBag<T>
         return predicate.accept(this.value)
                 ? this.value
                 : null;
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return predicate.accept(this.value)
+                ? Optional.of(this.value)
+                : Optional.empty();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.bag.mutable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBagIterable;
@@ -143,6 +144,18 @@ public abstract class AbstractMutableBagIterable<T>
     public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
         return this.getKeysView().detectWith(predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return this.getKeysView().detectOptional(predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return this.getKeysView().detectWithOptional(predicate, parameter);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImpl.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.RandomAccess;
 
 import net.jcip.annotations.Immutable;
@@ -607,6 +608,12 @@ class ImmutableSortedBagImpl<T>
     public T detect(Predicate<? super T> predicate)
     {
         return ArrayIterate.detect(this.elements, predicate);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return ArrayIterate.detectOptional(this.elements, predicate);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
@@ -119,12 +119,6 @@ public class CollectIterable<T, V>
     }
 
     @Override
-    public <P> V detectWith(Predicate2<? super V, ? super P> predicate, P parameter)
-    {
-        return this.detect(Predicates.bind(predicate, parameter));
-    }
-
-    @Override
     public <IV> IV injectInto(IV injectedValue, Function2<? super IV, ? super V, ? extends IV> f)
     {
         return Iterate.injectInto(injectedValue, this.adapted, (argument1, argument2) -> f.value(argument1, this.function.valueOf(argument2)));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CollectIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.function.Function;
@@ -116,6 +117,13 @@ public class CollectIterable<T, V>
     {
         T resultItem = Iterate.detect(this.adapted, Predicates.attributePredicate(this.function, predicate));
         return resultItem == null ? null : this.function.valueOf(resultItem);
+    }
+
+    @Override
+    public Optional<V> detectOptional(Predicate<? super V> predicate)
+    {
+        Optional<T> resultItem = Iterate.detectOptional(this.adapted, Predicates.attributePredicate(this.function, predicate));
+        return resultItem.map(this.function::valueOf);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CompositeIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CompositeIterable.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -98,6 +99,21 @@ public final class CompositeIterable<E>
             }
         }
         return null;
+    }
+
+    @Override
+    public Optional<E> detectOptional(Predicate<? super E> predicate)
+    {
+        for (int i = 0; i < this.iterables.size(); i++)
+        {
+            Iterable<E> eachIterable = this.iterables.get(i);
+            Optional<E> result = Iterate.detectOptional(eachIterable, predicate);
+            if (result.isPresent())
+            {
+                return result;
+            }
+        }
+        return Optional.empty();
     }
 
     public void add(Iterable<E> iterable)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DistinctIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DistinctIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.LazyIterable;
@@ -94,6 +95,14 @@ public class DistinctIterable<T>
         MutableSet<T> seenSoFar = UnifiedSet.newSet();
 
         return Iterate.detect(this.adapted, each -> seenSoFar.add(each) && predicate.accept(each));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        MutableSet<T> seenSoFar = UnifiedSet.newSet();
+
+        return Iterate.detectOptional(this.adapted, each -> seenSoFar.add(each) && predicate.accept(each));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -85,6 +86,12 @@ public class DropIterable<T> extends AbstractLazyIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect(this.adapted, Predicates.and(new DropIterablePredicate<>(this.count), predicate));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, Predicates.and(new DropIterablePredicate<>(this.count), predicate));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropWhileIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/DropWhileIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -86,6 +87,12 @@ public class DropWhileIterable<T> extends AbstractLazyIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect(this.adapted, Predicates.and(new DropWhileIterablePredicate<>(this.predicate), predicate));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, Predicates.and(new DropWhileIterablePredicate<>(this.predicate), predicate));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/FlatCollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/FlatCollectIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.function.Function;
@@ -63,7 +64,7 @@ public class FlatCollectIterable<T, V>
     public V detect(Predicate<? super V> predicate)
     {
         V[] result = (V[]) new Object[1];
-        Iterate.detect(this.adapted, each -> {
+        Iterate.anySatisfy(this.adapted, each -> {
             Iterable<V> iterable = this.function.valueOf(each);
             return Iterate.anySatisfy(iterable, each1 -> {
                 if (predicate.accept(each1))
@@ -75,6 +76,36 @@ public class FlatCollectIterable<T, V>
             });
         });
         return result[0];
+    }
+
+    @Override
+    public Optional<V> detectOptional(Predicate<? super V> predicate)
+    {
+        V[] result = (V[]) new Object[1];
+        Iterate.anySatisfy(this.adapted, each -> {
+            if (each == null)
+            {
+                throw new NullPointerException();
+            }
+            Iterable<V> iterable = this.function.valueOf(each);
+            if (iterable == null)
+            {
+                throw new NullPointerException();
+            }
+            return Iterate.anySatisfy(iterable, each1 -> {
+                if (predicate.accept(each1))
+                {
+                    if (each1 == null)
+                    {
+                        throw new NullPointerException();
+                    }
+                    result[0] = each1;
+                    return true;
+                }
+                return false;
+            });
+        });
+        return Optional.ofNullable(result[0]);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/LazyIterableAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/LazyIterableAdapter.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.lazy;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.LazyIterable;
@@ -206,5 +207,17 @@ public class LazyIterableAdapter<T>
     public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
         return Iterate.detectWith(this.adapted, predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return Iterate.detectWithOptional(this.adapted, predicate, parameter);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/RejectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/RejectIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -89,6 +90,12 @@ public class RejectIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect(this.adapted, Predicates.and(this.predicate, predicate));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, Predicates.and(this.predicate, predicate));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -86,6 +87,12 @@ public class SelectInstancesOfIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect((Iterable<T>) this.adapted, Predicates.and(Predicates.instanceOf(this.clazz), predicate));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional((Iterable<T>) this.adapted, Predicates.and(Predicates.instanceOf(this.clazz), predicate));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/SelectIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -86,6 +87,12 @@ public class SelectIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect(this.adapted, Predicates.and(this.predicate, predicate));
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, Predicates.and(this.predicate, predicate));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/TapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/TapIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.block.predicate.Predicate;
@@ -103,6 +104,15 @@ public class TapIterable<T>
     public T detect(Predicate<? super T> predicate)
     {
         return Iterate.detect(this.adapted, each -> {
+            this.procedure.value(each);
+            return predicate.accept(each);
+        });
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Iterate.detectOptional(this.adapted, each -> {
             this.procedure.value(each);
             return predicate.accept(each);
         });

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/AbstractArrayAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/AbstractArrayAdapter.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.RandomAccess;
 
 import org.eclipse.collections.api.block.HashingStrategy;
@@ -125,10 +126,21 @@ public abstract class AbstractArrayAdapter<T>
     }
 
     @Override
-    public T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
+    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        T result = this.detect(predicate);
-        return result == null ? function.value() : result;
+        return InternalArrayIterate.detectWith(this.items, this.items.length, predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return InternalArrayIterate.detectOptional(this.items, this.items.length, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return InternalArrayIterate.detectWithOptional(this.items, this.items.length, predicate, parameter);
     }
 
     @Override
@@ -498,22 +510,6 @@ public abstract class AbstractArrayAdapter<T>
     {
         ListIterate.rangeCheck(fromIndex, toIndex, this.items.length);
         InternalArrayIterate.forEachWithoutChecks(this.items, fromIndex, toIndex, procedure);
-    }
-
-    @Override
-    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return InternalArrayIterate.detectWith(this.items, this.items.length, predicate, parameter);
-    }
-
-    @Override
-    public <P> T detectWithIfNone(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter,
-            Function0<? extends T> function)
-    {
-        T result = this.detectWith(predicate, parameter);
-        return result == null ? function.value() : result;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
@@ -282,10 +282,9 @@ final class ImmutableArrayList<T>
     }
 
     @Override
-    public T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
+    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        T result = this.detect(predicate);
-        return result == null ? function.value() : result;
+        return InternalArrayIterate.detectWith(this.items, this.items.length, predicate, parameter);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
@@ -288,6 +288,17 @@ final class ImmutableArrayList<T>
     }
 
     @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return InternalArrayIterate.detectOptional(this.items, this.items.length, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return InternalArrayIterate.detectWithOptional(this.items, this.items.length, predicate, parameter);
+    }
+
     public int count(Predicate<? super T> predicate)
     {
         return InternalArrayIterate.count(this.items, this.items.length, predicate);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyList.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.RandomAccess;
 
 import net.jcip.annotations.Immutable;
@@ -248,6 +249,12 @@ final class ImmutableEmptyList<T>
     public T detect(Predicate<? super T> predicate)
     {
         return null;
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Random;
 import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
@@ -355,10 +356,21 @@ public abstract class AbstractMutableList<T>
     }
 
     @Override
-    public T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
+    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        T result = this.detect(predicate);
-        return result == null ? function.value() : result;
+        return ListIterate.detectWith(this, predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return ListIterate.detectOptional(this, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return ListIterate.detectWithOptional(this, predicate, parameter);
     }
 
     @Override
@@ -407,22 +419,6 @@ public abstract class AbstractMutableList<T>
     public <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function)
     {
         return ListIterate.maxBy(this, function);
-    }
-
-    @Override
-    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return ListIterate.detectWith(this, predicate, parameter);
-    }
-
-    @Override
-    public <P> T detectWithIfNone(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter,
-            Function0<? extends T> function)
-    {
-        T result = ListIterate.detectWith(this, predicate, parameter);
-        return result == null ? function.value() : result;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -905,10 +905,21 @@ public class FastList<T>
     }
 
     @Override
-    public T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> defaultValueBlock)
+    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        T result = this.detect(predicate);
-        return result == null ? defaultValueBlock.value() : result;
+        return InternalArrayIterate.detectWith(this.items, this.size, predicate, parameter);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return InternalArrayIterate.detectOptional(this.items, this.size, predicate);
+    }
+
+    @Override
+    public <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        return InternalArrayIterate.detectWithOptional(this.items, this.size, predicate, parameter);
     }
 
     @Override
@@ -957,22 +968,6 @@ public class FastList<T>
     public <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function)
     {
         return InternalArrayIterate.maxBy(this.items, this.size, function);
-    }
-
-    @Override
-    public <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter)
-    {
-        return InternalArrayIterate.detectWith(this.items, this.size, predicate, parameter);
-    }
-
-    @Override
-    public <P> T detectWithIfNone(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter,
-            Function0<? extends T> defaultValueBlock)
-    {
-        T result = this.detectWith(predicate, parameter);
-        return result == null ? defaultValueBlock.value() : result;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/AbstractMapIterable.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.map;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
@@ -184,6 +185,18 @@ public abstract class AbstractMapIterable<K, V> extends AbstractRichIterable<V> 
     public <P> V detectWith(Predicate2<? super V, ? super P> predicate, P parameter)
     {
         return this.valuesView().detectWith(predicate, parameter);
+    }
+
+    @Override
+    public Optional<V> detectOptional(Predicate<? super V> predicate)
+    {
+        return this.valuesView().detectOptional(predicate);
+    }
+
+    @Override
+    public <P> Optional<V> detectWithOptional(Predicate2<? super V, ? super P> predicate, P parameter)
+    {
+        return this.valuesView().detectWithOptional(predicate, parameter);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import net.jcip.annotations.NotThreadSafe;
@@ -1683,6 +1684,74 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         }
 
         return null;
+    }
+
+    @Override
+    public Optional<V> detectOptional(Predicate<? super V> predicate)
+    {
+        for (int i = 0; i < this.table.length; i += 2)
+        {
+            if (this.table[i] == CHAINED_KEY)
+            {
+                Object[] chainedTable = (Object[]) this.table[i + 1];
+                for (int j = 0; j < chainedTable.length; j += 2)
+                {
+                    if (chainedTable[j] != null)
+                    {
+                        V value = (V) chainedTable[j + 1];
+                        if (predicate.accept(value))
+                        {
+                            return Optional.of(value);
+                        }
+                    }
+                }
+            }
+            else if (this.table[i] != null)
+            {
+                V value = (V) this.table[i + 1];
+
+                if (predicate.accept(value))
+                {
+                    return Optional.of(value);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public <P> Optional<V> detectWithOptional(Predicate2<? super V, ? super P> predicate, P parameter)
+    {
+        for (int i = 0; i < this.table.length; i += 2)
+        {
+            if (this.table[i] == CHAINED_KEY)
+            {
+                Object[] chainedTable = (Object[]) this.table[i + 1];
+                for (int j = 0; j < chainedTable.length; j += 2)
+                {
+                    if (chainedTable[j] != null)
+                    {
+                        V value = (V) chainedTable[j + 1];
+                        if (predicate.accept(value, parameter))
+                        {
+                            return Optional.of(value);
+                        }
+                    }
+                }
+            }
+            else if (this.table[i] != null)
+            {
+                V value = (V) this.table[i + 1];
+
+                if (predicate.accept(value, parameter))
+                {
+                    return Optional.of(value);
+                }
+            }
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.set;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.collections.api.LazyIterable;
@@ -79,6 +80,8 @@ public abstract class AbstractUnifiedSet<T>
     protected abstract void rehash(int newCapacity);
 
     protected abstract T detect(Predicate<? super T> predicate, int start, int end);
+
+    protected abstract Optional<T> detectOptional(Predicate<? super T> predicate, int start, int end);
 
     @Override
     @SuppressWarnings("AbstractMethodOverridesAbstractMethod")
@@ -221,6 +224,12 @@ public abstract class AbstractUnifiedSet<T>
     public T detect(Predicate<? super T> predicate)
     {
         return this.detect(predicate, 0, this.getTable().length);
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return this.detectOptional(predicate, 0, this.getTable().length);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySet.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import net.jcip.annotations.Immutable;
@@ -335,6 +336,12 @@ final class ImmutableEmptySet<T>
     public T detect(Predicate<? super T> predicate)
     {
         return null;
+    }
+
+    @Override
+    public Optional<T> detectOptional(Predicate<? super T> predicate)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -771,6 +772,32 @@ public class UnifiedSet<T>
             }
         }
         return null;
+    }
+
+    @Override
+    protected Optional<T> detectOptional(Predicate<? super T> predicate, int start, int end)
+    {
+        for (int i = start; i < end; i++)
+        {
+            Object cur = this.table[i];
+            if (cur instanceof ChainedBucket)
+            {
+                Object chainedDetect = this.chainedDetect((ChainedBucket) cur, predicate);
+                if (chainedDetect != null)
+                {
+                    return Optional.of(this.nonSentinel(chainedDetect));
+                }
+            }
+            else if (cur != null)
+            {
+                T each = this.nonSentinel(cur);
+                if (predicate.accept(each))
+                {
+                    return Optional.of(each);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private Object chainedDetect(ChainedBucket bucket, Predicate<? super T> predicate)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -792,6 +793,32 @@ public class UnifiedSetWithHashingStrategy<T>
             }
         }
         return null;
+    }
+
+    @Override
+    protected Optional<T> detectOptional(Predicate<? super T> predicate, int start, int end)
+    {
+        for (int i = start; i < end; i++)
+        {
+            Object cur = this.table[i];
+            if (cur instanceof ChainedBucket)
+            {
+                Object chainedDetect = this.chainedDetect((ChainedBucket) cur, predicate);
+                if (chainedDetect != null)
+                {
+                    return Optional.of(this.nonSentinel(chainedDetect));
+                }
+            }
+            else if (cur != null)
+            {
+                T each = this.nonSentinel(cur);
+                if (predicate.accept(each))
+                {
+                    return Optional.of(each);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private Object chainedDetect(ChainedBucket bucket, Predicate<? super T> predicate)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
@@ -858,6 +859,33 @@ public final class ArrayIterate
             throw new IllegalArgumentException("Cannot perform a detectWith on null");
         }
         return InternalArrayIterate.detectWith(objectArray, objectArray.length, predicate, parameter);
+    }
+
+    /**
+     * @see Iterate#detectOptional(Iterable, Predicate)
+     */
+    public static <T> Optional<T> detectOptional(T[] objectArray, Predicate<? super T> predicate)
+    {
+        if (objectArray == null)
+        {
+            throw new IllegalArgumentException("Cannot perform a detect on null");
+        }
+        return InternalArrayIterate.detectOptional(objectArray, objectArray.length, predicate);
+    }
+
+    /**
+     * @see Iterate#detectWithOptional(Iterable, Predicate2, Object)
+     */
+    public static <T, P> Optional<T> detectWithOptional(
+            T[] objectArray,
+            Predicate2<? super T, ? super P> predicate,
+            P parameter)
+    {
+        if (objectArray == null)
+        {
+            throw new IllegalArgumentException("Cannot perform a detectWith on null");
+        }
+        return InternalArrayIterate.detectWithOptional(objectArray, objectArray.length, predicate, parameter);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
@@ -929,6 +930,53 @@ public final class ArrayListIterate
             return null;
         }
         return RandomAccessListIterate.detectWith(list, predicate, parameter);
+    }
+
+    /**
+     * @see Iterate#detectOptional(Iterable, Predicate)
+     */
+    public static <T> Optional<T> detectOptional(ArrayList<T> list, Predicate<? super T> predicate)
+    {
+        int size = list.size();
+        if (ArrayListIterate.isOptimizableArrayList(list, size))
+        {
+            T[] elements = ArrayListIterate.getInternalArray(list);
+            for (int i = 0; i < size; i++)
+            {
+                T item = elements[i];
+                if (predicate.accept(item))
+                {
+                    return Optional.of(item);
+                }
+            }
+            return Optional.empty();
+        }
+        return RandomAccessListIterate.detectOptional(list, predicate);
+    }
+
+    /**
+     * @see Iterate#detectWithOptional(Iterable, Predicate2, Object)
+     */
+    public static <T, P> Optional<T> detectWithOptional(
+            ArrayList<T> list,
+            Predicate2<? super T, ? super P> predicate,
+            P parameter)
+    {
+        int size = list.size();
+        if (ArrayListIterate.isOptimizableArrayList(list, size))
+        {
+            T[] elements = ArrayListIterate.getInternalArray(list);
+            for (int i = 0; i < size; i++)
+            {
+                T item = elements[i];
+                if (predicate.accept(item, parameter))
+                {
+                    return Optional.of(item);
+                }
+            }
+            return Optional.empty();
+        }
+        return RandomAccessListIterate.detectWithOptional(list, predicate, parameter);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
@@ -2334,10 +2334,29 @@ public final class Iterate
      *          person -> person.getFirstName().equals("John") && person.getLastName().equals("Smith"));
      * </pre>
      * <p>
+     *
+     * @throws NullPointerException if the element selected is null
+     * @since 8.0
      */
     public static <T> Optional<T> detectOptional(Iterable<T> iterable, Predicate<? super T> predicate)
     {
-        return Optional.ofNullable(detect(iterable, predicate));
+        if (iterable instanceof RichIterable)
+        {
+            return ((RichIterable<T>) iterable).detectOptional(predicate);
+        }
+        if (iterable instanceof ArrayList)
+        {
+            return ArrayListIterate.detectOptional((ArrayList<T>) iterable, predicate);
+        }
+        if (iterable instanceof RandomAccess)
+        {
+            return RandomAccessListIterate.detectOptional((List<T>) iterable, predicate);
+        }
+        if (iterable != null)
+        {
+            return IterableIterate.detectOptional(iterable, predicate);
+        }
+        throw new IllegalArgumentException("Cannot perform detectOptional on null");
     }
 
     /**
@@ -2351,13 +2370,32 @@ public final class Iterate
      *          (person, fullName) -> person.getFullName().equals(fullName), "John Smith");
      * </pre>
      * <p>
+     *
+     * @throws NullPointerException if the element selected is null
+     * @since 8.0
      */
     public static <T, P> Optional<T> detectWithOptional(
             Iterable<T> iterable,
             Predicate2<? super T, ? super P> predicate,
             P parameter)
     {
-        return Optional.ofNullable(detectWith(iterable, predicate, parameter));
+        if (iterable instanceof MutableCollection)
+        {
+            return ((MutableCollection<T>) iterable).detectWithOptional(predicate, parameter);
+        }
+        if (iterable instanceof ArrayList)
+        {
+            return ArrayListIterate.detectWithOptional((ArrayList<T>) iterable, predicate, parameter);
+        }
+        if (iterable instanceof RandomAccess)
+        {
+            return RandomAccessListIterate.detectWithOptional((List<T>) iterable, predicate, parameter);
+        }
+        if (iterable != null)
+        {
+            return IterableIterate.detectWithOptional(iterable, predicate, parameter);
+        }
+        throw new IllegalArgumentException("Cannot perform detectWith on null");
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.RandomAccess;
 
 import org.eclipse.collections.api.RichIterable;
@@ -867,6 +868,33 @@ public final class ListIterate
             return RandomAccessListIterate.detectWith(list, predicate, injectedValue);
         }
         return IterableIterate.detectWith(list, predicate, injectedValue);
+    }
+
+    /**
+     * @see Iterate#detectOptional(Iterable, Predicate)
+     */
+    public static <T> Optional<T> detectOptional(List<T> list, Predicate<? super T> predicate)
+    {
+        if (list instanceof RandomAccess)
+        {
+            return RandomAccessListIterate.detectOptional(list, predicate);
+        }
+        return IterableIterate.detectOptional(list, predicate);
+    }
+
+    /**
+     * @see Iterate#detectWithOptional(Iterable, Predicate2, Object)
+     */
+    public static <T, IV> Optional<T> detectWithOptional(
+            List<T> list,
+            Predicate2<? super T, ? super IV> predicate,
+            IV injectedValue)
+    {
+        if (list instanceof RandomAccess)
+        {
+            return RandomAccessListIterate.detectWithOptional(list, predicate, injectedValue);
+        }
+        return IterableIterate.detectWithOptional(list, predicate, injectedValue);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
@@ -775,6 +775,32 @@ public final class InternalArrayIterate
         return null;
     }
 
+    public static <T> Optional<T> detectOptional(T[] array, int size, Predicate<? super T> predicate)
+    {
+        for (int i = 0; i < size; i++)
+        {
+            T each = array[i];
+            if (predicate.accept(each))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static <T, P> Optional<T> detectWithOptional(T[] array, int size, Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        for (int i = 0; i < size; i++)
+        {
+            T each = array[i];
+            if (predicate.accept(each, parameter))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
+    }
+
     public static <T> void appendString(
             ListIterable<T> iterable,
             T[] array,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
@@ -699,7 +699,15 @@ public final class IteratorIterate
      */
     public static <T> Optional<T> detectOptional(Iterator<T> iterator, Predicate<? super T> predicate)
     {
-        return Optional.ofNullable(IteratorIterate.detect(iterator, predicate));
+        while (iterator.hasNext())
+        {
+            T each = iterator.next();
+            if (predicate.accept(each))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -707,7 +715,15 @@ public final class IteratorIterate
      */
     public static <T, P> Optional<T> detectWithOptional(Iterator<T> iterator, Predicate2<? super T, ? super P> predicate, P parameter)
     {
-        return Optional.ofNullable(IteratorIterate.detectWith(iterator, predicate, parameter));
+        while (iterator.hasNext())
+        {
+            T each = iterator.next();
+            if (predicate.accept(each, parameter))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.RandomAccess;
 
 import org.eclipse.collections.api.RichIterable;
@@ -999,6 +1000,34 @@ public final class RandomAccessListIterate
             }
         }
         return null;
+    }
+
+    public static <T> Optional<T> detectOptional(List<T> list, Predicate<? super T> predicate)
+    {
+        int size = list.size();
+        for (int i = 0; i < size; i++)
+        {
+            T each = list.get(i);
+            if (predicate.accept(each))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static <T, P> Optional<T> detectWithOptional(List<T> list, Predicate2<? super T, ? super P> predicate, P parameter)
+    {
+        int size = list.size();
+        for (int i = 0; i < size; i++)
+        {
+            T each = list.get(i);
+            if (predicate.accept(each, parameter))
+            {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
 
     public static <T, IV> Twin<MutableList<T>> selectAndRejectWith(

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoDetectOptionalNullTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoDetectOptionalNullTestCase.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.test;
+
+import org.junit.Test;
+
+public interface NoDetectOptionalNullTestCase extends RichIterableTestCase
+{
+    @Test
+    @Override
+    default void RichIterable_detectOptionalNull()
+    {
+        // Not applicable
+    }
+}

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
@@ -1369,6 +1369,15 @@ public interface RichIterableTestCase extends IterableTestCase
     }
 
     @Test
+    default void RichIterable_detectOptionalNull()
+    {
+        RichIterable<Integer> iterable = this.newWith(1, null, 3);
+
+        assertThrows(NullPointerException.class, () -> iterable.detectOptional(i -> i == null));
+        assertThrows(NullPointerException.class, () -> iterable.detectWithOptional((i, object) -> i == object, null));
+    }
+
+    @Test
     default void RichIterable_min_max()
     {
         assertEquals(Integer.valueOf(-1), this.newWith(-1, 0, 1).min());

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedIterableTestCase.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import static org.eclipse.collections.impl.test.Verify.assertThrows;
 import static org.junit.Assert.assertSame;
 
-public interface SortedIterableTestCase extends OrderedIterableTestCase
+public interface SortedIterableTestCase extends OrderedIterableTestCase, NoDetectOptionalNullTestCase
 {
     @Override
     <T> SortedIterable<T> newWith(T... elements);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/SelectInstancesOfIterableTestNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/SelectInstancesOfIterableTestNoIteratorTest.java
@@ -14,11 +14,12 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.impl.lazy.SelectInstancesOfIterable;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
 import org.eclipse.collections.test.LazyNoIteratorTestCase;
+import org.eclipse.collections.test.NoDetectOptionalNullTestCase;
 import org.eclipse.collections.test.list.mutable.FastListNoIterator;
 import org.junit.runner.RunWith;
 
 @RunWith(Java8Runner.class)
-public class SelectInstancesOfIterableTestNoIteratorTest implements LazyNoIteratorTestCase
+public class SelectInstancesOfIterableTestNoIteratorTest implements LazyNoIteratorTestCase, NoDetectOptionalNullTestCase
 {
     @Override
     public <T> LazyIterable<T> newWith(T... elements)

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentMutableHashMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ConcurrentMutableHashMapTest.java
@@ -15,12 +15,13 @@ import java.util.Random;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.ConcurrentMutableHashMap;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
+import org.eclipse.collections.test.NoDetectOptionalNullTestCase;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNull;
 
 @RunWith(Java8Runner.class)
-public class ConcurrentMutableHashMapTest implements MutableMapTestCase
+public class ConcurrentMutableHashMapTest implements MutableMapTestCase, NoDetectOptionalNullTestCase
 {
     private static final long CURRENT_TIME_MILLIS = System.currentTimeMillis();
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.lazy;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
@@ -423,6 +424,20 @@ public abstract class AbstractLazyIterableTestCase
     {
         Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detectWith(Object::equals, Integer.valueOf(3)));
         Assert.assertNull(this.lazyIterable.detectWith(Object::equals, Integer.valueOf(8)));
+    }
+
+    @Test
+    public void detectOptional()
+    {
+        Assert.assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectOptional(Integer.valueOf(3)::equals));
+        Assert.assertEquals(Optional.empty(), this.lazyIterable.detectOptional(Integer.valueOf(8)::equals));
+    }
+
+    @Test
+    public void detectWithOptional()
+    {
+        Assert.assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(3)));
+        Assert.assertEquals(Optional.empty(), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(8)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.lazy;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.list.MutableList;
@@ -118,5 +119,49 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
         Assert.assertEquals(
                 FastList.newListWith(3, 2, 4, 1, 5),
                 composite.distinct().toList());
+    }
+
+    @Override
+    public void detect()
+    {
+        CompositeIterable<Integer> composite = CompositeIterable.with(
+                FastList.newListWith(1, 2),
+                FastList.newList(),
+                FastList.newListWith(3, 4, 5, 6));
+        Assert.assertEquals(Integer.valueOf(3), composite.detect(Integer.valueOf(3)::equals));
+        Assert.assertNull(composite.detect(Integer.valueOf(8)::equals));
+    }
+
+    @Override
+    public void detectWith()
+    {
+        CompositeIterable<Integer> composite = CompositeIterable.with(
+                FastList.newListWith(1, 2),
+                FastList.newList(),
+                FastList.newListWith(3, 4, 5, 6));
+        Assert.assertEquals(Integer.valueOf(3), composite.detectWith(Object::equals, Integer.valueOf(3)));
+        Assert.assertNull(composite.detectWith(Object::equals, Integer.valueOf(8)));
+    }
+
+    @Override
+    public void detectOptional()
+    {
+        CompositeIterable<Integer> composite = CompositeIterable.with(
+                FastList.newListWith(1, 2),
+                FastList.newList(),
+                FastList.newListWith(3, 4, 5, 6));
+        Assert.assertEquals(Optional.of(Integer.valueOf(3)), composite.detectOptional(Integer.valueOf(3)::equals));
+        Assert.assertEquals(Optional.empty(), composite.detectOptional(Integer.valueOf(8)::equals));
+    }
+
+    @Override
+    public void detectWithOptional()
+    {
+        CompositeIterable<Integer> composite = CompositeIterable.with(
+                FastList.newListWith(1, 2),
+                FastList.newList(),
+                FastList.newListWith(3, 4, 5, 6));
+        Assert.assertEquals(Optional.of(Integer.valueOf(3)), composite.detectWithOptional(Object::equals, Integer.valueOf(3)));
+        Assert.assertEquals(Optional.empty(), composite.detectWithOptional(Object::equals, Integer.valueOf(8)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
@@ -216,6 +216,15 @@ public class IterableIterateTest
     }
 
     @Test
+    public void detectOptionalNull()
+    {
+        MutableList<Integer> objects = mList(1, null, 3);
+        Iterable<Integer> iterable = new IterableAdapter<>(objects);
+
+        Verify.assertThrows(NullPointerException.class, () -> Iterate.detectOptional(iterable, i -> i == null));
+    }
+
+    @Test
     public void detectWithOptional()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
@@ -234,6 +243,15 @@ public class IterableIterateTest
 
     @Test
     public void detectWithOptionalOver30()
+    {
+        MutableList<Integer> objects = mList(1, null, 3);
+        Iterable<Integer> iterable = new IterableAdapter<>(objects);
+
+        Verify.assertThrows(NullPointerException.class, () -> Iterate.detectWithOptional(iterable, (i, object) -> i == object, null));
+    }
+
+    @Test
+    public void detectWithOptionalNull()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
         Assert.assertEquals(Optional.of(1), Iterate.detectWithOptional(iterable, Object::equals, 1));


### PR DESCRIPTION
Revisiting the comment below from #115.

>There's one weird case where it's not ok to delegate to ofNullable(). The map, or iterable, could contain a null value and the predicate could be each -> each == null. There's no great way to handle that case, but it's not great to return empty() when something was actually found. The alternative would be calling Optional.of(null) which throws, but is arguably more correct.

Following what's suggested in the last line above and also what `Streams#findFirst()` does, I made detectOptional methods throw NullPointerException when null value is detected. 