### PR TITLE
Implement OrderedIterable.getFirstOptional() and OrderedIterable.getL…

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBag.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import net.jcip.annotations.GuardedBy;
@@ -654,5 +655,23 @@ public class SynchronizedSortedBag<T>
     public ParallelBag<T> asParallel(ExecutorService executorService, int batchSize)
     {
         throw new UnsupportedOperationException("asParallel() method is not supported for " + this.getClass().getSimpleName() + '.');
+    }
+
+    @Override
+    public Optional<T> getFirstOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getFirstOptional();
+        }
+    }
+
+    @Override
+    public Optional<T> getLastOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getLastOptional();
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.Random;
 import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
@@ -785,6 +786,34 @@ public final class MultiReaderFastList<T>
         try
         {
             return this.delegate.get(index);
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
+    }
+
+    @Override
+    public Optional<T> getFirstOptional()
+    {
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().getFirstOptional();
+        }
+        finally
+        {
+            this.unlockReadLock();
+        }
+    }
+
+    @Override
+    public Optional<T> getLastOptional()
+    {
+        this.acquireReadLock();
+        try
+        {
+            return this.getDelegate().getLastOptional();
         }
         finally
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableList.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 
@@ -213,6 +214,24 @@ public class SynchronizedMutableList<T>
         synchronized (this.getLock())
         {
             return this.getDelegate().get(index);
+        }
+    }
+
+    @Override
+    public Optional<T> getFirstOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getFirstOptional();
+        }
+    }
+
+    @Override
+    public Optional<T> getLastOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getLastOptional();
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/SynchronizedSortedMap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.map.sorted.mutable;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.SortedMap;
 
 import org.eclipse.collections.api.LazyIterable;
@@ -758,6 +759,24 @@ public class SynchronizedSortedMap<K, V>
         synchronized (this.lock)
         {
             return this.getDelegate().distinct();
+        }
+    }
+
+    @Override
+    public Optional<V> getFirstOptional()
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().getFirstOptional();
+        }
+    }
+
+    @Override
+    public Optional<V> getLastOptional()
+    {
+        synchronized (this.lock)
+        {
+            return this.getDelegate().getLastOptional();
         }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.ExecutorService;
@@ -195,6 +196,24 @@ public class SynchronizedSortedSet<T>
         synchronized (this.getLock())
         {
             return this.getDelegate().last();
+        }
+    }
+
+    @Override
+    public Optional<T> getFirstOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getFirstOptional();
+        }
+    }
+
+    @Override
+    public Optional<T> getLastOptional()
+    {
+        synchronized (this.getLock())
+        {
+            return this.getDelegate().getLastOptional();
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStack.java
@@ -579,9 +579,27 @@ public final class SynchronizedStack<T> implements MutableStack<T>, Serializable
     }
 
     @Override
+    public Optional<T> getFirstOptional()
+    {
+        synchronized (this.lock)
+        {
+            return this.delegate.getFirstOptional();
+        }
+    }
+
+    @Override
     public T getLast()
     {
         return this.delegate.getLast();
+    }
+
+    @Override
+    public Optional<T> getLastOptional()
+    {
+        synchronized (this.lock)
+        {
+            return this.delegate.getLastOptional();
+        }
     }
 
     @Override


### PR DESCRIPTION
…astOptional() (#123, #244)

Fix concurrency for synchronized classes and MultiReaderFastList.