### PR TITLE
Optimize implementations of groupByUniqueKey() by pre-sizing the target maps. #445

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -1619,7 +1619,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     @Override
     public \<VV> MutableMap\<VV, V> groupByUniqueKey(Function\<? super V, ? extends VV> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.\<VV, V>newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.\<VV, V>newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/AbstractImmutableBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/AbstractImmutableBag.java
@@ -216,7 +216,7 @@ public abstract class AbstractImmutableBag<T>
     @Override
     public <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap()).toImmutable();
+        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap(this.size())).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractMutableBagIterable.java
@@ -122,7 +122,7 @@ public abstract class AbstractMutableBagIterable<T>
     @Override
     public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBag.java
@@ -142,7 +142,7 @@ abstract class AbstractImmutableSortedBag<T>
     @Override
     public <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap()).toImmutable();
+        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap(this.size())).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
@@ -1119,7 +1119,7 @@ public abstract class AbstractSynchronizedRichIterable<T> implements RichIterabl
     {
         synchronized (this.lock)
         {
-            return this.delegate.groupByUniqueKey(function, UnifiedMap.newMap());
+            return this.delegate.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/AbstractLazyIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/AbstractLazyIterable.java
@@ -324,7 +324,7 @@ public abstract class AbstractLazyIterable<T>
     @Override
     public <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/lazy/parallel/AbstractParallelIterable.java
@@ -753,7 +753,7 @@ public abstract class AbstractParallelIterable<T, B extends Batch<T>> implements
     @Override
     public <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        MutableMap<V, T> result = ConcurrentHashMap.newMap();
+        MutableMap<V, T> result = ConcurrentHashMap.newMap(this.getBatchSize());
         this.forEach(value -> {
             V key = function.valueOf(value);
             if (result.put(key, value) != null)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -540,7 +540,7 @@ public class FastList<T>
     @Override
     public <K> MutableMap<K, T> groupByUniqueKey(Function<? super T, ? extends K> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/AbstractImmutableMap.java
@@ -437,7 +437,7 @@ public abstract class AbstractImmutableMap<K, V>
     @Override
     public <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap()).toImmutable();
+        return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap(this.size())).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
@@ -362,6 +362,6 @@ public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterabl
     @Override
     public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
@@ -111,7 +111,7 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
     @Override
     public <VV> MutableMapIterable<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/AbstractImmutableSortedMap.java
@@ -450,7 +450,7 @@ public abstract class AbstractImmutableSortedMap<K, V>
     @Override
     public <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap()).toImmutable();
+        return this.groupByUniqueKey(function, UnifiedMap.<V1, V>newMap(this.size())).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/AbstractMutableSortedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/AbstractMutableSortedMap.java
@@ -345,7 +345,7 @@ public abstract class AbstractMutableSortedMap<K, V> extends AbstractMutableMapI
     @Override
     public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/AbstractUnifiedSet.java
@@ -319,7 +319,7 @@ public abstract class AbstractUnifiedSet<T>
     public <V> MutableMap<V, T> groupByUniqueKey(
             Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -894,7 +894,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     @Override
     public <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap()).toImmutable();
+        return this.groupByUniqueKey(function, UnifiedMap.<V, T>newMap(this.size())).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -844,7 +844,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
     @Override
     public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
     {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap());
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
@@ -1439,7 +1439,7 @@ public final class RandomAccessListIterate
             List<T> list,
             Function<? super T, ? extends K> function)
     {
-        return RandomAccessListIterate.groupByUniqueKey(list, function, UnifiedMap.newMap());
+        return RandomAccessListIterate.groupByUniqueKey(list, function, UnifiedMap.newMap(list.size()));
     }
 
     public static <K, T, R extends MutableMap<K, T>> R groupByUniqueKey(


### PR DESCRIPTION
Signed-off-by: Lorenzo Addazi <lorenzo.addazi@tutanota.com>