### PR TITLE
[#226] Explicit configuration of Bundle-SymbolicName

### DIFF
--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -79,6 +79,7 @@
                             net.jcip.annotations;resolution:=optional,*
                         </Import-Package>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-SymbolicName>org.eclipse.collections.api</Bundle-SymbolicName>
                     </instructions>
                 </configuration>
             </plugin>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -86,6 +86,7 @@
                             net.jcip.annotations;resolution:=optional,*
                         </Import-Package>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-SymbolicName>org.eclipse.collections.forkjoin</Bundle-SymbolicName>
                     </instructions>
                 </configuration>
             </plugin>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -86,6 +86,7 @@
                             net.jcip.annotations;resolution:=optional,*
                         </Import-Package>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-SymbolicName>org.eclipse.collections.testutils</Bundle-SymbolicName>
                     </instructions>
                 </configuration>
             </plugin>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -85,6 +85,7 @@
                             net.jcip.annotations;resolution:=optional,*
                         </Import-Package>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-SymbolicName>org.eclipse.collections.impl</Bundle-SymbolicName>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The Bundle-SymbolicName property is explicitly configured to use more
concise bundle ids.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>