### PR TITLE
Fix for #491 - if map was grown as a result of addToValue, recompute …

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
@@ -558,7 +558,7 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
             return this.values[index];
         }
         this.addKeyValueAtIndex(key, toBeAdded, index);
-        return this.values[index];
+        return toBeAdded;
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
@@ -581,7 +581,7 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
             return this.values[index];
         }
         this.addKeyValueAtIndex(key, toBeAdded, index);
-        return this.values[index];
+        return toBeAdded;
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -532,7 +532,7 @@ public class <name1><name2>HashMap extends AbstractMutable<name2>ValuesMap imple
             return this.<valueArray>[index<valueIndex>];
         }
         this.addKeyValueAtIndex(key, toBeAdded, index);
-        return this.<valueArray>[index<valueIndex>];
+        return toBeAdded;
     }
 
     private void addKeyValueAtIndex(<type1> key, <type2> value, int index)

--- a/eclipse-collections-code-generator/src/main/resources/primitiveLiteral.stg
+++ b/eclipse-collections-code-generator/src/main/resources/primitiveLiteral.stg
@@ -193,6 +193,16 @@ castIntToNarrowType ::= [
     "double": "noCast"
 ]
 
+castLongToNarrowTypeWithParens ::= [
+    "byte": "byteCastWithParens",
+    "short": "shortCastWithParens",
+    "char": "charCastWithParens",
+    "int": "intCastWithParens",
+    "long": "noCast",
+    "float": "noCast",
+    "double": "noCast"
+]
+
 noCast(item) ::= <<
 <item>
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutableObjectPrimitiveMapTestCase.stg
@@ -26,6 +26,7 @@ import org.eclipse.collections.api.block.function.primitive.<name>To<name>Functi
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.map.primitive.AbstractObject<name>MapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
@@ -476,6 +477,12 @@ public abstract class AbstractMutableObject<name>MapTestCase extends AbstractObj
         Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("1")>), map2);
         Assert.assertEquals(<(literal.(type))("5")>, map2.addToValue(null, <(literal.(type))("4")>)<delta.(type)>);
         Assert.assertEquals(Object<name>HashMap.newWithKeysValues(null, <(literal.(type))("5")>), map2);
+        
+        MutableObject<name>Map\<String> map3 = this.getEmptyMap();
+        IntInterval.zeroTo(10).forEachWithIndex((each, index) -> {
+            <type> v = <(castIntToNarrowTypeWithParens.(type))("each + index")>;
+            Assert.assertEquals("Key:" + each, v, map3.addToValue(String.valueOf(each), v)<delta.(type)>);
+        });
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
@@ -30,10 +30,12 @@ import org.eclipse.collections.api.block.function.primitive.<name2>Function0;
 <if(!sameTwoPrimitives)>import org.eclipse.collections.api.block.function.primitive.<name2>To<name2>Function;<endif>
 import org.eclipse.collections.api.iterator.Mutable<name2>Iterator;
 import org.eclipse.collections.api.map.primitive.Mutable<name1><name2>Map;
+import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.set.primitive.<name1>Set;
-import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
+import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.map.primitive.Abstract<name1><name2>MapTestCase;
+import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.junit.Assert;
@@ -435,6 +437,25 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Assert.assertEquals(<(wideLiteral.(type2))("12")>, map1.addToValue(<(literal.(type1))("1")>, <(literal.(type2))("9")>)<(wideDelta.(type2))>);
         Assert.assertEquals(<(wideLiteral.(type2))("11")>, map1.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("10")>)<(wideDelta.(type2))>);
         Assert.assertEquals(expected, map1);
+        
+        Mutable<name1><name2>Map map2 = this.getEmptyMap();
+        MutableLongList list = LongLists.mutable.with(
+            936628237L,
+            4889384619L,
+            8733915902L,
+            2377747912L,
+            277382636L,
+            593670575L,
+            296725141L,
+            7131901003L,
+            9986389012L
+        );
+        
+        list.forEachWithIndex((each, index) -> {
+            <type1> k = <(castLongToNarrowTypeWithParens.(type1))("each")>;
+            <type2> v = <(castLongToNarrowTypeWithParens.(type2))("each + index")>;
+            Assert.assertEquals("Key:" + k, v, map2.addToValue(k, v)<(wideDelta.(type2))>);
+        });
     }
 
     @Test


### PR DESCRIPTION
…index or else it will be stale and return value will be aribitrary

Signed-off-by: John Dimeo <dimeo@elderresearch.com>