### PR TITLE
Fix compilation errors

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveHashBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveHashBag.stg
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.<name>Bag;
 import org.eclipse.collections.api.bag.primitive.Immutable<name>Bag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
@@ -40,7 +41,6 @@ import org.eclipse.collections.impl.block.procedure.checked.primitive.Checked<na
 import org.eclipse.collections.impl.iterator.Unmodifiable<name>Iterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.tuple.primitive.<name>IntPair;
-
 
 /**
  * Immutable<name>HashBag is the non-modifiable equivalent of {@link <name>HashBag}.
@@ -187,7 +187,8 @@ final class Immutable<name>HashBag implements Immutable<name>Bag, Serializable
     @Override
     public \<V> ImmutableBag\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        return this.delegate.collect(function).toImmutable();
+        MutableBag\<V> bag = this.delegate.collect(function);
+        return bag.toImmutable();
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
@@ -265,7 +265,8 @@ final class Immutable<name>ArrayList
     @Override
     public \<V> ImmutableList\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        return this.collect(function, FastList.newList(this.items.length)).toImmutable();
+        FastList\<V> list = this.collect(function, FastList.newList(this.items.length));
+        return list.toImmutable();
     }
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
@@ -34,6 +34,7 @@ import org.eclipse.collections.api.block.procedure.primitive.<name>Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.Object<name>Procedure;
 import org.eclipse.collections.api.map.primitive.Object<name>Map;
 import org.eclipse.collections.api.collection.ImmutableCollection;
+import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.collection.primitive.Immutable<name>Collection;
 import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
 import org.eclipse.collections.api.iterator.<name>Iterator;
@@ -135,7 +136,8 @@ final class ImmutableObject<name>HashMap\<K> extends AbstractImmutableObject<nam
     @Override
     public \<V> ImmutableCollection\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        return this.delegate.collect(function).toImmutable();
+        MutableCollection\<V> collection = this.delegate.collect(function);
+        return collection.toImmutable();
     }
 
     <(arithmeticMethods.(type))()>

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
@@ -96,6 +96,7 @@ import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
@@ -320,7 +321,8 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     @Override
     public \<VV> ImmutableBag\<VV> collect(Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.collect(function).toImmutable();
+        MutableBag\<VV> bag = this.delegate.collect(function);
+        return bag.toImmutable();
     }
 
     <collectPrimitive("Boolean", "boolean")>
@@ -334,13 +336,15 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     @Override
     public \<P, VV> ImmutableBag\<VV> collectWith(Function2\<? super V, ? super P, ? extends VV> function, P parameter)
     {
-        return this.delegate.collectWith(function, parameter).toImmutable();
+        MutableBag\<VV> bag = this.delegate.collectWith(function, parameter);
+        return bag.toImmutable();
     }
 
     @Override
     public \<VV> ImmutableBag\<VV> collectIf(Predicate\<? super V> predicate, Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.collectIf(predicate, function).toImmutable();
+        MutableBag\<VV> bag = this.delegate.collectIf(predicate, function);
+        return bag.toImmutable();
     }
 
     @Override
@@ -652,7 +656,8 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     @Override
     public \<VV> ImmutableBagMultimap\<VV, V> groupBy(Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.groupBy(function).toImmutable();
+        MutableBagMultimap\<VV, V> bagMultimap = this.delegate.groupBy(function);
+        return bagMultimap.toImmutable();
     }
 
     @Override
@@ -676,7 +681,8 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     @Override
     public \<VV> ImmutableMap\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
     {
-        return this.delegate.groupByUniqueKey(function).toImmutable();
+        MutableMap\<VV, V> map = this.delegate.groupByUniqueKey(function);
+        return map.toImmutable();
     }
 
     @Override
@@ -718,13 +724,15 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     @Override
     public \<K, VV> ImmutableMap\<K, VV> aggregateInPlaceBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Procedure2\<? super VV, ? super V> mutatingAggregator)
     {
-        return this.delegate.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator).toImmutable();
+        MutableMap\<K, VV> map = this.delegate.aggregateInPlaceBy(groupBy, zeroValueFactory, mutatingAggregator);
+        return map.toImmutable();
     }
 
     @Override
     public \<K, VV> ImmutableMap\<K, VV> aggregateBy(Function\<? super V, ? extends K> groupBy, Function0\<? extends VV> zeroValueFactory, Function2\<? super VV, ? super V, ? extends VV> nonMutatingAggregator)
     {
-        return this.delegate.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator).toImmutable();
+        MutableMap\<K, VV> map = this.delegate.aggregateBy(groupBy, zeroValueFactory, nonMutatingAggregator);
+        return map.toImmutable();
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
@@ -32,6 +32,7 @@ import org.eclipse.collections.api.Lazy<name1>Iterable;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.Lazy<name2>Iterable;<endif>
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.Mutable<name2>Bag;
 import org.eclipse.collections.api.bag.primitive.Immutable<name2>Bag;
 import org.eclipse.collections.api.block.function.primitive.<name2>ToObjectFunction;
@@ -217,7 +218,8 @@ final class Immutable<name1><name2>HashMap implements Immutable<name1><name2>Map
     @Override
     public \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function)
     {
-        return this.delegate.collect(function).toImmutable();
+        MutableBag\<V> bag = this.delegate.collect(function);
+        return bag.toImmutable();
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -1214,7 +1214,8 @@ public final class <name>HashSet extends Abstract<name>Set implements Mutable<na
         @Override
         public \<V> ImmutableSet\<V> collect(<name>ToObjectFunction\<? extends V> function)
         {
-            return this.collect(function, UnifiedSet.newSet(this.size())).toImmutable();
+            MutableSet\<V> set = this.collect(function, UnifiedSet.newSet(this.size()));
+            return set.toImmutable();
         }
 
         @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBag.java
@@ -236,7 +236,8 @@ final class ImmutableEmptyBag<T>
     @Override
     public ImmutableBag<T> newWithAll(Iterable<? extends T> elements)
     {
-        return HashBag.newBag(elements).toImmutable();
+        MutableBag<T> bag = HashBag.newBag(elements);
+        return bag.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBag.java
@@ -40,6 +40,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
+import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
 import org.eclipse.collections.api.set.ImmutableSet;
@@ -126,7 +127,8 @@ public class ImmutableHashBag<T>
     @Override
     public <V> ImmutableBagMultimap<V, T> groupBy(Function<? super T, ? extends V> function)
     {
-        return this.delegate.groupBy(function).toImmutable();
+        MutableBagMultimap<V, T> bagMultimap = this.delegate.groupBy(function);
+        return bagMultimap.toImmutable();
     }
 
     @Override
@@ -154,7 +156,8 @@ public class ImmutableHashBag<T>
     @Override
     public <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.delegate.groupByUniqueKey(function).toImmutable();
+        MutableMap<V, T> map = this.delegate.groupByUniqueKey(function);
+        return map.toImmutable();
     }
 
     @Override
@@ -366,7 +369,8 @@ public class ImmutableHashBag<T>
     @Override
     public <V> ImmutableBag<V> collect(Function<? super T, ? extends V> function)
     {
-        return this.delegate.collect(function).toImmutable();
+        MutableBag<V> bag = this.delegate.collect(function);
+        return bag.toImmutable();
     }
 
     @Override
@@ -380,7 +384,8 @@ public class ImmutableHashBag<T>
             Predicate<? super T> predicate,
             Function<? super T, ? extends V> function)
     {
-        return this.delegate.collectIf(predicate, function).toImmutable();
+        MutableBag<V> bag = this.delegate.collectIf(predicate, function);
+        return bag.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
@@ -135,7 +136,8 @@ final class ImmutableSingletonBag<T>
     @Override
     public ImmutableBag<T> newWithAll(Iterable<? extends T> elements)
     {
-        return HashBag.newBag(elements).with(this.value).toImmutable();
+        MutableBag<T> bag = HashBag.newBag(elements);
+        return bag.with(this.value).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMap.java
@@ -45,6 +45,8 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
+import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
@@ -388,25 +390,29 @@ public abstract class AbstractImmutableBiMap<K, V> extends AbstractBiMap<K, V> i
     @Override
     public <V1> ImmutableObjectLongMap<V1> sumByInt(Function<? super V, ? extends V1> groupBy, IntFunction<? super V> function)
     {
-        return this.delegate.sumByInt(groupBy, function).toImmutable();
+        ObjectLongMap<V1> map = this.delegate.sumByInt(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V1> ImmutableObjectDoubleMap<V1> sumByFloat(Function<? super V, ? extends V1> groupBy, FloatFunction<? super V> function)
     {
-        return this.delegate.sumByFloat(groupBy, function).toImmutable();
+        ObjectDoubleMap<V1> map = this.delegate.sumByFloat(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V1> ImmutableObjectLongMap<V1> sumByLong(Function<? super V, ? extends V1> groupBy, LongFunction<? super V> function)
     {
-        return this.delegate.sumByLong(groupBy, function).toImmutable();
+        ObjectLongMap<V1> map = this.delegate.sumByLong(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V1> ImmutableObjectDoubleMap<V1> sumByDouble(Function<? super V, ? extends V1> groupBy, DoubleFunction<? super V> function)
     {
-        return this.delegate.sumByDouble(groupBy, function).toImmutable();
+        ObjectDoubleMap<V1> map = this.delegate.sumByDouble(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollection.java
@@ -114,7 +114,8 @@ public abstract class AbstractImmutableCollection<T> extends AbstractRichIterabl
     @Override
     public <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return Iterate.groupByUniqueKey(this, function).toImmutable();
+        MutableMap<V, T> map = Iterate.groupByUniqueKey(this, function);
+        return map.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
@@ -538,7 +538,8 @@ public abstract class AbstractParallelIterable<T, B extends Batch<T>> implements
     @Override
     public MutableSortedBag<T> toSortedBag(Comparator<? super T> comparator)
     {
-        MutableSortedBag<T> result = TreeBag.newBag(comparator).asSynchronized();
+        MutableSortedBag<T> result = TreeBag.newBag(comparator);
+        result = result.asSynchronized();
         this.forEach(CollectionAddProcedure.on(result));
         return result;
     }
@@ -552,7 +553,8 @@ public abstract class AbstractParallelIterable<T, B extends Batch<T>> implements
     @Override
     public MutableSortedSet<T> toSortedSet(Comparator<? super T> comparator)
     {
-        MutableSortedSet<T> result = TreeSortedSet.newSet(comparator).asSynchronized();
+        MutableSortedSet<T> result = TreeSortedSet.newSet(comparator);
+        result = result.asSynchronized();
         this.forEach(CollectionAddProcedure.on(result));
         return result;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -210,7 +210,8 @@ public class UnifiedSetWithHashingStrategy<T>
 
     public static <K> UnifiedSetWithHashingStrategy<K> newSetWith(HashingStrategy<? super K> hashingStrategy, K... elements)
     {
-        return UnifiedSetWithHashingStrategy.newSet(hashingStrategy, elements.length).with(elements);
+        UnifiedSetWithHashingStrategy<K> set = UnifiedSetWithHashingStrategy.newSet(hashingStrategy, elements.length);
+        return set.with(elements);
     }
 
     public HashingStrategy<? super T> hashingStrategy()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -61,6 +61,8 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
+import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
+import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
@@ -801,25 +803,29 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     @Override
     public <V> ImmutableObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function)
     {
-        return this.delegate.asReversed().sumByInt(groupBy, function).toImmutable();
+        ObjectLongMap<V> map = this.delegate.asReversed().sumByInt(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V> ImmutableObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function)
     {
-        return this.delegate.asReversed().sumByFloat(groupBy, function).toImmutable();
+        ObjectDoubleMap<V> map = this.delegate.asReversed().sumByFloat(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V> ImmutableObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function)
     {
-        return this.delegate.asReversed().sumByLong(groupBy, function).toImmutable();
+        ObjectLongMap<V> map = this.delegate.asReversed().sumByLong(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override
     public <V> ImmutableObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function)
     {
-        return this.delegate.asReversed().sumByDouble(groupBy, function).toImmutable();
+        ObjectDoubleMap<V> map = this.delegate.asReversed().sumByDouble(groupBy, function);
+        return map.toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -156,7 +156,8 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
     public static <T> ArrayStack<T> newStackFromTopToBottom(Iterable<? extends T> items)
     {
         ArrayStack<T> stack = ArrayStack.newStack();
-        stack.delegate = FastList.newList(items).reverseThis();
+        FastList<T> list = FastList.newList(items);
+        stack.delegate = list.reverseThis();
         return stack;
     }
 


### PR DESCRIPTION
These compilation errors were revealed during attempt to use JDK 9 EA b162 for build of project - see https://github.com/eclipse/eclipse-collections/pull/234#issue-217022672

All they originate from the code that uses same pattern:
```java
class Pattern {
  interface MutableObjectByteMap {
    <V> MutableCollection<V> collect(ByteToObjectFunction<? extends V> function);
  }

  interface MutableCollection<T> {
    ImmutableCollection<T> toImmutable();
  }

  interface ImmutableCollection<T> { }

  interface ByteToObjectFunction<T> { }

  MutableObjectByteMap delegate;

  <V> ImmutableCollection<V> example(ByteToObjectFunction<? extends V> function) {
    return delegate.collect(function).toImmutable();
  }
}
```

Compilation of this `Pattern.java` with JDK 8u121 and OpenJDK 9b52 succeeds, but fails with OpenJDK 9b53:
```
Pattern.java:23: error: incompatible types: ImmutableCollection<CAP#1> cannot be converted to ImmutableCollection<V>
    return delegate.collect(function).toImmutable();
                                                 ^
  where V is a type-variable:
    V extends Object declared in method <V>example(ByteToObjectFunction<? extends V>)
  where CAP#1 is a fresh type-variable:
    CAP#1 extends V from capture of ? extends V
1 error
```

According to log of changes in OpenJDK 9 between b52 and b53 (http://hg.openjdk.java.net/jdk9/jdk9/langtools):
```
o  changeset:   2836:01d8ed7079f1
|  user:        katleman
|  date:        Thu Mar 05 11:26:21 2015 -0800
|  summary:     Added tag jdk9-b53 for changeset 99ff00581f36
|
@    changeset:   2835:99ff00581f36
|\   tag:         jdk9-b53
| |  parent:      2829:cdef738241cd
| |  parent:      2834:d6ec687ad8fb
| |  user:        lana
| |  date:        Thu Feb 26 20:17:06 2015 -0800
| |  summary:     Merge
| |
| o  changeset:   2834:d6ec687ad8fb
| |  user:        jjg
| |  date:        Wed Feb 25 14:35:39 2015 -0800
| |  summary:     8041628: Javadoc cross-compilation problem
| |
| o  changeset:   2833:f683944ffa42
| |  user:        jlahoda
| |  date:        Tue Feb 24 16:11:59 2015 +0100
| |  summary:     8067886: Inaccessible nested classes can be incorrectly imported
| |
| o  changeset:   2832:59af0866b952
| |  user:        juh
| |  date:        Mon Feb 23 11:42:16 2015 -0800
| |  summary:     8072663: Remove the sun.security.acl package which is not used in the JDK
| |
| o  changeset:   2831:e29b25f6101f
| |  user:        mcimadamore
| |  date:        Mon Feb 23 13:02:37 2015 +0000
| |  summary:     8071291: Compiler crashes trying to cast UnionType to IntersectionClassType
| |
| o  changeset:   2830:414b82835861
| |  parent:      2828:ee20efe0255d
| |  user:        dlsmith
| |  date:        Fri Feb 20 17:05:13 2015 -0700
| |  summary:     8039214: Inference should not map capture variables to their upper bounds
| |
o |  changeset:   2829:cdef738241cd
|/   user:        katleman
|    date:        Thu Feb 26 15:58:16 2015 -0800
|    summary:     Added tag jdk9-b52 for changeset ee20efe0255d
|
o    changeset:   2828:ee20efe0255d
|\   tag:         jdk9-b52
~ ~  parent:      2822:c5561bfde449
     parent:      2827:5e500700b168
     user:        lana
     date:        Thu Feb 19 16:38:54 2015 -0800
     summary:     Merge
```
this is caused by https://bugs.openjdk.java.net/browse/JDK-8039214 ( http://hg.openjdk.java.net/jdk9/jdk9/langtools/rev/414b82835861 )
Its subticket about release notes (https://bugs.openjdk.java.net/browse/JDK-8173583) states:
> The javac compiler's behavior when handling wildcards and "capture" type variables has been improved for conformance to the language specification. This improves type checking behavior in certain unusual circumstances. It is also a source-incompatible change: certain uses of wildcards that have compiled in the past may fail to compile because of a program's reliance on the javac bug.

Should be noted that this is consistent with what IntelliJ IDEA 2017.1 already reports even without JDK 9:

![intellij](https://cloud.githubusercontent.com/assets/138671/24429612/1d307938-1413-11e7-84b0-064cac307747.png)

as well as Eclipse Compiler for Java in Eclipse Neon.2:

![eclipse](https://cloud.githubusercontent.com/assets/138671/24429622/23c912e6-1413-11e7-880e-8f5c46f8aaf9.png)

After fix for this pattern for future investigations there will be only 7 errors in module `eclipse-collections` and only 2 in module `unit-tests` out of hundreds that appeared in https://github.com/eclipse/eclipse-collections/pull/234#issue-217022672