### PR TITLE
More fixes for Java 9 compatibility

### DIFF
--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -3846,6 +3846,10 @@ public final class Verify extends Assert
         }
     }
 
+    /**
+     * @deprecated since 8.2.0 as will not work with Java 9
+     */
+    @Deprecated
     public static void assertShallowClone(Cloneable object)
     {
         try
@@ -3858,6 +3862,10 @@ public final class Verify extends Assert
         }
     }
 
+    /**
+     * @deprecated since 8.2.0 as will not work with Java 9
+     */
+    @Deprecated
     public static void assertShallowClone(String itemName, Cloneable object)
     {
         try

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -48,6 +48,7 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -408,6 +409,7 @@ public class VerifyTest
     @Test
     public void shallowClone1()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         try
         {
             Cloneable unclonable = new Cloneable()
@@ -425,6 +427,7 @@ public class VerifyTest
     @Test
     public void shallowClone2()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         Cloneable simpleCloneable = new SimpleCloneable();
         Verify.assertShallowClone(simpleCloneable);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatistics.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatistics.java
@@ -65,6 +65,12 @@ public class SerializableDoubleSummaryStatistics
         }
         catch (Exception ignored)
         {
+            count = null;
+            sum = null;
+            sumCompensation = null;
+            simpleSum = null;
+            min = null;
+            max = null;
         }
         COUNT = count;
         SUM = sum;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatistics.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatistics.java
@@ -57,6 +57,10 @@ public class SerializableIntSummaryStatistics
         }
         catch (Exception ignored)
         {
+            count = null;
+            sum = null;
+            min = null;
+            max = null;
         }
         COUNT = count;
         SUM = sum;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatistics.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatistics.java
@@ -57,6 +57,10 @@ public class SerializableLongSummaryStatistics
         }
         catch (Exception e)
         {
+            count = null;
+            sum = null;
+            min = null;
+            max = null;
         }
         COUNT = count;
         SUM = sum;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
@@ -109,6 +109,8 @@ public final class ArrayListIterate
         }
         catch (Exception ignored)
         {
+            data = null;
+            size = null;
         }
         ELEMENT_DATA_FIELD = data;
         SIZE_FIELD = size;

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsSeralizationTest.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableDoubleSummaryStatisticsSeralizationTest
@@ -20,6 +21,8 @@ public class SerializableDoubleSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
+
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsSeralizationTest.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableIntSummaryStatisticsSeralizationTest
@@ -20,6 +21,8 @@ public class SerializableIntSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
+
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsSeralizationTest.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableLongSummaryStatisticsSeralizationTest
@@ -20,6 +21,8 @@ public class SerializableLongSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
+
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsSeralizationTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.collector;
 
 import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SummaryStatisticsSeralizationTest
@@ -18,6 +19,8 @@ public class SummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
+        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
+
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyADhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TdW1tYXJ5U3Rh\n"


### PR DESCRIPTION
1) Deprecate Verify#assertShallowClone()
2) Add Assume keyword for Serialization tests where reflection is used
3) Set fields as null in the ignored exception block: This is required as the exception is thrown at setAccessible(true). However, the field is not null, due to which Java 9 regression build fails due to IllegalAccessError (reflection for Java 9)