### PR TITLE
Optimize UnifiedMap#detectOptional(Predicate2) to not use an iterator. Closes #442.

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -8,6 +8,11 @@ New Functionality
 
 * Implement OrderedMapAdapter, the first implementation of MutableOrderedMap.
 
+Optimizations
+-------------------
+
+* Optimize UnifiedMap#detectOptional(org.eclipse.collections.api.block.predicate.Predicate2) to not use an iterator. 
+
 Bug Fixes
 -------------------
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -1765,6 +1765,42 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
     }
 
     @Override
+    public Optional<Pair<K, V>> detectOptional(Predicate2<? super K, ? super V> predicate)
+    {
+        for (int i = 0; i < this.table.length; i += 2)
+        {
+            if (this.table[i] == CHAINED_KEY)
+            {
+                Object[] chainedTable = (Object[]) this.table[i + 1];
+                for (int j = 0; j < chainedTable.length; j += 2)
+                {
+                    if (chainedTable[j] != null)
+                    {
+                        K key = this.nonSentinel(chainedTable[j]);
+                        V value = (V) chainedTable[j + 1];
+                        if (predicate.accept(key, value))
+                        {
+                            return Optional.of(Tuples.pair(key, value));
+                        }
+                    }
+                }
+            }
+            else if (this.table[i] != null)
+            {
+                K key = this.nonSentinel(this.table[i]);
+                V value = (V) this.table[i + 1];
+
+                if (predicate.accept(key, value))
+                {
+                    return Optional.of(Tuples.pair(key, value));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<V> detectOptional(Predicate<? super V> predicate)
     {
         for (int i = 0; i < this.table.length; i += 2)

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnifiedMapNoIteratorTest.java
@@ -95,14 +95,6 @@ public class UnifiedMapNoIteratorTest implements MutableMapTestCase, NoIteratorT
     }
 
     @Override
-    public void MapIterable_detectOptional()
-    {
-        /**
-         * TODO: {@link UnifiedMap#detectOptional(org.eclipse.collections.api.block.predicate.Predicate2)} should be optimized to not use an iterator
-         */
-    }
-
-    @Override
     public void MutableMapIterable_updateValue()
     {
         /**


### PR DESCRIPTION
Refer to issue #442. 