### PR TITLE
Add Regression builds for Java-10, Java-11, upgrade JaCoCo to 0.8.0

### DIFF
--- a/.travis-command-ea-builds.sh
+++ b/.travis-command-ea-builds.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Prevent accidental execution outside of Travis:
+if [ -z "${TRAVIS+false}" ]
+then
+  echo "TRAVIS environment variable is not set"
+  exit 1
+fi
+
+# Switch to desired JDK, download if required:
+function install_jdk_and_run_ea_build {
+  JDK_URL=$1
+
+  FILENAME="${JDK_URL##*/}"
+
+  rm -rf /tmp/jdk/$JDK
+  mkdir -p /tmp/jdk/$JDK
+
+  if [ ! -f "/tmp/jdk/$FILENAME" ]
+  then
+    curl -L $JDK_URL -o /tmp/jdk/$FILENAME
+  fi
+
+  echo "Extracting archive"
+  tar -xzf /tmp/jdk/$FILENAME -C /tmp/jdk/$JDK --strip-components 1
+  echo "Completed extracting archive"
+
+  export JAVA_HOME="/tmp/jdk/$JDK"
+  export JDK_HOME="${JAVA_HOME}"
+  export JAVAC="${JAVA_HOME}/bin/javac"
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+
+  $JAVA_HOME/bin/java -version
+  echo "export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g -XX:MaxPermSize=2048m'\" > ~/.mavenrc"
+  mvn -version
+  echo "Completed setting environment"
+  mvn install --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!p2-repository' --batch-mode --show-version -Djacoco.skip=true
+}
+
+case "$JDK" in
+Java8)
+  echo "Java 8 already exists in Travis!"
+  ;;
+Java9)
+  echo "Java 9 already exists in Travis!"
+  ;;
+Java10-EA)
+  install_jdk_and_run_ea_build "https://download.java.net/java/jdk10/archive/42/BCL/jdk-10-ea+42_linux-x64_bin.tar.gz"
+  ;;
+esac

--- a/.travis-command-ea-builds.sh
+++ b/.travis-command-ea-builds.sh
@@ -49,4 +49,7 @@ Java9)
 Java10-EA)
   install_jdk_and_run_ea_build "https://download.java.net/java/jdk10/archive/42/BCL/jdk-10-ea+42_linux-x64_bin.tar.gz"
   ;;
+Java11-EA)
+  install_jdk_and_run_ea_build "https://download.java.net/java/early_access/jdk11/3/BCL/jre-11-ea+3_linux-x64_bin.tar.gz"
+  ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,40 +17,62 @@ before_install:
 install:
   -
 
+env:
+  -JDK=Java8
+  -JDK=Java9
+  -JDK=Java10-EA
+
 matrix:
   fast_finish: true
   include:
     - jdk: oraclejdk8
       env:
         - DESC="acceptance tests"
+        - JDK=Java8
         - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:
         - DESC="findbugs"
+        - JDK=Java8
         - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!p2-repository' --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:
         - DESC="checkstyle"
+        - JDK=Java8
         - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:
         - DESC="unit tests"
+        - JDK=Java8
         - CMD="mvn install --batch-mode --show-version --errors"
 
     - jdk: oraclejdk8
       env:
         - DESC="compile jmh-tests and performance-tests"
+        - JDK=Java8
         - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --batch-mode --show-version --errors"
 
     - jdk: oraclejdk9
       env:
         - DESC="unit tests Java 9"
+        - JDK=Java9
         - CMD="mvn install --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!p2-repository' --batch-mode --show-version --errors"
 
-script: eval travis_wait 35 $CMD
+    - jdk: oraclejdk8
+      env:
+        - DESC="Java 10 regression"
+        - JDK=Java10-EA
+        - CMD=""
+
+  allow_failures:
+    - env: JDK=Java10-EA
+
+script:
+  - ./.travis-command-ea-builds.sh
+  - eval travis_wait 55 $CMD
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   -JDK=Java8
   -JDK=Java9
   -JDK=Java10-EA
+  -JDK=Java11-EA
 
 matrix:
   fast_finish: true
@@ -67,8 +68,15 @@ matrix:
         - JDK=Java10-EA
         - CMD=""
 
+    - jdk: oraclejdk8
+      env:
+        - DESC="Java 11 regression"
+        - JDK=Java11-EA
+        - CMD=""
+
   allow_failures:
     - env: JDK=Java10-EA
+    - env: JDK=Java11-EA
 
 script:
   - ./.travis-command-ea-builds.sh

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <checkstyle.version>8.8</checkstyle.version>
         <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
         <findbugs.plugin.version>3.0.3</findbugs.plugin.version>
-        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.0</jacoco.plugin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -352,6 +352,7 @@
                         </includes>
                         <argLine>-XX:-OmitStackTraceInFastThrow -Xms1024m -Xmx2048m @{argLine}</argLine>
                         <runOrder>random</runOrder>
+                        <!--<forkCount>2C</forkCount>-->
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Once Java-10 is released and has a GA build, we will replace Java-9 build with Java-10.
Please note JaCoCo execution is skipped in both the EA builds. Refer to JaCoCo issue: https://github.com/jacoco/jacoco/issues/629