### PR TITLE
Change boxed result array to primitive array to avoid unnecessary box…

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -357,7 +357,7 @@ public interface <name>Iterable extends PrimitiveIterable
     default <(wideType.(type))> reduce(<(wideName.(type))><name>To<(wideName.(type))>Function accumulator)
     {
         boolean[] seenOne = new boolean[1];
-        <(wideName.(type))>[] result = new <(wideName.(type))>[1];
+        <(wideType.(type))>[] result = new <(wideType.(type))>[1];
         this.each(each ->
         {
             if (seenOne[0])


### PR DESCRIPTION
…ing in primitive reduce.

Signed-off-by: Donald Raab <Donald.Raab@bnymellon.com>