### PR TITLE
maven-compiler-plugin 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
 
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Release notes about version 3.8.1:
https://blogs.apache.org/maven/entry/apache-maven-compiler-plugin-version1

Release notes about version 3.8.0:
https://blogs.apache.org/maven/entry/apache-maven-compiler-plugin-version