### PR TITLE
Fixing feature build

### DIFF
--- a/p2-feature/pom.xml
+++ b/p2-feature/pom.xml
@@ -11,12 +11,8 @@
   -->
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.collections</groupId>
-        <artifactId>eclipse-collections-parent</artifactId>
-        <version>9.1.0-SNAPSHOT</version>
-    </parent>
-
+    <groupId>org.eclipse.collections</groupId>
+    <version>9.1.0-SNAPSHOT</version>
     <artifactId>p2-feature</artifactId>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
The PR #383 introduced a separate build to provide Eclipse features to the Photon Simultaneous Release repository; however, it incorrectly referenced the original parent instead of being entirely standalone.

This change fixes the issue by removing the parent declaration from the p2-feature module.