### PR TITLE
Upgrade versions of library dependencies.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -32,8 +32,8 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-generator-annprocess/1.19/jmh-generator-annprocess-1.19.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-core/1.19/jmh-core-1.19.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-generator-annprocess/1.21/jmh-generator-annprocess-1.21.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-core/1.21/jmh-core-1.21.jar" />
           <entry name="$MAVEN_REPOSITORY$/net/sf/jopt-simple/jopt-simple/4.6/jopt-simple-4.6.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/apache/commons/commons-math3/3.2/commons-math3-3.2.jar" />
         </processorPath>

--- a/.idea/libraries/Maven__com_google_code_findbugs_jsr305_3_0_2.xml
+++ b/.idea/libraries/Maven__com_google_code_findbugs_jsr305_3_0_2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.code.findbugs:jsr305:3.0.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_errorprone_error_prone_annotations_2_1_3.xml
+++ b/.idea/libraries/Maven__com_google_errorprone_error_prone_annotations_2_1_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.errorprone:error_prone_annotations:2.1.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_j2objc_j2objc_annotations_1_1.xml
+++ b/.idea/libraries/Maven__com_google_j2objc_j2objc_annotations_1_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.j2objc:j2objc-annotations:1.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_checkerframework_checker_qual_2_0_0.xml
+++ b/.idea/libraries/Maven__org_checkerframework_checker_qual_2_0_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.checkerframework:checker-qual:2.0.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_codehaus_mojo_animal_sniffer_annotations_1_14.xml
+++ b/.idea/libraries/Maven__org_codehaus_mojo_animal_sniffer_annotations_1_14.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/scala_compiler.xml
+++ b/.idea/scala_compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaCompilerConfiguration">
-    <profile name="Maven 1" modules="scala-unit-tests,jmh-scala-tests" />
+    <profile name="Maven 1" modules="jmh-scala-tests,scala-unit-tests" />
   </component>
 </project>

--- a/acceptance-tests/acceptance-tests.iml
+++ b/acceptance-tests/acceptance-tests.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/eclipse-collections-forkjoin/eclipse-collections-forkjoin.iml
+++ b/eclipse-collections-forkjoin/eclipse-collections-forkjoin.iml
@@ -14,7 +14,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" />
     <orderEntry type="module" module-name="eclipse-collections" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/eclipse-collections-testutils/eclipse-collections-testutils.iml
+++ b/eclipse-collections-testutils/eclipse-collections-testutils.iml
@@ -14,7 +14,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="eclipse-collections-api" />
     <orderEntry type="module" module-name="eclipse-collections" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.11</version>
         </dependency>
 
         <!-- External dependencies -->

--- a/jmh-scala-tests/jmh-scala-tests.iml
+++ b/jmh-scala-tests/jmh-scala-tests.iml
@@ -11,7 +11,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.11.7" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.12.6" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
   </component>
 </module>

--- a/jmh-tests/jmh-tests.iml
+++ b/jmh-tests/jmh-tests.iml
@@ -14,17 +14,22 @@
     <orderEntry type="module" module-name="eclipse-collections" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="jmh-scala-tests" />
-    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.11.7" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.12.6" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
-    <orderEntry type="library" name="Maven: com.google.guava:guava:21.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:25.1-jre" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.checkerframework:checker-qual:2.0.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.openjdk.jmh:jmh-core:1.19" level="project" />
+    <orderEntry type="library" name="Maven: org.openjdk.jmh:jmh-core:1.21" level="project" />
     <orderEntry type="library" name="Maven: net.sf.jopt-simple:jopt-simple:4.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.2" level="project" />
-    <orderEntry type="library" name="Maven: com.carrotsearch:hppc:0.7.2" level="project" />
+    <orderEntry type="library" name="Maven: com.carrotsearch:hppc:0.8.1" level="project" />
     <orderEntry type="library" name="Maven: net.openhft:koloboke-api-jdk8:0.6.8" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.openhft:koloboke-impl-jdk8:0.6.8" level="project" />
     <orderEntry type="library" name="Maven: net.sf.trove4j:trove4j:3.0.3" level="project" />

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <sonar.skip>true</sonar.skip>
-        <jmh.version>1.19</jmh.version>
+        <jmh.version>1.21</jmh.version>
     </properties>
 
     <dependencies>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>hppc</artifactId>
-            <version>0.7.2</version>
+            <version>0.8.1</version>
         </dependency>
 
         <dependency>

--- a/performance-tests/performance-tests.iml
+++ b/performance-tests/performance-tests.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
 
         <slf4j.version>1.7.25</slf4j.version>
         <clover.version>4.0.6</clover.version>
-        <scala.version>2.11.7</scala.version>
-        <guava.version>21.0</guava.version>
+        <scala.version>2.12.6</scala.version>
+        <guava.version>25.1-jre</guava.version>
         <trove4j.version>3.0.3</trove4j.version>
         <checkstyle.version>8.11</checkstyle.version>
         <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>

--- a/scala-unit-tests/scala-unit-tests.iml
+++ b/scala-unit-tests/scala-unit-tests.iml
@@ -12,10 +12,10 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scala-lang:scala-library:2.11.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scala-lang:scala-library:2.12.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-nop:1.7.25" level="project" />
   </component>

--- a/serialization-tests/serialization-tests.iml
+++ b/serialization-tests/serialization-tests.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/unit-tests-java8/unit-tests-java8.iml
+++ b/unit-tests-java8/unit-tests-java8.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />

--- a/unit-tests/unit-tests.iml
+++ b/unit-tests/unit-tests.iml
@@ -14,7 +14,7 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />


### PR DESCRIPTION
- Upgrade JMH from 1.19 to 1.21.
- Upgrade HPPC from 0.7.2 to 0.8.1.
- Upgrade Guava from 21.0 to 25.1-jre.
- Upgrade Scala from 2.11.7 to 2.12.6.
- Upgrade version of commons-codec from 1.10 to 1.11.