### PR TITLE
[Re-submit] Cherry pick Javadoc fixes to 8.0.x branch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,7 @@
                     </links>
                     <destDir>${project.version}</destDir>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <excludePackageNames>org.openjdk,org.eclipse.collections.impl.jmh,org.eclipse.collections.codegenerator</excludePackageNames>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Re-submitting as mentioned in #158 .