### PR TITLE
reduce for primitive iterables

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/block/function/primitivePrimitiveToPrimitiveFunction1.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/block/function/primitivePrimitiveToPrimitiveFunction1.stg
@@ -1,0 +1,40 @@
+import "copyrightAndOthers.stg"
+
+hasTwoPrimitives() ::= "true"
+
+targetPath() ::= "org/eclipse/collections/api/block/function/primitive"
+
+fileName(primitive1, primitive2, sameTwoPrimitives) ::= "<primitive1.name><primitive2.name>To<primitive1.name>Function"
+
+class(primitive1, primitive2, sameTwoPrimitives) ::= <<
+<body(primitive1.type, primitive2.type, primitive1.name, primitive2.name)>
+>>
+
+body(type1, type2, name1, name2) ::= <<
+<copyrightAndOthers()>
+
+package org.eclipse.collections.api.block.function.primitive;
+
+import java.io.Serializable;
+
+/**
+ * This file was automatically generated from template file primitivePrimitiveToPrimitiveFunction.stg.
+ *
+ * @since 10.0.
+ */
+@FunctionalInterface
+public interface <name1><name2>To<name1>Function
+        extends <if(primitive1.specializedStream && sameTwoPrimitives)>java.util.function.<name1>BinaryOperator, <endif>Serializable
+{
+    <type1> valueOf(<type1> left, <type2> right);
+<if(primitive1.specializedStream && sameTwoPrimitives)>
+
+    @Override
+    default <type1> applyAs<name1>(<type1> left, <type2> right)
+    {
+        return this.valueOf(left, right);
+    }
+<endif>
+}
+
+>>

--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -15,9 +15,11 @@ body(type, name) ::= <<
 package org.eclipse.collections.api;
 
 import java.util.Collection;
+import java.util.NoSuchElementException;
 <(wideStatisticsImport.(type))>
 
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
+import org.eclipse.collections.api.block.function.primitive.<(wideName.(type))><name>To<(wideName.(type))>Function;
 import org.eclipse.collections.api.block.function.primitive.<name>ToBooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.<name>ToByteFunction;
 import org.eclipse.collections.api.block.function.primitive.<name>ToShortFunction;
@@ -329,6 +331,54 @@ public interface <name>Iterable extends PrimitiveIterable
     Lazy<name>Iterable asLazy();
 
     \<T> T injectInto(T injectedValue, Object<name>ToObjectFunction\<? super T, ? extends T> function);
+
+    /**
+     * @see #reduce(<(wideName.(type))><name>To<(wideName.(type))>Function)
+     *
+     * @since 10.0
+     */
+    default <(wideType.(type))> reduceIfEmpty(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator, <(wideType.(type))> defaultValue)
+    {
+        if (this.isEmpty())
+        {
+            return defaultValue;
+        }
+        else
+        {
+            return this.reduce(accumulator);
+        }
+    }
+
+    /**
+     * @see RichIterable#reduce(BinaryOperator)
+     *
+     * @since 10.0
+     */
+    default <(wideType.(type))> reduce(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator)
+    {
+        boolean[] seenOne = new boolean[1];
+        <(wideName.(type))>[] result = new <(wideName.(type))>[1];
+        this.each(each ->
+        {
+            if (seenOne[0])
+            {
+                result[0] = accumulator.valueOf(result[0], each);
+            }
+            else
+            {
+                seenOne[0] = true;
+                result[0] = <castWideType.(type)>each;
+            }
+        });
+        if (!seenOne[0])
+        {
+            throw new NoSuchElementException();
+        }
+        else
+        {
+            return result[0];
+        }
+    }
 
     /**
      * Partitions elements in fixed size chunks.

--- a/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractSynchronizedPrimitiveCollection.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractSynchronizedPrimitiveCollection.stg
@@ -22,6 +22,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
+import org.eclipse.collections.api.block.function.primitive.<(wideName.(type))><name>To<(wideName.(type))>Function;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
@@ -492,6 +493,24 @@ public abstract class AbstractSynchronized<name>Collection
         synchronized (this.lock)
         {
             return this.collection.injectInto(injectedValue, function);
+        }
+    }
+
+    @Override
+    public <(wideType.(type))> reduce(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator)
+    {
+        synchronized (this.lock)
+        {
+            return this.collection.reduce(accumulator);
+        }
+    }
+
+    @Override
+    public <(wideType.(type))> reduceIfEmpty(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator, <(wideType.(type))> defaultValue)
+    {
+        synchronized (this.lock)
+        {
+            return this.collection.reduceIfEmpty(accumulator, defaultValue);
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractUnmodifiablePrimitiveCollection.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractUnmodifiablePrimitiveCollection.stg
@@ -22,6 +22,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
+import org.eclipse.collections.api.block.function.primitive.<(wideName.(type))><name>To<(wideName.(type))>Function;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
@@ -353,6 +354,18 @@ public abstract class AbstractUnmodifiable<name>Collection
     public \<T> T injectInto(T injectedValue, Object<name>ToObjectFunction\<? super T, ? extends T> function)
     {
         return this.collection.injectInto(injectedValue, function);
+    }
+
+    @Override
+    public <(wideType.(type))> reduce(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator)
+    {
+        return this.collection.reduce(accumulator);
+    }
+
+    @Override
+    public <(wideType.(type))> reduceIfEmpty(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator, <(wideType.(type))> defaultValue)
+    {
+        return this.collection.reduceIfEmpty(accumulator, defaultValue);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/synchronizedPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/synchronizedPrimitiveIterable.stg
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
+import org.eclipse.collections.api.block.function.primitive.<(wideName.(type))><name>To<(wideName.(type))>Function;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
@@ -269,6 +270,24 @@ public class Synchronized<name>Iterable implements <name>Iterable, Serializable
         synchronized (this.lock)
         {
             return this.iterable.injectInto(injectedValue, function);
+        }
+    }
+
+    @Override
+    public <(wideType.(type))> reduce(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator)
+    {
+        synchronized (this.lock)
+        {
+            return this.iterable.reduce(accumulator);
+        }
+    }
+
+    @Override
+    public <(wideType.(type))> reduceIfEmpty(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator, <(wideType.(type))> defaultValue)
+    {
+        synchronized (this.lock)
+        {
+            return this.iterable.reduceIfEmpty(accumulator, defaultValue);
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/primitiveLiteral.stg
+++ b/eclipse-collections-code-generator/src/main/resources/primitiveLiteral.stg
@@ -130,6 +130,19 @@ wideType ::= [
     "long": "long",
     "float": "double",
     "double": "double",
+    "boolean": "boolean",
+    default: "no matching wide type"
+]
+
+wideName ::= [
+    "byte": "Long",
+    "short": "Long",
+    "char": "Long",
+    "int": "Long",
+    "long": "Long",
+    "float": "Double",
+    "double": "Double",
+    "boolean": "Boolean",
     default: "no matching wide type"
 ]
 
@@ -147,6 +160,7 @@ castWideType ::= [
     "long": "",
     "float": "(double) ",
     "double": "",
+    "boolean": "",
     default: "no matching wide type"
 ]
 

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -1005,6 +1005,28 @@ public void sumConsistentRounding()
         Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("38")>), sum3);
     }
 
+    @Test(expected = NoSuchElementException.class)
+    public void reduceOnEmptyThrows()
+    {
+        this.newWith().reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
+    }
+
+    @Test
+    public void reduce()
+    {
+        <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
+        <(wideType.(type))> sum1 = iterable1.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
+        Assert.assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
+
+        <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
+        <(wideType.(type))> sum2 = iterable2.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
+        Assert.assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
+
+        <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
+        <(wideType.(type))> sum3 = iterable3.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
+        Assert.assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
+    }
+
     @Test
     public void chunk()
     {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
@@ -352,6 +352,32 @@ public abstract class AbstractBooleanIterableTestCase
         Assert.assertEquals(new MutableInteger(2), result);
     }
 
+    @Test(expected = NoSuchElementException.class)
+    public void reduceOnEmptyThrows()
+    {
+        this.newWith().reduce((boolean result, boolean value) -> result && value);
+    }
+
+    @Test
+    public void reduce()
+    {
+        BooleanIterable iterable1 = this.newWith(true, false, true);
+        boolean and = iterable1.reduce((boolean result, boolean value) -> result && value);
+        Assert.assertEquals(false, and);
+
+        BooleanIterable iterable2 = this.newWith(true, true, true);
+        boolean and2 = iterable2.reduce((boolean result, boolean value) -> result && value);
+        Assert.assertEquals(true, and2);
+
+        BooleanIterable iterable3 = this.newWith(true, false, true);
+        boolean or = iterable3.reduce((boolean result, boolean value) -> result || value);
+        Assert.assertEquals(true, or);
+
+        BooleanIterable iterable4 = this.newWith(false, false, false);
+        boolean or2 = iterable4.reduce((boolean result, boolean value) -> result || value);
+        Assert.assertEquals(false, or2);
+    }
+
     @Test
     public void toArray()
     {


### PR DESCRIPTION
Hi,

This is a PR for #312, this is not finished, but I'm making this PR public in order to get feedbacks as soon as possible.

TODO:
- [x] add `reduce` and `reduceIfEmpty` to primitive iterables with simple implementation as a default method
- [x] check if there are other collections (than synchronized primitive iterable and synchronized ~~and unmodifiable~~ primitive collection) that needs a specialized implementation of reduce for correctness
- [x] make DoubleDoubleToDoubleFunction extend DoubleBinaryOperator (as well as with int and long) 
- [x] ~~introduce primitive optionals (for now I use `Optional` with primitive wrappers)~~
- [x] elegantly handle overflow problem (sum on int should give long…)
- [x] ~~add `reduceInPlace`~~

I think that after that, this can be merged and then we could open the following new issues:
- add optimized implementation of `reduce` and `reduceInPlace` in the right places
- other ideas?

Open questions:
- I feel like using a default method (as recommended, see https://github.com/eclipse/eclipse-collections/issues/312#issuecomment-438015186) is dangerous because you never know when it is needed to override or not the method. For example I almost missed abstract synchronized and unmodifiable primitive collections. I'm still not sure if I missed other implementations… If I had added the implementation in the abstract class, I would have a clearer view of the class hierarchies impacted by the addition of the method.

cc @donraab 