### PR TITLE
.travis.yml: prefix commands with travis_wait because they can execute…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ matrix:
 
 script:
   if ["$TRAVIS_EVENT_TYPE" == "cron"]; then
-      eval $CMD $SONAR_COMMAND;
+      eval travis_wait 35 $CMD $SONAR_COMMAND;
   else
-      eval $CMD;
+      eval travis_wait 35 $CMD;
   fi
 
 cache:


### PR DESCRIPTION
… for more than 10 minutes without writing output

This should fix random failures caused by "No output has been received in the last 10m0s". E.g.:

https://travis-ci.org/eclipse/eclipse-collections/jobs/215075863
https://travis-ci.org/eclipse/eclipse-collections/jobs/216632334
https://travis-ci.org/eclipse/eclipse-collections/jobs/216548057

see: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received for details.