### PR TITLE
Fixes #762. Fix fromToBy & injectInto issues with same start and end with negative step. Add unit tests to Interval as well, to cover the scenario.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -317,7 +317,7 @@ public final class IntInterval
     public void forEachWithIndex(IntIntProcedure procedure)
     {
         int index = 0;
-        if (this.from <= this.to)
+        if (this.goForward())
         {
             for (int i = this.from; i <= this.to; i += this.step)
             {
@@ -339,13 +339,18 @@ public final class IntInterval
         this.each(procedure);
     }
 
+    private boolean goForward()
+    {
+        return this.from <= this.to && this.step > 0;
+    }
+
     /**
      * @since 7.0.
      */
     @Override
     public void each(IntProcedure procedure)
     {
-        if (this.from <= this.to)
+        if (this.goForward())
         {
             for (int i = this.from; i <= this.to; i += this.step)
             {
@@ -615,7 +620,7 @@ public final class IntInterval
     public <T> T injectInto(T injectedValue, ObjectIntToObjectFunction<? super T, ? extends T> function)
     {
         T result = injectedValue;
-        if (this.from <= this.to)
+        if (this.goForward())
         {
             for (int i = this.from; i <= this.to; i += this.step)
             {
@@ -638,7 +643,7 @@ public final class IntInterval
         T result = injectedValue;
         int index = 0;
 
-        if (this.from <= this.to)
+        if (this.goForward())
         {
             for (int i = this.from; i <= this.to; i += this.step)
             {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
@@ -30,6 +31,7 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.math.IntegerSum;
+import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -63,6 +65,15 @@ public class IntervalTest
     public void fromToBy_throws_step_size_zero()
     {
         Interval.fromToBy(0, 0, 0);
+    }
+
+    @Test
+    public void fromToBy_with_same_start_and_end_with_negative_step()
+    {
+        MutableList<Integer> integers = Interval.fromToBy(2, 2, -2).toList();
+
+        Verify.assertEquals(1, integers.size());
+        Verify.assertContains(2, integers);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -199,6 +210,15 @@ public class IntervalTest
         Interval interval = Interval.oneTo(5);
         Assert.assertEquals(Integer.valueOf(20), interval.injectInto(5, AddFunction.INTEGER));
         Assert.assertEquals(Integer.valueOf(20), interval.reverseThis().injectInto(5, AddFunction.INTEGER));
+    }
+
+    @Test
+    public void injectIntoOnFromToBySameStartEndNegativeStepInterval()
+    {
+        Interval interval = Interval.fromToBy(2, 2, -2);
+
+        Assert.assertEquals(Integer.valueOf(0), interval.injectInto(-2, AddFunction.INTEGER));
+        Assert.assertEquals(Integer.valueOf(0), interval.reverseThis().injectInto(-2, AddFunction.INTEGER));
     }
 
     @Test
@@ -639,6 +659,17 @@ public class IntervalTest
         MutableList<Integer> backwardsResult = Lists.mutable.of();
         interval.forEachWithIndex(new AddParametersProcedure(backwardsResult), 3, 1);
         Assert.assertEquals(FastList.newListWith(8, 2, -4), backwardsResult);
+    }
+
+    @Test
+    public void forEach_with_same_start_and_end_with_negative_step()
+    {
+        Interval interval = Interval.fromToBy(2, 2, -2);
+
+        MutableInteger counter = new MutableInteger(0);
+        interval.forEach((Procedure<Integer>) each -> counter.add(1));
+
+        Assert.assertEquals(1, counter.toInteger().intValue());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.LazyIntIterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.procedure.primitive.IntProcedure;
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -69,6 +70,24 @@ public class IntIntervalTest
     public void fromToBy_throws_on_illegal_step()
     {
         IntInterval.fromToBy(5, 0, 1);
+    }
+
+    @Test
+    public void fromToBy_with_same_start_and_end_with_negative_step()
+    {
+        MutableIntList integers = IntInterval.fromToBy(2, 2, -2).toList();
+
+        Verify.assertEquals(1, integers.size());
+        Verify.assertEquals(2, integers.getFirst());
+    }
+
+    @Test
+    public void fromToBy_with_same_start_and_end_with_negative_step2()
+    {
+        MutableIntList integers = IntInterval.fromToBy(2, 2, -1).toList();
+
+        Verify.assertEquals(1, integers.size());
+        Verify.assertEquals(2, integers.getFirst());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -196,6 +215,14 @@ public class IntIntervalTest
         IntInterval interval2 = IntInterval.fromTo(3, 1);
         MutableInteger result2 = interval2.injectIntoWithIndex(new MutableInteger(0), (object, value, index) -> object.add(value * this.intInterval.get(index)));
         Assert.assertEquals(new MutableInteger(10), result2);
+    }
+
+    @Test
+    public void injectIntoOnFromToBySameStartEndNegativeStepInterval()
+    {
+        IntInterval interval = IntInterval.fromToBy(2, 2, -2);
+
+        Assert.assertEquals(new MutableInteger(0), interval.injectInto(new MutableInteger(-2), MutableInteger::add));
     }
 
     @Test
@@ -740,6 +767,17 @@ public class IntIntervalTest
         IntegerSum zeroSum = new IntegerSum(0);
         IntInterval.fromTo(0, -4).forEachWithIndex((each, index) -> zeroSum.add(each + index));
         Assert.assertEquals(0, zeroSum.getIntSum());
+    }
+
+    @Test
+    public void forEach_with_same_start_and_end_with_negative_step()
+    {
+        MutableInteger counter = new MutableInteger(0);
+
+        IntInterval interval = IntInterval.fromToBy(2, 2, -2);
+        interval.forEach((IntProcedure) each -> counter.add(1));
+
+        Assert.assertEquals(1, counter.toInteger().intValue());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Chandra Guntur <chandra.guntur@bnymellon.com>