### PR TITLE
Fix compilation issues.

### DIFF
--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -1669,7 +1669,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertTrue(message, Predicates.anySatisfy(predicate).accept(iterable));
+            Assert.assertTrue(message, Predicates.<T>anySatisfy(predicate).accept(iterable));
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Functions.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Functions.java
@@ -497,7 +497,7 @@ public final class Functions
     public static <T extends Comparable<? super T>, V> CaseFunction<T, V> caseDefault(
             Function<? super T, ? extends V> defaultFunction)
     {
-        return new CaseFunction<>(defaultFunction);
+        return new CaseFunction<T, V>(defaultFunction);
     }
 
     public static <T extends Comparable<? super T>, V> CaseFunction<T, V> caseDefault(
@@ -505,7 +505,7 @@ public final class Functions
             Predicate<? super T> predicate,
             Function<? super T, ? extends V> function)
     {
-        CaseFunction<T, V> caseFunction = Functions.caseDefault(defaultFunction);
+        CaseFunction<T, V> caseFunction = Functions.<T, V>caseDefault(defaultFunction);
         return caseFunction.addCase(predicate, function);
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Predicates.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Predicates.java
@@ -112,7 +112,7 @@ public abstract class Predicates<T>
 
     public static <T> Predicates<T> or(Predicate<? super T>... predicates)
     {
-        return new OrIterablePredicate<>(Arrays.asList(predicates));
+        return new OrIterablePredicate<T>(Arrays.asList(predicates));
     }
 
     public static <T> Predicates<T> and(Iterable<? extends Predicate<? super T>> predicates)
@@ -127,7 +127,7 @@ public abstract class Predicates<T>
 
     public static <T> Predicates<T> and(Predicate<? super T>... predicates)
     {
-        return new AndIterablePredicate<>(Arrays.asList(predicates));
+        return new AndIterablePredicate<T>(Arrays.asList(predicates));
     }
 
     public static <T> Predicates<T> not(Predicate<T> predicate)
@@ -147,7 +147,7 @@ public abstract class Predicates<T>
 
     public static <T> Predicates<T> noneOf(Predicate<? super T>... operations)
     {
-        return new NoneOfIterablePredicate<>(Arrays.asList(operations));
+        return new NoneOfIterablePredicate<T>(Arrays.asList(operations));
     }
 
     public static <T> Predicates<T> noneOf(Iterable<? extends Predicate<? super T>> operations)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Procedures.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Procedures.java
@@ -123,7 +123,7 @@ public final class Procedures
             Predicate<? super T> predicate,
             Procedure<? super T> procedure)
     {
-        return Procedures.caseDefault(defaultProcedure).addCase(predicate, procedure);
+        return Procedures.<T>caseDefault(defaultProcedure).addCase(predicate, procedure);
     }
 
     public static <T> Procedure<T> synchronizedEach(Procedure<T> procedure)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectIterable.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.annotation.Beta;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
@@ -98,20 +99,23 @@ public class ParallelCollectIterable<T, V> extends AbstractParallelIterableImpl<
     public <V1> UnsortedBagMultimap<V1, V> groupBy(Function<? super V, ? extends V1> function)
     {
         // TODO: Implement in parallel
-        return this.delegate.toBag().collect(this.function).groupBy(function);
+        MutableBag<V> mutableBag = this.delegate.toBag().collect(this.function);
+        return mutableBag.groupBy(function);
     }
 
     @Override
     public <V1> UnsortedBagMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function)
     {
         // TODO: Implement in parallel
-        return this.delegate.toBag().collect(this.function).groupByEach(function);
+        MutableBag<V> mutableBag = this.delegate.toBag().collect(this.function);
+        return mutableBag.groupByEach(function);
     }
 
     @Override
     public <V1> MapIterable<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
     {
         // TODO: Implement in parallel
-        return this.delegate.toBag().collect(this.function).groupByUniqueKey(function);
+        MutableBag<V> mutableBag = this.delegate.toBag().collect(this.function);
+        return mutableBag.groupByUniqueKey(function);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl;
 import java.util.Arrays;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.block.factory.Functions;
@@ -116,8 +117,9 @@ public class AnagramTest
         MutableList<RichIterable<String>> results = Lists.mutable.of();
         this.getWords().groupBy(Alphagram::new)
                 .multiValuesView().forEach(Procedures.ifTrue(iterable -> iterable.size() >= SIZE_THRESHOLD, results::add));
+        Procedure<String> procedure = Procedures.cast(LOGGER::info);
         results.sortThisByInt(iterable -> -iterable.size())
-                .forEach(Functions.bind(Procedures.cast(LOGGER::info), iterable -> iterable.size() + ": " + iterable));
+                .forEach(Functions.bind(procedure, iterable -> iterable.size() + ": " + iterable));
         Verify.assertIterableSize(SIZE_THRESHOLD, results.getLast());
     }
 
@@ -129,7 +131,8 @@ public class AnagramTest
         MutableList<MutableList<String>> results =
                 map.select(iterable -> iterable.size() >= SIZE_THRESHOLD, Lists.mutable.of())
                         .sortThisByInt(iterable -> -iterable.size());
-        results.forEach(Functions.bind(Procedures.cast(LOGGER::info), iterable -> iterable.size() + ": " + iterable));
+        Procedure<String> procedure = Procedures.cast(LOGGER::info);
+        results.forEach(Functions.bind(procedure, iterable -> iterable.size() + ": " + iterable));
         Assert.assertTrue(this.listContainsTestGroupAtElementsOneOrTwo(results));
         Verify.assertSize(SIZE_THRESHOLD, results.getLast());
     }


### PR DESCRIPTION
I think these are last of the compilation issues with JDK-9-EA-163.
Few notes:
`Functions`, `Predicates`, `Procedures`, `Verify`: Diamond operator is not able to infer the type arguments, so mentioning the types explicitly fixes the compilation problem.