### PR TITLE
Remove Java-8 check from tests.

### DIFF
--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -49,7 +49,6 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -410,7 +409,6 @@ public class VerifyTest
     @Test
     public void shallowClone1()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         try
         {
             Cloneable unclonable = new Cloneable()
@@ -428,7 +426,6 @@ public class VerifyTest
     @Test
     public void shallowClone2()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         Cloneable simpleCloneable = new SimpleCloneable();
         Verify.assertShallowClone(simpleCloneable);
     }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsSeralizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,7 +13,6 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableDoubleSummaryStatisticsSeralizationTest
@@ -21,8 +20,6 @@ public class SerializableDoubleSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsSeralizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,7 +13,6 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableIntSummaryStatisticsSeralizationTest
@@ -21,8 +20,6 @@ public class SerializableIntSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsSeralizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,7 +13,6 @@ package org.eclipse.collections.impl.collector;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableLongSummaryStatisticsSeralizationTest
@@ -21,8 +20,6 @@ public class SerializableLongSummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TZXJpYWxpemFi\n"

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsSeralizationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsSeralizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,7 +11,6 @@
 package org.eclipse.collections.impl.collector;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SummaryStatisticsSeralizationTest
@@ -19,8 +18,6 @@ public class SummaryStatisticsSeralizationTest
     @Test
     public void serializedForm()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         Verify.assertSerializedForm(
                 1L,
                 "rO0ABXNyADhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmNvbGxlY3Rvci5TdW1tYXJ5U3Rh\n"

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableDoubleSummaryStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.DoubleSummaryStatistics;
 
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableDoubleSummaryStatisticsTest
@@ -33,8 +32,6 @@ public class SerializableDoubleSummaryStatisticsTest
     @Test
     public void serialization()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         SerializableDoubleSummaryStatistics stats = SerializableDoubleSummaryStatistics.with(1.0, 2.0, 3.0);
         SerializableDoubleSummaryStatistics deserialized = SerializeTestHelper.serializeDeserialize(stats);
         Assert.assertTrue(stats.valuesEqual(deserialized));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableIntSummaryStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.IntSummaryStatistics;
 
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableIntSummaryStatisticsTest
@@ -33,8 +32,6 @@ public class SerializableIntSummaryStatisticsTest
     @Test
     public void serialization()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         SerializableIntSummaryStatistics stats = SerializableIntSummaryStatistics.with(1, 2, 3);
         SerializableIntSummaryStatistics deserialized = SerializeTestHelper.serializeDeserialize(stats);
         Assert.assertTrue(stats.valuesEqual(deserialized));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SerializableLongSummaryStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,7 +14,6 @@ import java.util.LongSummaryStatistics;
 
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SerializableLongSummaryStatisticsTest
@@ -33,8 +32,6 @@ public class SerializableLongSummaryStatisticsTest
     @Test
     public void serialization()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         SerializableLongSummaryStatistics stats = SerializableLongSummaryStatistics.with(1, 2, 3);
         SerializableLongSummaryStatistics deserialized = SerializeTestHelper.serializeDeserialize(stats);
         Assert.assertTrue(stats.valuesEqual(deserialized));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/SummaryStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -16,7 +16,6 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class SummaryStatisticsTest
@@ -90,8 +89,6 @@ public class SummaryStatisticsTest
     @Test
     public void serialization()
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
-
         SummaryStatistics<Object> stats = new SummaryStatistics<>().addIntFunction("1", each -> 1);
         SummaryStatistics<Object> deserialized = SerializeTestHelper.serializeDeserialize(stats);
         Assert.assertNotSame(stats, deserialized);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -24,7 +24,6 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class ListsTest
@@ -197,7 +196,6 @@ public class ListsTest
 
     private void assertPresizedListEquals(int initialCapacity, FastList<String> list)
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         try
         {
             Field itemsField = FastList.class.getDeclaredField("items");
@@ -266,7 +264,6 @@ public class ListsTest
 
     private static void assertPresizedMultiReaderListEquals(int initialCapacity, MultiReaderFastList<String> list)
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         try
         {
             Field delegateField = MultiReaderFastList.class.getDeclaredField("delegate");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
@@ -37,7 +37,6 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
@@ -1004,7 +1003,6 @@ public class SetsTest
 
     private void assertPresizedSetSizeEquals(int initialCapacity, UnifiedSet<String> set)
     {
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8."));
         try
         {
             Field tableField = UnifiedSet.class.getDeclaredField("table");


### PR DESCRIPTION
This check was added when reflection was banned by default in Java-9. But since it is only a warning currently, we don't need this check.