### PR TITLE
Add maven default goals.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,8 @@
     </dependencyManagement>
 
     <build>
+        <defaultGoal>clean install checkstyle:check</defaultGoal>
+
         <pluginManagement>
             <plugins>
 


### PR DESCRIPTION
This makes it so that if you invoke `mvn` without any goals, it will default to `mvn clean install checkstyle:check`