### PR TITLE
Add covariant override for subList() in ListIterable hierarchy, fix Javadoc warnings.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ImmutableList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ImmutableList.java
@@ -159,6 +159,7 @@ public interface ImmutableList<T>
      * @see List#subList(int, int)
      * @since 6.0
      */
+    @Override
     ImmutableList<T> subList(int fromIndex, int toIndex);
 
     @Override

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ListIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ListIterable.java
@@ -274,4 +274,10 @@ public interface ListIterable<T>
      */
     @Override
     int hashCode();
+
+    /**
+     * @see List#subList(int, int)
+     * @since 6.0
+     */
+    ListIterable<T> subList(int fromIndex, int toIndex);
 }

--- a/eclipse-collections-code-generator/src/main/resources/api/list/primitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/primitiveList.stg
@@ -17,8 +17,6 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.api.list.primitive;
 
-import java.util.List;
-
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.list.ListIterable;
@@ -42,13 +40,13 @@ public interface <name>List extends Reversible<name>Iterable
     \<V> ListIterable\<V> collect(<name>ToObjectFunction\<? extends V> function);
 
     /**
-     * Follows the same general contract as {@link List#equals(Object)}.
+     * Follows the same general contract as {@link java.util.List#equals(Object)}.
      */
     @Override
     boolean equals(Object o);
 
     /**
-     * Follows the same general contract as {@link List#hashCode()}.
+     * Follows the same general contract as {@link java.util.List#hashCode()}.
      */
     @Override
     int hashCode();
@@ -71,7 +69,7 @@ public interface <name>List extends Reversible<name>Iterable
     <name>List toReversed();
 
     /**
-     * @see {@link List#subList(int fromIndex, int toIndex)}
+     * @see java.util.List#subList(int fromIndex, int toIndex)
      * @since 5.0.
      */
     <name>List subList(int fromIndex, int toIndex);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -1457,7 +1457,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     }
 
     /**
-     * @deprecated in 7.0. Use {@link OrderedIterable#zip(Iterable)} instead.
+     * @deprecated in 7.0. Use {@link org.eclipse.collections.api.ordered.OrderedIterable#zip(Iterable)} instead.
      */
     @Deprecated
     @Override
@@ -1473,7 +1473,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     }
 
     /**
-     * @deprecated in 7.0. Use {@link OrderedIterable#zipWithIndex()} instead.
+     * @deprecated in 7.0. Use {@link org.eclipse.collections.api.ordered.OrderedIterable#zipWithIndex()} instead.
      */
     @Deprecated
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/AbstractBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/AbstractBiMap.java
@@ -53,7 +53,6 @@ import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
-import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Pair;
@@ -634,7 +633,7 @@ public abstract class AbstractBiMap<K, V> implements BiMap<K, V>
     }
 
     /**
-     * @deprecated in 8.0. Use {@link OrderedIterable#zip(Iterable, R)} instead.
+     * @deprecated in 8.0. Use {@link org.eclipse.collections.api.ordered.OrderedIterable#zip(Iterable, Collection)} instead.
      */
     @Override
     @Deprecated
@@ -644,7 +643,7 @@ public abstract class AbstractBiMap<K, V> implements BiMap<K, V>
     }
 
     /**
-     * @deprecated in 8.0. Use {@link OrderedIterable#zipWithIndex(R)} instead.
+     * @deprecated in 8.0. Use {@link org.eclipse.collections.api.ordered.OrderedIterable#zipWithIndex(Collection)} instead.
      */
     @Override
     @Deprecated

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEntryWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEntryWithHashingStrategy.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.collections.impl.map.strategy.immutable;
 
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.collections.api.block.HashingStrategy;
@@ -35,7 +34,7 @@ public final class ImmutableEntryWithHashingStrategy<K, V> extends AbstractImmut
     }
 
     /**
-     * Indicates whether an object equals this entry, following the behavior specified in {@link Map.Entry#equals(Object)}.
+     * Indicates whether an object equals this entry, following the behavior specified in {@link java.util.Map.Entry#equals(Object)}.
      */
     @Override
     public boolean equals(Object object)
@@ -50,7 +49,7 @@ public final class ImmutableEntryWithHashingStrategy<K, V> extends AbstractImmut
     }
 
     /**
-     * Return this entry's hash code, following the behavior specified in {@link Map.Entry#hashCode()}.
+     * Return this entry's hash code, following the behavior specified in {@link java.util.Map.Entry#hashCode()}.
      */
     @Override
     public int hashCode()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/ImmutableEntry.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/ImmutableEntry.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.collections.impl.tuple;
 
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.collections.impl.block.factory.Comparators;
@@ -30,7 +29,7 @@ public final class ImmutableEntry<K, V> extends AbstractImmutableEntry<K, V>
     }
 
     /**
-     * Indicates whether an object equals this entry, following the behavior specified in {@link Map.Entry#equals(Object)}.
+     * Indicates whether an object equals this entry, following the behavior specified in {@link java.util.Map.Entry#equals(Object)}.
      */
     @Override
     public boolean equals(Object object)
@@ -45,7 +44,7 @@ public final class ImmutableEntry<K, V> extends AbstractImmutableEntry<K, V>
     }
 
     /**
-     * Return this entry's hash code, following the behavior specified in {@link Map.Entry#hashCode()}.
+     * Return this entry's hash code, following the behavior specified in {@link java.util.Map.Entry#hashCode()}.
      */
     @Override
     public int hashCode()


### PR DESCRIPTION
Fixes #298.
Fixes #285.