### PR TITLE
Remove useless declaration of properties for SonarQube

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,6 @@
 
         <argLine></argLine>
 
-        <!--Sonar settings-->
-        <sonar.language>java</sonar.language>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-        <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
-        <sonar.clover.version>${clover.version}</sonar.clover.version>
         <project.previous.version>7.0.0</project.previous.version>
     </properties>
 


### PR DESCRIPTION
Removal of `sonar.language` allows to get rid of warnings such as
```
[WARNING] File '...' is ignored because it doens't belong to the forced langauge 'java'
```


Other (`sonar.dynamicAnalysis`, `sonar.core.codeCoveragePlugin`, `sonar.clover.version`) have no effect.