### PR TITLE
Improve efficiency of size method for concatenated rich iterables

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CompositeIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/CompositeIterable.java
@@ -122,6 +122,12 @@ public final class CompositeIterable<E>
     }
 
     @Override
+    public int size()
+    {
+       return (int) this.iterables.sumOfInt(Iterate::sizeOf);
+    }
+
+    @Override
     public Iterator<E> iterator()
     {
         return new CompositeIterator(this.iterables);


### PR DESCRIPTION
Get LazyIterableAdapter::concatenate and LazyIterate::composite to return a
new, specialized version of CompositeIterable, which implements a size
method whose complexity is O(k), where k is the number of concatenated rich
iterables, instead of O(n), where n is the total number of elements in the
concatenation.

See issue #279

Signed-off-by: Olivier Cinquin <olivier.cinquin@uci.edu>