### PR TITLE
Fix condition that triggers SonarQube analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
 script:
-- if [[ "$TRAVIS_EVENT_TYPE" == "cron" && DESC="unit tests" ]];
+  if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$DESC" == "unit tests" ]];
   then mvn install --batch-mode --show-version --errors sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=${SONARQUBE_TOKEN} -Dsonar.organization=eclipse-collections ;
   else eval $CMD;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env:
         - DESC="unit tests"
         - CMD="mvn install --batch-mode --show-version --errors"
+        - SONAR_COMMAND="sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=${SONARQUBE_TOKEN} -Dsonar.organization=eclipse-collections"
 
     - jdk: oraclejdk8
       env:
@@ -34,9 +35,10 @@ matrix:
         - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
 script:
-  if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$DESC" == "unit tests" ]];
-  then mvn install --batch-mode --show-version --errors sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=${SONARQUBE_TOKEN} -Dsonar.organization=eclipse-collections ;
-  else eval $CMD;
+  if ["$TRAVIS_EVENT_TYPE" == "cron"]; then
+      eval $CMD $SONAR_COMMAND;
+  else
+      eval $CMD;
   fi
 
 cache:


### PR DESCRIPTION
SonarQube analysis is executed for the each of 5 jobs - see https://travis-ci.org/eclipse/eclipse-collections/jobs/215394107 and https://travis-ci.org/eclipse/eclipse-collections/jobs/215394108 for example, whereas should be executed only for job that has `DESC` `unit tests`. Because of this generation of 5 reports approximately at the same time, server side processing fails for 4 out of 5 of those reports:
![sonarqube](https://cloud.githubusercontent.com/assets/138671/24356467/66d4054c-12fa-11e7-93de-bb7ef06d07b4.png)

This change fixes condition, so that only one job will be doing analysis.