### PR TITLE
fix-#615- Remove default methods in Factories which throw Unsupported…

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/list/MutableListFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/list/MutableListFactory.java
@@ -40,18 +40,12 @@ public interface MutableListFactory
     /**
      * Same as {@link #empty()}. but takes in initial capacity.
      */
-    default <T> MutableList<T> ofInitialCapacity(int capacity)
-    {
-        throw new UnsupportedOperationException("Adding default implementation so as to not break compatibility");
-    }
+    <T> MutableList<T> ofInitialCapacity(int capacity);
 
     /**
      * Same as {@link #empty()}. but takes in initial capacity.
      */
-    default <T> MutableList<T> withInitialCapacity(int capacity)
-    {
-        throw new UnsupportedOperationException("Adding default implementation so as to not break compatibility");
-    }
+    <T> MutableList<T> withInitialCapacity(int capacity);
 
     /**
      * Same as {@link #withAll(Iterable)}.


### PR DESCRIPTION
Signed-off-by: Daniel Dias <daniel.dias.analistati@gmail.com>

PR to #615 .

inside the collections-api factory classes, this class was the only one that had the default method with throw.

please review . 