### PR TITLE
Adding value extractors for primitive iterable types

### DIFF
--- a/eclipse-collections-bean-validation/pom.xml
+++ b/eclipse-collections-bean-validation/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2017 Goldman Sachs.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <groupId>org.eclipse.collections</groupId>
+        <version>9.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>eclipse-collections-bean-validation</artifactId>
+
+    <name>Eclipse Collections Bean Validation</name>
+
+    <description>Eclipse Collections Bean Validation provides a set of value extractor implementations which can be used
+        by Bean Validation to perform validation of elements in collections specific to Eclipse Collections framework.
+    </description>
+
+    <properties>
+        <hibernate-validator.version>6.0.2.Final</hibernate-validator.version>
+        <validation-api.version>2.0.0.Final</validation-api.version>
+        <javax.el.version>3.0.1-b08</javax.el.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>${validation-api.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+        <!-- Needed for HV -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>${javax.el.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/BooleanIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/BooleanIterableValueExtractor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.iterator.BooleanIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link BooleanIterable}.
+ */
+public class BooleanIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Boolean.class) BooleanIterable>
+{
+    @Override
+    public void extractValues(BooleanIterable originalValue, ValueReceiver receiver)
+    {
+        BooleanIterator iterator = originalValue.booleanIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<boolean-iterable element>", Boolean.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/ByteIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/ByteIterableValueExtractor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.iterator.ByteIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link BooleanIterable}.
+ */
+public class ByteIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Byte.class) ByteIterable>
+{
+    @Override
+    public void extractValues(ByteIterable originalValue, ValueReceiver receiver)
+    {
+        ByteIterator iterator = originalValue.byteIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<byte-iterable element>", Byte.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/CharIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/CharIterableValueExtractor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.iterator.CharIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link BooleanIterable}.
+ */
+public class CharIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Character.class) CharIterable>
+{
+    @Override
+    public void extractValues(CharIterable originalValue, ValueReceiver receiver)
+    {
+        CharIterator iterator = originalValue.charIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<char-iterable element>", Character.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/DoubleIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/DoubleIterableValueExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.iterator.DoubleIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link DoubleIterable}.
+ */
+public class DoubleIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Double.class) DoubleIterable>
+{
+    @Override
+    public void extractValues(DoubleIterable originalValue, ValueReceiver receiver)
+    {
+        DoubleIterator iterator = originalValue.doubleIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<double-iterable element>", Double.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/FloatIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/FloatIterableValueExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.iterator.FloatIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link FloatIterable}.
+ */
+public class FloatIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Float.class) FloatIterable>
+{
+    @Override
+    public void extractValues(FloatIterable originalValue, ValueReceiver receiver)
+    {
+        FloatIterator iterator = originalValue.floatIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<float-iterable element>", Float.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/IntIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/IntIterableValueExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.iterator.IntIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link IntIterable}.
+ */
+public class IntIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Integer.class) IntIterable>
+{
+    @Override
+    public void extractValues(IntIterable originalValue, ValueReceiver receiver)
+    {
+        IntIterator iterator = originalValue.intIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<int-iterable element>", Integer.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/LongIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/LongIterableValueExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.iterator.LongIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link LongIterable}.
+ */
+public class LongIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Long.class) LongIterable>
+{
+    @Override
+    public void extractValues(LongIterable originalValue, ValueReceiver receiver)
+    {
+        LongIterator iterator = originalValue.longIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<long-iterable element>", Long.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/ShortIterableValueExtractor.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/extractors/ShortIterableValueExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.eclipse.collections.api.ShortIterable;
+import org.eclipse.collections.api.iterator.ShortIterator;
+
+/**
+ * {@link ValueExtractor} implementation for collections implementing {@link ShortIterable}.
+ */
+public class ShortIterableValueExtractor implements ValueExtractor<@ExtractedValue(type = Short.class) ShortIterable>
+{
+    @Override
+    public void extractValues(ShortIterable originalValue, ValueReceiver receiver)
+    {
+        ShortIterator iterator = originalValue.shortIterator();
+        while (iterator.hasNext())
+        {
+            receiver.value("<short-iterable element>", Short.valueOf(iterator.next()));
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/package-info.java
+++ b/eclipse-collections-bean-validation/src/main/java/org/eclipse/collections/beanvalidation/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2015 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation;

--- a/eclipse-collections-bean-validation/src/main/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
+++ b/eclipse-collections-bean-validation/src/main/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
@@ -1,0 +1,8 @@
+org.eclipse.collections.beanvalidation.extractors.BooleanIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.ByteIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.CharIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.DoubleIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.FloatIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.IntIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.LongIterableValueExtractor
+org.eclipse.collections.beanvalidation.extractors.ShortIterableValueExtractor

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/AbstractNumberIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/AbstractNumberIterableValueExtractorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Collection;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractNumberIterableValueExtractorTest extends AbstractValueExtractorTest
+{
+    protected <T> void assertViolations(Collection<ConstraintViolation<T>> violations, String type)
+    {
+        assertFalse(violations.isEmpty());
+        assertEquals("Wrong number of violations", 3, violations.size());
+        for (ConstraintViolation<T> violation : violations)
+        {
+            assertEquals("must be greater than or equal to 10", violation.getMessage());
+            assertEquals("iterable.<" + type + "-iterable element>", violation.getPropertyPath().toString());
+            assertTrue(violation.getConstraintDescriptor().getAnnotation() instanceof Min);
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/AbstractValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/AbstractValueExtractorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.junit.Before;
+
+public abstract class AbstractValueExtractorTest
+{
+    protected Validator validator;
+
+    @Before
+    public void setUp()
+    {
+        HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class)
+                .configure();
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+        constraintMapping.constraintDefinition(Min.class)
+                .includeExistingValidators(true)
+                .validatedBy(CharMinValidator.class);
+
+        validator = configuration.addMapping(constraintMapping).buildValidatorFactory()
+                .getValidator();
+    }
+
+    public static class CharMinValidator implements ConstraintValidator<Min, Character>
+    {
+        private long min;
+
+        @Override
+        public void initialize(Min constraintAnnotation)
+        {
+            min = constraintAnnotation.value();
+        }
+
+        @Override
+        public boolean isValid(Character value, ConstraintValidatorContext context)
+        {
+            return value.charValue() > min;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/BooleanIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/BooleanIterableValueExtractorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BooleanIterableValueExtractorTest extends AbstractValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(BooleanArrayList.newListWith(true, false)));
+        assertFalse(violations.isEmpty());
+        assertEquals("Wrong number of violations", 1, violations.size());
+        for (ConstraintViolation<Foo> violation : violations)
+        {
+            assertEquals("must be true", violation.getMessage());
+            assertEquals("iterable.<boolean-iterable element>", violation.getPropertyPath().toString());
+            assertTrue(violation.getConstraintDescriptor().getAnnotation() instanceof AssertTrue);
+        }
+    }
+
+    private static class Foo
+    {
+        @AssertTrue(payload = Unwrapping.Unwrap.class)
+        private final BooleanIterable iterable;
+
+        private Foo(BooleanIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/ByteIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/ByteIterableValueExtractorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
+import org.junit.Test;
+
+public class ByteIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 11)));
+        assertViolations(violations, "byte");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final ByteIterable iterable;
+
+        private Foo(ByteIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/CharIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/CharIterableValueExtractorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
+import org.junit.Test;
+
+public class CharIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 11)));
+        assertViolations(violations, "char");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final CharIterable iterable;
+
+        private Foo(CharIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/DoubleIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/DoubleIterableValueExtractorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
+import org.junit.Test;
+
+public class DoubleIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(DoubleArrayList.newListWith(1.0, 2.0, 3.0, 11.0)));
+        assertViolations(violations, "double");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final DoubleIterable iterable;
+
+        private Foo(DoubleIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/FloatIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/FloatIterableValueExtractorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.FloatArrayList;
+import org.junit.Test;
+
+public class FloatIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 11.0f)));
+        assertViolations(violations, "float");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final FloatIterable iterable;
+
+        private Foo(FloatIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/IntIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/IntIterableValueExtractorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IntIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(IntArrayList.newListWith(1, 2, 3, 11)));
+        assertViolations(violations, "int");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final IntIterable iterable;
+
+        private Foo(IntIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/LongIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/LongIterableValueExtractorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
+import org.junit.Test;
+
+public class LongIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(LongArrayList.newListWith(1L, 2L, 3L, 11L)));
+        assertViolations(violations, "long");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final LongIterable iterable;
+
+        private Foo(LongIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/ShortIterableValueExtractorTest.java
+++ b/eclipse-collections-bean-validation/src/test/java/org/eclipse/collections/beanvalidation/extractors/ShortIterableValueExtractorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Marko Bekhta.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.beanvalidation.extractors;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Min;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.eclipse.collections.api.ShortIterable;
+import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
+import org.junit.Test;
+
+public class ShortIterableValueExtractorTest extends AbstractNumberIterableValueExtractorTest
+{
+    @Test
+    public void extractValues()
+    {
+        Set<ConstraintViolation<Foo>> violations = validator.validate(new Foo(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 11)));
+        assertViolations(violations, "short");
+    }
+
+    private static class Foo
+    {
+        @Min(value = 10, payload = Unwrapping.Unwrap.class)
+        private final ShortIterable iterable;
+
+        private Foo(ShortIterable iterable)
+        {
+            this.iterable = iterable;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <module>eclipse-collections</module>
         <module>eclipse-collections-testutils</module>
         <module>eclipse-collections-forkjoin</module>
+        <module>eclipse-collections-bean-validation</module>
         <module>unit-tests</module>
         <module>scala-unit-tests</module>
         <module>serialization-tests</module>


### PR DESCRIPTION
Hi all,

as per http://beanvalidation.org/2.0/spec/#valueextractordefinition Bean validation 2.0 offers so called ValueExtractor mechanism to allow adding constraints for containers. I've added a couple of such extractors in a separate module for primitive iterables. 
Do you think this would be a good addition for Eclipse Collections? If so - it'll be great if you can point me to other collections that are not yet included but should probably have such extractors. Looking forward for the feedback. Thanks!