### PR TITLE
Enable Java-12 EA build, allow EA build failures, upgrade JaCoCo to 0.8.2 to fix Java 11,12 build failures. Fixes #605

### DIFF
--- a/.travis-command-ea-builds.sh
+++ b/.travis-command-ea-builds.sh
@@ -60,4 +60,7 @@ Java10)
 Java11-EA)
   install_jdk_and_run_ea_build ${JDK11_EA_URL}
   ;;
+Java12-EA)
+  install_jdk_and_run_ea_build ${JDK12_EA_URL}
+  ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,17 @@ matrix:
         - CMD=""
 
   allow_failures:
-    - env: JDK=Java11-EA
+  - jdk: oraclejdk8
+    env:
+      - DESC="Java 11 regression"
+      - JDK=Java11-EA
+      - CMD=""
+
+  - jdk: oraclejdk8
+    env:
+      - DESC="Java 12 regression"
+      - JDK=Java12-EA
+      - CMD=""
 
 script:
   - ./.travis-command-ea-builds.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   -JDK=Java9
   -JDK=Java10
   -JDK=Java11-EA
+  -JDK=Java12-EA
 
 matrix:
   fast_finish: true
@@ -71,6 +72,12 @@ matrix:
       env:
         - DESC="Java 11 regression"
         - JDK=Java11-EA
+        - CMD=""
+
+    - jdk: oraclejdk8
+      env:
+        - DESC="Java 12 regression"
+        - JDK=Java12-EA
         - CMD=""
 
   allow_failures:

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <checkstyle.version>8.11</checkstyle.version>
         <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
         <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
-        <jacoco.plugin.version>0.8.1</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.2</jacoco.plugin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Fixes #605 