### PR TITLE
fix(MapIterable): flipUniqueValues to throw error when it has duplicates

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMap.java
@@ -143,6 +143,10 @@ final class ImmutableDoubletonMap<K, V>
     @Override
     public ImmutableMap<V, K> flipUniqueValues()
     {
+        if (Comparators.nullSafeEquals(this.value1, this.value2))
+        {
+            throw new IllegalStateException("Duplicate value: " + this.value1 + " found at key: " + this.key1 + " and key: " + this.key2);
+        }
         return Maps.immutable.with(this.value1, this.key1, this.value2, this.key2);
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.eclipse.collections.impl.test.Verify.assertThrows;
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -70,8 +71,9 @@ public class ImmutableUnifiedMapTest implements ImmutableMapTestCase
                 UnifiedMap.newWithKeysValues(3, "Three", 2, "Two", 1, "One"),
                 result);
 
-        // TODO: Fix bug, flipUniqueValues is implemented incorrectly in immutable maps. Compare ImmutableDoubletonMap and DoubletonMap for example.
-        this.newWithKeysValues(1, "2", 2, "2").flipUniqueValues();
+        assertThrows(
+                IllegalStateException.class,
+                () -> this.newWithKeysValues(1, "2", 2, "2").flipUniqueValues());
     }
 
     @Test


### PR DESCRIPTION
Closes #443 

(P.s. a minor start 🙂 )

cc: r? @nikhilnanivadekar 