### PR TITLE
Fixes javadoc links to point to 9.2.0 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The method reference in the example above can also be replaced with a lambda:
 ```java
 MutableList<String> lastNames = people.collect(person -> person.getLastName());
 ```
-Eclipse Collections has support for both [Mutable](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/collection/MutableCollection.html) and [Immutable](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/collection/ImmutableCollection.html) collections, and the return types of methods are covariant.  While the collect method on a MutableList returned a MutableList, the collect method on an ImmutableList will return an ImmutableList.  Here we use the same Lists factory to create an ImmutableList.
+Eclipse Collections has support for both [Mutable](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/collection/MutableCollection.html) and [Immutable](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/collection/ImmutableCollection.html) collections, and the return types of methods are covariant.  While the collect method on a MutableList returned a MutableList, the collect method on an ImmutableList will return an ImmutableList.  Here we use the same Lists factory to create an ImmutableList.
 
 ```java
 ImmutableList<Person> people = Lists.immutable.with(person1, person2, person3);
 ImmutableList<String> lastNames = people.collect(Person::getLastName);
 Assert.assertEquals("Smith, Watson, Williams", lastNames.makeString());
 ```
-Eclipse Collections has a [lazy API](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/LazyIterable.html) as well, which is available by calling the method asLazy().  The method collect will now return a LazyIterable.  The LazyIterable that is returned does not evaluate anything until the call to a terminal method is made.  In this case, the call to makeString() will force the LazyIterable to collect the last names. 
+Eclipse Collections has a [lazy API](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/LazyIterable.html) as well, which is available by calling the method asLazy().  The method collect will now return a LazyIterable.  The LazyIterable that is returned does not evaluate anything until the call to a terminal method is made.  In this case, the call to makeString() will force the LazyIterable to collect the last names. 
 
 ```java
 ImmutableList<Person> people = Lists.immutable.with(person1, person2, person3);
@@ -93,7 +93,7 @@ MutableList<Person> people = Lists.mutable.with(person1, person2, person3);
 Stream<String> lastNames = people.stream().map(Person::getLastName);
 Assert.assertEquals("Smith, Watson, Williams", lastNames.collect(Collectors.joining(", "));
 ```
-Eclipse Collections 8.0 also introduced a new set of Collectors in the class [Collectors2](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/collector/Collectors2.html).  The Collectors2.makeString() is equivalent to Collectors2.joining(", "), but does not require the object in the Stream to be a String.
+Eclipse Collections 8.0 also introduced a new set of Collectors in the class [Collectors2](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/collector/Collectors2.html).  The Collectors2.makeString() is equivalent to Collectors2.joining(", "), but does not require the object in the Stream to be a String.
 
 ```java
 MutableList<Person> people = Lists.mutable.with(person1, person2, person3);

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -133,7 +133,7 @@ The most commonly-used iteration patterns in Eclipse Collections are:
 
 > Filter a collection to create a new collection: includes **select**, **reject**, and **partition**.
 
-Methods using the *Select* pattern return a new collection comprising those elements from the source collection that satisfy some logical condition. *Reject* is the inverse pattern, returning a new collection of elements that do *not* satisfy the condition. The condition is a boolean expression in the form of single-argument code block that implements the [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) interface.
+Methods using the *Select* pattern return a new collection comprising those elements from the source collection that satisfy some logical condition. *Reject* is the inverse pattern, returning a new collection of elements that do *not* satisfy the condition. The condition is a boolean expression in the form of single-argument code block that implements the [**Predicate**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/Predicate.html) interface.
 
 #### Select pattern examples:
 
@@ -167,13 +167,13 @@ MutableList<Integer> greaterThanFifty =
     });
 ```
 
-Here, a [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is created using the [**Predicates**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) factory:
+Here, a [**Predicate**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/Predicate.html) is created using the [**Predicates**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/block/factory/Predicates.html) factory:
 
 ```java
 MutableList<Integer> greaterThanFifty = list.select(Predicates.greaterThan(50));
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Integer> greaterThanFifty = list.stream()
@@ -212,7 +212,7 @@ List<Integer> notGreaterThanFifty =
     list.reject(each -> each > 50);
 ```
 
-###### EC (w/[Predicates](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) Factory)
+###### EC (w/[Predicates](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/block/factory/Predicates.html) Factory)
 
 ```java
 list.reject(Predicates.greaterThan(50));
@@ -247,7 +247,7 @@ These Eclipse Collections methods implement the Select and Reject pattern:
 
 ##### reject(Predicate): RichIterable
 
-The [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is evaluated for each element of the collection. The selected elements are those where the Predicate returned true (false for rejected). The selected (or rejected) elements are returned in a new collection of the same type.
+The [**Predicate**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/Predicate.html) is evaluated for each element of the collection. The selected elements are those where the Predicate returned true (false for rejected). The selected (or rejected) elements are returned in a new collection of the same type.
 
 ##### select(Predicate, *targetCollection*): *targetCollection*
 
@@ -259,7 +259,7 @@ Same as the **select**/**reject** methods with one argument, but results are add
 
 ##### rejectWith(Predicate2, *argument*): RichIterable
 
-For each element of the collection, [**Predicate2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) is evaluated with the element as one argument, plus one additional argument; selected or rejected elements are returned in a new collection of the same type. See [Reusing a code block](#performance-optimized-methods-reusing-two-argument-code-blocks "Using selectWith, rejectWith, and collectWith inside other iteration patterns (or loops) where code blocks can be created outside of the outer iteration patterns or made static.") for more information.
+For each element of the collection, [**Predicate2**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/Predicate2.html) is evaluated with the element as one argument, plus one additional argument; selected or rejected elements are returned in a new collection of the same type. See [Reusing a code block](#performance-optimized-methods-reusing-two-argument-code-blocks "Using selectWith, rejectWith, and collectWith inside other iteration patterns (or loops) where code blocks can be created outside of the outer iteration patterns or made static.") for more information.
 
 ##### selectWith(Predicate2, *argument*, *targetCollection*): *targetCollection*
 
@@ -271,7 +271,7 @@ Same as the **selectWith**/**rejectWith** methods, but results are added to the 
 
 > Create two collections using **Select** and **Reject**.
 
-The *Partition* pattern allocates each element of a collection into one of two new collections depending on whether the element satisfies the condition expressed by the **Predicate**. In effect, it combines the [*Select* and *Reject* patterns](#selectreject-pattern "Filter a collection to create a new collection: includes select, reject, and partition."). The collections are returned in a [**PartitionIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/partition/PartitionIterable.html) specialized for the type of the source collection. You can retrieve the selected and rejected elements from the **PartitionIterable**. In this example, the list of people is partitioned into lists of adults and children.
+The *Partition* pattern allocates each element of a collection into one of two new collections depending on whether the element satisfies the condition expressed by the **Predicate**. In effect, it combines the [*Select* and *Reject* patterns](#selectreject-pattern "Filter a collection to create a new collection: includes select, reject, and partition."). The collections are returned in a [**PartitionIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/partition/PartitionIterable.html) specialized for the type of the source collection. You can retrieve the selected and rejected elements from the **PartitionIterable**. In this example, the list of people is partitioned into lists of adults and children.
 
 ###### EC (w/lambda)
 
@@ -314,7 +314,7 @@ These Eclipse Collections methods implement the partition pattern:
 
 ##### partition(Predicate): PartitionIterable
 
-Returns a **PartitionIterable**, a logical pair of containers. The first container consists of all elements that satisfy the **Predicate**. The second container consists of all elements that do not satisfy the **Predicate**. The subtypes of **PartitionIterable** correspond with the subtypes of [**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html).
+Returns a **PartitionIterable**, a logical pair of containers. The first container consists of all elements that satisfy the **Predicate**. The second container consists of all elements that do not satisfy the **Predicate**. The subtypes of **PartitionIterable** correspond with the subtypes of [**RichIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/RichIterable.html).
 
 ##### partitionWith(Predicate2, *argument*): PartitionIterable
 
@@ -324,7 +324,7 @@ For each element of the collection, **Predicate2** is evaluated with the element
 
 > Transform a collection's elements, creating a new collection: includes **collect**, **flatCollect**, and **groupBy**.
 
-The *Collect* pattern methods return a new collection whose data elements are the results of an evaluation performed by the code block; that is, each element of the original collection is mapped to a new object, which is usually a different type. The code block used as the **collect** method's parameter implements the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) interface.
+The *Collect* pattern methods return a new collection whose data elements are the results of an evaluation performed by the code block; that is, each element of the original collection is mapped to a new object, which is usually a different type. The code block used as the **collect** method's parameter implements the [**Function**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function.html) interface.
 
 ###### Pseudocode
 
@@ -362,7 +362,7 @@ Function<Person, Address> addressFunction =
 MutableList<Address> addresses = people.collect(addressFunction);
 ```
 
-Notice that this assumes each person in the **people** collection has just one address. If, instead, a person has multiple addresses, the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) returns a list of addresses for each person (a list that has only one element if the person has just one address); the result is a List of Lists:
+Notice that this assumes each person in the **people** collection has just one address. If, instead, a person has multiple addresses, the [**Function**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function.html) returns a list of addresses for each person (a list that has only one element if the person has just one address); the result is a List of Lists:
 
 ###### EC (w/lambda and method reference)
 
@@ -435,11 +435,11 @@ These Eclipse Collections methods implement the Collect pattern:
 
 ##### collect(Function): RichIterable
 
-For each element of the collection, the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) is evaluated with the current element as the argument; returns a new collection with the transformed type.
+For each element of the collection, the [**Function**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function.html) is evaluated with the current element as the argument; returns a new collection with the transformed type.
 
 ##### collectInt(IntFunction): IntIterable
 
-Similar to **collect**, but it takes an [**IntFunction**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html) and returns a primitive collection which extends from [**IntIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/IntIterable.html). There are variants for all eight primitives: **collectBoolean**, **collectFloat** etc.
+Similar to **collect**, but it takes an [**IntFunction**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html) and returns a primitive collection which extends from [**IntIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/IntIterable.html). There are variants for all eight primitives: **collectBoolean**, **collectFloat** etc.
 
 ##### collect(Function, *targetCollection*): *targetCollection*
 
@@ -447,7 +447,7 @@ Same as **collect**, except that the results are added to the specified *targetC
 
 ##### collectInt(IntFunction, *targetCollection*): *targetCollection*
 
-Same as **collectInt**, except that the results are added to the specified *targetCollection*, which extends [**MutableIntCollection**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/collection/primitive/MutableIntCollection.html). There are variants for all eight primitives.
+Same as **collectInt**, except that the results are added to the specified *targetCollection*, which extends [**MutableIntCollection**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/collection/primitive/MutableIntCollection.html). There are variants for all eight primitives.
 
 ##### collectIf(Predicate, Function): RichIterable
 
@@ -459,7 +459,7 @@ Same as **collectIf**, except that the results are added to the specified *targe
 
 ##### collectWith(Function2, *argument2*): RichIterable
 
-Same as **collect**, but the [**Function2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function2.html) is evaluated with the element as one argument, plus one additional argument; returns a new collection of the same size and the transformed type.
+Same as **collect**, but the [**Function2**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function2.html) is evaluated with the element as one argument, plus one additional argument; returns a new collection of the same size and the transformed type.
 
 ##### collectWith(Function2, *argument2*, *targetCollection*): *targetCollection*
 
@@ -514,7 +514,7 @@ MutableList<Address> addresses =
        });
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Address> flatAddress = people.stream()
@@ -543,11 +543,11 @@ for (Person person : people)
 
 Create a Multimap from a collection by grouping on a selected or generated key value.
 
-The *GroupBy* pattern gathers the elements on the collection into a map-like container called a [**Multimap**](#multimap "A map-like container that can have multiple values for each key"), which associates multiple values for each key. The **Function** is applied to each element and the result is used as the key into the [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) where the element should appear as the value.
+The *GroupBy* pattern gathers the elements on the collection into a map-like container called a [**Multimap**](#multimap "A map-like container that can have multiple values for each key"), which associates multiple values for each key. The **Function** is applied to each element and the result is used as the key into the [**Multimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/Multimap.html) where the element should appear as the value.
 
 ##### groupBy(Function): Multimap
 
-Group the elements into a new [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html); uses the **Function** to get the key for each element.
+Group the elements into a new [**Multimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/Multimap.html); uses the **Function** to get the key for each element.
 
 ##### groupBy(Function, *targetMultimap*) : targetMultimap
 
@@ -631,7 +631,7 @@ Returns the first element that evaluates as *true* for the specified **Predicate
 
 ##### detectWithIfNone(Predicate2, *parameter*, Function0): element (or Function0 result)
 
-Same as **detectWith**, but if no element causes [**Predicate2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) to evaluate as *true*, return the result of evaluating [**Function0**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function0.html).
+Same as **detectWith**, but if no element causes [**Predicate2**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/Predicate2.html) to evaluate as *true*, return the result of evaluating [**Function0**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function0.html).
 
 #### []() AnySatisfy pattern
 
@@ -814,11 +814,11 @@ for (int i = 0; i < list.size(); i++)
 
 ##### each(Procedure): void
 
-For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
+For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
 
 ##### forEach(Procedure): void
 
-For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
+For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
 
 ##### forEachIf(Predicate, Procedure): void
 
@@ -826,15 +826,15 @@ For each element that satisfies the **Predicate**, executes the **Procedure** on
 
 ##### forEach(*fromIndex*, *toindex*, Procedure): void
 
-Iterates over the section of a [**ListIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ListIterable.html) covered by the specified indexes (inclusive).
+Iterates over the section of a [**ListIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/list/ListIterable.html) covered by the specified indexes (inclusive).
 
 ##### forEachWith(Procedure2, *parameter*): void
 
-For each element of the collection, the [**Procedure2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure2.html) is evaluated with the element as the first argument, and the specified *parameter* as the second argument.
+For each element of the collection, the [**Procedure2**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/procedure/Procedure2.html) is evaluated with the element as the first argument, and the specified *parameter* as the second argument.
 
 ##### forEachWithIndex(ObjectIntProcedure): void
 
-Iterates over a collection passing each element and the current relative int index to the specified instance of [**ObjectIntProcedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/primitive/ObjectIntProcedure.html).
+Iterates over a collection passing each element and the current relative int index to the specified instance of [**ObjectIntProcedure**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/procedure/primitive/ObjectIntProcedure.html).
 
 ##### forEachWithIndex(*fromIndex*, *toIndex*, ObjectIntProcedure): void
 
@@ -925,11 +925,11 @@ Return the final result of all evaluations using as the arguments each element o
 []() RichIterable
 ----------------
 
-[**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html) is the most important interface in Eclipse Collections. It provides the blueprint for all non-mutating iteration patterns. It represents an object made up of elements that can be individually and consecutively viewed or evaluated (an *iterable*), and it prescribes the actions that can be performed with each evaluation (the patterns). The most commonly used implementations include [**FastList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/FastList.html) and [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html).
+[**RichIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/RichIterable.html) is the most important interface in Eclipse Collections. It provides the blueprint for all non-mutating iteration patterns. It represents an object made up of elements that can be individually and consecutively viewed or evaluated (an *iterable*), and it prescribes the actions that can be performed with each evaluation (the patterns). The most commonly used implementations include [**FastList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/list/mutable/FastList.html) and [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html).
 
-[**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html) is extended by [**ListIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ListIterable.html), [**SetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/SetIterable.html), [**Bag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/Bag.html), [**StackIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/StackIterable.html), and [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html). A **MapIterable** of keys and values is also a **RichIterable** of values.
+[**RichIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/RichIterable.html) is extended by [**ListIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/list/ListIterable.html), [**SetIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/set/SetIterable.html), [**Bag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/Bag.html), [**StackIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/stack/StackIterable.html), and [**MapIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/MapIterable.html). A **MapIterable** of keys and values is also a **RichIterable** of values.
 
-**RichIterable** is also extended by [**MutableCollection**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/collection/MutableCollection.html), and indirectly by [**MutableList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/MutableList.html) and [**MutableSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/MutableSet.html) (which also extend the mutable Java Collection types **List** and **Set**). Another subinterface defines a non-JDK container, [**MutableBag**](#mutablebag "A mutable unordered collection allowing duplicates; the most common implementation is HashBag.") (or multiset); yet another, [**ImmutableCollection**](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified."), delineates the immutable forms of these Eclipse Collections containers. These latter two interfaces are detailed in the [Collections and containers](#collections-and-containers) topic.
+**RichIterable** is also extended by [**MutableCollection**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/collection/MutableCollection.html), and indirectly by [**MutableList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/list/MutableList.html) and [**MutableSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/set/MutableSet.html) (which also extend the mutable Java Collection types **List** and **Set**). Another subinterface defines a non-JDK container, [**MutableBag**](#mutablebag "A mutable unordered collection allowing duplicates; the most common implementation is HashBag.") (or multiset); yet another, [**ImmutableCollection**](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified."), delineates the immutable forms of these Eclipse Collections containers. These latter two interfaces are detailed in the [Collections and containers](#collections-and-containers) topic.
 
 The subinterface [**LazyIterable**](#lazy-iteration "Deferring evaluation until necessary.") for the most part replicates **RichIterable**, but overrides some specific collection-returning methods - **collect**, **collectIf**, **select**, **reject**, and **flatCollect** - so that they delay their actual execution until the returned collection is needed, a technique called "lazy iteration."
 
@@ -941,7 +941,7 @@ The subinterface [**LazyIterable**](#lazy-iteration "Deferring evaluation until 
 
 ##### *richIterable*.asLazy()
 
-Returns a deferred-evaluation iterable of type [**LazyIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/LazyIterable.html). (Note the list below of other Eclipse Collections methods that return lazy Iterables.)
+Returns a deferred-evaluation iterable of type [**LazyIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/LazyIterable.html). (Note the list below of other Eclipse Collections methods that return lazy Iterables.)
 
 In a way, lazy iteration is a companion to the [short-circuit iteration pattern](#concept648 "Methods that control processing by testing a collection for a logical condition: includes detect, anySatisfy, and allSatisfy."), in which iteration ceases as soon the method's purpose is achieved. In the last line of the example below, the **anySatisfy** method quits execution when it detects the "address2" element in the **addresses** list created by **collect**. The third element ("address 3") is never examined by **anySatisfy** - although it was present in **addresses**.
 
@@ -1030,7 +1030,7 @@ An unmodifiable view of each key's values, without the key.
 
 An API that combines parallel iteration with lazy evaluation.
 
-Parallel-eager utility is available through the [**ParallelIterate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/parallel/ParallelIterate.html) utility class. Serial-lazy evaluation is available through **LazyIterable**, the view returned by **RichIterable**.**asLazy()**. The [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/ParallelIterable.html) interface defines a view where iteration is both parallel and lazy. Sub-interfaces of **ParallelIterable** are returned from the various implementations of **asParallel(** **ExecutorService** **executorService**, **int** **batchSize** **)**. The **ParallelIterable** API is new in 5.0 and considered experimental, as indicated by the **@Beta** annotation. API tagged as **@Beta** may be altered in ways that are not backward-compatible, even in minor versions of Eclipse Collections. The method **asParallel** is not on interfaces like **RichIterable** in version 5.0, but rather on a few supported collections, including **FastList** and **UnifiedSet**.
+Parallel-eager utility is available through the [**ParallelIterate**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/parallel/ParallelIterate.html) utility class. Serial-lazy evaluation is available through **LazyIterable**, the view returned by **RichIterable**.**asLazy()**. The [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/ParallelIterable.html) interface defines a view where iteration is both parallel and lazy. Sub-interfaces of **ParallelIterable** are returned from the various implementations of **asParallel(** **ExecutorService** **executorService**, **int** **batchSize** **)**. The **ParallelIterable** API is new in 5.0 and considered experimental, as indicated by the **@Beta** annotation. API tagged as **@Beta** may be altered in ways that are not backward-compatible, even in minor versions of Eclipse Collections. The method **asParallel** is not on interfaces like **RichIterable** in version 5.0, but rather on a few supported collections, including **FastList** and **UnifiedSet**.
 
 ```java
 FastList integers = Lists.mutable.with(1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -1051,14 +1051,14 @@ threadPool.shutdown();
 Assert.assertEquals(Lists.mutable.with("2", "4", "6", "8"), strings);
 ```
 
-In this code example, the calls to **select** and **collect** are lazy, as indicated by the fact that they return subclasses of [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/ParallelIterable.html). The call to **toList()** forces evaluation.
+In this code example, the calls to **select** and **collect** are lazy, as indicated by the fact that they return subclasses of [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/ParallelIterable.html). The call to **toList()** forces evaluation.
 
 The two parameters to **asParallel(ExecutorService** *executorService*, **int** *batchSize***)** are used to configure parallelism.
 
 |                   |                                                                                                                                                                                                                                                                                                                                                            |
 |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | *executorService* | This code example set up a thread pool with one thread per core, which is appropriate for CPU bound tasks. A thread pool used for IO bound tasks should be infinite or should have one thread per IO-bound resource, for example, one thread per database connection. It often makes sense to share thread pools between multiple calls to **asParallel**. |
-| *batchSize*       | The batch size determines the number of elements from the backing collection (**FastList** or **UnifiedSet**) that get processed by each task submitted to the thread pool. Appropriate batch sizes for CPU-bound tasks are usually larger, in the 10,000 to 100,000 range.                                                                                |
+| *batchSize*       | The batch size determines the number of elements from the backing collection (**FastList** or **UnifiedSet**) that get processed by each task submitted to the thread pool. Appropriate batch sizes for CPU-bound tasks are usually larger, in the 9.2.0 to 100,000 range.                                                                                |
 
 #### []() Performance
 
@@ -1070,7 +1070,7 @@ It's possible to cancel a parallel-lazy computation in progress. It requires a t
 
 ### []() RichIterable methods
 
-These methods are available on all implementations of [**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html).
+These methods are available on all implementations of [**RichIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/RichIterable.html).
 
 #### []() Building strings
 
@@ -1111,7 +1111,7 @@ String defaultString =
     list.stream().map(Object::toString).collect(Collectors.joining()); // "1/2/3"
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Integer> list = Lists.mutable.with(1, 2, 3);
@@ -1181,7 +1181,7 @@ int count =
 
 Returns the number of elements that satisfy the **Predicate2**. The second parameter to **countWith** is passed as the second parameter to the **Predicate2**.
 
-###### EC (w/[Predicates2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates2.html) factory)
+###### EC (w/[Predicates2](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/block/factory/Predicates2.html) factory)
 
 ```java
 int count = 
@@ -1318,15 +1318,15 @@ people.min(Comparators.byFunction(Person::getAge));
 
 Methods that create maps of aggregated values by grouping them on a calculated key.
 
-**aggregateBy** groups the elements in the **RichIterable** by the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html). Then all the elements that map to the same key are aggregated together using the [**Function2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function2.html). The third parameter, a [**Function0**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function0.html), creates the initial value in each aggregation. Aggregate results are allowed to be immutable as they will be replaced in the map.
+**aggregateBy** groups the elements in the **RichIterable** by the [**Function**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function.html). Then all the elements that map to the same key are aggregated together using the [**Function2**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function2.html). The third parameter, a [**Function0**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/Function0.html), creates the initial value in each aggregation. Aggregate results are allowed to be immutable as they will be replaced in the map.
 
-**aggregateBy** is conceptually analogous to calling a **groupBy** method on a **RichIterable** to create a **Multimap**,and then calling **injectInto** on each collection of the **Multimap** values to create a [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html).
+**aggregateBy** is conceptually analogous to calling a **groupBy** method on a **RichIterable** to create a **Multimap**,and then calling **injectInto** on each collection of the **Multimap** values to create a [**MapIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/MapIterable.html).
 
 **aggregateInPlaceBy** is similar to **aggregateBy**, but it mutates values in the output map instead of replacing them. Thus in this case, the aggregate results must be mutable.
 
 ##### aggregateBy(Function, Function0, Function2): MapIterable
 
-Returns a [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html) by grouping results by keys supplied by evaluating a **Function**.
+Returns a [**MapIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/MapIterable.html) by grouping results by keys supplied by evaluating a **Function**.
 
 ###### EC (w/lambda and method reference)
 
@@ -1617,9 +1617,9 @@ This style encourages adding more behavior to the classes held in the containers
 
 Methods for iterating over Maps and Multimaps.
 
-The [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html) and [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) interfaces are *associative arrays*, meaning they contain key-value pairs. All of the keys in a Map are unique; a **Multimap** can have multiple values associated with each key.
+The [**MapIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/MapIterable.html) and [**Multimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/Multimap.html) interfaces are *associative arrays*, meaning they contain key-value pairs. All of the keys in a Map are unique; a **Multimap** can have multiple values associated with each key.
 
-The **Multimap** interface does not extend MapIterable. **Multimap** has a number of subinterfaces, such as [**ListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/list/ListMultimap.html), [**SetMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/set/SetMultimap.html), and [**BagMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/bag/BagMultimap.html), each with custom behavior for how to handle the collection of values associated with each key.
+The **Multimap** interface does not extend MapIterable. **Multimap** has a number of subinterfaces, such as [**ListMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/list/ListMultimap.html), [**SetMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/set/SetMultimap.html), and [**BagMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/bag/BagMultimap.html), each with custom behavior for how to handle the collection of values associated with each key.
 
 ### []() Creating iterable views of maps
 
@@ -1673,7 +1673,7 @@ The **updateValue**, **getIfAbsent** and **ifPresentApply** methods locate a spe
 
 ##### add(Pair&lt;K, V&gt;): value
 
-Adds the given key-value pair to the map. It's a convenience method for working with [**Pair**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/tuple/Pair.html)s, similar to **put(**K, V**)**.
+Adds the given key-value pair to the map. It's a convenience method for working with [**Pair**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/tuple/Pair.html)s, similar to **put(**K, V**)**.
 
 ##### updateValue(*key*, Function0, Function): value
 
@@ -1729,7 +1729,7 @@ We'll begin with the Eclipse Collections implementations of types having analogs
 []() Basic collection types
 --------------------------
 
-The most commonly-used Eclipse Collections classes are [**FastList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/FastList.html), [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html), and [**UnifiedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/UnifiedMap.html). These collections serve as drop-in replacements for their corresponding types in the Java Collections Framework (JCF). Note that these Eclipse Collections classes do not extend the JCF implementations; they are instead new implementations of both JCF and Eclipse Collections interfaces, as this (highly-simplified) diagram summarizes:
+The most commonly-used Eclipse Collections classes are [**FastList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/list/mutable/FastList.html), [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html), and [**UnifiedMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/map/mutable/UnifiedMap.html). These collections serve as drop-in replacements for their corresponding types in the Java Collections Framework (JCF). Note that these Eclipse Collections classes do not extend the JCF implementations; they are instead new implementations of both JCF and Eclipse Collections interfaces, as this (highly-simplified) diagram summarizes:
 
 ![Container comparision](containerCompare.png)
 
@@ -1741,7 +1741,7 @@ The methods of the JCF types are primarily focused on adding or removing element
 
 A **ListIterable** is a **RichIterable** which maintains its elements in insertion order and allows duplicate elements.
 
-**ListIterable** has two mutable subinterfaces **MutableList** and [**FixedSizeList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/FixedSizeList.html) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**ImmutableList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ImmutableList.html).
+**ListIterable** has two mutable subinterfaces **MutableList** and [**FixedSizeList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/list/FixedSizeList.html) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**ImmutableList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/list/ImmutableList.html).
 
 The **ListIterable** interface includes the **binarySearch** method, which is similar to the static method **binarySearch** on **java.util.Collections**, but available from the object-oriented API.
 
@@ -1933,7 +1933,7 @@ The Eclipse Collections **newListWith()** method also provides varargs support, 
 List<Integer> integers = FastList.newListWith(1, 2, 3);
 ```
 
-There are also factory classes in Eclipse Collections named for each type (e.g. [Lists](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Lists.html), [Sets](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html), [Maps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html), [Bags](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Bags.html), [Stacks](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Stacks.html), [BiMaps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/BiMaps.html), [Multimaps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Multimaps.html), etc.)
+There are also factory classes in Eclipse Collections named for each type (e.g. [Lists](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Lists.html), [Sets](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Sets.html), [Maps](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Sets.html), [Bags](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Bags.html), [Stacks](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Stacks.html), [BiMaps](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/BiMaps.html), [Multimaps](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Multimaps.html), etc.)
 
 ###### EC 
 
@@ -1980,8 +1980,8 @@ These refactorings are analogous for **UnifiedSet** and **UnifiedMap**.
 
 A **SetIterable** is a **RichIterable** that allows no duplicate elements. It can be sorted or unsorted.
 
--   A [**SortedSetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/sorted/SortedSetIterable.html) is a **SetIterable** that maintains its elements in sorted order.
--   An [**UnsortedSetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/UnsortedSetIterable.html) is a **SetIterable** that maintains its elements in a hash table in an unpredictable order.
+-   A [**SortedSetIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/set/sorted/SortedSetIterable.html) is a **SetIterable** that maintains its elements in sorted order.
+-   An [**UnsortedSetIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/set/UnsortedSetIterable.html) is a **SetIterable** that maintains its elements in a hash table in an unpredictable order.
 
 **UnsortedSetIterable** has two mutable subinterfaces (**MutableSet** and **FixedSizeSet**) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface (**ImmutableSet**).
 
@@ -2013,7 +2013,7 @@ Set<String> comparison = UnifiedSet.newSetWith("IBM", "Microsoft", "Verizon", "C
 
 > Contains unique items that are sorted by some comparator or their natural ordering.
 
-A [**MutableSortedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/sorted/MutableSortedSet.html) follows the same contract as a **MutableSet**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedSet** is **TreeSortedSet**.
+A [**MutableSortedSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/set/sorted/MutableSortedSet.html) follows the same contract as a **MutableSet**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedSet** is **TreeSortedSet**.
 
 Here is an example of a MutableSortedSet containing numbers in reverse order:
 
@@ -2038,7 +2038,7 @@ The **MapIterable** interface (extending **RichIterable**) is the top-level inte
 
 > A mutable **MapIterable** that implements java.util.Map; the most common implementation is **UnifiedMap**.
 
-The [**MutableMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MutableMap.html) interface defines an association of key/value pairs. It extends the **MapIterable** interface, which furnishes a set of iteration methods especially for the key/value structure of a Map collection. These include unmodifiable views of keys, values or pair-entries using the **keysView**, **valuesView** and **entriesView** methods, respectively.
+The [**MutableMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/MutableMap.html) interface defines an association of key/value pairs. It extends the **MapIterable** interface, which furnishes a set of iteration methods especially for the key/value structure of a Map collection. These include unmodifiable views of keys, values or pair-entries using the **keysView**, **valuesView** and **entriesView** methods, respectively.
 
 The mutable subinterfaces of **MapIterable** also extend the JCF Map interface.
 
@@ -2061,7 +2061,7 @@ MutableMap<Integer, String> map = UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3
 
 > A sorted Map.
 
-A [**MutableSortedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/sorted/MutableSortedMap.html) follows the same contract as a **MutableMap**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedMap** is [**TreeSortedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.html).
+A [**MutableSortedMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/map/sorted/MutableSortedMap.html) follows the same contract as a **MutableMap**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedMap** is [**TreeSortedMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.html).
 
 This code block creates a TreeSortedMap which sorts in reverse order:
 
@@ -2076,9 +2076,9 @@ MutableSortedMap<String, Integer> sortedMap = TreeSortedMap.newMapWith(Comparato
 
 > A map that allows users to add key-value pairs and look up from either direction
 
-[**BiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bimap/BiMap.html) is an interface that defines a bi-directional map, i.e, a map that allows users to look up from both directions. Both the keys and the values in a **BiMap** are unique.
+[**BiMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bimap/BiMap.html) is an interface that defines a bi-directional map, i.e, a map that allows users to look up from both directions. Both the keys and the values in a **BiMap** are unique.
 
-**BiMap** extends **MapIterable** and [**MutableBiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bimap/MutableBiMap.html) extends **MutableMap**. The standard implementation is [**HashBiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bimap/mutable/HashBiMap.html).
+**BiMap** extends **MapIterable** and [**MutableBiMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bimap/MutableBiMap.html) extends **MutableMap**. The standard implementation is [**HashBiMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/bimap/mutable/HashBiMap.html).
 
 ###### EC
 
@@ -2132,12 +2132,12 @@ Assert.assertEquals(Integer.valueOf(2), inverse.put("2", 4));
 
 > An unordered collection that allows duplicates.
 
-A [**Bag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/Bag.html) is a **RichIterable** that allows duplicate elements and efficient querying of the number of occurrences of each element. It can be sorted or unsorted.
+A [**Bag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/Bag.html) is a **RichIterable** that allows duplicate elements and efficient querying of the number of occurrences of each element. It can be sorted or unsorted.
 
--   A [**SortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/SortedBag.html) is a **Bag** that maintains its elements in sorted order.
--   An [**UnsortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/UnsortedBag.html) is a **Bag** that maintains its elements in a hash table in an unpredictable order.
+-   A [**SortedBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/sorted/SortedBag.html) is a **Bag** that maintains its elements in sorted order.
+-   An [**UnsortedBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/UnsortedBag.html) is a **Bag** that maintains its elements in a hash table in an unpredictable order.
 
-**UnsortedBag** has two subinterfaces, [**MutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/MutableBag.html) and [**ImmutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/ImmutableBag.html). **SortedBag** has two subinterfaces, [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) and [**ImmutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.html).
+**UnsortedBag** has two subinterfaces, [**MutableBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/MutableBag.html) and [**ImmutableBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/ImmutableBag.html). **SortedBag** has two subinterfaces, [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) and [**ImmutableSortedBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.html).
 
 A **Bag** is conceptually like a **Map** from elements to the number of occurrences of that element.
 
@@ -2183,9 +2183,9 @@ The distinctive methods on **Bag** are:
 
 #### []() MutableBag
 
-> A mutable unordered collection allowing duplicates; the most common implementation is [**HashBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
+> A mutable unordered collection allowing duplicates; the most common implementation is [**HashBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
 
-The [**MutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/MutableBag.html) interface includes methods for manipulating the number of occurrences of an item. For example, to determine the number of unique elements in a MutableBag, use the **sizeDistinct** method. The most common implementation of **MutableBag** is [**HashBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
+The [**MutableBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/MutableBag.html) interface includes methods for manipulating the number of occurrences of an item. For example, to determine the number of unique elements in a MutableBag, use the **sizeDistinct** method. The most common implementation of **MutableBag** is [**HashBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
 
 ###### EC 
 
@@ -2209,7 +2209,7 @@ The distinctive methods on **MutableBag** are:
 
 > A sorted collection that allows duplicates.
 
-A [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) is a **Bag**that maintains order. It defaults to natural order, but can take a comparator to sort. The most common implementation of **MutableSortedBag** is [**TreeBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.html) which uses a **SortedMap** as its underlying data store.
+A [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) is a **Bag**that maintains order. It defaults to natural order, but can take a comparator to sort. The most common implementation of **MutableSortedBag** is [**TreeBag**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.html) which uses a **SortedMap** as its underlying data store.
 
 For example, this **MutableSortedBag** would contain integers sorted in reverse order:
 
@@ -2229,15 +2229,15 @@ MutableSortedBag<Integer> revIntegers =
 
 > A collection that maintains "last-in, first-out" order, iterating over elements in reverse insertion order.
 
-A [**StackIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/StackIterable.html) is a **RichIterable** enforcing a "last-in, first-out" order; its methods always iterate over elements in reverse insertion order, (beginning with the most-recently added element). For example the **getFirst** method returns the the last element to have been added - the "top" of the stack.
+A [**StackIterable**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/stack/StackIterable.html) is a **RichIterable** enforcing a "last-in, first-out" order; its methods always iterate over elements in reverse insertion order, (beginning with the most-recently added element). For example the **getFirst** method returns the the last element to have been added - the "top" of the stack.
 
-**StackIterable** has a mutable and an [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**MutableStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/MutableStack.html) and [**ImmutableStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/ImmutableStack.html), respectively.
+**StackIterable** has a mutable and an [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**MutableStack**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/stack/MutableStack.html) and [**ImmutableStack**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/stack/ImmutableStack.html), respectively.
 
 #### []() MutableStack
 
 > A mutable collection that maintains "last-in, first-out" order, iterating over elements in reverse insertion order.
 
-The most common implementation of **MutableStack** is [**ArrayStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/stack/mutable/ArrayStack.html). The closest JCF equivalent to **ArrayStack** is **java.util.Stack**, which extends **Vector** but does not enforce strict LIFO iteration.
+The most common implementation of **MutableStack** is [**ArrayStack**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/stack/mutable/ArrayStack.html). The closest JCF equivalent to **ArrayStack** is **java.util.Stack**, which extends **Vector** but does not enforce strict LIFO iteration.
 
 The distinctive methods on **MutableStack** are **push**, **pop**, and **peek**.
 
@@ -2277,11 +2277,11 @@ MutableStack mutableStack =
 
 > A map-like container that can have multiple values for each key
 
-In a [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) container, each key can be associated with multiple values. It is, in this sense, similar to a Map, but one whose values consist of individual collections of a specified type, called the *backing collection*. A **Multimap** is useful in situations where you would otherwise use **Map**&lt;K, Collection&lt;V&gt;&gt;.
+In a [**Multimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/Multimap.html) container, each key can be associated with multiple values. It is, in this sense, similar to a Map, but one whose values consist of individual collections of a specified type, called the *backing collection*. A **Multimap** is useful in situations where you would otherwise use **Map**&lt;K, Collection&lt;V&gt;&gt;.
 
 Unlike the other basic Eclipse Collections containers, **Multimap** does not extend **RichIterable**, but resides along with its subinterfaces in a separate API. The **RichIterable** methods are extended by the backing collection types.
 
-Depending on the implementation, the "values" in a Multimap can be stored in Lists, Sets or Bags. For example, the [**FastListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/multimap/list/FastListMultimap.html) class is backed by a **UnifiedMap** that associates each key with a **FastList** that preserves the order in which the values are added and allows duplicate to be added.
+Depending on the implementation, the "values" in a Multimap can be stored in Lists, Sets or Bags. For example, the [**FastListMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/multimap/list/FastListMultimap.html) class is backed by a **UnifiedMap** that associates each key with a **FastList** that preserves the order in which the values are added and allows duplicate to be added.
 
 A **Multimap** is the type returned by the [**groupBy**](#groupby-pattern "Create a Multimap from a collection by grouping on a selected or generated key value.") method. Here is an example in which we group a list of words by their length, obtaining a **Multimap** with integer (word=length) keys and lists of words having that length for values.
 
@@ -2300,7 +2300,7 @@ A **Multimap** is the type returned by the [**groupBy**](#groupby-pattern "Creat
 
 The code that performs this action uses the [**groupBy**](#groupby-pattern "Create a Multimap from a collection by grouping on a selected or generated key value.") method.
 
-###### EC (w/[StringFunctions](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/StringFunctions.html))
+###### EC (w/[StringFunctions](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/block/factory/StringFunctions.html))
 
 ```java
 MutableList<String> words = Lists.mutable.with("here", "are", "a", "few",
@@ -2318,9 +2318,9 @@ MutableListMultimap<Integer, String> multimap =
     words.groupBy(String::length);
 ```
 
-The interface [**MutableListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/list/MutableListMultimap.html) extends the **Multimap** interface and tells us the type of its backing collections. Since **words** is a **MutableList**, the output is a **MutableListMultimap**. The word "are" is allowed to occur twice in the list at key 3.
+The interface [**MutableListMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/list/MutableListMultimap.html) extends the **Multimap** interface and tells us the type of its backing collections. Since **words** is a **MutableList**, the output is a **MutableListMultimap**. The word "are" is allowed to occur twice in the list at key 3.
 
-If we change **words** to a **MutableSet**, the result will be a [**MutableSetMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/set/MutableSetMultimap.html), which will eliminate duplicate entries.
+If we change **words** to a **MutableSet**, the result will be a [**MutableSetMultimap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/multimap/set/MutableSetMultimap.html), which will eliminate duplicate entries.
 
 ###### EC (w/StringFunctions)
 
@@ -2370,9 +2370,9 @@ The interface hierarchies for primitive types correspond closely with the interf
 
 ### Primitive Lists
 
-The primitive list implementations are backed by an array like **FastList**, but with a primitive array instead of an **Object\[\]**. They are named [**IntArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/IntArrayList.html), [**FloatArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/FloatArrayList.html) etc.
+The primitive list implementations are backed by an array like **FastList**, but with a primitive array instead of an **Object\[\]**. They are named [**IntArrayList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/list/mutable/primitive/IntArrayList.html), [**FloatArrayList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/list/mutable/primitive/FloatArrayList.html) etc.
 
-[**BooleanArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.html) is a special case. Current JVMs use one byte per boolean in a **boolean\[\]** (instead of one bit per boolean). Thus the **BooleanArrayList** is backed by a **java.util.BitSet** as an optimization.
+[**BooleanArrayList**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.html) is a special case. Current JVMs use one byte per boolean in a **boolean\[\]** (instead of one bit per boolean). Thus the **BooleanArrayList** is backed by a **java.util.BitSet** as an optimization.
 
 To create an **IntArrayList**, use one of the following:
 
@@ -2394,7 +2394,7 @@ Assert.assertEquals(IntLists.mutable.with(1, 3, 5), IntInterval.oneToBy(5, 2));
 
 ### Primitive Sets
 
-The primitive set implementations are hash-table backed. They are named [**IntHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/IntHashSet.html), [**FloatHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/FloatHashSet.html) etc. [**BooleanHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.html) is implemented using a single integer to hold one of four possible states: (\[\], \[F\], \[T\], or \[T, F\]). All other sets use open addressing and quadratic probing.
+The primitive set implementations are hash-table backed. They are named [**IntHashSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/set/mutable/primitive/IntHashSet.html), [**FloatHashSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/set/mutable/primitive/FloatHashSet.html) etc. [**BooleanHashSet**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.html) is implemented using a single integer to hold one of four possible states: (\[\], \[F\], \[T\], or \[T, F\]). All other sets use open addressing and quadratic probing.
 
 ### Primitive Stacks
 
@@ -2408,9 +2408,9 @@ Similar to **HashBag**, but both item and count are primitives.
 
 There are three types of primitive maps:
 
--   Object To Primitive ([**ObjectIntHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/ObjectIntHashMap.html), ObjectFloatHashMap etc.)
--   Primitive To Object ([**IntObjectHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMap.html), FloatObjectHashMap etc.)
--   Primitive To Primitive ([**IntIntHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMap.html), IntLongHashMap etc.)
+-   Object To Primitive ([**ObjectIntHashMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/map/mutable/primitive/ObjectIntHashMap.html), ObjectFloatHashMap etc.)
+-   Primitive To Object ([**IntObjectHashMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMap.html), FloatObjectHashMap etc.)
+-   Primitive To Primitive ([**IntIntHashMap**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMap.html), IntLongHashMap etc.)
 
 All the maps use open addressing and quadratic probing.
 
@@ -2538,7 +2538,7 @@ If you know the implementation class of the container (for example, **FastList**
 -   Call the class constructor; for example, **FastList**&lt;String&gt; names = new **FastList**;
 -   Call a factory method on the collection class, such as **newList** or **newListWith**; for example, **MutableList**&lt;V&gt; result = **FastList.newList**(this.size);
 
-If, however, the specific collection class to implement is unknown, you can call a factory class to create the container. Eclipse Collections container-factory classes are named for the plural of the respective container name. For example, for a **List**, the factory class is [**Lists**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Lists.html); a **Set** is created by the class [**Sets**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html).
+If, however, the specific collection class to implement is unknown, you can call a factory class to create the container. Eclipse Collections container-factory classes are named for the plural of the respective container name. For example, for a **List**, the factory class is [**Lists**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Lists.html); a **Set** is created by the class [**Sets**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/Sets.html).
 
 You can specify the content and mutable state of the container in parameters. This approach to container creation, when used consistently, has the added benefit of being more readable.
 
@@ -2598,7 +2598,7 @@ ImmutableList<String> list_c =
 The techniques for creating mutable or immutable primitive containers are the same as those for object collections.
 
 -   If you know the implementation class, you can call its constructor or its factory method.
--   Otherwise use the applicable factory class named for the plural of the type, that is, with the pattern: &lt;PrimitiveType&gt;&lt;ContainerType&gt;s. For example to create an **IntList**, you would use the [**IntLists**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/primitive/IntLists.html) factory for the appropriate methods; for a **DoubleSet**, you would call in methods in [**DoubleSets**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/primitive/DoubleSets.html).
+-   Otherwise use the applicable factory class named for the plural of the type, that is, with the pattern: &lt;PrimitiveType&gt;&lt;ContainerType&gt;s. For example to create an **IntList**, you would use the [**IntLists**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/primitive/IntLists.html) factory for the appropriate methods; for a **DoubleSet**, you would call in methods in [**DoubleSets**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/impl/factory/primitive/DoubleSets.html).
 
 <!-- -->
 
@@ -2717,7 +2717,7 @@ Verify.assertSize(1, texans);
 
 In each case, if the value of *state* field for any element in **people** equals "TX" then the **select** method includes that element in the result list, **texans**.
 
-This chapter introduces the most commonly-used code blocks and the Eclipse Collections methods that use them. Along with the code block types described here, the current version of Eclipse Collections offers a full suite of primitive code blocks (and corresponding code block factories like [**IntFunction**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html), [**IntPredicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/primitive/IntPredicate.html), [**IntProcedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/primitive/IntProcedure.html) etc.) These code blocks are used by methods on primitive collections.
+This chapter introduces the most commonly-used code blocks and the Eclipse Collections methods that use them. Along with the code block types described here, the current version of Eclipse Collections offers a full suite of primitive code blocks (and corresponding code block factories like [**IntFunction**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html), [**IntPredicate**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/predicate/primitive/IntPredicate.html), [**IntProcedure**](http://www.eclipse.org/collections/javadoc/9.2.0/org/eclipse/collections/api/block/procedure/primitive/IntProcedure.html) etc.) These code blocks are used by methods on primitive collections.
 
 ##### []() About *parameter* and *argument*:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -133,7 +133,7 @@ The most commonly-used iteration patterns in Eclipse Collections are:
 
 > Filter a collection to create a new collection: includes **select**, **reject**, and **partition**.
 
-Methods using the *Select* pattern return a new collection comprising those elements from the source collection that satisfy some logical condition. *Reject* is the inverse pattern, returning a new collection of elements that do *not* satisfy the condition. The condition is a boolean expression in the form of single-argument code block that implements the [**Predicate**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) interface.
+Methods using the *Select* pattern return a new collection comprising those elements from the source collection that satisfy some logical condition. *Reject* is the inverse pattern, returning a new collection of elements that do *not* satisfy the condition. The condition is a boolean expression in the form of single-argument code block that implements the [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) interface.
 
 #### Select pattern examples:
 
@@ -167,13 +167,13 @@ MutableList<Integer> greaterThanFifty =
     });
 ```
 
-Here, a [**Predicate**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is created using the [**Predicates**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) factory:
+Here, a [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is created using the [**Predicates**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) factory:
 
 ```java
 MutableList<Integer> greaterThanFifty = list.select(Predicates.greaterThan(50));
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Integer> greaterThanFifty = list.stream()
@@ -212,7 +212,7 @@ List<Integer> notGreaterThanFifty =
     list.reject(each -> each > 50);
 ```
 
-###### EC (w/[Predicates](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) Factory)
+###### EC (w/[Predicates](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates.html) Factory)
 
 ```java
 list.reject(Predicates.greaterThan(50));
@@ -247,7 +247,7 @@ These Eclipse Collections methods implement the Select and Reject pattern:
 
 ##### reject(Predicate): RichIterable
 
-The [**Predicate**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is evaluated for each element of the collection. The selected elements are those where the Predicate returned true (false for rejected). The selected (or rejected) elements are returned in a new collection of the same type.
+The [**Predicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate.html) is evaluated for each element of the collection. The selected elements are those where the Predicate returned true (false for rejected). The selected (or rejected) elements are returned in a new collection of the same type.
 
 ##### select(Predicate, *targetCollection*): *targetCollection*
 
@@ -259,7 +259,7 @@ Same as the **select**/**reject** methods with one argument, but results are add
 
 ##### rejectWith(Predicate2, *argument*): RichIterable
 
-For each element of the collection, [**Predicate2**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) is evaluated with the element as one argument, plus one additional argument; selected or rejected elements are returned in a new collection of the same type. See [Reusing a code block](#performance-optimized-methods-reusing-two-argument-code-blocks "Using selectWith, rejectWith, and collectWith inside other iteration patterns (or loops) where code blocks can be created outside of the outer iteration patterns or made static.") for more information.
+For each element of the collection, [**Predicate2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) is evaluated with the element as one argument, plus one additional argument; selected or rejected elements are returned in a new collection of the same type. See [Reusing a code block](#performance-optimized-methods-reusing-two-argument-code-blocks "Using selectWith, rejectWith, and collectWith inside other iteration patterns (or loops) where code blocks can be created outside of the outer iteration patterns or made static.") for more information.
 
 ##### selectWith(Predicate2, *argument*, *targetCollection*): *targetCollection*
 
@@ -271,7 +271,7 @@ Same as the **selectWith**/**rejectWith** methods, but results are added to the 
 
 > Create two collections using **Select** and **Reject**.
 
-The *Partition* pattern allocates each element of a collection into one of two new collections depending on whether the element satisfies the condition expressed by the **Predicate**. In effect, it combines the [*Select* and *Reject* patterns](#selectreject-pattern "Filter a collection to create a new collection: includes select, reject, and partition."). The collections are returned in a [**PartitionIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/partition/PartitionIterable.html) specialized for the type of the source collection. You can retrieve the selected and rejected elements from the **PartitionIterable**. In this example, the list of people is partitioned into lists of adults and children.
+The *Partition* pattern allocates each element of a collection into one of two new collections depending on whether the element satisfies the condition expressed by the **Predicate**. In effect, it combines the [*Select* and *Reject* patterns](#selectreject-pattern "Filter a collection to create a new collection: includes select, reject, and partition."). The collections are returned in a [**PartitionIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/partition/PartitionIterable.html) specialized for the type of the source collection. You can retrieve the selected and rejected elements from the **PartitionIterable**. In this example, the list of people is partitioned into lists of adults and children.
 
 ###### EC (w/lambda)
 
@@ -314,7 +314,7 @@ These Eclipse Collections methods implement the partition pattern:
 
 ##### partition(Predicate): PartitionIterable
 
-Returns a **PartitionIterable**, a logical pair of containers. The first container consists of all elements that satisfy the **Predicate**. The second container consists of all elements that do not satisfy the **Predicate**. The subtypes of **PartitionIterable** correspond with the subtypes of [**RichIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/RichIterable.html).
+Returns a **PartitionIterable**, a logical pair of containers. The first container consists of all elements that satisfy the **Predicate**. The second container consists of all elements that do not satisfy the **Predicate**. The subtypes of **PartitionIterable** correspond with the subtypes of [**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html).
 
 ##### partitionWith(Predicate2, *argument*): PartitionIterable
 
@@ -324,7 +324,7 @@ For each element of the collection, **Predicate2** is evaluated with the element
 
 > Transform a collection's elements, creating a new collection: includes **collect**, **flatCollect**, and **groupBy**.
 
-The *Collect* pattern methods return a new collection whose data elements are the results of an evaluation performed by the code block; that is, each element of the original collection is mapped to a new object, which is usually a different type. The code block used as the **collect** method's parameter implements the [**Function**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function.html) interface.
+The *Collect* pattern methods return a new collection whose data elements are the results of an evaluation performed by the code block; that is, each element of the original collection is mapped to a new object, which is usually a different type. The code block used as the **collect** method's parameter implements the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) interface.
 
 ###### Pseudocode
 
@@ -362,7 +362,7 @@ Function<Person, Address> addressFunction =
 MutableList<Address> addresses = people.collect(addressFunction);
 ```
 
-Notice that this assumes each person in the **people** collection has just one address. If, instead, a person has multiple addresses, the [**Function**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function.html) returns a list of addresses for each person (a list that has only one element if the person has just one address); the result is a List of Lists:
+Notice that this assumes each person in the **people** collection has just one address. If, instead, a person has multiple addresses, the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) returns a list of addresses for each person (a list that has only one element if the person has just one address); the result is a List of Lists:
 
 ###### EC (w/lambda and method reference)
 
@@ -435,11 +435,11 @@ These Eclipse Collections methods implement the Collect pattern:
 
 ##### collect(Function): RichIterable
 
-For each element of the collection, the [**Function**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function.html) is evaluated with the current element as the argument; returns a new collection with the transformed type.
+For each element of the collection, the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html) is evaluated with the current element as the argument; returns a new collection with the transformed type.
 
 ##### collectInt(IntFunction): IntIterable
 
-Similar to **collect**, but it takes an [**IntFunction**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html) and returns a primitive collection which extends from [**IntIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/IntIterable.html). There are variants for all eight primitives: **collectBoolean**, **collectFloat** etc.
+Similar to **collect**, but it takes an [**IntFunction**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html) and returns a primitive collection which extends from [**IntIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/IntIterable.html). There are variants for all eight primitives: **collectBoolean**, **collectFloat** etc.
 
 ##### collect(Function, *targetCollection*): *targetCollection*
 
@@ -447,7 +447,7 @@ Same as **collect**, except that the results are added to the specified *targetC
 
 ##### collectInt(IntFunction, *targetCollection*): *targetCollection*
 
-Same as **collectInt**, except that the results are added to the specified *targetCollection*, which extends [**MutableIntCollection**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/collection/primitive/MutableIntCollection.html). There are variants for all eight primitives.
+Same as **collectInt**, except that the results are added to the specified *targetCollection*, which extends [**MutableIntCollection**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/collection/primitive/MutableIntCollection.html). There are variants for all eight primitives.
 
 ##### collectIf(Predicate, Function): RichIterable
 
@@ -459,7 +459,7 @@ Same as **collectIf**, except that the results are added to the specified *targe
 
 ##### collectWith(Function2, *argument2*): RichIterable
 
-Same as **collect**, but the [**Function2**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function2.html) is evaluated with the element as one argument, plus one additional argument; returns a new collection of the same size and the transformed type.
+Same as **collect**, but the [**Function2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function2.html) is evaluated with the element as one argument, plus one additional argument; returns a new collection of the same size and the transformed type.
 
 ##### collectWith(Function2, *argument2*, *targetCollection*): *targetCollection*
 
@@ -514,7 +514,7 @@ MutableList<Address> addresses =
        });
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Address> flatAddress = people.stream()
@@ -543,11 +543,11 @@ for (Person person : people)
 
 Create a Multimap from a collection by grouping on a selected or generated key value.
 
-The *GroupBy* pattern gathers the elements on the collection into a map-like container called a [**Multimap**](#multimap "A map-like container that can have multiple values for each key"), which associates multiple values for each key. The **Function** is applied to each element and the result is used as the key into the [**Multimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/Multimap.html) where the element should appear as the value.
+The *GroupBy* pattern gathers the elements on the collection into a map-like container called a [**Multimap**](#multimap "A map-like container that can have multiple values for each key"), which associates multiple values for each key. The **Function** is applied to each element and the result is used as the key into the [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) where the element should appear as the value.
 
 ##### groupBy(Function): Multimap
 
-Group the elements into a new [**Multimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/Multimap.html); uses the **Function** to get the key for each element.
+Group the elements into a new [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html); uses the **Function** to get the key for each element.
 
 ##### groupBy(Function, *targetMultimap*) : targetMultimap
 
@@ -631,7 +631,7 @@ Returns the first element that evaluates as *true* for the specified **Predicate
 
 ##### detectWithIfNone(Predicate2, *parameter*, Function0): element (or Function0 result)
 
-Same as **detectWith**, but if no element causes [**Predicate2**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) to evaluate as *true*, return the result of evaluating [**Function0**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function0.html).
+Same as **detectWith**, but if no element causes [**Predicate2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/Predicate2.html) to evaluate as *true*, return the result of evaluating [**Function0**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function0.html).
 
 #### []() AnySatisfy pattern
 
@@ -814,11 +814,11 @@ for (int i = 0; i < list.size(); i++)
 
 ##### each(Procedure): void
 
-For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
+For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
 
 ##### forEach(Procedure): void
 
-For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
+For each element, the [**Procedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure.html) is evaluated with the element as the argument.
 
 ##### forEachIf(Predicate, Procedure): void
 
@@ -826,15 +826,15 @@ For each element that satisfies the **Predicate**, executes the **Procedure** on
 
 ##### forEach(*fromIndex*, *toindex*, Procedure): void
 
-Iterates over the section of a [**ListIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/list/ListIterable.html) covered by the specified indexes (inclusive).
+Iterates over the section of a [**ListIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ListIterable.html) covered by the specified indexes (inclusive).
 
 ##### forEachWith(Procedure2, *parameter*): void
 
-For each element of the collection, the [**Procedure2**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/procedure/Procedure2.html) is evaluated with the element as the first argument, and the specified *parameter* as the second argument.
+For each element of the collection, the [**Procedure2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/Procedure2.html) is evaluated with the element as the first argument, and the specified *parameter* as the second argument.
 
 ##### forEachWithIndex(ObjectIntProcedure): void
 
-Iterates over a collection passing each element and the current relative int index to the specified instance of [**ObjectIntProcedure**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/procedure/primitive/ObjectIntProcedure.html).
+Iterates over a collection passing each element and the current relative int index to the specified instance of [**ObjectIntProcedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/primitive/ObjectIntProcedure.html).
 
 ##### forEachWithIndex(*fromIndex*, *toIndex*, ObjectIntProcedure): void
 
@@ -925,11 +925,11 @@ Return the final result of all evaluations using as the arguments each element o
 []() RichIterable
 ----------------
 
-[**RichIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/RichIterable.html) is the most important interface in Eclipse Collections. It provides the blueprint for all non-mutating iteration patterns. It represents an object made up of elements that can be individually and consecutively viewed or evaluated (an *iterable*), and it prescribes the actions that can be performed with each evaluation (the patterns). The most commonly used implementations include [**FastList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/list/mutable/FastList.html) and [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html).
+[**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html) is the most important interface in Eclipse Collections. It provides the blueprint for all non-mutating iteration patterns. It represents an object made up of elements that can be individually and consecutively viewed or evaluated (an *iterable*), and it prescribes the actions that can be performed with each evaluation (the patterns). The most commonly used implementations include [**FastList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/FastList.html) and [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html).
 
-[**RichIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/RichIterable.html) is extended by [**ListIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/list/ListIterable.html), [**SetIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/set/SetIterable.html), [**Bag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/Bag.html), [**StackIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/stack/StackIterable.html), and [**MapIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/MapIterable.html). A **MapIterable** of keys and values is also a **RichIterable** of values.
+[**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html) is extended by [**ListIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ListIterable.html), [**SetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/SetIterable.html), [**Bag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/Bag.html), [**StackIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/StackIterable.html), and [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html). A **MapIterable** of keys and values is also a **RichIterable** of values.
 
-**RichIterable** is also extended by [**MutableCollection**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/collection/MutableCollection.html), and indirectly by [**MutableList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/list/MutableList.html) and [**MutableSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/set/MutableSet.html) (which also extend the mutable Java Collection types **List** and **Set**). Another subinterface defines a non-JDK container, [**MutableBag**](#mutablebag "A mutable unordered collection allowing duplicates; the most common implementation is HashBag.") (or multiset); yet another, [**ImmutableCollection**](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified."), delineates the immutable forms of these Eclipse Collections containers. These latter two interfaces are detailed in the [Collections and containers](#collections-and-containers) topic.
+**RichIterable** is also extended by [**MutableCollection**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/collection/MutableCollection.html), and indirectly by [**MutableList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/MutableList.html) and [**MutableSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/MutableSet.html) (which also extend the mutable Java Collection types **List** and **Set**). Another subinterface defines a non-JDK container, [**MutableBag**](#mutablebag "A mutable unordered collection allowing duplicates; the most common implementation is HashBag.") (or multiset); yet another, [**ImmutableCollection**](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified."), delineates the immutable forms of these Eclipse Collections containers. These latter two interfaces are detailed in the [Collections and containers](#collections-and-containers) topic.
 
 The subinterface [**LazyIterable**](#lazy-iteration "Deferring evaluation until necessary.") for the most part replicates **RichIterable**, but overrides some specific collection-returning methods - **collect**, **collectIf**, **select**, **reject**, and **flatCollect** - so that they delay their actual execution until the returned collection is needed, a technique called "lazy iteration."
 
@@ -941,7 +941,7 @@ The subinterface [**LazyIterable**](#lazy-iteration "Deferring evaluation until 
 
 ##### *richIterable*.asLazy()
 
-Returns a deferred-evaluation iterable of type [**LazyIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/LazyIterable.html). (Note the list below of other Eclipse Collections methods that return lazy Iterables.)
+Returns a deferred-evaluation iterable of type [**LazyIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/LazyIterable.html). (Note the list below of other Eclipse Collections methods that return lazy Iterables.)
 
 In a way, lazy iteration is a companion to the [short-circuit iteration pattern](#concept648 "Methods that control processing by testing a collection for a logical condition: includes detect, anySatisfy, and allSatisfy."), in which iteration ceases as soon the method's purpose is achieved. In the last line of the example below, the **anySatisfy** method quits execution when it detects the "address2" element in the **addresses** list created by **collect**. The third element ("address 3") is never examined by **anySatisfy** - although it was present in **addresses**.
 
@@ -1030,7 +1030,7 @@ An unmodifiable view of each key's values, without the key.
 
 An API that combines parallel iteration with lazy evaluation.
 
-Parallel-eager utility is available through the [**ParallelIterate**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/parallel/ParallelIterate.html) utility class. Serial-lazy evaluation is available through **LazyIterable**, the view returned by **RichIterable**.**asLazy()**. The [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/ParallelIterable.html) interface defines a view where iteration is both parallel and lazy. Sub-interfaces of **ParallelIterable** are returned from the various implementations of **asParallel(** **ExecutorService** **executorService**, **int** **batchSize** **)**. The **ParallelIterable** API is new in 5.0 and considered experimental, as indicated by the **@Beta** annotation. API tagged as **@Beta** may be altered in ways that are not backward-compatible, even in minor versions of Eclipse Collections. The method **asParallel** is not on interfaces like **RichIterable** in version 5.0, but rather on a few supported collections, including **FastList** and **UnifiedSet**.
+Parallel-eager utility is available through the [**ParallelIterate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/parallel/ParallelIterate.html) utility class. Serial-lazy evaluation is available through **LazyIterable**, the view returned by **RichIterable**.**asLazy()**. The [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/ParallelIterable.html) interface defines a view where iteration is both parallel and lazy. Sub-interfaces of **ParallelIterable** are returned from the various implementations of **asParallel(** **ExecutorService** **executorService**, **int** **batchSize** **)**. The **ParallelIterable** API is new in 5.0 and considered experimental, as indicated by the **@Beta** annotation. API tagged as **@Beta** may be altered in ways that are not backward-compatible, even in minor versions of Eclipse Collections. The method **asParallel** is not on interfaces like **RichIterable** in version 5.0, but rather on a few supported collections, including **FastList** and **UnifiedSet**.
 
 ```java
 FastList integers = Lists.mutable.with(1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -1051,7 +1051,7 @@ threadPool.shutdown();
 Assert.assertEquals(Lists.mutable.with("2", "4", "6", "8"), strings);
 ```
 
-In this code example, the calls to **select** and **collect** are lazy, as indicated by the fact that they return subclasses of [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/ParallelIterable.html). The call to **toList()** forces evaluation.
+In this code example, the calls to **select** and **collect** are lazy, as indicated by the fact that they return subclasses of [**ParallelIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/ParallelIterable.html). The call to **toList()** forces evaluation.
 
 The two parameters to **asParallel(ExecutorService** *executorService*, **int** *batchSize***)** are used to configure parallelism.
 
@@ -1070,7 +1070,7 @@ It's possible to cancel a parallel-lazy computation in progress. It requires a t
 
 ### []() RichIterable methods
 
-These methods are available on all implementations of [**RichIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/RichIterable.html).
+These methods are available on all implementations of [**RichIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/RichIterable.html).
 
 #### []() Building strings
 
@@ -1111,7 +1111,7 @@ String defaultString =
     list.stream().map(Object::toString).collect(Collectors.joining()); // "1/2/3"
 ```
 
-###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
+###### Java 8 Streams w/[Collectors2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/collector/Collectors2.html)
 
 ```java
 MutableList<Integer> list = Lists.mutable.with(1, 2, 3);
@@ -1181,7 +1181,7 @@ int count =
 
 Returns the number of elements that satisfy the **Predicate2**. The second parameter to **countWith** is passed as the second parameter to the **Predicate2**.
 
-###### EC (w/[Predicates2](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/block/factory/Predicates2.html) factory)
+###### EC (w/[Predicates2](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/Predicates2.html) factory)
 
 ```java
 int count = 
@@ -1318,15 +1318,15 @@ people.min(Comparators.byFunction(Person::getAge));
 
 Methods that create maps of aggregated values by grouping them on a calculated key.
 
-**aggregateBy** groups the elements in the **RichIterable** by the [**Function**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function.html). Then all the elements that map to the same key are aggregated together using the [**Function2**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function2.html). The third parameter, a [**Function0**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/Function0.html), creates the initial value in each aggregation. Aggregate results are allowed to be immutable as they will be replaced in the map.
+**aggregateBy** groups the elements in the **RichIterable** by the [**Function**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function.html). Then all the elements that map to the same key are aggregated together using the [**Function2**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function2.html). The third parameter, a [**Function0**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/Function0.html), creates the initial value in each aggregation. Aggregate results are allowed to be immutable as they will be replaced in the map.
 
-**aggregateBy** is conceptually analogous to calling a **groupBy** method on a **RichIterable** to create a **Multimap**,and then calling **injectInto** on each collection of the **Multimap** values to create a [**MapIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/MapIterable.html).
+**aggregateBy** is conceptually analogous to calling a **groupBy** method on a **RichIterable** to create a **Multimap**,and then calling **injectInto** on each collection of the **Multimap** values to create a [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html).
 
 **aggregateInPlaceBy** is similar to **aggregateBy**, but it mutates values in the output map instead of replacing them. Thus in this case, the aggregate results must be mutable.
 
 ##### aggregateBy(Function, Function0, Function2): MapIterable
 
-Returns a [**MapIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/MapIterable.html) by grouping results by keys supplied by evaluating a **Function**.
+Returns a [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html) by grouping results by keys supplied by evaluating a **Function**.
 
 ###### EC (w/lambda and method reference)
 
@@ -1617,9 +1617,9 @@ This style encourages adding more behavior to the classes held in the containers
 
 Methods for iterating over Maps and Multimaps.
 
-The [**MapIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/MapIterable.html) and [**Multimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/Multimap.html) interfaces are *associative arrays*, meaning they contain key-value pairs. All of the keys in a Map are unique; a **Multimap** can have multiple values associated with each key.
+The [**MapIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MapIterable.html) and [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) interfaces are *associative arrays*, meaning they contain key-value pairs. All of the keys in a Map are unique; a **Multimap** can have multiple values associated with each key.
 
-The **Multimap** interface does not extend MapIterable. **Multimap** has a number of subinterfaces, such as [**ListMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/list/ListMultimap.html), [**SetMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/set/SetMultimap.html), and [**BagMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/bag/BagMultimap.html), each with custom behavior for how to handle the collection of values associated with each key.
+The **Multimap** interface does not extend MapIterable. **Multimap** has a number of subinterfaces, such as [**ListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/list/ListMultimap.html), [**SetMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/set/SetMultimap.html), and [**BagMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/bag/BagMultimap.html), each with custom behavior for how to handle the collection of values associated with each key.
 
 ### []() Creating iterable views of maps
 
@@ -1673,7 +1673,7 @@ The **updateValue**, **getIfAbsent** and **ifPresentApply** methods locate a spe
 
 ##### add(Pair&lt;K, V&gt;): value
 
-Adds the given key-value pair to the map. It's a convenience method for working with [**Pair**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/tuple/Pair.html)s, similar to **put(**K, V**)**.
+Adds the given key-value pair to the map. It's a convenience method for working with [**Pair**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/tuple/Pair.html)s, similar to **put(**K, V**)**.
 
 ##### updateValue(*key*, Function0, Function): value
 
@@ -1729,7 +1729,7 @@ We'll begin with the Eclipse Collections implementations of types having analogs
 []() Basic collection types
 --------------------------
 
-The most commonly-used Eclipse Collections classes are [**FastList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/list/mutable/FastList.html), [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html), and [**UnifiedMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/map/mutable/UnifiedMap.html). These collections serve as drop-in replacements for their corresponding types in the Java Collections Framework (JCF). Note that these Eclipse Collections classes do not extend the JCF implementations; they are instead new implementations of both JCF and Eclipse Collections interfaces, as this (highly-simplified) diagram summarizes:
+The most commonly-used Eclipse Collections classes are [**FastList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/FastList.html), [**UnifiedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/UnifiedSet.html), and [**UnifiedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/UnifiedMap.html). These collections serve as drop-in replacements for their corresponding types in the Java Collections Framework (JCF). Note that these Eclipse Collections classes do not extend the JCF implementations; they are instead new implementations of both JCF and Eclipse Collections interfaces, as this (highly-simplified) diagram summarizes:
 
 ![Container comparision](containerCompare.png)
 
@@ -1741,7 +1741,7 @@ The methods of the JCF types are primarily focused on adding or removing element
 
 A **ListIterable** is a **RichIterable** which maintains its elements in insertion order and allows duplicate elements.
 
-**ListIterable** has two mutable subinterfaces **MutableList** and [**FixedSizeList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/list/FixedSizeList.html) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**ImmutableList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/list/ImmutableList.html).
+**ListIterable** has two mutable subinterfaces **MutableList** and [**FixedSizeList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/FixedSizeList.html) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**ImmutableList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/list/ImmutableList.html).
 
 The **ListIterable** interface includes the **binarySearch** method, which is similar to the static method **binarySearch** on **java.util.Collections**, but available from the object-oriented API.
 
@@ -1933,7 +1933,7 @@ The Eclipse Collections **newListWith()** method also provides varargs support, 
 List<Integer> integers = FastList.newListWith(1, 2, 3);
 ```
 
-There are also factory classes in Eclipse Collections named for each type (e.g. [Lists](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Lists.html), [Sets](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Sets.html), [Maps](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Sets.html), [Bags](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Bags.html), [Stacks](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Stacks.html), [BiMaps](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/BiMaps.html), [Multimaps](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Multimaps.html), etc.)
+There are also factory classes in Eclipse Collections named for each type (e.g. [Lists](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Lists.html), [Sets](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html), [Maps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html), [Bags](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Bags.html), [Stacks](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Stacks.html), [BiMaps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/BiMaps.html), [Multimaps](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Multimaps.html), etc.)
 
 ###### EC 
 
@@ -1980,8 +1980,8 @@ These refactorings are analogous for **UnifiedSet** and **UnifiedMap**.
 
 A **SetIterable** is a **RichIterable** that allows no duplicate elements. It can be sorted or unsorted.
 
--   A [**SortedSetIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/set/sorted/SortedSetIterable.html) is a **SetIterable** that maintains its elements in sorted order.
--   An [**UnsortedSetIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/set/UnsortedSetIterable.html) is a **SetIterable** that maintains its elements in a hash table in an unpredictable order.
+-   A [**SortedSetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/sorted/SortedSetIterable.html) is a **SetIterable** that maintains its elements in sorted order.
+-   An [**UnsortedSetIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/UnsortedSetIterable.html) is a **SetIterable** that maintains its elements in a hash table in an unpredictable order.
 
 **UnsortedSetIterable** has two mutable subinterfaces (**MutableSet** and **FixedSizeSet**) and one [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface (**ImmutableSet**).
 
@@ -2013,7 +2013,7 @@ Set<String> comparison = UnifiedSet.newSetWith("IBM", "Microsoft", "Verizon", "C
 
 > Contains unique items that are sorted by some comparator or their natural ordering.
 
-A [**MutableSortedSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/set/sorted/MutableSortedSet.html) follows the same contract as a **MutableSet**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedSet** is **TreeSortedSet**.
+A [**MutableSortedSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/set/sorted/MutableSortedSet.html) follows the same contract as a **MutableSet**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedSet** is **TreeSortedSet**.
 
 Here is an example of a MutableSortedSet containing numbers in reverse order:
 
@@ -2038,7 +2038,7 @@ The **MapIterable** interface (extending **RichIterable**) is the top-level inte
 
 > A mutable **MapIterable** that implements java.util.Map; the most common implementation is **UnifiedMap**.
 
-The [**MutableMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/MutableMap.html) interface defines an association of key/value pairs. It extends the **MapIterable** interface, which furnishes a set of iteration methods especially for the key/value structure of a Map collection. These include unmodifiable views of keys, values or pair-entries using the **keysView**, **valuesView** and **entriesView** methods, respectively.
+The [**MutableMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/MutableMap.html) interface defines an association of key/value pairs. It extends the **MapIterable** interface, which furnishes a set of iteration methods especially for the key/value structure of a Map collection. These include unmodifiable views of keys, values or pair-entries using the **keysView**, **valuesView** and **entriesView** methods, respectively.
 
 The mutable subinterfaces of **MapIterable** also extend the JCF Map interface.
 
@@ -2061,7 +2061,7 @@ MutableMap<Integer, String> map = UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3
 
 > A sorted Map.
 
-A [**MutableSortedMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/map/sorted/MutableSortedMap.html) follows the same contract as a **MutableMap**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedMap** is [**TreeSortedMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.html).
+A [**MutableSortedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/map/sorted/MutableSortedMap.html) follows the same contract as a **MutableMap**, but sorts its elements by their natural order, or through a comparator parameter set by the user. The implementation for **MutableSortedMap** is [**TreeSortedMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMap.html).
 
 This code block creates a TreeSortedMap which sorts in reverse order:
 
@@ -2076,9 +2076,9 @@ MutableSortedMap<String, Integer> sortedMap = TreeSortedMap.newMapWith(Comparato
 
 > A map that allows users to add key-value pairs and look up from either direction
 
-[**BiMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bimap/BiMap.html) is an interface that defines a bi-directional map, i.e, a map that allows users to look up from both directions. Both the keys and the values in a **BiMap** are unique.
+[**BiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bimap/BiMap.html) is an interface that defines a bi-directional map, i.e, a map that allows users to look up from both directions. Both the keys and the values in a **BiMap** are unique.
 
-**BiMap** extends **MapIterable** and [**MutableBiMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bimap/MutableBiMap.html) extends **MutableMap**. The standard implementation is [**HashBiMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/bimap/mutable/HashBiMap.html).
+**BiMap** extends **MapIterable** and [**MutableBiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bimap/MutableBiMap.html) extends **MutableMap**. The standard implementation is [**HashBiMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bimap/mutable/HashBiMap.html).
 
 ###### EC
 
@@ -2132,12 +2132,12 @@ Assert.assertEquals(Integer.valueOf(2), inverse.put("2", 4));
 
 > An unordered collection that allows duplicates.
 
-A [**Bag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/Bag.html) is a **RichIterable** that allows duplicate elements and efficient querying of the number of occurrences of each element. It can be sorted or unsorted.
+A [**Bag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/Bag.html) is a **RichIterable** that allows duplicate elements and efficient querying of the number of occurrences of each element. It can be sorted or unsorted.
 
--   A [**SortedBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/sorted/SortedBag.html) is a **Bag** that maintains its elements in sorted order.
--   An [**UnsortedBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/UnsortedBag.html) is a **Bag** that maintains its elements in a hash table in an unpredictable order.
+-   A [**SortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/SortedBag.html) is a **Bag** that maintains its elements in sorted order.
+-   An [**UnsortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/UnsortedBag.html) is a **Bag** that maintains its elements in a hash table in an unpredictable order.
 
-**UnsortedBag** has two subinterfaces, [**MutableBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/MutableBag.html) and [**ImmutableBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/ImmutableBag.html). **SortedBag** has two subinterfaces, [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) and [**ImmutableSortedBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.html).
+**UnsortedBag** has two subinterfaces, [**MutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/MutableBag.html) and [**ImmutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/ImmutableBag.html). **SortedBag** has two subinterfaces, [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) and [**ImmutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.html).
 
 A **Bag** is conceptually like a **Map** from elements to the number of occurrences of that element.
 
@@ -2183,9 +2183,9 @@ The distinctive methods on **Bag** are:
 
 #### []() MutableBag
 
-> A mutable unordered collection allowing duplicates; the most common implementation is [**HashBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
+> A mutable unordered collection allowing duplicates; the most common implementation is [**HashBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
 
-The [**MutableBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/MutableBag.html) interface includes methods for manipulating the number of occurrences of an item. For example, to determine the number of unique elements in a MutableBag, use the **sizeDistinct** method. The most common implementation of **MutableBag** is [**HashBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
+The [**MutableBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/MutableBag.html) interface includes methods for manipulating the number of occurrences of an item. For example, to determine the number of unique elements in a MutableBag, use the **sizeDistinct** method. The most common implementation of **MutableBag** is [**HashBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/mutable/HashBag.html).
 
 ###### EC 
 
@@ -2209,7 +2209,7 @@ The distinctive methods on **MutableBag** are:
 
 > A sorted collection that allows duplicates.
 
-A [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) is a **Bag**that maintains order. It defaults to natural order, but can take a comparator to sort. The most common implementation of **MutableSortedBag** is [**TreeBag**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.html) which uses a **SortedMap** as its underlying data store.
+A [**MutableSortedBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/bag/sorted/MutableSortedBag.html) is a **Bag**that maintains order. It defaults to natural order, but can take a comparator to sort. The most common implementation of **MutableSortedBag** is [**TreeBag**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/bag/sorted/mutable/TreeBag.html) which uses a **SortedMap** as its underlying data store.
 
 For example, this **MutableSortedBag** would contain integers sorted in reverse order:
 
@@ -2229,15 +2229,15 @@ MutableSortedBag<Integer> revIntegers =
 
 > A collection that maintains "last-in, first-out" order, iterating over elements in reverse insertion order.
 
-A [**StackIterable**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/stack/StackIterable.html) is a **RichIterable** enforcing a "last-in, first-out" order; its methods always iterate over elements in reverse insertion order, (beginning with the most-recently added element). For example the **getFirst** method returns the the last element to have been added - the "top" of the stack.
+A [**StackIterable**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/StackIterable.html) is a **RichIterable** enforcing a "last-in, first-out" order; its methods always iterate over elements in reverse insertion order, (beginning with the most-recently added element). For example the **getFirst** method returns the the last element to have been added - the "top" of the stack.
 
-**StackIterable** has a mutable and an [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**MutableStack**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/stack/MutableStack.html) and [**ImmutableStack**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/stack/ImmutableStack.html), respectively.
+**StackIterable** has a mutable and an [immutable](#immutable-collections "A read-only snapshot of a collection; once created, it can never be modified.") subinterface [**MutableStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/MutableStack.html) and [**ImmutableStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/stack/ImmutableStack.html), respectively.
 
 #### []() MutableStack
 
 > A mutable collection that maintains "last-in, first-out" order, iterating over elements in reverse insertion order.
 
-The most common implementation of **MutableStack** is [**ArrayStack**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/stack/mutable/ArrayStack.html). The closest JCF equivalent to **ArrayStack** is **java.util.Stack**, which extends **Vector** but does not enforce strict LIFO iteration.
+The most common implementation of **MutableStack** is [**ArrayStack**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/stack/mutable/ArrayStack.html). The closest JCF equivalent to **ArrayStack** is **java.util.Stack**, which extends **Vector** but does not enforce strict LIFO iteration.
 
 The distinctive methods on **MutableStack** are **push**, **pop**, and **peek**.
 
@@ -2277,11 +2277,11 @@ MutableStack mutableStack =
 
 > A map-like container that can have multiple values for each key
 
-In a [**Multimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/Multimap.html) container, each key can be associated with multiple values. It is, in this sense, similar to a Map, but one whose values consist of individual collections of a specified type, called the *backing collection*. A **Multimap** is useful in situations where you would otherwise use **Map**&lt;K, Collection&lt;V&gt;&gt;.
+In a [**Multimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/Multimap.html) container, each key can be associated with multiple values. It is, in this sense, similar to a Map, but one whose values consist of individual collections of a specified type, called the *backing collection*. A **Multimap** is useful in situations where you would otherwise use **Map**&lt;K, Collection&lt;V&gt;&gt;.
 
 Unlike the other basic Eclipse Collections containers, **Multimap** does not extend **RichIterable**, but resides along with its subinterfaces in a separate API. The **RichIterable** methods are extended by the backing collection types.
 
-Depending on the implementation, the "values" in a Multimap can be stored in Lists, Sets or Bags. For example, the [**FastListMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/multimap/list/FastListMultimap.html) class is backed by a **UnifiedMap** that associates each key with a **FastList** that preserves the order in which the values are added and allows duplicate to be added.
+Depending on the implementation, the "values" in a Multimap can be stored in Lists, Sets or Bags. For example, the [**FastListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/multimap/list/FastListMultimap.html) class is backed by a **UnifiedMap** that associates each key with a **FastList** that preserves the order in which the values are added and allows duplicate to be added.
 
 A **Multimap** is the type returned by the [**groupBy**](#groupby-pattern "Create a Multimap from a collection by grouping on a selected or generated key value.") method. Here is an example in which we group a list of words by their length, obtaining a **Multimap** with integer (word=length) keys and lists of words having that length for values.
 
@@ -2300,7 +2300,7 @@ A **Multimap** is the type returned by the [**groupBy**](#groupby-pattern "Creat
 
 The code that performs this action uses the [**groupBy**](#groupby-pattern "Create a Multimap from a collection by grouping on a selected or generated key value.") method.
 
-###### EC (w/[StringFunctions](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/block/factory/StringFunctions.html))
+###### EC (w/[StringFunctions](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/block/factory/StringFunctions.html))
 
 ```java
 MutableList<String> words = Lists.mutable.with("here", "are", "a", "few",
@@ -2318,9 +2318,9 @@ MutableListMultimap<Integer, String> multimap =
     words.groupBy(String::length);
 ```
 
-The interface [**MutableListMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/list/MutableListMultimap.html) extends the **Multimap** interface and tells us the type of its backing collections. Since **words** is a **MutableList**, the output is a **MutableListMultimap**. The word "are" is allowed to occur twice in the list at key 3.
+The interface [**MutableListMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/list/MutableListMultimap.html) extends the **Multimap** interface and tells us the type of its backing collections. Since **words** is a **MutableList**, the output is a **MutableListMultimap**. The word "are" is allowed to occur twice in the list at key 3.
 
-If we change **words** to a **MutableSet**, the result will be a [**MutableSetMultimap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/multimap/set/MutableSetMultimap.html), which will eliminate duplicate entries.
+If we change **words** to a **MutableSet**, the result will be a [**MutableSetMultimap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/multimap/set/MutableSetMultimap.html), which will eliminate duplicate entries.
 
 ###### EC (w/StringFunctions)
 
@@ -2370,9 +2370,9 @@ The interface hierarchies for primitive types correspond closely with the interf
 
 ### Primitive Lists
 
-The primitive list implementations are backed by an array like **FastList**, but with a primitive array instead of an **Object\[\]**. They are named [**IntArrayList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/list/mutable/primitive/IntArrayList.html), [**FloatArrayList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/list/mutable/primitive/FloatArrayList.html) etc.
+The primitive list implementations are backed by an array like **FastList**, but with a primitive array instead of an **Object\[\]**. They are named [**IntArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/IntArrayList.html), [**FloatArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/FloatArrayList.html) etc.
 
-[**BooleanArrayList**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.html) is a special case. Current JVMs use one byte per boolean in a **boolean\[\]** (instead of one bit per boolean). Thus the **BooleanArrayList** is backed by a **java.util.BitSet** as an optimization.
+[**BooleanArrayList**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.html) is a special case. Current JVMs use one byte per boolean in a **boolean\[\]** (instead of one bit per boolean). Thus the **BooleanArrayList** is backed by a **java.util.BitSet** as an optimization.
 
 To create an **IntArrayList**, use one of the following:
 
@@ -2394,7 +2394,7 @@ Assert.assertEquals(IntLists.mutable.with(1, 3, 5), IntInterval.oneToBy(5, 2));
 
 ### Primitive Sets
 
-The primitive set implementations are hash-table backed. They are named [**IntHashSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/set/mutable/primitive/IntHashSet.html), [**FloatHashSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/set/mutable/primitive/FloatHashSet.html) etc. [**BooleanHashSet**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.html) is implemented using a single integer to hold one of four possible states: (\[\], \[F\], \[T\], or \[T, F\]). All other sets use open addressing and quadratic probing.
+The primitive set implementations are hash-table backed. They are named [**IntHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/IntHashSet.html), [**FloatHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/FloatHashSet.html) etc. [**BooleanHashSet**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.html) is implemented using a single integer to hold one of four possible states: (\[\], \[F\], \[T\], or \[T, F\]). All other sets use open addressing and quadratic probing.
 
 ### Primitive Stacks
 
@@ -2408,9 +2408,9 @@ Similar to **HashBag**, but both item and count are primitives.
 
 There are three types of primitive maps:
 
--   Object To Primitive ([**ObjectIntHashMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/map/mutable/primitive/ObjectIntHashMap.html), ObjectFloatHashMap etc.)
--   Primitive To Object ([**IntObjectHashMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMap.html), FloatObjectHashMap etc.)
--   Primitive To Primitive ([**IntIntHashMap**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMap.html), IntLongHashMap etc.)
+-   Object To Primitive ([**ObjectIntHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/ObjectIntHashMap.html), ObjectFloatHashMap etc.)
+-   Primitive To Object ([**IntObjectHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMap.html), FloatObjectHashMap etc.)
+-   Primitive To Primitive ([**IntIntHashMap**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMap.html), IntLongHashMap etc.)
 
 All the maps use open addressing and quadratic probing.
 
@@ -2538,7 +2538,7 @@ If you know the implementation class of the container (for example, **FastList**
 -   Call the class constructor; for example, **FastList**&lt;String&gt; names = new **FastList**;
 -   Call a factory method on the collection class, such as **newList** or **newListWith**; for example, **MutableList**&lt;V&gt; result = **FastList.newList**(this.size);
 
-If, however, the specific collection class to implement is unknown, you can call a factory class to create the container. Eclipse Collections container-factory classes are named for the plural of the respective container name. For example, for a **List**, the factory class is [**Lists**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Lists.html); a **Set** is created by the class [**Sets**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/Sets.html).
+If, however, the specific collection class to implement is unknown, you can call a factory class to create the container. Eclipse Collections container-factory classes are named for the plural of the respective container name. For example, for a **List**, the factory class is [**Lists**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Lists.html); a **Set** is created by the class [**Sets**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/Sets.html).
 
 You can specify the content and mutable state of the container in parameters. This approach to container creation, when used consistently, has the added benefit of being more readable.
 
@@ -2598,7 +2598,7 @@ ImmutableList<String> list_c =
 The techniques for creating mutable or immutable primitive containers are the same as those for object collections.
 
 -   If you know the implementation class, you can call its constructor or its factory method.
--   Otherwise use the applicable factory class named for the plural of the type, that is, with the pattern: &lt;PrimitiveType&gt;&lt;ContainerType&gt;s. For example to create an **IntList**, you would use the [**IntLists**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/primitive/IntLists.html) factory for the appropriate methods; for a **DoubleSet**, you would call in methods in [**DoubleSets**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/impl/factory/primitive/DoubleSets.html).
+-   Otherwise use the applicable factory class named for the plural of the type, that is, with the pattern: &lt;PrimitiveType&gt;&lt;ContainerType&gt;s. For example to create an **IntList**, you would use the [**IntLists**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/primitive/IntLists.html) factory for the appropriate methods; for a **DoubleSet**, you would call in methods in [**DoubleSets**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/impl/factory/primitive/DoubleSets.html).
 
 <!-- -->
 
@@ -2717,7 +2717,7 @@ Verify.assertSize(1, texans);
 
 In each case, if the value of *state* field for any element in **people** equals "TX" then the **select** method includes that element in the result list, **texans**.
 
-This chapter introduces the most commonly-used code blocks and the Eclipse Collections methods that use them. Along with the code block types described here, the current version of Eclipse Collections offers a full suite of primitive code blocks (and corresponding code block factories like [**IntFunction**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html), [**IntPredicate**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/predicate/primitive/IntPredicate.html), [**IntProcedure**](http://www.eclipse.org/collections/javadoc/8.0.0/org/eclipse/collections/api/block/procedure/primitive/IntProcedure.html) etc.) These code blocks are used by methods on primitive collections.
+This chapter introduces the most commonly-used code blocks and the Eclipse Collections methods that use them. Along with the code block types described here, the current version of Eclipse Collections offers a full suite of primitive code blocks (and corresponding code block factories like [**IntFunction**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/function/primitive/IntFunction.html), [**IntPredicate**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/predicate/primitive/IntPredicate.html), [**IntProcedure**](http://www.eclipse.org/collections/javadoc/10.0.0/org/eclipse/collections/api/block/procedure/primitive/IntProcedure.html) etc.) These code blocks are used by methods on primitive collections.
 
 ##### []() About *parameter* and *argument*:
 


### PR DESCRIPTION
Changes links from version 8.0.0 to 9.2.0, the current release with documentation online...

Signed-off-by: Leonardo Lima <leomrlima@gmail.com>