### PR TITLE
Optimize List.clear methods to avoid clearing unused memory

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -109,7 +109,7 @@ public class <name>ArrayList extends Abstract<name>Iterable
 
     public void clear()
     {
-        Arrays.fill(this.items, <(zero.(type))>);
+        Arrays.fill(this.items, 0, size, <(zero.(type))>);
         this.size = 0;
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -215,7 +215,7 @@ public class FastList<T>
     @Override
     public void clear()
     {
-        Arrays.fill(this.items, null);
+        Arrays.fill(this.items, 0, size, null);
         this.size = 0;
     }
 


### PR DESCRIPTION
Fixes goldmansachs/gs-collections#33

Signed-off-by: Christopher Clark <csquared@cs.washington.edu>