### PR TITLE
Implement a Map factory method that takes a Map parameter. Fixes #457.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/MutableMapFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/MutableMapFactory.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.collections.api.factory.map;
 
+import java.util.Map;
+
+import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 
 public interface MutableMapFactory
@@ -68,4 +71,12 @@ public interface MutableMapFactory
     <K, V> MutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4);
 
     <K, V> MutableMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4);
+
+    <K, V> MutableMap<K, V> ofMap(Map<? extends K, ? extends V> map);
+
+    <K, V> MutableMap<K, V> withMap(Map<? extends K, ? extends V> map);
+
+    <K, V> MutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
+
+    <K, V> MutableMap<K, V> withMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MutableMapFactoryImpl.java
@@ -10,8 +10,12 @@
 
 package org.eclipse.collections.impl.map.mutable;
 
+import java.util.Map;
+
 import org.eclipse.collections.api.factory.map.MutableMapFactory;
+import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.factory.Maps;
 
 public enum MutableMapFactoryImpl implements MutableMapFactory
 {
@@ -93,5 +97,31 @@ public enum MutableMapFactoryImpl implements MutableMapFactory
     public <K, V> MutableMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
     {
         return UnifiedMap.newWithKeysValues(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> ofMap(Map<? extends K, ? extends V> map)
+    {
+        return this.withMap(map);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> withMap(Map<? extends K, ? extends V> map)
+    {
+        return UnifiedMap.newMap(map);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable)
+    {
+        return this.withMapIterable(mapIterable);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> withMapIterable(MapIterable<? extends K, ? extends V> mapIterable)
+    {
+        MutableMap<K, V> output = Maps.mutable.withInitialCapacity(mapIterable.size());
+        mapIterable.forEachKeyValue(output::put);
+        return output;
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -11,9 +11,11 @@
 package org.eclipse.collections.impl.factory;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 
 import org.eclipse.collections.api.factory.map.FixedSizeMapFactory;
 import org.eclipse.collections.api.factory.map.ImmutableMapFactory;
+import org.eclipse.collections.api.factory.map.MutableMapFactory;
 import org.eclipse.collections.api.factory.map.sorted.MutableSortedMapFactory;
 import org.eclipse.collections.api.map.FixedSizeMap;
 import org.eclipse.collections.api.map.ImmutableMap;
@@ -21,6 +23,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -246,5 +249,23 @@ public class MapsTest
         {
             Assert.fail("No access the field table in UnifiedMap");
         }
+    }
+
+    @Test
+    public void ofAll()
+    {
+        MutableMapFactory factory = Maps.mutable;
+
+        Assert.assertEquals(UnifiedMap.newMap(), factory.ofMap(new HashMap<>()));
+        Verify.assertInstanceOf(UnifiedMap.class, factory.ofMap(new HashMap<>()));
+
+        Assert.assertEquals(UnifiedMap.newMap(), factory.ofMapIterable(Maps.immutable.with()));
+        Verify.assertInstanceOf(UnifiedMap.class, factory.ofMapIterable(Maps.immutable.with()));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMap(Maps.mutable.with(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, factory.ofMap(Maps.mutable.with(1, 1)));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMapIterable(Maps.mutable.with(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, factory.ofMapIterable(Maps.mutable.with(1, 1)));
     }
 }


### PR DESCRIPTION
For ImmutableMapFactory, we already have ofAll() and withAll(). But ofMap() and ofMapIterable() are verbose, intuitive and unambiguous. 