### PR TITLE
Add check on FastList for initialCapacity < 0 #365

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -134,6 +134,10 @@ public class FastList<T>
 
     public FastList(int initialCapacity)
     {
+        if (initialCapacity < 0)
+        {
+            throw new IllegalArgumentException("Expected initial capacity is greater than or equal to 0. Was: " + initialCapacity);
+        }
         this.items = initialCapacity == 0 ? (T[]) ZERO_SIZED_ARRAY : (T[]) new Object[initialCapacity];
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -1209,4 +1209,10 @@ public class FastListTest extends AbstractListTestCase
     {
         this.newWith().max();
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeInitialCapacity()
+    {
+        new FastList<>(-1);
+    }
 }


### PR DESCRIPTION
This is for issue https://github.com/eclipse/eclipse-collections/issues/365 

Signed-off-by: sone tsuyoshi <Tsuyoshi.Sone@gs.com>