### PR TITLE
Replace usages of Comparators.nullSafeEquals() with Objects.equals().

### DIFF
--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapAcceptanceTest.java
@@ -19,11 +19,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.CollidingInt;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -1701,11 +1701,11 @@ public class UnifiedMapAcceptanceTest
 
             Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
 
-            if (!Comparators.nullSafeEquals(this.key, entry.getKey()))
+            if (!Objects.equals(this.key, entry.getKey()))
             {
                 return false;
             }
-            return Comparators.nullSafeEquals(this.value, entry.getValue());
+            return Objects.equals(this.value, entry.getValue());
         }
 
         @Override

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.Callable;
@@ -2055,7 +2056,7 @@ public final class Verify extends Assert
             {
                 Object eachExpected = expectedList.get(index);
                 Object eachActual = actualList.get(index);
-                if (!Comparators.nullSafeEquals(eachExpected, eachActual))
+                if (!Objects.equals(eachExpected, eachActual))
                 {
                     junit.framework.Assert.failNotEquals(listName + " first differed at element [" + index + "];", eachExpected, eachActual);
                 }
@@ -2236,7 +2237,7 @@ public final class Verify extends Assert
                     Object eachExpected = expectedIterator.next();
                     Object eachActual = actualIterator.next();
 
-                    if (!Comparators.nullSafeEquals(eachExpected, eachActual))
+                    if (!Objects.equals(eachExpected, eachActual))
                     {
                         //noinspection UseOfObsoleteAssert
                         junit.framework.Assert.failNotEquals(iterableName + " first differed at element [" + index + "];", eachExpected, eachActual);
@@ -2284,7 +2285,7 @@ public final class Verify extends Assert
                 Object expectedKey = expectedEntry.getKey();
                 Object expectedValue = expectedEntry.getValue();
                 Object actualValue = actualMap.get(expectedKey);
-                if (!Comparators.nullSafeEquals(actualValue, expectedValue))
+                if (!Objects.equals(actualValue, expectedValue))
                 {
                     Assert.fail("Values differ at key " + expectedKey + " expected " + expectedValue + " but was " + actualValue);
                 }
@@ -2571,7 +2572,7 @@ public final class Verify extends Assert
                 Object expectedKey = expectedKeyValues[i++];
                 Object expectedValue = expectedKeyValues[i++];
                 Object actualValue = actualMap.get(expectedKey);
-                if (!Comparators.nullSafeEquals(expectedValue, actualValue))
+                if (!Objects.equals(expectedValue, actualValue))
                 {
                     missingEntries.put(
                             expectedKey,
@@ -3076,7 +3077,7 @@ public final class Verify extends Assert
             Verify.assertContainsKey(mapName, expectedKey, actualMap);
 
             Object actualValue = actualMap.get(expectedKey);
-            if (!Comparators.nullSafeEquals(actualValue, expectedValue))
+            if (!Objects.equals(actualValue, expectedValue))
             {
                 Assert.fail(
                         mapName
@@ -3129,7 +3130,7 @@ public final class Verify extends Assert
             Verify.assertContainsKey(mapIterableName, expectedKey, mapIterable);
 
             Object actualValue = mapIterable.get(expectedKey);
-            if (!Comparators.nullSafeEquals(actualValue, expectedValue))
+            if (!Objects.equals(actualValue, expectedValue))
             {
                 Assert.fail(
                         mapIterableName
@@ -3182,7 +3183,7 @@ public final class Verify extends Assert
             Verify.assertContainsKey(mapIterableName, expectedKey, mutableMapIterable);
 
             Object actualValue = mutableMapIterable.get(expectedKey);
-            if (!Comparators.nullSafeEquals(actualValue, expectedValue))
+            if (!Objects.equals(actualValue, expectedValue))
             {
                 Assert.fail(
                         mapIterableName
@@ -3235,7 +3236,7 @@ public final class Verify extends Assert
             Verify.assertContainsKey(mapIterableName, expectedKey, immutableMapIterable);
 
             Object actualValue = immutableMapIterable.get(expectedKey);
-            if (!Comparators.nullSafeEquals(actualValue, expectedValue))
+            if (!Objects.equals(actualValue, expectedValue))
             {
                 Assert.fail(
                         mapIterableName
@@ -3563,7 +3564,7 @@ public final class Verify extends Assert
             Verify.assertObjectNotNull(listName, list);
 
             Object actualItem = list.get(index);
-            if (!Comparators.nullSafeEquals(expectedItem, actualItem))
+            if (!Objects.equals(expectedItem, actualItem))
             {
                 Assert.assertEquals(
                         listName + " has incorrect element at index:<" + index + '>',
@@ -3590,7 +3591,7 @@ public final class Verify extends Assert
         {
             Assert.assertNotNull(array);
             Object actualItem = array[index];
-            if (!Comparators.nullSafeEquals(expectedItem, actualItem))
+            if (!Objects.equals(expectedItem, actualItem))
             {
                 Assert.assertEquals(
                         arrayName + " has incorrect element at index:<" + index + '>',

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBag.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.collections.api.bag.Bag;
@@ -37,7 +38,6 @@ import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.procedure.MultimapEachPutProcedure;
 import org.eclipse.collections.impl.factory.Bags;
@@ -186,7 +186,7 @@ final class ImmutableSingletonBag<T>
     @Override
     public boolean contains(Object object)
     {
-        return Comparators.nullSafeEquals(this.value, object);
+        return Objects.equals(this.value, object);
     }
 
     @Override
@@ -393,7 +393,7 @@ final class ImmutableSingletonBag<T>
     @Override
     public int occurrencesOf(Object item)
     {
-        return Comparators.nullSafeEquals(this.value, item) ? 1 : 0;
+        return Objects.equals(this.value, item) ? 1 : 0;
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/AbstractMutableCollection.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.collection.mutable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.function.BinaryOperator;
@@ -37,7 +38,6 @@ import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.AbstractRichIterable;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
@@ -211,7 +211,7 @@ public abstract class AbstractMutableCollection<T>
         Iterator<T> iterator = this.iterator();
         while (iterator.hasNext())
         {
-            if (Comparators.nullSafeEquals(o, iterator.next()))
+            if (Objects.equals(o, iterator.next()))
             {
                 iterator.remove();
                 return true;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapter.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.Set;
 
@@ -21,7 +22,6 @@ import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.block.procedure.CollectionRemoveProcedure;
 import org.eclipse.collections.impl.factory.Lists;
@@ -150,7 +150,7 @@ public final class CollectionAdapter<T>
         }
 
         CollectionAdapter<?> that = (CollectionAdapter<?>) o;
-        return Comparators.nullSafeEquals(this.delegate, that.delegate);
+        return Objects.equals(this.delegate, that.delegate);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/DoubletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/DoubletonList.java
@@ -14,12 +14,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * A DoubletonList is a two-element memory efficient List. It is created by calling Lists.fixedSize.of(one, two).
@@ -100,7 +100,7 @@ final class DoubletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1) || Comparators.nullSafeEquals(obj, this.element2);
+        return Objects.equals(obj, this.element1) || Objects.equals(obj, this.element2);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/QuadrupletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/QuadrupletonList.java
@@ -14,12 +14,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * This is a four element memory efficient List which is created by calling Lists.fixedSize.of(one, two, three, four).
@@ -90,10 +90,10 @@ final class QuadrupletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3)
-                || Comparators.nullSafeEquals(obj, this.element4);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3)
+                || Objects.equals(obj, this.element4);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/QuintupletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/QuintupletonList.java
@@ -14,12 +14,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * This is a five element memory efficient List which is created by calling Lists.fixedSize.of(one, two, three, four, five).
@@ -94,11 +94,11 @@ final class QuintupletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3)
-                || Comparators.nullSafeEquals(obj, this.element4)
-                || Comparators.nullSafeEquals(obj, this.element5);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3)
+                || Objects.equals(obj, this.element4)
+                || Objects.equals(obj, this.element5);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/SextupletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/SextupletonList.java
@@ -14,12 +14,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * This is a six element immutable List which is created by calling Lists.fixedSize.of(one, two, three, four, five, six).
@@ -111,12 +111,12 @@ final class SextupletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3)
-                || Comparators.nullSafeEquals(obj, this.element4)
-                || Comparators.nullSafeEquals(obj, this.element5)
-                || Comparators.nullSafeEquals(obj, this.element6);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3)
+                || Objects.equals(obj, this.element4)
+                || Objects.equals(obj, this.element5)
+                || Objects.equals(obj, this.element6);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/SingletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/SingletonList.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.function.Function;
@@ -30,7 +31,6 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * This class is a memory efficient list with one element. Unlike Collections.singletonList(), it can be sorted. It is
@@ -78,7 +78,7 @@ final class SingletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1);
+        return Objects.equals(obj, this.element1);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/TripletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/fixed/TripletonList.java
@@ -14,12 +14,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * This is a three element memory efficient List which is created by calling Lists.fixedSize.of(one, two, three).
@@ -86,9 +86,9 @@ final class TripletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableList.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
 import java.util.function.UnaryOperator;
@@ -60,7 +61,6 @@ import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.list.PartitionImmutableList;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.block.procedure.CollectIfProcedure;
@@ -138,7 +138,7 @@ abstract class AbstractImmutableList<T>
         int localSize = this.size();
         for (int i = 0; i < localSize; i++)
         {
-            if (!Comparators.nullSafeEquals(this.get(i), list.get(i)))
+            if (!Objects.equals(this.get(i), list.get(i)))
             {
                 return false;
             }
@@ -156,7 +156,7 @@ abstract class AbstractImmutableList<T>
             {
                 return false;
             }
-            if (!Comparators.nullSafeEquals(this.get(i), iterator.next()))
+            if (!Objects.equals(this.get(i), iterator.next()))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableDoubletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableDoubletonList.java
@@ -11,11 +11,11 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Lists;
 
 /**
@@ -85,7 +85,7 @@ final class ImmutableDoubletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1) || Comparators.nullSafeEquals(obj, this.element2);
+        return Objects.equals(obj, this.element1) || Objects.equals(obj, this.element2);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonList.java
@@ -11,11 +11,11 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Lists;
 
 /**
@@ -44,7 +44,7 @@ final class ImmutableSingletonList<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1);
+        return Objects.equals(obj, this.element1);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.concurrent.ExecutorService;
@@ -599,7 +600,7 @@ public abstract class AbstractMutableList<T>
     {
         for (int i = 0; i < this.size(); i++)
         {
-            if (Comparators.nullSafeEquals(this.get(i), object))
+            if (Objects.equals(this.get(i), object))
             {
                 return i;
             }
@@ -612,7 +613,7 @@ public abstract class AbstractMutableList<T>
     {
         for (int i = this.size() - 1; i >= 0; i--)
         {
-            if (Comparators.nullSafeEquals(this.get(i), object))
+            if (Objects.equals(this.get(i), object))
             {
                 return i;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/FastList.java
@@ -23,6 +23,7 @@ import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.LongSummaryStatistics;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.Spliterator;
@@ -1542,7 +1543,7 @@ public class FastList<T>
         }
         for (int i = 0; i < this.size; i++)
         {
-            if (!Comparators.nullSafeEquals(this.items[i], that.items[i]))
+            if (!Objects.equals(this.items[i], that.items[i]))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/DoubletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/DoubletonMap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.function.Function2;
@@ -28,7 +29,6 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -81,12 +81,12 @@ final class DoubletonMap<K, V>
     public MutableMap<K, V> withKeyValue(K addKey, V addValue)
     {
         // Map behavior specifies that if you put in a duplicate key, you replace the value
-        if (Comparators.nullSafeEquals(this.key1, addKey))
+        if (Objects.equals(this.key1, addKey))
         {
             this.value1 = addValue;
             return this;
         }
-        if (Comparators.nullSafeEquals(this.key2, addKey))
+        if (Objects.equals(this.key2, addKey))
         {
             this.value2 = addValue;
             return this;
@@ -97,11 +97,11 @@ final class DoubletonMap<K, V>
     @Override
     public MutableMap<K, V> withoutKey(K key)
     {
-        if (Comparators.nullSafeEquals(key, this.key1))
+        if (Objects.equals(key, this.key1))
         {
             return new SingletonMap<>(this.key2, this.value2);
         }
-        if (Comparators.nullSafeEquals(key, this.key2))
+        if (Objects.equals(key, this.key2))
         {
             return new SingletonMap<>(this.key1, this.value1);
         }
@@ -124,23 +124,23 @@ final class DoubletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key2, key) || Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key2, key) || Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value2, value) || Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value2, value) || Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key2, key))
+        if (Objects.equals(this.key2, key))
         {
             return this.value2;
         }
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }
@@ -197,7 +197,7 @@ final class DoubletonMap<K, V>
     @Override
     public MutableMap<V, K> flipUniqueValues()
     {
-        if (Comparators.nullSafeEquals(this.value1, this.value2))
+        if (Objects.equals(this.value1, this.value2))
         {
             throw new IllegalStateException("Duplicate value: " + this.value1 + " found at key: " + this.key1 + " and key: " + this.key2);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/FixedSizeMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/FixedSizeMapFactoryImpl.java
@@ -10,9 +10,10 @@
 
 package org.eclipse.collections.impl.map.fixed;
 
+import java.util.Objects;
+
 import org.eclipse.collections.api.factory.map.FixedSizeMapFactory;
 import org.eclipse.collections.api.map.FixedSizeMap;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 public class FixedSizeMapFactoryImpl implements FixedSizeMapFactory
 {
@@ -59,7 +60,7 @@ public class FixedSizeMapFactoryImpl implements FixedSizeMapFactory
     @Override
     public <K, V> FixedSizeMap<K, V> with(K key1, V value1, K key2, V value2)
     {
-        if (Comparators.nullSafeEquals(key1, key2))
+        if (Objects.equals(key1, key2))
         {
             return this.of(key1, value2);
         }
@@ -75,19 +76,19 @@ public class FixedSizeMapFactoryImpl implements FixedSizeMapFactory
     @Override
     public <K, V> FixedSizeMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3)
     {
-        if (Comparators.nullSafeEquals(key1, key2) && Comparators.nullSafeEquals(key2, key3))
+        if (Objects.equals(key1, key2) && Objects.equals(key2, key3))
         {
             return this.of(key1, value3);
         }
-        if (Comparators.nullSafeEquals(key1, key2))
+        if (Objects.equals(key1, key2))
         {
             return this.of(key1, value2, key3, value3);
         }
-        if (Comparators.nullSafeEquals(key1, key3))
+        if (Objects.equals(key1, key3))
         {
             return this.of(key2, value2, key1, value3);
         }
-        if (Comparators.nullSafeEquals(key2, key3))
+        if (Objects.equals(key2, key3))
         {
             return this.of(key1, value1, key2, value3);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/SingletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/SingletonMap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.function.Function2;
@@ -28,7 +29,6 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Sets;
@@ -71,7 +71,7 @@ final class SingletonMap<K, V>
     public MutableMap<K, V> withKeyValue(K addKey, V addValue)
     {
         // Map behavior specifies that if you put in a duplicate key, you replace the value
-        if (Comparators.nullSafeEquals(this.key1, addKey))
+        if (Objects.equals(this.key1, addKey))
         {
             this.value1 = addValue;
             return this;
@@ -82,7 +82,7 @@ final class SingletonMap<K, V>
     @Override
     public MutableMap<K, V> withoutKey(K key)
     {
-        if (Comparators.nullSafeEquals(key, this.key1))
+        if (Objects.equals(key, this.key1))
         {
             return new EmptyMap<>();
         }
@@ -105,19 +105,19 @@ final class SingletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/TripletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/fixed/TripletonMap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.function.Function2;
@@ -28,7 +29,6 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -85,17 +85,17 @@ final class TripletonMap<K, V>
     public MutableMap<K, V> withKeyValue(K addKey, V addValue)
     {
         // Map behavior specifies that if you put in a duplicate key, you replace the value
-        if (Comparators.nullSafeEquals(this.key1, addKey))
+        if (Objects.equals(this.key1, addKey))
         {
             this.value1 = addValue;
             return this;
         }
-        if (Comparators.nullSafeEquals(this.key2, addKey))
+        if (Objects.equals(this.key2, addKey))
         {
             this.value2 = addValue;
             return this;
         }
-        if (Comparators.nullSafeEquals(this.key3, addKey))
+        if (Objects.equals(this.key3, addKey))
         {
             this.value3 = addValue;
             return this;
@@ -114,15 +114,15 @@ final class TripletonMap<K, V>
     @Override
     public MutableMap<K, V> withoutKey(K key)
     {
-        if (Comparators.nullSafeEquals(key, this.key1))
+        if (Objects.equals(key, this.key1))
         {
             return new DoubletonMap<>(this.key2, this.value2, this.key3, this.value3);
         }
-        if (Comparators.nullSafeEquals(key, this.key2))
+        if (Objects.equals(key, this.key2))
         {
             return new DoubletonMap<>(this.key1, this.value1, this.key3, this.value3);
         }
-        if (Comparators.nullSafeEquals(key, this.key3))
+        if (Objects.equals(key, this.key3))
         {
             return new DoubletonMap<>(this.key1, this.value1, this.key2, this.value2);
         }
@@ -151,31 +151,31 @@ final class TripletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key3, key)
-                || Comparators.nullSafeEquals(this.key2, key)
-                || Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key3, key)
+                || Objects.equals(this.key2, key)
+                || Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value3, value)
-                || Comparators.nullSafeEquals(this.value2, value)
-                || Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value3, value)
+                || Objects.equals(this.value2, value)
+                || Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key3, key))
+        if (Objects.equals(this.key3, key))
         {
             return this.value3;
         }
-        if (Comparators.nullSafeEquals(this.key2, key))
+        if (Objects.equals(this.key2, key))
         {
             return this.value2;
         }
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }
@@ -237,15 +237,15 @@ final class TripletonMap<K, V>
     @Override
     public MutableMap<V, K> flipUniqueValues()
     {
-        if (Comparators.nullSafeEquals(this.value1, this.value2))
+        if (Objects.equals(this.value1, this.value2))
         {
             throw new IllegalStateException("Duplicate value: " + this.value1 + " found at key: " + this.key1 + " and key: " + this.key2);
         }
-        if (Comparators.nullSafeEquals(this.value2, this.value3))
+        if (Objects.equals(this.value2, this.value3))
         {
             throw new IllegalStateException("Duplicate value: " + this.value2 + " found at key: " + this.key2 + " and key: " + this.key3);
         }
-        if (Comparators.nullSafeEquals(this.value3, this.value1))
+        if (Objects.equals(this.value3, this.value1))
         {
             throw new IllegalStateException("Duplicate value: " + this.value3 + " found at key: " + this.key3 + " and key: " + this.key3);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.map.immutable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.RichIterable;
@@ -23,7 +24,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -78,23 +78,23 @@ final class ImmutableDoubletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key2, key) || Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key2, key) || Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value2, value) || Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value2, value) || Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key2, key))
+        if (Objects.equals(this.key2, key))
         {
             return this.value2;
         }
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }
@@ -143,7 +143,7 @@ final class ImmutableDoubletonMap<K, V>
     @Override
     public ImmutableMap<V, K> flipUniqueValues()
     {
-        if (Comparators.nullSafeEquals(this.value1, this.value2))
+        if (Objects.equals(this.value1, this.value2))
         {
             throw new IllegalStateException("Duplicate value: " + this.value1 + " found at key: " + this.key1 + " and key: " + this.key2);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.map.immutable;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.collections.api.factory.map.ImmutableMapFactory;
 import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 public class ImmutableMapFactoryImpl implements ImmutableMapFactory
 {
@@ -59,7 +59,7 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
     @Override
     public <K, V> ImmutableMap<K, V> with(K key1, V value1, K key2, V value2)
     {
-        if (Comparators.nullSafeEquals(key1, key2))
+        if (Objects.equals(key1, key2))
         {
             return this.of(key1, value2);
         }
@@ -75,19 +75,19 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
     @Override
     public <K, V> ImmutableMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3)
     {
-        if (Comparators.nullSafeEquals(key1, key2) && Comparators.nullSafeEquals(key2, key3))
+        if (Objects.equals(key1, key2) && Objects.equals(key2, key3))
         {
             return this.of(key1, value3);
         }
-        if (Comparators.nullSafeEquals(key1, key2))
+        if (Objects.equals(key1, key2))
         {
             return this.of(key1, value2, key3, value3);
         }
-        if (Comparators.nullSafeEquals(key1, key3))
+        if (Objects.equals(key1, key3))
         {
             return this.of(key2, value2, key1, value3);
         }
-        if (Comparators.nullSafeEquals(key2, key3))
+        if (Objects.equals(key2, key3))
         {
             return this.of(key1, value1, key2, value3);
         }
@@ -104,27 +104,27 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
     @Override
     public <K, V> ImmutableMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
     {
-        if (Comparators.nullSafeEquals(key1, key2))
+        if (Objects.equals(key1, key2))
         {
             return this.of(key1, value2, key3, value3, key4, value4);
         }
-        if (Comparators.nullSafeEquals(key1, key3))
+        if (Objects.equals(key1, key3))
         {
             return this.of(key2, value2, key1, value3, key4, value4);
         }
-        if (Comparators.nullSafeEquals(key1, key4))
+        if (Objects.equals(key1, key4))
         {
             return this.of(key2, value2, key3, value3, key1, value4);
         }
-        if (Comparators.nullSafeEquals(key2, key3))
+        if (Objects.equals(key2, key3))
         {
             return this.of(key1, value1, key2, value3, key4, value4);
         }
-        if (Comparators.nullSafeEquals(key2, key4))
+        if (Objects.equals(key2, key4))
         {
             return this.of(key1, value1, key3, value3, key2, value4);
         }
-        if (Comparators.nullSafeEquals(key3, key4))
+        if (Objects.equals(key3, key4))
         {
             return this.of(key1, value1, key2, value2, key3, value4);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.map.immutable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.RichIterable;
@@ -23,7 +24,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -88,37 +88,37 @@ final class ImmutableQuadrupletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key4, key)
-                || Comparators.nullSafeEquals(this.key3, key)
-                || Comparators.nullSafeEquals(this.key2, key)
-                || Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key4, key)
+                || Objects.equals(this.key3, key)
+                || Objects.equals(this.key2, key)
+                || Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value4, value)
-                || Comparators.nullSafeEquals(this.value3, value)
-                || Comparators.nullSafeEquals(this.value2, value)
-                || Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value4, value)
+                || Objects.equals(this.value3, value)
+                || Objects.equals(this.value2, value)
+                || Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key4, key))
+        if (Objects.equals(this.key4, key))
         {
             return this.value4;
         }
-        if (Comparators.nullSafeEquals(this.key3, key))
+        if (Objects.equals(this.key3, key))
         {
             return this.value3;
         }
-        if (Comparators.nullSafeEquals(this.key2, key))
+        if (Objects.equals(this.key2, key))
         {
             return this.value2;
         }
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.map.immutable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.RichIterable;
@@ -23,7 +24,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Sets;
@@ -71,19 +71,19 @@ final class ImmutableSingletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.map.immutable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.RichIterable;
@@ -23,7 +24,6 @@ import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -83,31 +83,31 @@ final class ImmutableTripletonMap<K, V>
     @Override
     public boolean containsKey(Object key)
     {
-        return Comparators.nullSafeEquals(this.key3, key)
-                || Comparators.nullSafeEquals(this.key2, key)
-                || Comparators.nullSafeEquals(this.key1, key);
+        return Objects.equals(this.key3, key)
+                || Objects.equals(this.key2, key)
+                || Objects.equals(this.key1, key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        return Comparators.nullSafeEquals(this.value3, value)
-                || Comparators.nullSafeEquals(this.value2, value)
-                || Comparators.nullSafeEquals(this.value1, value);
+        return Objects.equals(this.value3, value)
+                || Objects.equals(this.value2, value)
+                || Objects.equals(this.value1, value);
     }
 
     @Override
     public V get(Object key)
     {
-        if (Comparators.nullSafeEquals(this.key3, key))
+        if (Objects.equals(this.key3, key))
         {
             return this.value3;
         }
-        if (Comparators.nullSafeEquals(this.key2, key))
+        if (Objects.equals(this.key2, key))
         {
             return this.value2;
         }
-        if (Comparators.nullSafeEquals(this.key1, key))
+        if (Objects.equals(this.key1, key))
         {
             return this.value1;
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMap.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -94,7 +95,7 @@ public class ImmutableTreeMap<K, V>
         }
         for (int index = 0; index < this.size(); index++)
         {
-            if (!Comparators.nullSafeEquals(this.values[index], other.get(this.keys[index])))
+            if (!Objects.equals(this.values[index], other.get(this.keys[index])))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEntryWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEntryWithHashingStrategy.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.map.strategy.immutable;
 
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.eclipse.collections.api.block.HashingStrategy;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.tuple.AbstractImmutableEntry;
 
 public final class ImmutableEntryWithHashingStrategy<K, V> extends AbstractImmutableEntry<K, V>
@@ -43,7 +43,7 @@ public final class ImmutableEntryWithHashingStrategy<K, V> extends AbstractImmut
         {
             Entry<?, ?> that = (Entry<?, ?>) object;
             return this.hashingStrategy.equals(this.key, (K) that.getKey())
-                    && Comparators.nullSafeEquals(this.value, that.getValue());
+                    && Objects.equals(this.value, that.getValue());
         }
         return false;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/DoubletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/DoubletonSet.java
@@ -16,13 +16,13 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 final class DoubletonSet<T>
         extends AbstractMemoryEfficientMutableSet<T>
@@ -83,8 +83,8 @@ final class DoubletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2);
     }
 
     @Override
@@ -173,11 +173,11 @@ final class DoubletonSet<T>
     @Override
     public MutableSet<T> without(T element)
     {
-        if (Comparators.nullSafeEquals(element, this.element1))
+        if (Objects.equals(element, this.element1))
         {
             return new SingletonSet<>(this.element2);
         }
-        if (Comparators.nullSafeEquals(element, this.element2))
+        if (Objects.equals(element, this.element2))
         {
             return new SingletonSet<>(this.element1);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryImpl.java
@@ -10,12 +10,12 @@
 
 package org.eclipse.collections.impl.set.fixed;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.eclipse.collections.api.factory.set.FixedSizeSetFactory;
 import org.eclipse.collections.api.set.FixedSizeSet;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.collector.Collectors2;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
@@ -64,7 +64,7 @@ public class FixedSizeSetFactoryImpl implements FixedSizeSetFactory
     @Override
     public <T> FixedSizeSet<T> with(T one, T two)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one);
         }
@@ -80,15 +80,15 @@ public class FixedSizeSetFactoryImpl implements FixedSizeSetFactory
     @Override
     public <T> FixedSizeSet<T> with(T one, T two, T three)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one, three);
         }
-        if (Comparators.nullSafeEquals(one, three))
+        if (Objects.equals(one, three))
         {
             return this.of(one, two);
         }
-        if (Comparators.nullSafeEquals(two, three))
+        if (Objects.equals(two, three))
         {
             return this.of(one, two);
         }
@@ -104,27 +104,27 @@ public class FixedSizeSetFactoryImpl implements FixedSizeSetFactory
     @Override
     public <T> FixedSizeSet<T> with(T one, T two, T three, T four)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one, three, four);
         }
-        if (Comparators.nullSafeEquals(one, three))
+        if (Objects.equals(one, three))
         {
             return this.of(one, two, four);
         }
-        if (Comparators.nullSafeEquals(one, four))
+        if (Objects.equals(one, four))
         {
             return this.of(one, two, three);
         }
-        if (Comparators.nullSafeEquals(two, three))
+        if (Objects.equals(two, three))
         {
             return this.of(one, two, four);
         }
-        if (Comparators.nullSafeEquals(two, four))
+        if (Objects.equals(two, four))
         {
             return this.of(one, two, three);
         }
-        if (Comparators.nullSafeEquals(three, four))
+        if (Objects.equals(three, four))
         {
             return this.of(one, two, three);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSet.java
@@ -16,13 +16,13 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
 final class QuadrupletonSet<T>
@@ -95,10 +95,10 @@ final class QuadrupletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3)
-                || Comparators.nullSafeEquals(obj, this.element4);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3)
+                || Objects.equals(obj, this.element4);
     }
 
     @Override
@@ -215,19 +215,19 @@ final class QuadrupletonSet<T>
     @Override
     public MutableSet<T> without(T element)
     {
-        if (Comparators.nullSafeEquals(element, this.element1))
+        if (Objects.equals(element, this.element1))
         {
             return new TripletonSet<>(this.element2, this.element3, this.element4);
         }
-        if (Comparators.nullSafeEquals(element, this.element2))
+        if (Objects.equals(element, this.element2))
         {
             return new TripletonSet<>(this.element1, this.element3, this.element4);
         }
-        if (Comparators.nullSafeEquals(element, this.element3))
+        if (Objects.equals(element, this.element3))
         {
             return new TripletonSet<>(this.element1, this.element2, this.element4);
         }
-        if (Comparators.nullSafeEquals(element, this.element4))
+        if (Objects.equals(element, this.element4))
         {
             return new TripletonSet<>(this.element1, this.element2, this.element3);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/SingletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/SingletonSet.java
@@ -17,13 +17,13 @@ import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 class SingletonSet<T>
         extends AbstractMemoryEfficientMutableSet<T>
@@ -82,7 +82,7 @@ class SingletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1);
+        return Objects.equals(obj, this.element1);
     }
 
     @Override
@@ -162,7 +162,7 @@ class SingletonSet<T>
     @Override
     public MutableSet<T> without(T element)
     {
-        if (Comparators.nullSafeEquals(element, this.element1))
+        if (Objects.equals(element, this.element1))
         {
             return new EmptySet<>();
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/TripletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/TripletonSet.java
@@ -17,13 +17,13 @@ import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 final class TripletonSet<T>
         extends AbstractMemoryEfficientMutableSet<T>
@@ -91,9 +91,9 @@ final class TripletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3);
     }
 
     @Override
@@ -198,15 +198,15 @@ final class TripletonSet<T>
     @Override
     public MutableSet<T> without(T element)
     {
-        if (Comparators.nullSafeEquals(element, this.element1))
+        if (Objects.equals(element, this.element1))
         {
             return new DoubletonSet<>(this.element2, this.element3);
         }
-        if (Comparators.nullSafeEquals(element, this.element2))
+        if (Objects.equals(element, this.element2))
         {
             return new DoubletonSet<>(this.element1, this.element3);
         }
-        if (Comparators.nullSafeEquals(element, this.element3))
+        if (Objects.equals(element, this.element3))
         {
             return new DoubletonSet<>(this.element1, this.element2);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSet.java
@@ -13,13 +13,13 @@ package org.eclipse.collections.impl.set.immutable;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Sets;
 
 final class ImmutableDoubletonSet<T>
@@ -82,7 +82,7 @@ final class ImmutableDoubletonSet<T>
     {
         if (this.contains(element))
         {
-            return Comparators.nullSafeEquals(element, this.element1)
+            return Objects.equals(element, this.element1)
                     ? Sets.immutable.with(this.element2)
                     : Sets.immutable.with(this.element1);
         }
@@ -92,7 +92,7 @@ final class ImmutableDoubletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1) || Comparators.nullSafeEquals(obj, this.element2);
+        return Objects.equals(obj, this.element1) || Objects.equals(obj, this.element2);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSet.java
@@ -13,13 +13,13 @@ package org.eclipse.collections.impl.set.immutable;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Sets;
 
 final class ImmutableQuadrupletonSet<T>
@@ -90,15 +90,15 @@ final class ImmutableQuadrupletonSet<T>
     {
         if (this.contains(element))
         {
-            if (Comparators.nullSafeEquals(element, this.element1))
+            if (Objects.equals(element, this.element1))
             {
                 return Sets.immutable.with(this.element2, this.element3, this.element4);
             }
-            if (Comparators.nullSafeEquals(element, this.element2))
+            if (Objects.equals(element, this.element2))
             {
                 return Sets.immutable.with(this.element1, this.element3, this.element4);
             }
-            if (Comparators.nullSafeEquals(element, this.element3))
+            if (Objects.equals(element, this.element3))
             {
                 return Sets.immutable.with(this.element1, this.element2, this.element4);
             }
@@ -110,10 +110,10 @@ final class ImmutableQuadrupletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3)
-                || Comparators.nullSafeEquals(obj, this.element4);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3)
+                || Objects.equals(obj, this.element4);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableSetFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableSetFactoryImpl.java
@@ -10,9 +10,10 @@
 
 package org.eclipse.collections.impl.set.immutable;
 
+import java.util.Objects;
+
 import org.eclipse.collections.api.factory.set.ImmutableSetFactory;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.utility.Iterate;
 
 public class ImmutableSetFactoryImpl implements ImmutableSetFactory
@@ -58,7 +59,7 @@ public class ImmutableSetFactoryImpl implements ImmutableSetFactory
     @Override
     public <T> ImmutableSet<T> with(T one, T two)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one);
         }
@@ -74,15 +75,15 @@ public class ImmutableSetFactoryImpl implements ImmutableSetFactory
     @Override
     public <T> ImmutableSet<T> with(T one, T two, T three)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one, three);
         }
-        if (Comparators.nullSafeEquals(one, three))
+        if (Objects.equals(one, three))
         {
             return this.of(one, two);
         }
-        if (Comparators.nullSafeEquals(two, three))
+        if (Objects.equals(two, three))
         {
             return this.of(one, two);
         }
@@ -98,27 +99,27 @@ public class ImmutableSetFactoryImpl implements ImmutableSetFactory
     @Override
     public <T> ImmutableSet<T> with(T one, T two, T three, T four)
     {
-        if (Comparators.nullSafeEquals(one, two))
+        if (Objects.equals(one, two))
         {
             return this.of(one, three, four);
         }
-        if (Comparators.nullSafeEquals(one, three))
+        if (Objects.equals(one, three))
         {
             return this.of(one, two, four);
         }
-        if (Comparators.nullSafeEquals(one, four))
+        if (Objects.equals(one, four))
         {
             return this.of(one, two, three);
         }
-        if (Comparators.nullSafeEquals(two, three))
+        if (Objects.equals(two, three))
         {
             return this.of(one, two, four);
         }
-        if (Comparators.nullSafeEquals(two, four))
+        if (Objects.equals(two, four))
         {
             return this.of(one, two, three);
         }
-        if (Comparators.nullSafeEquals(three, four))
+        if (Objects.equals(three, four))
         {
             return this.of(one, two, three);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSet.java
@@ -13,13 +13,13 @@ package org.eclipse.collections.impl.set.immutable;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Sets;
 
 final class ImmutableSingletonSet<T>
@@ -85,7 +85,7 @@ final class ImmutableSingletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1);
+        return Objects.equals(obj, this.element1);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSet.java
@@ -13,13 +13,13 @@ package org.eclipse.collections.impl.set.immutable;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.Sets;
 
 final class ImmutableTripletonSet<T>
@@ -86,11 +86,11 @@ final class ImmutableTripletonSet<T>
     {
         if (this.contains(element))
         {
-            if (Comparators.nullSafeEquals(element, this.element1))
+            if (Objects.equals(element, this.element1))
             {
                 return Sets.immutable.with(this.element2, this.element3);
             }
-            if (Comparators.nullSafeEquals(element, this.element2))
+            if (Objects.equals(element, this.element2))
             {
                 return Sets.immutable.with(this.element1, this.element3);
             }
@@ -102,9 +102,9 @@ final class ImmutableTripletonSet<T>
     @Override
     public boolean contains(Object obj)
     {
-        return Comparators.nullSafeEquals(obj, this.element1)
-                || Comparators.nullSafeEquals(obj, this.element2)
-                || Comparators.nullSafeEquals(obj, this.element3);
+        return Objects.equals(obj, this.element1)
+                || Objects.equals(obj, this.element2)
+                || Objects.equals(obj, this.element3);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.EmptyStackException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
@@ -83,7 +84,6 @@ import org.eclipse.collections.api.stack.primitive.ImmutableIntStack;
 import org.eclipse.collections.api.stack.primitive.ImmutableLongStack;
 import org.eclipse.collections.api.stack.primitive.ImmutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
@@ -1109,7 +1109,7 @@ final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
         Iterator<?> thatIterator = that.iterator();
         while (thisIterator.hasNext() && thatIterator.hasNext())
         {
-            if (!Comparators.nullSafeEquals(thisIterator.next(), thatIterator.next()))
+            if (!Objects.equals(thisIterator.next(), thatIterator.next()))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/ArrayStack.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.EmptyStackException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.collections.api.LazyIterable;
@@ -79,7 +80,6 @@ import org.eclipse.collections.api.stack.primitive.MutableIntStack;
 import org.eclipse.collections.api.stack.primitive.MutableLongStack;
 import org.eclipse.collections.api.stack.primitive.MutableShortStack;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.procedure.MutatingAggregationProcedure;
 import org.eclipse.collections.impl.block.procedure.NonMutatingAggregationProcedure;
@@ -1077,7 +1077,7 @@ public class ArrayStack<T> implements MutableStack<T>, Externalizable
         Iterator<?> thatIterator = that.iterator();
         while (thisIterator.hasNext() && thatIterator.hasNext())
         {
-            if (!Comparators.nullSafeEquals(thisIterator.next(), thatIterator.next()))
+            if (!Objects.equals(thisIterator.next(), thatIterator.next()))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/ImmutableEntry.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/ImmutableEntry.java
@@ -11,8 +11,7 @@
 package org.eclipse.collections.impl.tuple;
 
 import java.util.Map.Entry;
-
-import org.eclipse.collections.impl.block.factory.Comparators;
+import java.util.Objects;
 
 public final class ImmutableEntry<K, V> extends AbstractImmutableEntry<K, V>
 {
@@ -37,8 +36,8 @@ public final class ImmutableEntry<K, V> extends AbstractImmutableEntry<K, V>
         if (object instanceof Entry)
         {
             Entry<?, ?> that = (Entry<?, ?>) object;
-            return Comparators.nullSafeEquals(this.key, that.getKey())
-                    && Comparators.nullSafeEquals(this.value, that.getValue());
+            return Objects.equals(this.key, that.getKey())
+                    && Objects.equals(this.value, that.getValue());
         }
         return false;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/PairImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/PairImpl.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.tuple;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Comparators;
 
 /**
  * A PairImpl is a container that holds two related objects. It is the equivalent of an Association in Smalltalk, or an
@@ -71,8 +71,8 @@ class PairImpl<T1, T2>
 
         Pair<?, ?> that = (Pair<?, ?>) o;
 
-        return Comparators.nullSafeEquals(this.one, that.getOne())
-                && Comparators.nullSafeEquals(this.two, that.getTwo());
+        return Objects.equals(this.one, that.getOne())
+                && Objects.equals(this.two, that.getTwo());
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
 
@@ -71,7 +72,6 @@ import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.api.tuple.Twin;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -115,7 +115,7 @@ public final class ListIterate
         int localSize = one.size();
         for (int i = 0; i < localSize; i++)
         {
-            if (!Comparators.nullSafeEquals(one.get(i), two.get(i)))
+            if (!Objects.equals(one.get(i), two.get(i)))
             {
                 return false;
             }
@@ -129,7 +129,7 @@ public final class ListIterate
         Iterator<?> twoIterator = two.iterator();
         for (int i = 0; i < localSize; i++)
         {
-            if (!twoIterator.hasNext() || !Comparators.nullSafeEquals(one.get(i), twoIterator.next()))
+            if (!twoIterator.hasNext() || !Objects.equals(one.get(i), twoIterator.next()))
             {
                 return false;
             }
@@ -143,7 +143,7 @@ public final class ListIterate
         Iterator<?> twoIterator = two.iterator();
         while (oneIterator.hasNext())
         {
-            if (!twoIterator.hasNext() || !Comparators.nullSafeEquals(oneIterator.next(), twoIterator.next()))
+            if (!twoIterator.hasNext() || !Objects.equals(oneIterator.next(), twoIterator.next()))
             {
                 return false;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterate.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.function.BiConsumer;
@@ -50,7 +51,6 @@ import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Twin;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.procedure.CountProcedure;
 import org.eclipse.collections.impl.block.procedure.FastListCollectIfProcedure;
 import org.eclipse.collections.impl.block.procedure.FastListCollectProcedure;
@@ -93,7 +93,7 @@ public final class InternalArrayIterate
     {
         for (int i = 0; i < size; i++)
         {
-            if (!Comparators.nullSafeEquals(array[i], list.get(i)))
+            if (!Objects.equals(array[i], list.get(i)))
             {
                 return false;
             }
@@ -110,7 +110,7 @@ public final class InternalArrayIterate
             {
                 return false;
             }
-            if (!Comparators.nullSafeEquals(array[i], iterator.next()))
+            if (!Objects.equals(array[i], iterator.next()))
             {
                 return false;
             }
@@ -355,7 +355,7 @@ public final class InternalArrayIterate
     {
         for (int i = 0; i < size; i++)
         {
-            if (Comparators.nullSafeEquals(array[i], object))
+            if (Objects.equals(array[i], object))
             {
                 return i;
             }
@@ -367,7 +367,7 @@ public final class InternalArrayIterate
     {
         for (int i = size - 1; i >= 0; i--)
         {
-            if (Comparators.nullSafeEquals(array[i], object))
+            if (Objects.equals(array[i], object))
             {
                 return i;
             }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
@@ -10,8 +10,9 @@
 
 package org.eclipse.collections.impl.block.function;
 
+import java.util.Objects;
+
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.Verify;
@@ -84,7 +85,7 @@ public class CaseFunctionTest
             {
                 return false;
             }
-            return Comparators.nullSafeEquals(this.description, foo.description);
+            return Objects.equals(this.description, foo.description);
         }
 
         @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.collection.MutableCollection;
@@ -338,8 +339,8 @@ public abstract class AbstractListTestCase
         Assert.assertFalse(nonRandomAccess.corresponds(integers1, Predicates2.lessThan()));
 
         MutableList<String> nullBlanks = this.newWith(null, "", " ", null);
-        Assert.assertTrue(nullBlanks.corresponds(FastList.newListWith(null, "", " ", null), Comparators::nullSafeEquals));
-        Assert.assertFalse(nullBlanks.corresponds(FastList.newListWith("", null, " ", ""), Comparators::nullSafeEquals));
+        Assert.assertTrue(nullBlanks.corresponds(FastList.newListWith(null, "", " ", null), Objects::equals));
+        Assert.assertFalse(nullBlanks.corresponds(FastList.newListWith("", null, " ", ""), Objects::equals));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Craig P. Motlin <cmotlin@gmail.com>