### PR TITLE
Implement LazyIterate.cartesianProduct

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/factory/Sets.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/factory/Sets.java
@@ -285,8 +285,8 @@ public final class Sets
         return Sets.cartesianProduct(set1, set2, Tuples::pair);
     }
 
-    public static <A, B, C> LazyIterable<C> cartesianProduct(Set<A> set1, Set<B> set2, Function2<A, B, C> function)
+    public static <A, B, C> LazyIterable<C> cartesianProduct(Set<A> set1, Set<B> set2, Function2<? super A, ? super B, ? extends C> function)
     {
-        return LazyIterate.flatCollect(set1, first -> LazyIterate.collect(set2, second -> function.value(first, second)));
+        return LazyIterate.cartesianProduct(set1, set2, function);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/LazyIterate.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.utility;
 import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.tuple.Pair;
@@ -33,6 +34,7 @@ import org.eclipse.collections.impl.lazy.TakeWhileIterable;
 import org.eclipse.collections.impl.lazy.TapIterable;
 import org.eclipse.collections.impl.lazy.ZipIterable;
 import org.eclipse.collections.impl.lazy.ZipWithIndexIterable;
+import org.eclipse.collections.impl.tuple.Tuples;
 
 /**
  * LazyIterate is a factory class which creates "deferred" iterables around the specified iterables. A "deferred"
@@ -195,5 +197,33 @@ public final class LazyIterate
     public static <T> LazyIterable<T> tap(Iterable<T> iterable, Procedure<? super T> procedure)
     {
         return new TapIterable<>(iterable, procedure);
+    }
+
+    /**
+     * Create a deferred cartesian product of the two specified iterables.
+     *
+     * See {@link LazyIterate#cartesianProduct(Iterable, Iterable, Function2)} about performance and presence of duplicates.
+     *
+     * @since 10.0
+     */
+    public static <A, B> LazyIterable<Pair<A, B>> cartesianProduct(Iterable<A> iterable1, Iterable<B> iterable2)
+    {
+        return LazyIterate.cartesianProduct(iterable1, iterable2, Tuples::pair);
+    }
+
+    /**
+     * Create a deferred cartesian product of the two specified iterables.
+     *
+     * This operation has O(n^2) performance.
+     *
+     * The presence of duplicates in the resulting iterable is both dependent on the
+     * presence of duplicates in the two specified iterables, and on the behaviour
+     * of the terminating operation that is applied to the resulting lazy iterable.
+     *
+     * @since 10.0
+     */
+    public static <A, B, C> LazyIterable<C> cartesianProduct(Iterable<A> iterable1, Iterable<B> iterable2, Function2<? super A, ? super B, ? extends C> function)
+    {
+        return LazyIterate.flatCollect(iterable1, first -> LazyIterate.collect(iterable2, second -> function.value(first, second)));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/SetIterables.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/SetIterables.java
@@ -158,6 +158,6 @@ public final class SetIterables
 
     public static <A, B, C> LazyIterable<C> cartesianProduct(SetIterable<A> set1, SetIterable<B> set2, Function2<A, B, C> function)
     {
-        return LazyIterate.flatCollect(set1, first -> LazyIterate.collect(set2, second -> function.value(first, second)));
+        return LazyIterate.cartesianProduct(set1, set2, function);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
@@ -11,17 +11,24 @@
 package org.eclipse.collections.impl.utility;
 
 import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.block.function.AddFunction;
+import org.eclipse.collections.impl.factory.Bags;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -178,5 +185,86 @@ public class LazyIterateTest
     public void classIsNonInstantiable()
     {
         Verify.assertClassNonInstantiable(LazyIterate.class);
+    }
+
+    @Test
+    public void cartesianProduct()
+    {
+        MutableList<Integer> iterable1 = Lists.mutable.with(1, 2);
+        MutableList<Integer> iterable2 = Lists.mutable.with(2, 3, 4);
+        MutableBag<Pair<Integer, Integer>> expectedCartesianProduct1 = Bags.mutable.with(
+                Tuples.pair(1, 2),
+                Tuples.pair(2, 2),
+                Tuples.pair(1, 3),
+                Tuples.pair(2, 3),
+                Tuples.pair(1, 4),
+                Tuples.pair(2, 4));
+        Assert.assertEquals(expectedCartesianProduct1, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
+        MutableBag<Pair<Integer, Integer>> expectedCartesianProduct2 = Bags.mutable.with(
+                Tuples.pair(2, 1),
+                Tuples.pair(3, 1),
+                Tuples.pair(4, 1),
+                Tuples.pair(2, 2),
+                Tuples.pair(3, 2),
+                Tuples.pair(4, 2));
+        Assert.assertEquals(expectedCartesianProduct2, LazyIterate.cartesianProduct(iterable2, iterable1).toBag());
+    }
+
+    @Test
+    public void cartesianProductDuplicatesToConcreteCollections()
+    {
+        MutableList<Integer> iterable1 = Lists.mutable.with(1, 1);
+        MutableList<Integer> iterable2 = Lists.mutable.with(2, 2);
+        MutableBag<Pair<Integer, Integer>> expectedBag = Bags.mutable.with(
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2));
+        Assert.assertEquals(expectedBag, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
+        MutableSet<Pair<Integer, Integer>> expectedSet = Sets.mutable.with(Tuples.pair(1, 2));
+        Assert.assertEquals(expectedSet, LazyIterate.cartesianProduct(iterable1, iterable2).toSet());
+        MutableList<Pair<Integer, Integer>> expectedList = Lists.mutable.with(
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2),
+                Tuples.pair(1, 2));
+        Assert.assertEquals(expectedList, LazyIterate.cartesianProduct(iterable1, iterable2).toList());
+    }
+
+    @Test
+    public void cartesianProductWithFunction()
+    {
+        MutableList<Integer> iterable1 = Lists.mutable.with(1, 2);
+        MutableList<Integer> iterable2 = Lists.mutable.with(2, 3, 4);
+        MutableBag<Pair<Integer, Integer>> expectedCartesianProduct = Bags.mutable.with(
+                Tuples.pair(1, 2),
+                Tuples.pair(2, 2),
+                Tuples.pair(1, 3),
+                Tuples.pair(2, 3),
+                Tuples.pair(1, 4),
+                Tuples.pair(2, 4));
+        Assert.assertEquals(
+                expectedCartesianProduct,
+                LazyIterate.cartesianProduct(iterable1, iterable2, Tuples::pair).toBag());
+        MutableBag<MutableList<Integer>> expectedCartesianProduct2 = Bags.mutable.with(
+                Lists.mutable.with(2, 1),
+                Lists.mutable.with(3, 1),
+                Lists.mutable.with(4, 1),
+                Lists.mutable.with(2, 2),
+                Lists.mutable.with(3, 2),
+                Lists.mutable.with(4, 2));
+        Assert.assertEquals(
+                expectedCartesianProduct2,
+                LazyIterate.cartesianProduct(iterable2, iterable1, Lists.mutable::with).toBag());
+    }
+
+    @Test
+    public void cartesianProduct_empty()
+    {
+        Assert.assertEquals(
+                Bags.mutable.empty(),
+                LazyIterate.cartesianProduct(
+                        Lists.mutable.with(1, 2),
+                        Lists.mutable.empty()).toBag());
     }
 }


### PR DESCRIPTION
This generalize the already available `Sets.cartesianProduct` and `SetIterables.cartesianProduct` to any `Iterable`.

This is something I did need many times and I was bothered to have to convert my two `LazyIterable`s into concrete `Set`s just to get the product of their elements.