### PR TITLE
Resolve #475

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -263,15 +263,15 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
     }
 
     @Override
-    public MutableMap<K, V> newEmpty()
+    public UnifiedMap<K, V> newEmpty()
     {
         return new UnifiedMap<>();
     }
 
     @Override
-    public MutableMap<K, V> newEmpty(int capacity)
+    public <RK, RV> UnifiedMap<RK, RV> newEmpty(int capacity)
     {
-        return UnifiedMap.newMap(capacity);
+        return new UnifiedMap<>(capacity, this.loadFactor);
     }
 
     private int fastCeil(float v)
@@ -313,7 +313,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         this.maxSize = Math.min(capacity - 1, (int) (capacity * this.loadFactor));
     }
 
-    protected final int index(Object key)
+    protected int index(Object key)
     {
         // This function ensures that hashCodes that differ only by
         // constant multiples at each bit position have a bounded
@@ -1628,7 +1628,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
     @Override
     public <R> MutableMap<K, R> collectValues(Function2<? super K, ? super V, ? extends R> function)
     {
-        UnifiedMap<K, R> target = UnifiedMap.newMap();
+        UnifiedMap<K, R> target = (UnifiedMap<K, R>) this.newEmpty();
         target.loadFactor = this.loadFactor;
         target.occupied = this.occupied;
         target.allocate(this.table.length >> 1);
@@ -2161,7 +2161,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         public boolean retainAll(Collection<?> collection)
         {
             int retainedSize = collection.size();
-            UnifiedMap<K, V> retainedCopy = new UnifiedMap<>(retainedSize, UnifiedMap.this.loadFactor);
+            UnifiedMap<K, V> retainedCopy = UnifiedMap.this.newEmpty(retainedSize);
             for (Object key : collection)
             {
                 this.putIfFound(key, retainedCopy);
@@ -2677,7 +2677,7 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         public boolean retainAll(Collection<?> collection)
         {
             int retainedSize = collection.size();
-            UnifiedMap<K, V> retainedCopy = new UnifiedMap<>(retainedSize, UnifiedMap.this.loadFactor);
+            UnifiedMap<K, V> retainedCopy = UnifiedMap.this.newEmpty(retainedSize);
 
             for (Object obj : collection)
             {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -121,7 +121,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
 
     protected int maxSize;
 
-    private HashingStrategy<? super K> hashingStrategy;
+    protected HashingStrategy<? super K> hashingStrategy;
 
     /**
      * @deprecated No argument default constructor used for serialization. Instantiating an UnifiedMapWithHashingStrategyMultimap with
@@ -305,15 +305,15 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
     }
 
     @Override
-    public MutableMap<K, V> newEmpty()
+    public UnifiedMapWithHashingStrategy<K, V> newEmpty()
     {
         return new UnifiedMapWithHashingStrategy<>(this.hashingStrategy);
     }
 
     @Override
-    public MutableMap<K, V> newEmpty(int capacity)
+    public UnifiedMapWithHashingStrategy<K, V> newEmpty(int capacity)
     {
-        return UnifiedMapWithHashingStrategy.newMap(this.hashingStrategy, capacity);
+        return new UnifiedMapWithHashingStrategy<>(this.hashingStrategy, capacity, this.loadFactor);
     }
 
     private int fastCeil(float v)
@@ -356,7 +356,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         this.maxSize = Math.min(capacity - 1, (int) (capacity * this.loadFactor));
     }
 
-    protected final int index(K key)
+    protected int index(K key)
     {
         // This function ensures that hashCodes that differ only by
         // constant multiples at each bit position have a bounded
@@ -1673,7 +1673,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
     @Override
     public <R> MutableMap<K, R> collectValues(Function2<? super K, ? super V, ? extends R> function)
     {
-        UnifiedMapWithHashingStrategy<K, R> target = UnifiedMapWithHashingStrategy.newMap(this.hashingStrategy);
+        @SuppressWarnings("unchecked")
+        UnifiedMapWithHashingStrategy<K, R> target = (UnifiedMapWithHashingStrategy<K, R>) this.newEmpty();
         target.loadFactor = this.loadFactor;
         target.occupied = this.occupied;
         target.allocate(this.table.length >> 1);
@@ -1816,8 +1817,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         public boolean retainAll(Collection<?> collection)
         {
             int retainedSize = collection.size();
-            UnifiedMapWithHashingStrategy<K, V> retainedCopy = new UnifiedMapWithHashingStrategy<>(
-                    UnifiedMapWithHashingStrategy.this.hashingStrategy, retainedSize, UnifiedMapWithHashingStrategy.this.loadFactor);
+            UnifiedMapWithHashingStrategy<K, V> retainedCopy = UnifiedMapWithHashingStrategy.this.newEmpty(retainedSize);
             for (Object key : collection)
             {
                 this.putIfFound(key, retainedCopy);
@@ -2334,9 +2334,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         public boolean retainAll(Collection<?> collection)
         {
             int retainedSize = collection.size();
-            UnifiedMapWithHashingStrategy<K, V> retainedCopy = new UnifiedMapWithHashingStrategy<>(
-                    UnifiedMapWithHashingStrategy.this.hashingStrategy, retainedSize, UnifiedMapWithHashingStrategy.this.loadFactor);
-
+            UnifiedMapWithHashingStrategy<K, V> retainedCopy = UnifiedMapWithHashingStrategy.this.newEmpty(retainedSize);
             for (Object obj : collection)
             {
                 if (obj instanceof Entry)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
@@ -88,6 +88,8 @@ public abstract class AbstractUnifiedSet<T>
     @SuppressWarnings("AbstractMethodOverridesAbstractMethod")
     public abstract MutableSet<T> clone();
 
+    public abstract MutableSet<T> newEmpty(int size);
+
     protected abstract boolean shortCircuit(
             Predicate<? super T> predicate,
             boolean expected,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
@@ -211,7 +211,7 @@ public class UnifiedSet<T>
         this.table = new Object[sizeToAllocate];
     }
 
-    protected final int index(Object key)
+    protected int index(Object key)
     {
         // This function ensures that hashCodes that differ only by
         // constant multiples at each bit position have a bounded
@@ -622,6 +622,12 @@ public class UnifiedSet<T>
     public UnifiedSet<T> newEmpty()
     {
         return UnifiedSet.newSet();
+    }
+
+    @Override
+    public UnifiedSet<T> newEmpty(int size)
+    {
+        return UnifiedSet.newSet(size);
     }
 
     @Override
@@ -1582,7 +1588,7 @@ public class UnifiedSet<T>
     private boolean retainAllFromNonSet(Iterable<?> iterable)
     {
         int retainedSize = Iterate.sizeOf(iterable);
-        UnifiedSet<T> retainedCopy = new UnifiedSet<>(retainedSize, this.loadFactor);
+        UnifiedSet<T> retainedCopy = this.newEmpty(retainedSize);
         for (Object key : iterable)
         {
             this.addIfFound((T) key, retainedCopy);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -91,7 +91,7 @@ public class UnifiedSetWithHashingStrategy<T>
 
     protected transient int occupied;
 
-    private HashingStrategy<? super T> hashingStrategy;
+    protected HashingStrategy<? super T> hashingStrategy;
 
     /**
      * @deprecated No argument default constructor used for serialization. Instantiating an UnifiedSetWithHashingStrategyMultimap with
@@ -239,7 +239,7 @@ public class UnifiedSetWithHashingStrategy<T>
         this.table = new Object[sizeToAllocate];
     }
 
-    protected final int index(T key)
+    protected int index(T key)
     {
         // This function ensures that hashCodes that differ only by
         // constant multiples at each bit position have a bounded
@@ -644,6 +644,12 @@ public class UnifiedSetWithHashingStrategy<T>
     public UnifiedSetWithHashingStrategy<T> newEmpty()
     {
         return UnifiedSetWithHashingStrategy.newSet(this.hashingStrategy);
+    }
+
+    @Override
+    public UnifiedSetWithHashingStrategy<T> newEmpty(int size)
+    {
+        return UnifiedSetWithHashingStrategy.newSet(this.hashingStrategy, size, this.loadFactor);
     }
 
     @Override
@@ -1620,7 +1626,7 @@ public class UnifiedSetWithHashingStrategy<T>
     private boolean retainAllFromNonSet(Iterable<?> iterable)
     {
         int retainedSize = Iterate.sizeOf(iterable);
-        UnifiedSetWithHashingStrategy<T> retainedCopy = new UnifiedSetWithHashingStrategy<>(this.hashingStrategy, retainedSize, this.loadFactor);
+        UnifiedSetWithHashingStrategy<T> retainedCopy = this.newEmpty(retainedSize);
         for (Object key : iterable)
         {
             this.addIfFound((T) key, retainedCopy);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapOverridesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapOverridesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.map.mutable;
+
+import java.util.Map;
+
+import org.eclipse.collections.api.map.MutableMap;
+
+public class UnifiedMapOverridesTest extends UnifiedMapTest
+{
+    public static class UnifiedMapOverrides<K, V> extends UnifiedMap<K, V>
+    {
+        public UnifiedMapOverrides()
+        {
+        }
+
+        UnifiedMapOverrides(int initialCapacity, float loadFactor)
+        {
+            super(initialCapacity, loadFactor);
+        }
+
+        UnifiedMapOverrides(Map<? extends K, ? extends V> map)
+        {
+            super(map);
+        }
+
+        @Override
+        protected int index(Object key)
+        {
+            int h = key == null ? 0 : key.hashCode();
+            return (h & (this.table.length >> 1) - 1) << 1;
+        }
+
+        @Override
+        public UnifiedMapOverrides<K, V> clone()
+        {
+            return new UnifiedMapOverrides<>(this);
+        }
+
+        @Override
+        public UnifiedMapOverrides<K, V> newEmpty()
+        {
+            return new UnifiedMapOverrides<>();
+        }
+
+        @Override
+        public UnifiedMapOverrides<K, V> newEmpty(int capacity)
+        {
+            return new UnifiedMapOverrides<>(capacity, this.loadFactor);
+        }
+    }
+
+    private static <K, V> UnifiedMap<K, V> myNewMap()
+    {
+        return new UnifiedMapOverrides<>();
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMap()
+    {
+        return myNewMap();
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeyValue(K key, V value)
+    {
+        UnifiedMap<K, V> map = myNewMap();
+        return map.withKeysValues(key, value);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(K key1, V value1, K key2, V value2)
+    {
+        UnifiedMap<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        UnifiedMap<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2, key3, value3);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        UnifiedMap<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyOverridesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyOverridesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.map.strategy.mutable;
+
+import java.util.Map;
+
+import org.eclipse.collections.api.block.HashingStrategy;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+
+public class UnifiedMapWithHashingStrategyOverridesTest extends UnifiedMapWithHashingStrategyTest
+{
+    public static final class UnifiedMapWithHashingStrategyOverrides<K, V> extends UnifiedMapWithHashingStrategy<K, V>
+    {
+        public UnifiedMapWithHashingStrategyOverrides()
+        {
+        }
+
+        UnifiedMapWithHashingStrategyOverrides(HashingStrategy<? super K> strategy)
+        {
+            super(strategy);
+        }
+
+        UnifiedMapWithHashingStrategyOverrides(HashingStrategy<? super K> hashingStrategy, Map<? extends K, ? extends V> map)
+        {
+            super(hashingStrategy, map);
+        }
+
+        UnifiedMapWithHashingStrategyOverrides(HashingStrategy<? super K> hashingStrategy, int capacity, float loadFactor)
+        {
+            super(hashingStrategy, capacity, loadFactor);
+        }
+
+        @Override
+        protected int index(K key)
+        {
+            int h = this.hashingStrategy.computeHashCode(key);
+            return (h & (this.table.length >> 1) - 1) << 1;
+        }
+
+        @Override
+        public UnifiedMapWithHashingStrategyOverrides<K, V> clone()
+        {
+            return new UnifiedMapWithHashingStrategyOverrides<>(this.hashingStrategy, this);
+        }
+
+        @Override
+        public UnifiedMapWithHashingStrategyOverrides<K, V> newEmpty()
+        {
+            return new UnifiedMapWithHashingStrategyOverrides<>(this.hashingStrategy);
+        }
+
+        @Override
+        public UnifiedMapWithHashingStrategyOverrides<K, V> newEmpty(int capacity)
+        {
+            return new UnifiedMapWithHashingStrategyOverrides<K, V>(this.hashingStrategy, capacity, this.loadFactor);
+        }
+    }
+
+    private static <K, V> UnifiedMapWithHashingStrategy<K, V> myNewMap()
+    {
+        HashingStrategy<K> nshs = HashingStrategies.nullSafeHashingStrategy(HashingStrategies.defaultStrategy());
+        UnifiedMapWithHashingStrategy<K, V> map = new UnifiedMapWithHashingStrategyOverrides<>(nshs);
+        return map;
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMap()
+    {
+        return myNewMap();
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeyValue(K key, V value)
+    {
+        UnifiedMapWithHashingStrategy<K, V> map = myNewMap();
+        return map.withKeysValues(key, value);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(K key1, V value1, K key2, V value2)
+    {
+        UnifiedMapWithHashingStrategy<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(
+            K key1, V value1, K key2, V value2, K key3,
+            V value3)
+    {
+        UnifiedMapWithHashingStrategy<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2, key3, value3);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newMapWithKeysValues(
+            K key1, V value1, K key2, V value2, K key3,
+            V value3, K key4, V value4)
+    {
+        UnifiedMapWithHashingStrategy<K, V> map = myNewMap();
+        return map.withKeysValues(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetOverridesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetOverridesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.set.mutable;
+
+public class UnifiedSetOverridesTest extends UnifiedSetTest
+{
+    public static class UnifiedSetOverriddes<T> extends UnifiedSet<T>
+    {
+        public UnifiedSetOverriddes(int size)
+        {
+            super(size);
+        }
+
+        @Override
+        protected int index(Object key)
+        {
+            int h = key == null ? 0 : key.hashCode();
+            return h & this.table.length - 1;
+        }
+
+        @Override
+        public UnifiedSetOverriddes<T> newEmpty(int size)
+        {
+            return new UnifiedSetOverriddes<>(size);
+        }
+    }
+
+    @Override
+    protected <T> UnifiedSet<T> newWith(T... littleElements)
+    {
+        UnifiedSet<T> set = new UnifiedSetOverriddes<T>(littleElements.length);
+        return set.with(littleElements);
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyOverridesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyOverridesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.set.mutable;
+
+import org.eclipse.collections.api.block.HashingStrategy;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
+
+public class UnifiedSetWithHashingStrategyOverridesTest extends UnifiedSetWithHashingStrategyTest
+{
+    public static class UnifiedSetWithHashingStrategyOverrides<T> extends UnifiedSetWithHashingStrategy<T>
+    {
+        public UnifiedSetWithHashingStrategyOverrides(HashingStrategy<? super T> hashingStrategy, int initialCapacity)
+        {
+            super(hashingStrategy, initialCapacity);
+        }
+
+        @Override
+        protected int index(T key)
+        {
+            int h = this.hashingStrategy.computeHashCode(key);
+            return h & this.table.length - 1;
+        }
+
+        @Override
+        public UnifiedSetWithHashingStrategyOverrides<T> newEmpty()
+        {
+            return new UnifiedSetWithHashingStrategyOverrides<T>(this.hashingStrategy, 0);
+        }
+
+        @Override
+        public UnifiedSetWithHashingStrategyOverrides<T> newEmpty(int size)
+        {
+            return new UnifiedSetWithHashingStrategyOverrides<T>(this.hashingStrategy, size);
+        }
+    }
+
+    @Override
+    protected <T> MutableSet<T> newWith(T... littleElements)
+    {
+        HashingStrategy<T> nshs = HashingStrategies.nullSafeHashingStrategy(HashingStrategies.defaultStrategy());
+        UnifiedSetWithHashingStrategyOverrides<T> set = new UnifiedSetWithHashingStrategyOverrides<>(nshs, littleElements.length);
+        return set.with(littleElements);
+    }
+}


### PR DESCRIPTION
Some unit tests depend on the ability of collections to create copies of themselves or empty instances of the same class so most of the code changes are around that.