### PR TITLE
Fix addAll() method in CompositeFastList to return false on isEmpty()…

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
@@ -225,11 +225,13 @@ public final class CompositeFastList<E>
     @Override
     public boolean addAll(Collection<? extends E> collection)
     {
-        if (!collection.isEmpty())
+        if (collection.isEmpty())
         {
-            Collection<? extends E> collectionToAdd = collection instanceof FastList ? collection : new FastList<E>(collection);
-            this.addComposited(collectionToAdd);
+            return false;
         }
+        Collection<? extends E> collectionToAdd =
+                collection instanceof FastList ? collection : FastList.newList(collection);
+        this.addComposited(collectionToAdd);
         return true;
     }
 
@@ -679,7 +681,8 @@ public final class CompositeFastList<E>
         @Override
         public void value(FastList<E> list)
         {
-            list.each(object -> {
+            list.each(object ->
+            {
                 this.objectIntProcedure.value(
                         object,
                         this.index);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl.collection.mutable;
 
+import java.util.Collections;
+
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
@@ -93,6 +95,7 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> collection = this.newWith();
         Assert.assertTrue(collection.addAll(FastList.newListWith(1, 2, 3)));
+        Assert.assertFalse(collection.addAll(Collections.emptyList()));
         Verify.assertContainsAll(collection, 1, 2, 3);
 
         boolean result = collection.addAll(FastList.newListWith(1, 2, 3));


### PR DESCRIPTION
… case. Fixes #141.

Signed-off-by: Donald Raab <Donald.Raab@gs.com>