### PR TITLE
Deploy junit-trait-runner module.

### DIFF
--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -25,10 +25,6 @@
 
     <name>Eclipse Collections Test Trait JUnit Runner</name>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <prerequisites>
         <maven>3.0.5</maven>
     </prerequisites>


### PR DESCRIPTION
Enabling junit-trait-runner deployment again for 8.0.0 release.

I suspect the [deployment error we saw earlier](https://hudson.eclipse.org/collections/job/deploy/12/console) (Connection Reset) was related to the issues below. I hope the workaround (turn off clean workspace option) would work. Let's try and see how it goes. 

https://bugs.eclipse.org/bugs/show_bug.cgi?id=497132
https://bugs.eclipse.org/bugs/show_bug.cgi?id=492412