### PR TITLE
Change groupByUniqueKey() so that its target extends MutableMapIterable instead of MutableMap.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -57,6 +57,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -2121,7 +2122,7 @@ public interface RichIterable<T>
      * @see #groupByUniqueKey(Function)
      * @since 6.0
      */
-    <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target);
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectEmptyMap.stg
@@ -89,6 +89,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 <if(!primitive.longPrimitive)><if(!primitive.doublePrimitive)>import org.eclipse.collections.api.map.primitive.ImmutableObject<name>Map;<endif><endif>
@@ -803,7 +804,7 @@ final class Immutable<name>ObjectEmptyMap\<V> implements Immutable<name>ObjectMa
     }
 
     @Override
-    public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
+    public \<VV, R extends MutableMapIterable\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
     {
         return target;
     }

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectHashMap.stg
@@ -89,6 +89,7 @@ import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObject<name>Map;
@@ -694,7 +695,7 @@ final class Immutable<name>ObjectHashMap\<V> extends AbstractImmutable<name>Obje
     }
 
     @Override
-    public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
+    public \<VV, R extends MutableMapIterable\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
     {
         return this.delegate.groupByUniqueKey(function, target);
     }

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitiveObjectSingletonMap.stg
@@ -91,6 +91,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObject<name>Map;
@@ -846,7 +847,7 @@ final class Immutable<name>ObjectSingletonMap\<V> extends AbstractImmutable<name
     }
 
     @Override
-    public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
+    public \<VV, R extends MutableMapIterable\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
     {
         if (target.put(function.valueOf(this.value1), this.value1) != null)
         {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -98,6 +98,7 @@ import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
@@ -1623,7 +1624,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     }
 
     @Override
-    public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(
+    public \<VV, R extends MutableMapIterable\<VV, V>\> R groupByUniqueKey(
                 Function\<? super V, ? extends VV> function,
                 R target)
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitiveObjectMap.stg
@@ -93,6 +93,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Mutable<name>ObjectMap;
 <if(!primitive.longPrimitive)><if(!primitive.doublePrimitive)>import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;<endif><endif>
@@ -1323,7 +1324,7 @@ public class Synchronized<name>ObjectMap\<V>
     }
 
     @Override
-    public \<VV, R extends MutableMap\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
+    public \<VV, R extends MutableMapIterable\<VV, V>\> R groupByUniqueKey(Function\<? super V, ? extends VV> function, R target)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitiveObjectMap.stg
@@ -87,6 +87,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.Immutable<name>ObjectMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
@@ -933,7 +934,7 @@ public class Unmodifiable<name>ObjectMap\<V>
     }
 
     @Override
-    public \<V1, R extends MutableMap\<V1, V>\> R groupByUniqueKey(Function\<? super V, ? extends V1> function, R target)
+    public \<V1, R extends MutableMapIterable\<V1, V>\> R groupByUniqueKey(Function\<? super V, ? extends V1> function, R target)
     {
         return this.map.groupByUniqueKey(function, target);
     }

--- a/eclipse-collections-forkjoin/src/main/java/org/eclipse/collections/impl/forkjoin/FJIterate.java
+++ b/eclipse-collections-forkjoin/src/main/java/org/eclipse/collections/impl/forkjoin/FJIterate.java
@@ -24,6 +24,7 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.impl.block.procedure.MultimapPutProcedure;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
@@ -885,7 +886,7 @@ public final class FJIterate
                 FJIterate.DEFAULT_MIN_FORK_SIZE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -917,7 +918,7 @@ public final class FJIterate
                 FJIterate.FORK_JOIN_POOL);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -953,7 +954,7 @@ public final class FJIterate
                 executor);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -987,7 +988,7 @@ public final class FJIterate
                 FJIterate.DEFAULT_MIN_FORK_SIZE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1019,7 +1020,7 @@ public final class FJIterate
                 FJIterate.FORK_JOIN_POOL);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1057,7 +1058,7 @@ public final class FJIterate
         return map;
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/AbstractRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/AbstractRichIterable.java
@@ -51,6 +51,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.set.MutableSet;
@@ -727,7 +728,7 @@ public abstract class AbstractRichIterable<T> implements RichIterable<T>
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/UnmodifiableRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/UnmodifiableRichIterable.java
@@ -59,6 +59,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -807,7 +808,7 @@ public class UnmodifiableRichIterable<T>
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/AbstractBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/AbstractBiMap.java
@@ -51,6 +51,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.set.MutableSet;
@@ -677,7 +678,7 @@ public abstract class AbstractBiMap<K, V> implements BiMap<K, V>
     }
 
     @Override
-    public <VV, R extends MutableMap<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
+    public <VV, R extends MutableMapIterable<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
     {
         return this.getDelegate().groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMap.java
@@ -63,6 +63,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -1035,7 +1036,7 @@ public class UnmodifiableBiMap<K, V> implements MutableBiMap<K, V>, Serializable
     }
 
     @Override
-    public <VV, R extends MutableMap<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
+    public <VV, R extends MutableMapIterable<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
     {
         return this.delegate.groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MutatingAggregationProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/MutatingAggregationProcedure.java
@@ -14,7 +14,7 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
-import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 
 /**
  * This procedure is used to apply an aggregate function like sum on a grouped set of data.  The values in the
@@ -24,12 +24,16 @@ import org.eclipse.collections.api.map.MutableMap;
 public final class MutatingAggregationProcedure<T, K, V> implements Procedure<T>
 {
     private static final long serialVersionUID = 1L;
-    private final MutableMap<K, V> map;
+    private final MutableMapIterable<K, V> map;
     private final Function<? super T, ? extends K> groupBy;
     private final Function0<? extends V> zeroValueFactory;
     private final Procedure2<? super V, ? super T> mutatingAggregator;
 
-    public MutatingAggregationProcedure(MutableMap<K, V> map, Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Procedure2<? super V, ? super T> mutatingAggregator)
+    public MutatingAggregationProcedure(
+            MutableMapIterable<K, V> map,
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Procedure2<? super V, ? super T> mutatingAggregator)
     {
         this.map = map;
         this.groupBy = groupBy;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/NonMutatingAggregationProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/NonMutatingAggregationProcedure.java
@@ -14,7 +14,7 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.procedure.Procedure;
-import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 
 /**
  * This procedure is used to apply an aggregate function like sum on a grouped set of data.  The values in the
@@ -24,12 +24,16 @@ import org.eclipse.collections.api.map.MutableMap;
 public final class NonMutatingAggregationProcedure<T, K, V> implements Procedure<T>
 {
     private static final long serialVersionUID = 1L;
-    private final MutableMap<K, V> map;
+    private final MutableMapIterable<K, V> map;
     private final Function<? super T, ? extends K> groupBy;
     private final Function0<? extends V> zeroValueFactory;
     private final Function2<? super V, ? super T, ? extends V> nonMutatingAggregator;
 
-    public NonMutatingAggregationProcedure(MutableMap<K, V> map, Function<? super T, ? extends K> groupBy, Function0<? extends V> zeroValueFactory, Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
+    public NonMutatingAggregationProcedure(
+            MutableMapIterable<K, V> map,
+            Function<? super T, ? extends K> groupBy,
+            Function0<? extends V> zeroValueFactory,
+            Function2<? super V, ? super T, ? extends V> nonMutatingAggregator)
     {
         this.map = map;
         this.groupBy = groupBy;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/AbstractSynchronizedRichIterable.java
@@ -60,6 +60,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -1124,7 +1125,7 @@ public abstract class AbstractSynchronizedRichIterable<T> implements RichIterabl
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.java
@@ -52,6 +52,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -909,7 +910,7 @@ public abstract class AbstractCollectionAdapter<T>
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMultiReaderMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMultiReaderMutableCollection.java
@@ -54,6 +54,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -1760,7 +1761,7 @@ public abstract class AbstractMultiReaderMutableCollection<T> implements Mutable
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {
@@ -2034,7 +2035,7 @@ public abstract class AbstractMultiReaderMutableCollection<T> implements Mutable
         }
 
         @Override
-        public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+        public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
                 Function<? super T, ? extends V> function,
                 R target)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractUnmodifiableMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractUnmodifiableMutableCollection.java
@@ -52,6 +52,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -928,7 +929,7 @@ public class AbstractUnmodifiableMutableCollection<T> implements MutableCollecti
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
@@ -807,7 +807,7 @@ public final class Collectors2
      *
      * <p>Equivalent to using @{@link RichIterable#groupByUniqueKey(Function, MutableMap)}</p>
      */
-    public static <T, K, R extends MutableMap<K, T>> Collector<T, ?, R> groupByUniqueKey(
+    public static <T, K, R extends MutableMapIterable<K, T>> Collector<T, ?, R> groupByUniqueKey(
             Function<? super T, ? extends K> groupBy,
             Supplier<R> supplier)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -73,6 +73,7 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -548,7 +549,7 @@ public class FastList<T>
     }
 
     @Override
-    public <K, R extends MutableMap<K, T>> R groupByUniqueKey(Function<? super T, ? extends K> function, R target)
+    public <K, R extends MutableMapIterable<K, T>> R groupByUniqueKey(Function<? super T, ? extends K> function, R target)
     {
         return InternalArrayIterate.groupByUniqueKey(this.items, this.size, function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
@@ -59,6 +59,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -771,7 +772,7 @@ public class UnmodifiableMutableMap<K, V>
     }
 
     @Override
-    public <VV, R extends MutableMap<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
+    public <VV, R extends MutableMapIterable<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
     {
         return this.getMutableMap().groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMap.java
@@ -806,7 +806,7 @@ public class UnmodifiableTreeMap<K, V>
     }
 
     @Override
-    public <VV, R extends MutableMap<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
+    public <VV, R extends MutableMapIterable<VV, V>> R groupByUniqueKey(Function<? super V, ? extends VV> function, R target)
     {
         return this.getMutableSortedMap().groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ParallelIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ParallelIterate.java
@@ -34,6 +34,7 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -974,7 +975,7 @@ public final class ParallelIterate
                 ParallelIterate.DEFAULT_MIN_FORK_SIZE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1006,7 +1007,7 @@ public final class ParallelIterate
                 ParallelIterate.EXECUTOR_SERVICE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1042,7 +1043,7 @@ public final class ParallelIterate
                 executor);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1076,7 +1077,7 @@ public final class ParallelIterate
                 ParallelIterate.DEFAULT_MIN_FORK_SIZE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1108,7 +1109,7 @@ public final class ParallelIterate
                 ParallelIterate.EXECUTOR_SERVICE);
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -1146,7 +1147,7 @@ public final class ParallelIterate
         return map;
     }
 
-    public static <T, K, V, R extends MutableMap<K, V>> R aggregateInPlaceBy(
+    public static <T, K, V, R extends MutableMapIterable<K, V>> R aggregateInPlaceBy(
             Iterable<T> iterable,
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -57,6 +57,7 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
@@ -898,7 +899,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
     {
         return this.delegate.asReversed().groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -55,6 +55,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -848,7 +849,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
     {
         return this.delegate.asReversed().groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStack.java
@@ -53,6 +53,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -1242,7 +1243,7 @@ public final class SynchronizedStack<T> implements MutableStack<T>, Serializable
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStack.java
@@ -52,6 +52,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -828,7 +829,7 @@ public final class UnmodifiableStack<T> implements MutableStack<T>, Serializable
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
     {
         return this.mutableStack.groupByUniqueKey(function, target);
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
@@ -59,6 +59,7 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -1477,7 +1478,7 @@ public final class ArrayIterate
     /**
      * @see Iterate#groupByUniqueKey(Iterable, Function)
      */
-    public static <T, V> MutableMap<V, T> groupByUniqueKey(
+    public static <T, V> MutableMapIterable<V, T> groupByUniqueKey(
             T[] array,
             Function<? super T, ? extends V> function)
     {
@@ -1485,9 +1486,9 @@ public final class ArrayIterate
     }
 
     /**
-     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMap)
+     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMapIterable)
      */
-    public static <T, V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public static <T, V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             T[] array,
             Function<? super T, ? extends V> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayListIterate.java
@@ -61,6 +61,7 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.set.MutableSet;
@@ -1834,9 +1835,9 @@ public final class ArrayListIterate
     }
 
     /**
-     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMap)
+     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMapIterable)
      */
-    public static <T, V, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public static <T, V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             ArrayList<T> list,
             Function<? super T, ? extends V> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
@@ -61,6 +61,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -3485,9 +3486,9 @@ public final class Iterate
     }
 
     /**
-     * @see RichIterable#groupByUniqueKey(Function, MutableMap)
+     * @see RichIterable#groupByUniqueKey(Function, MutableMapIterable)
      */
-    public static <V, T, R extends MutableMap<V, T>> R groupByUniqueKey(
+    public static <V, T, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Iterable<T> iterable,
             Function<? super T, ? extends V> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
@@ -64,6 +64,7 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -1569,9 +1570,9 @@ public final class ListIterate
     }
 
     /**
-     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMap)
+     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMapIterable)
      */
-    public static <K, T, R extends MutableMap<K, T>> R groupByUniqueKey(
+    public static <K, T, R extends MutableMapIterable<K, T>> R groupByUniqueKey(
             List<T> list,
             Function<? super T, ? extends K> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
@@ -42,7 +42,7 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -285,7 +285,7 @@ public final class InternalArrayIterate
         return target;
     }
 
-    public static <T, K, R extends MutableMap<K, T>> R groupByUniqueKey(
+    public static <T, K, R extends MutableMapIterable<K, T>> R groupByUniqueKey(
             T[] array,
             int size,
             Function<? super T, ? extends K> function,

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IterableIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IterableIterate.java
@@ -53,6 +53,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -951,9 +952,9 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMap)
+     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMapIterable)
      */
-    public static <K, T, R extends MutableMap<K, T>> R groupByUniqueKey(
+    public static <K, T, R extends MutableMapIterable<K, T>> R groupByUniqueKey(
             Iterable<T> iterable,
             Function<? super T, ? extends K> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
@@ -53,6 +53,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.multimap.ImmutableMultimap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
@@ -1080,9 +1081,9 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMap)
+     * @see Iterate#groupByUniqueKey(Iterable, Function, MutableMapIterable)
      */
-    public static <K, T, R extends MutableMap<K, T>> R groupByUniqueKey(
+    public static <K, T, R extends MutableMapIterable<K, T>> R groupByUniqueKey(
             Iterator<T> iterator,
             Function<? super T, ? extends K> function,
             R target)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterate.java
@@ -63,6 +63,7 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.list.primitive.MutableShortList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.ObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ObjectLongMap;
 import org.eclipse.collections.api.multimap.MutableMultimap;
@@ -1442,7 +1443,7 @@ public final class RandomAccessListIterate
         return RandomAccessListIterate.groupByUniqueKey(list, function, UnifiedMap.newMap(list.size()));
     }
 
-    public static <K, T, R extends MutableMap<K, T>> R groupByUniqueKey(
+    public static <K, T, R extends MutableMapIterable<K, T>> R groupByUniqueKey(
             List<T> list,
             Function<? super T, ? extends K> function,
             R target)

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyIterableTestHelper.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyIterableTestHelper.java
@@ -58,6 +58,7 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
@@ -652,7 +653,7 @@ public class LazyIterableTestHelper<T> implements LazyIterable<T>
     }
 
     @Override
-    public <V, R extends MutableMap<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
+    public <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(Function<? super T, ? extends V> function, R target)
     {
         return null;
     }


### PR DESCRIPTION
This fixes a mistake, but it's a breaking change.