### PR TITLE
Optimize factory method to not create redundant array copies. 

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryImpl.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl.list.fixed;
 
+import java.util.Collection;
+
 import net.jcip.annotations.Immutable;
 import org.eclipse.collections.api.factory.list.FixedSizeListFactory;
 import org.eclipse.collections.api.list.FixedSizeList;
@@ -149,6 +151,15 @@ public class FixedSizeListFactoryImpl implements FixedSizeListFactory
     @Override
     public <T> FixedSizeList<T> withAll(Iterable<? extends T> items)
     {
+        if (items instanceof Collection)
+        {
+            Collection<? extends T> collection = (Collection<? extends T>) items;
+            if (collection.size() <= 6)
+            {
+                return this.of((T[]) collection.toArray());
+            }
+            return ArrayAdapter.newArray(collection);
+        }
         return this.of((T[]) Iterate.toArray(items));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableListFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableListFactoryImpl.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl.list.immutable;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.RandomAccess;
 
@@ -254,6 +256,26 @@ public final class ImmutableListFactoryImpl implements ImmutableListFactory
         {
             return this.empty();
         }
-        return this.of((T[]) Iterate.toArray(items));
+        if (items instanceof Collection)
+        {
+            Collection<? extends T> collection = (Collection<? extends T>) items;
+            if (collection.size() < 11)
+            {
+                return this.of((T[]) collection.toArray());
+            }
+            return ImmutableArrayList.newList(collection);
+        }
+        Iterator<? extends T> iterator = items.iterator();
+        int size = 0;
+        while (size < 11 && iterator.hasNext())
+        {
+            iterator.next();
+            size++;
+        }
+        if (size < 11)
+        {
+            return this.of((T[]) Iterate.toArray(items));
+        }
+        return ImmutableArrayList.newList(items);
     }
 }


### PR DESCRIPTION
Fixes #217.