### PR TITLE
Add new APIs, `ofOccurrences` and `withOccurrences`, to bag mutable and immutable factories 

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/bag/ImmutableBagFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/bag/ImmutableBagFactory.java
@@ -13,7 +13,9 @@ package org.eclipse.collections.api.factory.bag;
 import java.util.stream.Stream;
 
 import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Bags;
+import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 
 /**
  * A factory which creates instances of type {@link ImmutableBag}.
@@ -47,7 +49,110 @@ public interface ImmutableBagFactory
      */
     <T> ImmutableBag<T> of(T... elements);
 
+    /**
+     * Same as {@link #withOccurrences(Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> ofOccurrences(T element, int occurrence)
+    {
+        return this.withOccurrences(element, occurrence);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2, element3, occurrence3);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int, Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3, T element4, int occurrence4)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2, element3, occurrence3, element4, occurrence4);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(ObjectIntPair[])}
+     *
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> ofOccurrences(ObjectIntPair<T>... elementsWithOccurrences)
+    {
+        return this.withOccurrences(elementsWithOccurrences);
+    }
+
     <T> ImmutableBag<T> with(T... elements);
+
+    /**
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> withOccurrences(T element, int occurrence)
+    {
+        MutableBag<T> mutableBag = Bags.mutable.withOccurrences(element, occurrence);
+        return mutableBag.toImmutable();
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2)
+    {
+        MutableBag<T> mutableBag = Bags.mutable.withOccurrences(
+                element1, occurrence1,
+                element2, occurrence2);
+        return mutableBag.toImmutable();
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3)
+    {
+        MutableBag<T> mutableBag = Bags.mutable.withOccurrences(
+                element1, occurrence1,
+                element2, occurrence2,
+                element3, occurrence3);
+        return mutableBag.toImmutable();
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3, T element4, int occurrence4)
+    {
+        MutableBag<T> mutableBag = Bags.mutable.withOccurrences(
+                element1, occurrence1,
+                element2, occurrence2,
+                element3, occurrence3,
+                element4, occurrence4);
+        return mutableBag.toImmutable();
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> ImmutableBag<T> withOccurrences(ObjectIntPair<T>... elementsWithOccurrences)
+    {
+        return Bags.mutable.withOccurrences(elementsWithOccurrences).toImmutable();
+    }
 
     /**
      * Same as {@link #withAll(Iterable)}.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/bag/MutableBagFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/bag/MutableBagFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.factory.bag;
 import java.util.stream.Stream;
 
 import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 
 /**
  * A factory which creates instances of type {@link MutableBag}.
@@ -48,7 +49,116 @@ public interface MutableBagFactory
         return this.with(elements);
     }
 
+    /**
+     * Same as {@link #withOccurrences(Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> MutableBag<T> ofOccurrences(T element, int occurrence)
+    {
+        return this.withOccurrences(element, occurrence);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> MutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> MutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2, element3, occurrence3);
+    }
+
+    /**
+     * Same as {@link #withOccurrences(Object, int, Object, int, Object, int, Object, int)}.
+     *
+     * @since 10.3
+     */
+    default <T> MutableBag<T> ofOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3, T element4, int occurrence4)
+    {
+        return this.withOccurrences(element1, occurrence1, element2, occurrence2, element3, occurrence3, element4, occurrence4);
+    }
+
+    /**
+     *  Same as {@link #withOccurrences(ObjectIntPair[])}.
+     *
+     *  @since 10.3
+     */
+    default <T> MutableBag<T> ofOccurrences(ObjectIntPair<T>... elementsWithOccurrences)
+    {
+        return this.withOccurrences(elementsWithOccurrences);
+    }
+
     <T> MutableBag<T> with(T... elements);
+
+    /**
+     * @since 10.3
+     */
+    default <T> MutableBag<T> withOccurrences(T element, int occurrence)
+    {
+        MutableBag<T> bag = this.empty();
+        bag.addOccurrences(element, occurrence);
+        return bag;
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> MutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2)
+    {
+        MutableBag<T> bag = this.empty();
+        bag.addOccurrences(element1, occurrence1);
+        bag.addOccurrences(element2, occurrence2);
+        return bag;
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> MutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3)
+    {
+        MutableBag<T> bag = this.empty();
+        bag.addOccurrences(element1, occurrence1);
+        bag.addOccurrences(element2, occurrence2);
+        bag.addOccurrences(element3, occurrence3);
+        return bag;
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> MutableBag<T> withOccurrences(T element1, int occurrence1, T element2, int occurrence2, T element3, int occurrence3, T element4, int occurrence4)
+    {
+        MutableBag<T> bag = this.empty();
+        bag.addOccurrences(element1, occurrence1);
+        bag.addOccurrences(element2, occurrence2);
+        bag.addOccurrences(element3, occurrence3);
+        bag.addOccurrences(element4, occurrence4);
+        return bag;
+    }
+
+    /**
+     * @since 10.3
+     */
+    default <T> MutableBag<T> withOccurrences(ObjectIntPair<T>... elementsWithOccurrences)
+    {
+        MutableBag<T> bag = this.empty();
+        for (ObjectIntPair<T> itemToAdd : elementsWithOccurrences)
+        {
+            bag.addOccurrences(itemToAdd.getOne(), itemToAdd.getTwo());
+        }
+        return bag;
+    }
 
     /**
      * Same as {@link #withAll(Iterable)}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
@@ -346,7 +346,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     public void selectDuplicates()
     {
         Verify.assertBagsEqual(
-                Bags.immutable.with("2", "2", "3", "3", "3", "4", "4", "4", "4"),
+                Bags.immutable.ofOccurrences(PrimitiveTuples.pair("2", 2), PrimitiveTuples.pair("3", 3), PrimitiveTuples.pair("4", 4)),
                 this.newBag().selectDuplicates());
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
@@ -450,7 +450,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     @Test
     public void topOccurrences()
     {
-        MutableBagIterable<String> strings = this.newWithOccurrences(
+        MutableBagIterable<String> strings = Bags.mutable.withOccurrences(
                 PrimitiveTuples.pair("one", 1),
                 PrimitiveTuples.pair("two", 2),
                 PrimitiveTuples.pair("three", 3),
@@ -485,7 +485,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     @Test
     public void bottomOccurrences()
     {
-        MutableBagIterable<String> strings = this.newWithOccurrences(
+        MutableBagIterable<String> strings = Bags.mutable.ofOccurrences(
                 PrimitiveTuples.pair("one", 1),
                 PrimitiveTuples.pair("two", 2),
                 PrimitiveTuples.pair("three", 3),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
@@ -56,6 +56,13 @@ public class BagsTest
         Verify.assertInstanceOf(MutableBag.class, bagFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
         Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.fromStream(Stream.of(1, 2, 2, 3, 3, 3)));
         Verify.assertInstanceOf(MutableBag.class, bagFactory.fromStream(Stream.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertBagsEqual(HashBag.newBagWith(1), bagFactory.ofOccurrences(1, 1));
+        Verify.assertInstanceOf(MutableBag.class, bagFactory.ofOccurrences(1, 1));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2), bagFactory.ofOccurrences(1, 1, 2, 2));
+        Verify.assertInstanceOf(MutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
+        Verify.assertInstanceOf(MutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
+        Verify.assertInstanceOf(MutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
     }
 
     @Test
@@ -88,6 +95,14 @@ public class BagsTest
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofAll(HashBag.newBagWith(1, 2, 3)));
         Assert.assertEquals(HashBag.newBagWith(3, 2, 1), bagFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.fromStream(Stream.of(1, 2, 3)));
+        Assert.assertEquals(HashBag.newBagWith(1), bagFactory.ofOccurrences(1, 1));
+        Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 2), bagFactory.ofOccurrences(1, 1, 2, 2));
+        Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
+        Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
+        Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
     }
 
     @Test


### PR DESCRIPTION
Fix #739 