### PR TITLE
Change IntelliJ copyright plugin setting to format header with the message "Goldman Sachs and others" to make it more convenient for external contributors.

### DIFF
--- a/.idea/copyright/Eclipse.xml
+++ b/.idea/copyright/Eclipse.xml
@@ -1,9 +1,7 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright (c) &amp;#36;today.year Goldman Sachs.&#10;All rights reserved. This program and the accompanying materials&#10;are made available under the terms of the Eclipse Public License v1.0&#10;and Eclipse Distribution License v. 1.0 which accompany this distribution.&#10;The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html&#10;and the Eclipse Distribution License is available at&#10;http://www.eclipse.org/org/documents/edl-v10.php." />
-    <option name="keyword" value="Copyright" />
-    <option name="allowReplaceKeyword" value="Goldman Sachs" />
+    <option name="allowReplaceRegexp" value="Goldman Sachs" />
     <option name="myName" value="Eclipse" />
-    <option name="myLocal" value="true" />
+    <option name="notice" value="Copyright (c) &amp;#36;today.year Goldman Sachs and others.&#10;All rights reserved. This program and the accompanying materials&#10;are made available under the terms of the Eclipse Public License v1.0&#10;and Eclipse Distribution License v. 1.0 which accompany this distribution.&#10;The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html&#10;and the Eclipse Distribution License is available at&#10;http://www.eclipse.org/org/documents/edl-v10.php." />
   </copyright>
 </component>


### PR DESCRIPTION
The idea here is to flip the default way that the copyright plugin is configured. At this point, most contributors are outside GS, so the default copyright header probably ought to be "Goldman Sachs and others". Those contributing from within GS can still change the configuration of this plugin, but they'll have to always decide between the two strings on a file by file basis anyway.