### PR TITLE
Optimize constructors of ImmutableTreeSet.

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
@@ -49,6 +49,12 @@ public class SortedSetsTest
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6));
         Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(
+                SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8),
+                factory.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
         Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
         Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
         Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl.factory;
 
+import java.util.Comparator;
+
 import org.eclipse.collections.api.factory.set.sorted.ImmutableSortedSetFactory;
 import org.eclipse.collections.api.factory.set.sorted.MutableSortedSetFactory;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
@@ -30,6 +32,15 @@ public class SortedSetsTest
         ImmutableSortedSetFactory factory = SortedSets.immutable;
         Assert.assertEquals(UnifiedSet.newSet(), factory.of());
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of());
+        Assert.assertEquals(UnifiedSet.newSet(), factory.with());
+        Verify.assertInstanceOf(ImmutableSortedSet.class, factory.with());
+        Assert.assertEquals(TreeSortedSet.newSet(Comparators.reverseNaturalOrder()), factory.empty(Comparators.reverseNaturalOrder()));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, factory.empty(Comparators.reverseNaturalOrder()));
+        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of(new Integer[0]));
+        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of((Object[]) null));
+        Assert.assertEquals(UnifiedSet.newSetWith(), factory.of(Comparators.reverseNaturalOrder()));
+        Assert.assertEquals(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder()).comparator(), factory.of(Comparators.reverseNaturalOrder()).comparator());
+        Assert.assertEquals(TreeSortedSet.newSetWith().comparator(), factory.of((Comparator<Integer>) null).comparator());
         Assert.assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(1, 2, 2));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2));
         Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(1, 2, 3, 4));
@@ -38,6 +49,18 @@ public class SortedSetsTest
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6));
         Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        Assert.assertEquals(SortedSets.mutable.empty(), factory.ofSortedSet(SortedSets.mutable.with()));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.ofAll(null, Lists.mutable.empty()));
     }
 
     @Test


### PR DESCRIPTION
These two fixes will optimize the construction of ImmutableTreeSet.
A note regarding optimizing constructor with array as an input parameter, there are 3 copies of array created. This will lead to excess garbage, but I do not know how I can avoid that. I am open to feedback. Below are the JMH Test results, where you can observe that we will improve performance by a great degree.

JMH Tests:

Version|Benchmark|Mode|Cnt|Score|Sign|Error|Units
-------|---------|-----|---|-----|----|-----|--------------
Old|array1Dups|thrpt|40|48,196.78|±|3130.292|ops/s|
New|array1Dups|thrpt|40|48,631.08|±|4602.933|ops/s|
Old|array1Dups_Reversed|thrpt|40|44,815.05|±|4799.93|ops/s|
New|array1Dups_Reversed|thrpt|40|48,380.77|±|4943.369|ops/s|
Old|array1NoDups|thrpt|40|44,204.53|±|3108.543|ops/s|
New|array1NoDups|thrpt|40|47,496.67|±|3807.926|ops/s|
Old|array1NoDups_Reversed|thrpt|40|43,528.15|±|3802.678|ops/s|
New|array1NoDups_Reversed|thrpt|40|48,096.34|±|3700.513|ops/s|
Old|array2Dups|thrpt|40|45,318.71|±|4412.587|ops/s|
New|array2Dups|thrpt|40|50,081.42|±|4893.897|ops/s|
Old|array2Dups_Reversed|thrpt|40|47,816.12|±|3059.621|ops/s|
New|array2Dups_Reversed|thrpt|40|45,297.24|±|4964.968|ops/s|
Old|array2NoDups|thrpt|40|46,645.78|±|3844.511|ops/s|
New|array2NoDups|thrpt|40|48,618.48|±|6102.112|ops/s|
Old|array2NoDups_Reversed|thrpt|40|46,061.01|±|3451.913|ops/s|
New|array2NoDups_Reversed|thrpt|40|42,639.21|±|4219.212|ops/s|
Old|array3Dups|thrpt|40|5.47|±|0.102|ops/s|
New|array3Dups|thrpt|40|83.01|±|6.897|ops/s|
Old|array3Dups_Reversed|thrpt|40|5.43|±|0.097|ops/s|
New|array3Dups_Reversed|thrpt|40|63.09|±|5.403|ops/s|
Old|array3NoDups|thrpt|40|9.07|±|0.205|ops/s|
New|array3NoDups|thrpt|40|214.23|±|20.084|ops/s|
Old|array3NoDups_Reversed|thrpt|40|8.86|±|0.177|ops/s|
New|array3NoDups_Reversed|thrpt|40|138.72|±|10.222|ops/s|
Old|sortedSet1|thrpt|40|41,825.34|±|2378.599|ops/s|
New|sortedSet1|thrpt|40|44,281.74|±|2863.907|ops/s|
Old|sortedSet1_Reversed|thrpt|40|42,487.72|±|2428.451|ops/s|
New|sortedSet1_Reversed|thrpt|40|42,752.79|±|2914.845|ops/s|
Old|sortedSet2|thrpt|40|39,684.53|±|2909.825|ops/s|
New|sortedSet2|thrpt|40|44,615.35|±|5022.053|ops/s|
Old|sortedSet2_Reversed|thrpt|40|41,201.95|±|1919.821|ops/s|
New|sortedSet2_Reversed|thrpt|40|45,632.81|±|4904.587|ops/s|
Old|sortedSet3|thrpt|40|41.99|±|3.718|ops/s|
New|sortedSet3|thrpt|40|84.79|±|3.478|ops/s|
Old|sortedSet3_Reversed|thrpt|40|38.01|±|2.511|ops/s|
New|sortedSet3_Reversed|thrpt|40|65.54|±|2.073|ops/s|

JMH Test code:
```
@State(Scope.Thread)
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.SECONDS)
@Warmup(iterations = 30)
@Measurement(iterations = 20)
@Fork(2)
public class ImmutableSetConstructorTest {
    public static final SerializableComparator<Integer> REVERSE_COMPARATOR = Comparators.reverseNaturalOrder();

    @State(Scope.Thread)
    public static class Initialize {
        public SortedSet<Integer> input1;
        public SortedSet<Integer> input2;
        public SortedSet<Integer> input3;

        public SortedSet<Integer> input1Reversed;
        public SortedSet<Integer> input2Reversed;
        public SortedSet<Integer> input3Reversed;

        public Integer[] array1NoDups;
        public Integer[] array1Dups;
        public Integer[] array2NoDups;
        public Integer[] array2Dups;
        public Integer[] array3NoDups;
        public Integer[] array3Dups;

        @Setup(Level.Invocation)
        public void setup() {
            Interval interval1 = Interval.fromTo(0, 6);
            input1 = SortedSets.mutable.withAll(interval1);
            input1Reversed = SortedSets.mutable.withAll(REVERSE_COMPARATOR, interval1);
            Interval interval2 = Interval.fromTo(0, 10);
            input2 = SortedSets.mutable.withAll(interval2);
            input2Reversed = SortedSets.mutable.withAll(REVERSE_COMPARATOR, interval2);
            Interval interval3 = Interval.fromTo(0, 500_000);
            input3 = SortedSets.mutable.withAll(interval3);
            input3Reversed = SortedSets.mutable.withAll(REVERSE_COMPARATOR, interval3);

            array1NoDups = input1.toArray(new Integer[0]);
            array2NoDups = input2.toArray(new Integer[0]);
            array3NoDups = input3.toArray(new Integer[0]);

            MutableList<Integer> list1 = Lists.mutable.withAll(interval1);
            list1.addAll(interval1);
            MutableList<Integer> list2 = Lists.mutable.withAll(interval2);
            list2.addAll(interval2);
            MutableList<Integer> list3 = Lists.mutable.withAll(interval3);
            list3.addAll(interval3);

            array1Dups = list1.toArray(new Integer[0]);
            array2Dups = list2.toArray(new Integer[0]);
            array3Dups = list3.toArray(new Integer[0]);

        }
    }

    @Benchmark
    public int sortedSet1(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input1).size();
    }

    @Benchmark
    public int sortedSet1_Reversed(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input1Reversed).size();
    }

    @Benchmark
    public int sortedSet2(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input2).size();
    }

    @Benchmark
    public int sortedSet2_Reversed(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input2Reversed).size();
    }

    @Benchmark
    public int sortedSet3(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input3).size();
    }

    @Benchmark
    public int sortedSet3_Reversed(Initialize initialize) {
        return SortedSets.immutable.ofSortedSet(initialize.input3Reversed).size();
    }

    @Benchmark
    public int array1NoDups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array1NoDups).size();
    }

    @Benchmark
    public int array1NoDups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array1NoDups).size();
    }

    @Benchmark
    public int array1Dups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array1Dups).size();
    }

    @Benchmark
    public int array1Dups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array1Dups).size();
    }

    @Benchmark
    public int array2NoDups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array2NoDups).size();
    }

    @Benchmark
    public int array2NoDups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array2NoDups).size();
    }

    @Benchmark
    public int array2Dups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array2Dups).size();
    }

    @Benchmark
    public int array2Dups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array2Dups).size();
    }

    @Benchmark
    public int array3NoDups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array3NoDups).size();
    }

    @Benchmark
    public int array3NoDups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array3NoDups).size();
    }

    @Benchmark
    public int array3Dups(Initialize initialize) {
        return SortedSets.immutable.with(initialize.array3Dups).size();
    }

    @Benchmark
    public int array3Dups_Reversed(Initialize initialize) {
        return SortedSets.immutable.with(REVERSE_COMPARATOR, initialize.array3Dups).size();
    }
}

```