### PR TITLE
Add .mvn/maven.config with options --show-version and --errors.

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+--show-version
+--errors

--- a/.travis-command-ea-builds.sh
+++ b/.travis-command-ea-builds.sh
@@ -44,7 +44,7 @@ function install_jdk_and_run_ea_build {
   echo "export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g -XX:MaxPermSize=2048m'\" > ~/.mavenrc"
   mvn -version
   echo "Completed setting environment"
-  mvn install --show-version --errors
+  mvn install
 }
 
 case "$JDK" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,36 +30,36 @@ matrix:
       env:
         - DESC="acceptance tests"
         - JDK=Java8
-        - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all --show-version --errors"
+        - CMD="mvn install --projects acceptance-tests --also-make --activate-profiles all"
 
     - jdk: oraclejdk8
       env:
         - DESC="findbugs"
         - JDK=Java8
-        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!jcstress-tests,!p2-repository' --activate-profiles all -DskipTests=true --show-version --errors"
+        - CMD="mvn install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!jcstress-tests,!p2-repository' --activate-profiles all -DskipTests=true"
     - jdk: oraclejdk8
       env:
         - DESC="checkstyle"
         - JDK=Java8
-        - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true --show-version --errors"
+        - CMD="mvn install checkstyle:check --activate-profiles all -DskipTests=true"
 
     - jdk: oraclejdk8
       env:
         - DESC="unit tests"
         - JDK=Java8
-        - CMD="mvn install --show-version --errors"
+        - CMD="mvn install"
 
     - jdk: oraclejdk8
       env:
         - DESC="compile jmh-tests and performance-tests"
         - JDK=Java8
-        - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true --show-version --errors"
+        - CMD="mvn install --projects jmh-tests,performance-tests --also-make --activate-profiles all -DskipTests=true"
 
     - jdk: oraclejdk9
       env:
         - DESC="unit tests Java 9"
         - JDK=Java9
-        - CMD="mvn install --show-version --errors"
+        - CMD="mvn install"
 
     - jdk: oraclejdk8
       env:


### PR DESCRIPTION
This change makes it so that the flags --show-version and --errors are always on, so you don't need to specify them on the command line.