### PR TITLE
[#223] Create a  p2 repository (based on EBR)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - jdk: oraclejdk8
       env:
         - DESC="findbugs"
-        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!p2-repository' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:

--- a/p2-repository/README.md
+++ b/p2-repository/README.md
@@ -1,0 +1,14 @@
+Eclipse Collections OSGi/p2 Build
+=================================
+
+This process uses Maven artifacts and converts them into OSGi bundles and makes
+them available as a p2 repository.
+
+It runs as part of the main build and expects to find the artifacts in the
+current Maven reactor.
+
+The p2 repository will be available at `org.eclipse.collections/target/repository`.
+
+Note, the `p2-repository` POM acts as a parent for recipes and also integrates the
+recipes into the build process as modules. Each recipe is a Maven project with
+`eclipse-bundle-recipe` type packaging.

--- a/p2-repository/org.eclipse.collections/.project
+++ b/p2-repository/org.eclipse.collections/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+        <name>org.eclipse.collections</name>
+        <comment></comment>
+        <projects>
+        </projects>
+        <buildSpec>
+        </buildSpec>
+        <natures>
+        </natures>
+</projectDescription>

--- a/p2-repository/org.eclipse.collections/osgi.bnd
+++ b/p2-repository/org.eclipse.collections/osgi.bnd
@@ -1,0 +1,12 @@
+package-version=${version;===;${Bundle-Version}}
+eclipse-collections-api-version=${version;===;8.1.0}
+jcip-annotations-version=${version;===;1.0}
+
+Export-Package: \
+ !about.html,!about_files, \
+ *.internal*;x-internal:=true;version="${package-version}", \
+ *.impl*;x-internal:=true;version="${package-version}", \
+ *;version="${package-version}"
+
+Import-Package: \
+ *;resolution:=optional

--- a/p2-repository/org.eclipse.collections/pom.xml
+++ b/p2-repository/org.eclipse.collections/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.collections</groupId>
+    <artifactId>p2-repository</artifactId>
+    <version>8.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.eclipse.collections</artifactId>
+  <packaging>eclipse-bundle-recipe</packaging>
+
+  <name>Eclipse Collections OSGi Bundle</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2-repository/org.eclipse.collections/src/main/resources/OSGI-INF/l10n/bundle.properties
+++ b/p2-repository/org.eclipse.collections/src/main/resources/OSGI-INF/l10n/bundle.properties
@@ -1,0 +1,3 @@
+# Bundle Localization
+bundleName = Eclipse Collections Main Library
+bundleVendor = Eclipse Collections

--- a/p2-repository/org.eclipse.collections/src/main/resources/about.html
+++ b/p2-repository/org.eclipse.collections/src/main/resources/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>March 23, 2017</p>
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/p2-repository/pom.xml
+++ b/p2-repository/pom.xml
@@ -1,0 +1,341 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.collections</groupId>
+    <artifactId>eclipse-collections-parent</artifactId>
+    <version>8.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>p2-repository</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Eclipse Collections p2 Repository Build</name>
+
+  <modules>
+	  <module>org.eclipse.collections</module>
+  </modules>
+
+  <properties>
+
+    <!-- include everything from all dependencies by default -->
+    <recipe.includes>**/*</recipe.includes>
+
+    <!-- but filter out maven instructions, we'll generate new ones below -->
+    <recipe.excludes>META-INF/maven/**/*.*</recipe.excludes>
+
+    <!-- BND specific instructions which can be overridden by recipe -->
+    <recipe.Bundle-Name>%bundleName</recipe.Bundle-Name>
+    <recipe.Bundle-Description />
+    <recipe.Bundle-Vendor>%bundleVendor</recipe.Bundle-Vendor>
+
+    <!-- remove some clutter from the generated manifests -->
+    <recipe.removeheaders>Ignore-Package,Include-Resource,Private-Package,Embed-Dependency,Built-By,Build-Jdk,Bnd-*,Tool</recipe.removeheaders>
+
+    <!-- for Orbit, by default we'll also remove the Require-Bundle header; recipe poms may override if they need this header -->
+    <recipe.removeadditionalheaders>Require-Bundle</recipe.removeadditionalheaders>
+
+    <!-- read BND settings from 'osgi.bnd' located next to pom.xml -->
+    <recipe.bndfile>osgi.bnd</recipe.bndfile>
+
+    <!-- pattern/format used for the qualifier -->
+    <recipe.qualifier.format>'v'yyyyMMdd-HHmm</recipe.qualifier.format>
+
+    <!-- project defaults -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- versions used for plug-ins below -->
+    <tycho-version>1.0.0</tycho-version>
+    <tycho-extras-version>1.0.0</tycho-extras-version>
+
+    <!-- versions of the EBR plug-in to use -->
+    <ebr-version>1.0.0-SNAPSHOT</ebr-version>
+
+    <!-- property for generating Eclipse source reference bundle headers -->
+    <tycho.scmUrl>scm:git:https://github.com/eclipse/eclipse-collections.git</tycho.scmUrl>
+
+    <!-- by default complain if working tree is dirty (error|warning|ignore) -->
+    <dirtyWorkingTree>warning</dirtyWorkingTree>
+
+    <!-- set default vendor -->
+    <bundleVendor>Eclipse Collections</bundleVendor>
+
+    <!-- values needed for generating repositories -->
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+    <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
+    <buildType>I</buildType>
+    <buildId>${buildType}${buildTimestamp}</buildId>
+    <buildLabel>${buildType}-${buildId}-${buildTimestamp}</buildLabel>
+
+  </properties>
+
+  <pluginRepositories>
+    <!-- configure the EBR plug-in repo -->
+    <pluginRepository>
+        <id>ebr-releases</id>
+        <url>https://repo.eclipse.org/content/repositories/ebr-releases/</url>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+        <id>ebr-snapshots</id>
+        <url>https://repo.eclipse.org/content/repositories/ebr-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+    </pluginRepository>
+    <pluginRepository>
+        <id>cbi-releases</id>
+        <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+        <id>cbi-snapshots</id>
+        <url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <profiles>
+    <profile>
+      <id>eclipse-sign</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-pack200a-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>eclipse-bundle-recipe</supportedProjectType>
+              </supportedProjectTypes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>pack200-normalize</id>
+                <goals>
+                  <goal>normalize</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.eclipse.cbi.maven.plugins</groupId>
+            <artifactId>eclipse-jarsigner-plugin</artifactId>
+            <version>1.1.3</version>
+            <configuration>
+                <resigningStrategy>OVERWRITE</resigningStrategy>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-pack200b-plugin</artifactId>
+            <version>${tycho-extras-version}</version>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>eclipse-bundle-recipe</supportedProjectType>
+              </supportedProjectTypes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>pack200-pack</id>
+                <goals>
+                  <goal>pack</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-p2-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <executions>
+              <execution>
+                <id>p2-metadata</id>
+                <goals>
+                  <goal>p2-metadata</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>eclipse-bundle-recipe</supportedProjectType>
+                <supportedProjectType>eclipse-feature</supportedProjectType>
+              </supportedProjectTypes>
+              <defaultP2Metadata>false</defaultP2Metadata>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <!-- configure default plug-ins -->
+
+      <!-- enable Tycho -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+
+      <!-- target platform configuration -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <environments>
+            <environment>
+              <os>*</os>
+              <ws>*</ws>
+              <arch>*</arch>
+            </environment>
+          </environments>
+          <includePackedArtifacts>true</includePackedArtifacts>
+        </configuration>
+      </plugin>
+
+      <!-- configure build qualifier generation as well as source reference headers -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-sourceref-jgit</artifactId>
+            <version>${tycho-version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-buildtimestamp-jgit</artifactId>
+            <version>${tycho-version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <!-- use qualifier from properties -->
+          <format>${recipe.qualifier.format}</format>
+          <!-- generate bundle .qualifier from Git tags/commits -->
+          <timestampProvider>jgit</timestampProvider>
+          <!-- allow to ignore dirty working trees -->
+          <jgit.dirtyWorkingTree>${dirtyWorkingTree}</jgit.dirtyWorkingTree>
+          <!-- generate source references -->
+          <sourceReferences>
+            <generate>true</generate>
+          </sourceReferences>
+        </configuration>
+      </plugin>
+
+
+      <!-- configure bundle build so that properties defined above will be considered -->
+      <plugin>
+        <groupId>org.eclipse.ebr</groupId>
+        <artifactId>ebr-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <includes>${recipe.includes}</includes>
+          <excludes>${recipe.excludes}</excludes>
+          <bndInstructions>
+            <Bundle-Name>${recipe.Bundle-Name}</Bundle-Name>
+            <Bundle-Vendor>${recipe.Bundle-Vendor}</Bundle-Vendor>
+            <Bundle-Description>${recipe.Bundle-Description}</Bundle-Description>
+            <_removeheaders>${recipe.removeheaders},${recipe.removeadditionalheaders}</_removeheaders>
+            <_include>-${recipe.bndfile}</_include>
+          </bndInstructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+    <pluginManagement>
+      <!-- define versions and defaults for plug-ins used in Maven -->
+
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-maven-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-director-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-repository-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>target-platform-configuration</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-source-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-source-feature-plugin</artifactId>
+          <version>${tycho-extras-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-custom-bundle-plugin</artifactId>
+          <version>${tycho-extras-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-p2-extras-plugin</artifactId>
+          <version>${tycho-extras-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.ebr</groupId>
+          <artifactId>ebr-maven-plugin</artifactId>
+          <version>${ebr-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.ebr</groupId>
+          <artifactId>ebr-tycho-extras-plugin</artifactId>
+          <version>${ebr-version}</version>
+        </plugin>
+      </plugins>
+
+    </pluginManagement>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <module>junit-trait-runner</module>
         <module>unit-tests-java8</module>
         <module>test-coverage</module>
+        <module>p2-repository</module>
     </modules>
 
     <properties>
@@ -292,7 +293,9 @@
                                     </requireMavenVersion>
                                     <requirePluginVersions>
                                         <unCheckedPluginList>
-                                            org.eclipse.collections:eclipse-collections-code-generator-maven-plugin
+                                            org.eclipse.collections:eclipse-collections-code-generator-maven-plugin,
+                                            org.eclipse.ebr:ebr-maven-plugin,
+                                            org.eclipse.ebr:ebr-tycho-extras-plugin
                                         </unCheckedPluginList>
                                     </requirePluginVersions>
                                 </rules>


### PR DESCRIPTION
This adds the initial recipe for generating an OSGi bundle for Eclipse Collections. The bundle is a combination of the main library and the api. It runs as part of the main build an produces a p2 repo with what is available in the Maven reactor.

#223 

/cc @kthoms @nikhilnanivadekar 