### PR TITLE
Disable junit-trait-runner module deployment.

### DIFF
--- a/junit-trait-runner/pom.xml
+++ b/junit-trait-runner/pom.xml
@@ -25,6 +25,10 @@
 
     <name>Eclipse Collections Test Trait JUnit Runner</name>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <prerequisites>
         <maven>3.0.5</maven>
     </prerequisites>


### PR DESCRIPTION
In Hudson build, junit-trait-runner deployment failed with "Connection reset" error that's similar to these bugs ([494371](https://bugs.eclipse.org/bugs/show_bug.cgi?format=multiple&id=494371) and [492421](https://bugs.eclipse.org/bugs/show_bug.cgi?id=492412)). Need to file Eclipse/Hudson bug to track the issue. 

https://hudson.eclipse.org/collections/job/deploy/17/console

In the meantime we disable the deployment of junit-trait-runner.