### PR TITLE
Add Serialization Tests for CollectPrimitiveProcedure

### DIFF
--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureSerializationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectBooleanProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAE5vcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdEJvb2xlYW5Qcm9jZWR1cmUAAAAAAAAAAQIAAkwAEWJvb2xlYW5Db2xsZWN0\n"
+                        + "aW9udABLTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9N\n"
+                        + "dXRhYmxlQm9vbGVhbkNvbGxlY3Rpb247TAAPYm9vbGVhbkZ1bmN0aW9udABGTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9ibG9jay9mdW5jdGlvbi9wcmltaXRpdmUvQm9vbGVhbkZ1bmN0aW9u\n"
+                        + "O3hwcHA=",
+                new CollectBooleanProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectByteProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectByteProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectByteProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdEJ5dGVQcm9jZWR1cmUAAAAAAAAAAQIAAkwADmJ5dGVDb2xsZWN0aW9udABI\n"
+                        + "TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb247TAAMYnl0ZUZ1bmN0aW9udABDTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25z\n"
+                        + "L2FwaS9ibG9jay9mdW5jdGlvbi9wcmltaXRpdmUvQnl0ZUZ1bmN0aW9uO3hwcHA=",
+                new CollectByteProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectCharProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectCharProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectCharProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdENoYXJQcm9jZWR1cmUAAAAAAAAAAQIAAkwADmNoYXJDb2xsZWN0aW9udABI\n"
+                        + "TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb247TAAMY2hhckZ1bmN0aW9udABDTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25z\n"
+                        + "L2FwaS9ibG9jay9mdW5jdGlvbi9wcmltaXRpdmUvQ2hhckZ1bmN0aW9uO3hwcHA=",
+                new CollectCharProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectDoubleProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectDoubleProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectDoubleProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAE1vcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdERvdWJsZVByb2NlZHVyZQAAAAAAAAABAgACTAAQZG91YmxlQ29sbGVjdGlv\n"
+                        + "bnQASkxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0\n"
+                        + "YWJsZURvdWJsZUNvbGxlY3Rpb247TAAOZG91YmxlRnVuY3Rpb250AEVMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2Jsb2NrL2Z1bmN0aW9uL3ByaW1pdGl2ZS9Eb3VibGVGdW5jdGlvbjt4cHBw\n",
+                new CollectDoubleProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectIntProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectIntProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectIntProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdEludFByb2NlZHVyZQAAAAAAAAABAgACTAANaW50Q29sbGVjdGlvbnQAR0xv\n"
+                        + "cmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUlu\n"
+                        + "dENvbGxlY3Rpb247TAALaW50RnVuY3Rpb250AEJMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBp\n"
+                        + "L2Jsb2NrL2Z1bmN0aW9uL3ByaW1pdGl2ZS9JbnRGdW5jdGlvbjt4cHBw",
+                new CollectIntProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectLongProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectLongProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectLongProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdExvbmdQcm9jZWR1cmUAAAAAAAAAAQIAAkwADmxvbmdDb2xsZWN0aW9udABI\n"
+                        + "TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb247TAAMbG9uZ0Z1bmN0aW9udABDTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25z\n"
+                        + "L2FwaS9ibG9jay9mdW5jdGlvbi9wcmltaXRpdmUvTG9uZ0Z1bmN0aW9uO3hwcHA=",
+                new CollectLongProcedure(null, null));
+    }
+}

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectShortProcedureSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectShortProcedureSerializationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.block.procedure.primitive;
+
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Test;
+
+public class CollectShortProcedureSerializationTest
+{
+    @Test
+    public void serializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLnByb2NlZHVyZS5wcmlt\n"
+                        + "aXRpdmUuQ29sbGVjdFNob3J0UHJvY2VkdXJlAAAAAAAAAAECAAJMAA9zaG9ydENvbGxlY3Rpb250\n"
+                        + "AElMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFi\n"
+                        + "bGVTaG9ydENvbGxlY3Rpb247TAANc2hvcnRGdW5jdGlvbnQARExvcmcvZWNsaXBzZS9jb2xsZWN0\n"
+                        + "aW9ucy9hcGkvYmxvY2svZnVuY3Rpb24vcHJpbWl0aXZlL1Nob3J0RnVuY3Rpb247eHBwcA==",
+                new CollectShortProcedure(null, null));
+    }
+}


### PR DESCRIPTION
Adding Serialization Test for CollectPrimitiveProcedure as discussed in https://github.com/eclipse/eclipse-collections/pull/531
Signed-off-by: sone tsuyoshi <Tsuyoshi.Sone@gs.com>