### PR TITLE
Refresh IntelliJ project files to remove commons-codec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 target
 .maven
+.mvn/wrapper/
+mvnw
+mvnw.cmd
 jmh-scala-tests/.cache-main
 scala-unit-tests/.cache-tests
 test-coverage/**
@@ -32,7 +35,7 @@ test-coverage/**
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-.idea/modules
+.idea/scala_compiler.xml
 
 # CMake
 cmake-build-*/

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <addNotNullAssertions enabled="false" />
-    <wildcardResourcePatterns>
-      <entry name="!?*.java" />
-    </wildcardResourcePatterns>
     <annotationProcessing>
       <profile name="Maven default annotation processors profile" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/acceptance-tests" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/eclipse-collections" charset="UTF-8" />

--- a/.idea/scala_compiler.xml
+++ b/.idea/scala_compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaCompilerConfiguration">
-    <profile name="Maven 1" modules="jmh-scala-tests,scala-unit-tests" />
+    <profile name="Maven 1" modules="scala-unit-tests,jmh-scala-tests" />
   </component>
 </project>

--- a/acceptance-tests/acceptance-tests.iml
+++ b/acceptance-tests/acceptance-tests.iml
@@ -12,7 +12,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/eclipse-collections-forkjoin/eclipse-collections-forkjoin.iml
+++ b/eclipse-collections-forkjoin/eclipse-collections-forkjoin.iml
@@ -14,7 +14,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" />
     <orderEntry type="module" module-name="eclipse-collections" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/eclipse-collections-testutils/eclipse-collections-testutils.iml
+++ b/eclipse-collections-testutils/eclipse-collections-testutils.iml
@@ -14,7 +14,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="eclipse-collections-api" />
     <orderEntry type="module" module-name="eclipse-collections" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/jmh-tests/jmh-tests.iml
+++ b/jmh-tests/jmh-tests.iml
@@ -14,7 +14,6 @@
     <orderEntry type="module" module-name="eclipse-collections" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="jmh-scala-tests" />
     <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.12.6" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />

--- a/performance-tests/performance-tests.iml
+++ b/performance-tests/performance-tests.iml
@@ -12,7 +12,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="module" module-name="eclipse-collections-forkjoin" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/scala-unit-tests/scala-unit-tests.iml
+++ b/scala-unit-tests/scala-unit-tests.iml
@@ -12,7 +12,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.scala-lang:scala-library:2.12.6" level="project" />

--- a/serialization-tests/serialization-tests.iml
+++ b/serialization-tests/serialization-tests.iml
@@ -12,7 +12,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/unit-tests-java8/unit-tests-java8.iml
+++ b/unit-tests-java8/unit-tests-java8.iml
@@ -12,7 +12,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />

--- a/unit-tests/unit-tests.iml
+++ b/unit-tests/unit-tests.iml
@@ -14,7 +14,6 @@
     <orderEntry type="module" module-name="eclipse-collections-api" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections" scope="TEST" />
     <orderEntry type="module" module-name="eclipse-collections-testutils" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />


### PR DESCRIPTION
Looked at #581 again after @mohrezaei's comment.

The removal of commons-codec affects *.iml files intentionally. The other xml files aren't supposed to be changed, which is frustrating / confusing. In this commit I'm syncing up the iml files which should exactly match across all our computers. I'm also syncing the other xml files in the hope that they match, or at least match more closely. If there are remaining diffs, I'd like to see them.

Projects that use maven or gradle's auto-import can usually delete modules.xml, compiler.xml, encodings.xml, and *.iml. Since we're using and experimenting with TeamCity Inspections builds, we do require these files for those builds to pass. I did try deleting subsets of the files to see what would happen and it does break the Inspections functionality unfortunately.

I'm trying to think of other creative solutions. If there is a way to get git to ignore files that are already committed, maybe we could work in a way where you never see changed to IDE project files, and every once in a while I could sync them up to make sure TeamCity is working well and contributors who use IntelliJ aren't running into problems. I know that it's not as simple as adding *.iml to .gitignore.