### PR TITLE
Remove Apache Felix plugin, Add Java 9 regression build

### DIFF
--- a/.travis-command-jdk9.sh
+++ b/.travis-command-jdk9.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Prevent accidental execution outside of Travis:
+if [ -z "${TRAVIS+false}" ]
+then
+  echo "TRAVIS environment variable is not set"
+  exit 1
+fi
+
+# Switch to desired JDK, download if required:
+function install_jdk {
+  JDK_URL="http://download.java.net/java/jdk9/archive/178/binaries/jdk-9+178_linux-x64_bin.tar.gz"
+
+  FILENAME="jre-9+178_linux-x64_bin.tar.gz"
+
+  rm -rf /tmp/jdk/$JDK
+  mkdir -p /tmp/jdk/$JDK
+
+  if [ ! -f "/tmp/jdk/$FILENAME" ]
+  then
+    curl -L $JDK_URL -o /tmp/jdk/$FILENAME
+  fi
+
+  echo "Extracting archive"
+  tar -xzf /tmp/jdk/$FILENAME -C /tmp/jdk/$JDK --strip-components 1
+  echo "Completed extracting archive"
+
+  if [ -z "${2+false}" ]
+  then
+    export JAVA_HOME="/tmp/jdk/$JDK"
+    export JDK_HOME="${JAVA_HOME}"
+    export JAVAC="${JAVA_HOME}/bin/javac"
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+  fi
+  $JAVA_HOME/bin/java -version
+  echo "Completed setting environment"
+}
+
+source $HOME/.jdk_switcher_rc
+case "$JDK" in
+Java8)
+  echo "Java 8 build already executed!"
+  ;;
+Java9)
+  install_jdk
+  ;;
+esac
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,29 +22,41 @@ matrix:
       env:
         - DESC="acceptance tests"
         - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all --batch-mode --show-version --errors"
+        - JDK=Java8
 
     - jdk: oraclejdk8
       env:
         - DESC="findbugs"
         - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!p2-repository' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - JDK=Java8
 
     - jdk: oraclejdk8
       env:
         - DESC="checkstyle"
         - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - JDK=Java8
 
     - jdk: oraclejdk8
       env:
         - DESC="unit tests"
         - CMD="mvn install --batch-mode --show-version --errors"
         - SONAR_COMMAND="sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=${SONARQUBE_TOKEN} -Dsonar.organization=eclipse-collections"
+        - JDK=Java8
 
     - jdk: oraclejdk8
       env:
         - DESC="compile jmh-tests and performance-tests"
         - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
+        - JDK=Java8
+
+    - jdk: oraclejdk8
+      env:
+        - DESC="Java 9 regression"
+        - JDK=Java9
+        - CMD="mvn install --batch-mode --show-version --errors -Dbytecode.version=1.9 -DargLine=-Djava.locale.providers=JRE,SPI"
 
 script:
+  - ./.travis-command-jdk9.sh
   - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]];
     then eval travis_wait 35 $CMD $SONAR_COMMAND;
     else eval travis_wait 35 $CMD;

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>eclipse-collections-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Eclipse Collections API</name>
 
@@ -61,21 +61,6 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.eclipse.collections.api.*</Export-Package>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-                        <Import-Package>
-                            net.jcip.annotations;resolution:=optional,*
-                        </Import-Package>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                    </instructions>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>eclipse-collections-forkjoin</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Eclipse Collections Fork Join Utilities</name>
 
@@ -73,21 +73,6 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.eclipse.collections.impl.forkjoin</Export-Package>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-                        <Import-Package>
-                            net.jcip.annotations;resolution:=optional,*
-                        </Import-Package>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                    </instructions>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>eclipse-collections-testutils</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Eclipse Collections Test Utilities</name>
 
@@ -79,21 +79,6 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.eclipse.collections.impl.test</Export-Package>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-                        <Import-Package>
-                            net.jcip.annotations;resolution:=optional,*
-                        </Import-Package>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                    </instructions>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>eclipse-collections</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Eclipse Collections Main Library</name>
 
@@ -71,21 +71,6 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.eclipse.collections.impl.*</Export-Package>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
-                        <Import-Package>
-                            net.jcip.annotations;resolution:=optional,*
-                        </Import-Package>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                    </instructions>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -311,14 +311,7 @@
                     <artifactId>clirr-maven-plugin</artifactId>
                     <version>2.7</version>
                 </plugin>
-
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.1</version>
-                    <extensions>true</extensions>
-                </plugin>
-
+                
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>


### PR DESCRIPTION
1) Remove Apache Felix plugin:
Removal of Apache Felix plugin will result in OSGi bundles not exported under eclipse-collections, eclipse-collections-api. However, these bundles are exported in p2 repository. Users should start using the same.
This will reflect in the release notes.

This is a compatibility breaking change.

2) Java 9 Regression builds