### PR TITLE
Adding builder style construction to MapFactories

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.factory.map;
 import java.util.Map;
 
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
 
 public interface ImmutableMapFactory
 {
@@ -67,4 +68,6 @@ public interface ImmutableMapFactory
     <K, V> ImmutableMap<K, V> ofAll(Map<K, V> map);
 
     <K, V> ImmutableMap<K, V> withAll(Map<K, V> map);
+
+    <K, V> MapBuilder<K, V> newBuilderWith(K key, V value);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/MutableMapFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/MutableMapFactory.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
 
 public interface MutableMapFactory
 {
@@ -77,4 +78,6 @@ public interface MutableMapFactory
     <K, V> MutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
 
     <K, V> MutableMap<K, V> withMapIterable(MapIterable<? extends K, ? extends V> mapIterable);
+
+    <K, V> MapBuilder<K, V> newBuilderWith(K key, V value);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/builder/MapBuilder.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/builder/MapBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.map.builder;
+
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+
+/**
+ * MapBuilders are used to conveniently construct maps with more than 4 key-value pair entries during declaration.
+ * For maps with less than 5 entries, use Maps.[im]mutable.of()/with or Maps.[im]mutable.of()/with().
+ * Each builder is safe to reuse. MapBuilders maintains their own state even after calling build() or buildImmutable().
+ * Repeated calls of build() or buildMutable() return new copies of appropriately hydrated maps each time.
+ */
+public interface MapBuilder<K, V>
+{
+    /**
+     * A chained map.put(Key, Value). Subsequent calls with the same key will overwrite the previous entry.
+     *
+     * @return a reusable builder to chain additional entries into or construct the target map with build()
+     */
+    MapBuilder<K, V> and(K key, V value);
+
+    /**
+     * Builds an ImmutableMap by default as the builder pattern is synonymous with creating immutable objects.
+     *
+     * @return an ImmutableMap with entries provided to this builder.
+     */
+    ImmutableMap<K, V> build();
+
+    /**
+     * Returns a MutableMap allowing future mutation. Effectively the same as calling build().toMap() but with explicit
+     * naming.
+     *
+     * @return an Mutable copy of the desired map with entries passed to this builder.
+     */
+    MutableMap<K, V> buildMutable();
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/builder/MapBuilderImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/builder/MapBuilderImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.map.builder;
+
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+
+public class MapBuilderImpl<K, V> implements MapBuilder<K, V>
+{
+    private final MutableMap<K, V> map;
+
+    /**
+     * Constructs a new MapBuilder simultaneously configuring the Key and Value types for use.
+     */
+    public MapBuilderImpl(MutableMap<K, V> initialMap)
+    {
+        this.map = initialMap;
+    }
+
+    @Override
+    public MapBuilder<K, V> and(K key, V value)
+    {
+        this.map.put(key, value);
+        return this;
+    }
+
+    @Override
+    public ImmutableMap<K, V> build()
+    {
+        return this.map.toImmutable();
+    }
+
+    @Override
+    public MutableMap<K, V> buildMutable()
+    {
+        return UnifiedMap.newMap(this.map);
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
@@ -12,9 +12,12 @@ package org.eclipse.collections.impl.map.immutable;
 
 import java.util.Map;
 
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.map.ImmutableMapFactory;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
 import org.eclipse.collections.impl.block.factory.Comparators;
+import org.eclipse.collections.impl.map.builder.MapBuilderImpl;
 
 public class ImmutableMapFactoryImpl implements ImmutableMapFactory
 {
@@ -183,5 +186,11 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
             default:
                 throw new AssertionError();
         }
+    }
+
+    @Override
+    public <K, V> MapBuilder<K, V> newBuilderWith(K key, V value)
+    {
+        return new MapBuilderImpl<>(Maps.mutable.with(key, value));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MutableMapFactoryImpl.java
@@ -15,7 +15,9 @@ import java.util.Map;
 import org.eclipse.collections.api.factory.map.MutableMapFactory;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
 import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.map.builder.MapBuilderImpl;
 
 public class MutableMapFactoryImpl implements MutableMapFactory
 {
@@ -123,5 +125,11 @@ public class MutableMapFactoryImpl implements MutableMapFactory
         MutableMap<K, V> output = Maps.mutable.withInitialCapacity(mapIterable.size());
         mapIterable.forEachKeyValue(output::put);
         return output;
+    }
+
+    @Override
+    public <K, V> MapBuilder<K, V> newBuilderWith(K key, V value)
+    {
+        return new MapBuilderImpl<>(this.with(key, value));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.factory.map.sorted.MutableSortedMapFactory;
 import org.eclipse.collections.api.map.FixedSizeMap;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.builder.MapBuilder;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
@@ -93,8 +94,8 @@ public class MapsTest
         Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
 
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
-        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quattro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quattro")));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quattro")));
     }
 
     @Test
@@ -267,5 +268,52 @@ public class MapsTest
 
         Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMapIterable(Maps.mutable.with(1, 1)));
         Verify.assertInstanceOf(UnifiedMap.class, factory.ofMapIterable(Maps.mutable.with(1, 1)));
+    }
+
+    @Test
+    public void builder()
+    {
+        MapBuilder<Integer, Integer> builder = Maps.mutable.newBuilderWith(-1, -1);
+        for (int i = 1; i <= 5; i++)
+        {
+            builder.and(i, i);
+            ImmutableMap<Integer, Integer> builtMap = builder.build();
+            Verify.assertSize(i + 1, builtMap); // + 1 for the initial type-setting entry
+        }
+        Verify.assertSize(6, builder.build());
+        Verify.assertMapsEqual(builder.build().toMap(), builder.buildMutable());
+    }
+
+    @Test
+    public void builderConstructionContainsExpectedValues()
+    {
+        MutableMap<Integer, Integer> map = Maps.mutable
+                .newBuilderWith(0, 0)
+                .and(1, 1)
+                .and(2, 2)
+                .and(3, 3)
+                .and(4, 4)
+                .buildMutable();
+
+        Verify.assertSize(5, map);
+        for (int i = 0; i < 5; i++)
+        {
+            Verify.assertContainsKeyValue(i, i, map);
+        }
+    }
+
+    @Test
+    public void builderObeysMapConstructs()
+    {
+        MutableMap<Integer, String> map = Maps.mutable
+                .newBuilderWith(1, "One")
+                .and(2, "Dos")
+                .and(3, "Drei")
+                .and(4, "Quattro")
+                .and(5, "Cinco")    //Confirm this gets overwritten.
+                .and(5, "Fem")      //We already had Spanish ;)
+                .buildMutable();
+        Verify.assertSize(5, map);
+        Verify.assertContainsAllKeyValues(map, 1, "One", 2, "Dos", 3, "Drei", 4, "Quattro", 5, "Fem");
     }
 }


### PR DESCRIPTION
This small convenient new feature empowers EC Map users to construct/instantiate maps with as many entries as they need, surpassing the current limit of 4. This is achieved by leveraging the builder pattern. The common use case for this feature is when users want/need to create static maps that hold configuration mappings within their applications. This feature eliminates the need to hydrate such maps inside static blocks which commonly induces code smell.