### PR TITLE
Fix Java 8 Collectors#joining(String, String, String) usage

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1104,7 +1104,7 @@ String defaultString = list.makeString(); //"1, 2, 3"
 ```java
 MutableList<Integer> list = Lists.mutable.with(1, 2, 3);
 String myDelim = 
-    list.stream().map(Object::toString).collect(Collectors.joining("[", "/", "]")); // "[1/2/3]"
+    list.stream().map(Object::toString).collect(Collectors.joining("/", "[", "]")); // "[1/2/3]"
 String mySeper = 
     list.stream().map(Object::toString).collect(Collectors.joining("/")); // "1/2/3"
 String defaultString = 


### PR DESCRIPTION
Invalid argument order: [Collectors#joining(CharSequence delimiter, CharSequence prefix, CharSequence suffix)](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#joining-java.lang.CharSequence-java.lang.CharSequence-java.lang.CharSequence-)