### PR TITLE
Add jarsign step as part of deploy build. Closes #152.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,13 @@
         <project.previous.version>7.0.0</project.previous.version>
     </properties>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.eclipse.org</id>
+            <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencyManagement>
         <dependencies>
 
@@ -398,6 +405,11 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                    <artifactId>eclipse-jarsigner-plugin</artifactId>
+                    <version>1.1.3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -644,6 +656,20 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <version>1.1.3</version>
+                        <executions>
+                            <execution>
+                                <id>jarsign</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Ive been experimenting this with a [branch](https://github.com/eclipse/eclipse-collections/tree/signjar) in eclipse repo and all build issues have been sorted out by now.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=510109
https://bugs.eclipse.org/bugs/show_bug.cgi?id=512691

After this is merged, I'll get rid of `signjar` branch and `signjar-expr` tag in eclipse repo.