### PR TITLE
Change collect and collectWith with target collections on InternalArr…

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -307,28 +307,22 @@ public class FastList<T>
 
     private void addAllFastList(FastList<T> source)
     {
-        int sourceSize = source.size();
-        int newSize = this.size + sourceSize;
-        this.ensureCapacity(newSize);
-        System.arraycopy(source.items, 0, this.items, this.size, sourceSize);
+        int newSize = this.ensureCapacityForAddAll(source);
+        System.arraycopy(source.items, 0, this.items, this.size, source.size());
         this.size = newSize;
     }
 
     private void addAllArrayList(ArrayList<T> source)
     {
-        int sourceSize = source.size();
-        int newSize = this.size + sourceSize;
-        this.ensureCapacity(newSize);
-        ArrayListIterate.toArray(source, this.items, this.size, sourceSize);
+        int newSize = this.ensureCapacityForAddAll(source);
+        ArrayListIterate.toArray(source, this.items, this.size, source.size());
         this.size = newSize;
     }
 
     private void addAllRandomAccessList(List<T> source)
     {
-        int sourceSize = source.size();
-        int newSize = this.size + sourceSize;
-        this.ensureCapacity(newSize);
-        RandomAccessListIterate.toArray(source, this.items, this.size, sourceSize);
+        int newSize = this.ensureCapacityForAddAll(source);
+        RandomAccessListIterate.toArray(source, this.items, this.size, source.size());
         this.size = newSize;
     }
 
@@ -423,6 +417,26 @@ public class FastList<T>
             return true;
         }
         return false;
+    }
+
+    private void ensureCapacityForAdd()
+    {
+        if (this.items == DEFAULT_SIZED_EMPTY_ARRAY)
+        {
+            this.items = (T[]) new Object[10];
+        }
+        else
+        {
+            this.transferItemsToNewArrayWithCapacity(this.sizePlusFiftyPercent(this.size));
+        }
+    }
+
+    private int ensureCapacityForAddAll(Collection<T> source)
+    {
+        int sourceSize = source.size();
+        int newSize = this.size + sourceSize;
+        this.ensureCapacity(newSize);
+        return newSize;
     }
 
     public void ensureCapacity(int minCapacity)
@@ -994,18 +1008,6 @@ public class FastList<T>
         }
         this.items[this.size++] = newItem;
         return true;
-    }
-
-    private void ensureCapacityForAdd()
-    {
-        if (this.items == DEFAULT_SIZED_EMPTY_ARRAY)
-        {
-            this.items = (T[]) new Object[10];
-        }
-        else
-        {
-            this.transferItemsToNewArrayWithCapacity(this.sizePlusFiftyPercent(this.size));
-        }
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.utility.internal;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
@@ -450,6 +451,14 @@ public final class InternalArrayIterate
             Function<? super T, ? extends V> function,
             R target)
     {
+        if (target instanceof FastList)
+        {
+            ((FastList) target).ensureCapacity(target.size() + size);
+        }
+        else if (target instanceof ArrayList)
+        {
+            ((ArrayList) target).ensureCapacity(target.size() + size);
+        }
         for (int i = 0; i < size; i++)
         {
             target.add(function.valueOf(array[i]));
@@ -475,13 +484,21 @@ public final class InternalArrayIterate
             int size,
             Function2<? super T, ? super P, ? extends V> function,
             P parameter,
-            R targetCollection)
+            R target)
     {
+        if (target instanceof FastList)
+        {
+            ((FastList) target).ensureCapacity(target.size() + size);
+        }
+        else if (target instanceof ArrayList)
+        {
+            ((ArrayList) target).ensureCapacity(target.size() + size);
+        }
         for (int i = 0; i < size; i++)
         {
-            targetCollection.add(function.value(array[i], parameter));
+            target.add(function.value(array[i], parameter));
         }
-        return targetCollection;
+        return target;
     }
 
     public static <T, V, R extends Collection<V>> R collectIf(


### PR DESCRIPTION
…ayIterate to use ensureCapacity for FastLists and ArrayLists.

Signed-off-by: Donald Raab <Donald.Raab@gs.com>