### PR TITLE
Yak shaving: upgrade maven-jar-plugin and maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
 
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.2</version>
                 </plugin>
 
                 <plugin>
@@ -255,7 +255,7 @@
 
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <phase>verify</phase>


### PR DESCRIPTION
First step regarding Java 9 - is to execute tests with it.

In absence of usage of [Maven Toolchains](https://maven.apache.org/guides/mini/guide-using-toolchains.html), build should itself be executed with JDK 9 EA because `maven-surefire-plugin` uses JDK that was used for Maven execution. But  currently it fails - see
* [log prior to upgrade of `maven-jar-plugin`](https://github.com/eclipse/eclipse-collections/files/870527/log1.txt)
* [log after upgrade of `maven-jar-plugin`, but prior to upgrade of `maven-source-plugin`](https://github.com/eclipse/eclipse-collections/files/870529/log2.txt)

After upgrade of both there are still problems with JDK 9 EA - compilation errors:
* [in module `eclipse-collections`](https://github.com/eclipse/eclipse-collections/files/870530/log3.txt)
* and even after build with JDK 8 and usage of JDK 9 EA to build [only module `unit-tests`](https://github.com/eclipse/eclipse-collections/files/870532/log4.txt)

However this might be a bug in javac (I'm investigating), so suggest to apply this change anyway, because
* first of all it allows to investigate and report to OpenJDK any problems with compilation
* it is IMO good practice to keep Maven plugins up-to-date