### PR TITLE
Add static factory methods to interfaces.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/ImmutableBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/ImmutableBag.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.bag;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableCharBag;
@@ -33,6 +35,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
@@ -48,6 +51,36 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
  */
 public interface ImmutableBag<T> extends UnsortedBag<T>, ImmutableBagIterable<T>
 {
+    static <T> ImmutableBag<T> empty()
+    {
+        return Bags.immutable.empty();
+    }
+
+    static <T> ImmutableBag<T> of()
+    {
+        return Bags.immutable.of();
+    }
+
+    static <T> ImmutableBag<T> of(T element)
+    {
+        return Bags.immutable.of(element);
+    }
+
+    static <T> ImmutableBag<T> of(T... elements)
+    {
+        return Bags.immutable.of(elements);
+    }
+
+    static <T> ImmutableBag<T> ofAll(Iterable<? extends T> items)
+    {
+        return Bags.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableBag<T> fromStream(Stream<? extends T> stream)
+    {
+        return Bags.immutable.fromStream(stream);
+    }
+
     @Override
     ImmutableBag<T> newWith(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MutableBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MutableBag.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.bag;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.MutableByteBag;
 import org.eclipse.collections.api.bag.primitive.MutableCharBag;
@@ -33,6 +35,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
@@ -51,6 +54,31 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableBag<T>
         extends UnsortedBag<T>, MutableBagIterable<T>
 {
+    static <T> MutableBag<T> empty()
+    {
+        return Bags.mutable.empty();
+    }
+
+    static <T> MutableBag<T> of()
+    {
+        return Bags.mutable.of();
+    }
+
+    static <T> MutableBag<T> of(T... elements)
+    {
+        return Bags.mutable.of(elements);
+    }
+
+    static <T> MutableBag<T> ofAll(Iterable<? extends T> items)
+    {
+        return Bags.mutable.ofAll(items);
+    }
+
+    static <T> MutableBag<T> fromStream(Stream<? extends T> stream)
+    {
+        return Bags.mutable.fromStream(stream);
+    }
+
     @Override
     MutableMap<T, Integer> toMapOfItemToCount();
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/ImmutableSortedBag.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.bag.sorted;
 
+import java.util.Comparator;
+
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.ImmutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
@@ -29,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.SortedBags;
 import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
@@ -55,6 +58,51 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableSortedBag<T>
         extends ImmutableBagIterable<T>, SortedBag<T>
 {
+    static <T> ImmutableSortedBag<T> empty()
+    {
+        return SortedBags.immutable.empty();
+    }
+
+    static <T> ImmutableSortedBag<T> empty(Comparator<? super T> comparator)
+    {
+        return SortedBags.immutable.empty(comparator);
+    }
+
+    static <T> ImmutableSortedBag<T> of()
+    {
+        return SortedBags.immutable.of();
+    }
+
+    static <T> ImmutableSortedBag<T> of(T... items)
+    {
+        return SortedBags.immutable.of(items);
+    }
+
+    static <T> ImmutableSortedBag<T> ofAll(Iterable<? extends T> items)
+    {
+        return SortedBags.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableSortedBag<T> of(Comparator<? super T> comparator, T... items)
+    {
+        return SortedBags.immutable.of(comparator, items);
+    }
+
+    static <T> ImmutableSortedBag<T> of(Comparator<? super T> comparator)
+    {
+        return SortedBags.immutable.of(comparator);
+    }
+
+    static <T> ImmutableSortedBag<T> ofAll(Comparator<? super T> comparator, Iterable<? extends T> items)
+    {
+        return SortedBags.immutable.ofAll(comparator, items);
+    }
+
+    static <T> ImmutableSortedBag<T> ofSortedBag(SortedBag<T> bag)
+    {
+        return SortedBags.immutable.ofSortedBag(bag);
+    }
+
     @Override
     ImmutableSortedBag<T> newWith(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/MutableSortedBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/sorted/MutableSortedBag.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.bag.sorted;
 
+import java.util.Comparator;
+
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
@@ -29,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.SortedBags;
 import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
@@ -52,6 +55,46 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableSortedBag<T>
         extends SortedBag<T>, MutableBagIterable<T>, Cloneable
 {
+    static <T> MutableSortedBag<T> empty()
+    {
+        return SortedBags.mutable.empty();
+    }
+
+    static <T> MutableSortedBag<T> empty(Comparator<? super T> comparator)
+    {
+        return SortedBags.mutable.empty(comparator);
+    }
+
+    static <T> MutableSortedBag<T> of()
+    {
+        return SortedBags.mutable.of();
+    }
+
+    static <T> MutableSortedBag<T> of(Comparator<? super T> comparator)
+    {
+        return SortedBags.mutable.of(comparator);
+    }
+
+    static <T> MutableSortedBag<T> of(T... elements)
+    {
+        return SortedBags.mutable.of(elements);
+    }
+
+    static <T> MutableSortedBag<T> of(Comparator<? super T> comparator, T... elements)
+    {
+        return SortedBags.mutable.of(comparator, elements);
+    }
+
+    static <T> MutableSortedBag<T> ofAll(Iterable<? extends T> items)
+    {
+        return SortedBags.mutable.ofAll(items);
+    }
+
+    static <T> MutableSortedBag<T> ofAll(Comparator<? super T> comparator, Iterable<? extends T> items)
+    {
+        return SortedBags.mutable.ofAll(comparator, items);
+    }
+
     @Override
     MutableSortedBag<T> selectByOccurrences(IntPredicate predicate);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/ImmutableBiMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/ImmutableBiMap.java
@@ -10,12 +10,16 @@
 
 package org.eclipse.collections.api.bimap;
 
+import java.util.Map;
+
 import org.eclipse.collections.api.bag.ImmutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.BiMaps;
+import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.ImmutableMapIterable;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -30,6 +34,51 @@ import org.eclipse.collections.api.tuple.Pair;
  */
 public interface ImmutableBiMap<K, V> extends BiMap<K, V>, ImmutableMapIterable<K, V>
 {
+    static <K, V> ImmutableBiMap<K, V> empty()
+    {
+        return BiMaps.immutable.empty();
+    }
+
+    static <K, V> ImmutableBiMap<K, V> of()
+    {
+        return BiMaps.immutable.of();
+    }
+
+    static <K, V> ImmutableBiMap<K, V> of(K key, V value)
+    {
+        return BiMaps.immutable.of(key, value);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return BiMaps.immutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return BiMaps.immutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return BiMaps.immutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> ofAll(Map<K, V> map)
+    {
+        return BiMaps.immutable.ofAll(map);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> ofAll(MutableBiMap<K, V> biMap)
+    {
+        return BiMaps.immutable.ofAll(biMap);
+    }
+
+    static <K, V> ImmutableBiMap<K, V> ofAll(ImmutableMap<K, V> immutableMap)
+    {
+        return BiMaps.immutable.ofAll(immutableMap);
+    }
+
     @Override
     ImmutableBiMap<K, V> newWithKeyValue(K key, V value);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/MutableBiMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/MutableBiMap.java
@@ -17,6 +17,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.BiMaps;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -31,6 +32,36 @@ import org.eclipse.collections.api.tuple.Pair;
  */
 public interface MutableBiMap<K, V> extends BiMap<K, V>, MutableMapIterable<K, V>, Cloneable
 {
+    static <K, V> MutableBiMap<K, V> empty()
+    {
+        return BiMaps.mutable.empty();
+    }
+
+    static <K, V> MutableBiMap<K, V> of()
+    {
+        return BiMaps.mutable.of();
+    }
+
+    static <K, V> MutableBiMap<K, V> of(K key, V value)
+    {
+        return BiMaps.mutable.of(key, value);
+    }
+
+    static <K, V> MutableBiMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return BiMaps.mutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> MutableBiMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return BiMaps.mutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> MutableBiMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return BiMaps.mutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
     @Override
     MutableBiMap<K, V> newEmpty();
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
@@ -10,8 +10,11 @@
 
 package org.eclipse.collections.api.list;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.FixedSizeCollection;
+import org.eclipse.collections.api.factory.Lists;
 
 /**
  * A FixedSizeList is a list that may be mutated, but cannot grow or shrink in size. The typical
@@ -21,6 +24,61 @@ import org.eclipse.collections.api.collection.FixedSizeCollection;
 public interface FixedSizeList<T>
         extends MutableList<T>, FixedSizeCollection<T>
 {
+    static <T> FixedSizeList<T> empty()
+    {
+        return Lists.fixedSize.empty();
+    }
+
+    static <T> FixedSizeList<T> of()
+    {
+        return Lists.fixedSize.of();
+    }
+
+    static <T> FixedSizeList<T> of(T one)
+    {
+        return Lists.fixedSize.of(one);
+    }
+
+    static <T> FixedSizeList<T> of(T one, T two)
+    {
+        return Lists.fixedSize.of(one, two);
+    }
+
+    static <T> FixedSizeList<T> of(T one, T two, T three)
+    {
+        return Lists.fixedSize.of(one, two, three);
+    }
+
+    static <T> FixedSizeList<T> of(T one, T two, T three, T four)
+    {
+        return Lists.fixedSize.of(one, two, three, four);
+    }
+
+    static <T> FixedSizeList<T> of(T one, T two, T three, T four, T five)
+    {
+        return Lists.fixedSize.of(one, two, three, four, five);
+    }
+
+    static <T> FixedSizeList<T> of(T one, T two, T three, T four, T five, T six)
+    {
+        return Lists.fixedSize.of(one, two, three, four, five, six);
+    }
+
+    static <T> FixedSizeList<T> of(T... items)
+    {
+        return Lists.fixedSize.of(items);
+    }
+
+    static <T> FixedSizeList<T> ofAll(Iterable<? extends T> items)
+    {
+        return Lists.fixedSize.ofAll(items);
+    }
+
+    static <T> FixedSizeList<T> fromStream(Stream<? extends T> stream)
+    {
+        return Lists.fixedSize.fromStream(stream);
+    }
+
     @Override
     FixedSizeList<T> toReversed();
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ImmutableList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/ImmutableList.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.list;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
@@ -28,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.ImmutableCollection;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
 import org.eclipse.collections.api.list.primitive.ImmutableCharList;
@@ -49,6 +51,81 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableList<T>
         extends ImmutableCollection<T>, ListIterable<T>
 {
+    static <T> ImmutableList<T> empty()
+    {
+        return Lists.immutable.empty();
+    }
+
+    static <T> ImmutableList<T> of()
+    {
+        return Lists.immutable.of();
+    }
+
+    static <T> ImmutableList<T> of(T one)
+    {
+        return Lists.immutable.of(one);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two)
+    {
+        return Lists.immutable.of(one, two);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three)
+    {
+        return Lists.immutable.of(one, two, three);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four)
+    {
+        return Lists.immutable.of(one, two, three, four);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five)
+    {
+        return Lists.immutable.of(one, two, three, four, five);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five, T six)
+    {
+        return Lists.immutable.of(one, two, three, four, five, six);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five, T six, T seven)
+    {
+        return Lists.immutable.of(one, two, three, four, five, six, seven);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five, T six, T seven, T eight)
+    {
+        return Lists.immutable.of(one, two, three, four, five, six, seven, eight);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five, T six, T seven, T eight, T nine)
+    {
+        return Lists.immutable.of(one, two, three, four, five, six, seven, eight, nine);
+    }
+
+    static <T> ImmutableList<T> of(T one, T two, T three, T four, T five, T six, T seven, T eight, T nine, T ten)
+    {
+        return Lists.immutable.of(one, two, three, four, five, six, seven, eight, nine, ten);
+    }
+
+    static <T> ImmutableList<T> of(T... items)
+    {
+        return Lists.immutable.of(items);
+    }
+
+    static <T> ImmutableList<T> ofAll(Iterable<? extends T> items)
+    {
+        return Lists.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableList<T> fromStream(Stream<? extends T> stream)
+    {
+        return Lists.immutable.fromStream(stream);
+    }
+
     @Override
     ImmutableList<T> newWith(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MutableList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MutableList.java
@@ -14,9 +14,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
@@ -50,6 +52,41 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableList<T>
         extends MutableCollection<T>, List<T>, Cloneable, ListIterable<T>
 {
+    static <T> MutableList<T> empty()
+    {
+        return Lists.mutable.empty();
+    }
+
+    static <T> MutableList<T> of()
+    {
+        return Lists.mutable.of();
+    }
+
+    static <T> MutableList<T> of(T... items)
+    {
+        return Lists.mutable.of(items);
+    }
+
+    static <T> MutableList<T> ofInitialCapacity(int capacity)
+    {
+        return Lists.mutable.ofInitialCapacity(capacity);
+    }
+
+    static <T> MutableList<T> ofAll(Iterable<? extends T> iterable)
+    {
+        return Lists.mutable.ofAll(iterable);
+    }
+
+    static <T> MutableList<T> fromStream(Stream<? extends T> stream)
+    {
+        return Lists.mutable.fromStream(stream);
+    }
+
+    static <T> MutableList<T> withNValues(int size, Function0<? extends T> factory)
+    {
+        return Lists.mutable.withNValues(size, factory);
+    }
+
     @Override
     MutableList<T> with(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/FixedSizeMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/FixedSizeMap.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.Maps;
 
 /**
  * A FixedSizeMap is a map that may be mutated, but cannot grow or shrink in size.
@@ -22,6 +23,31 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 public interface FixedSizeMap<K, V>
         extends MutableMap<K, V>
 {
+    static <K, V> FixedSizeMap<K, V> empty()
+    {
+        return Maps.fixedSize.empty();
+    }
+
+    static <K, V> FixedSizeMap<K, V> of()
+    {
+        return Maps.fixedSize.of();
+    }
+
+    static <K, V> FixedSizeMap<K, V> of(K key, V value)
+    {
+        return Maps.fixedSize.of(key, value);
+    }
+
+    static <K, V> FixedSizeMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return Maps.fixedSize.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> FixedSizeMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return Maps.fixedSize.of(key1, value1, key2, value2, key3, value3);
+    }
+
     /**
      * @throws UnsupportedOperationException the {@code clear} operation is not supported by this map.
      */

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.map;
 
+import java.util.Map;
+
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.ImmutableByteBag;
@@ -34,6 +36,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -48,6 +51,46 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableMap<K, V>
         extends UnsortedMapIterable<K, V>, ImmutableMapIterable<K, V>
 {
+    static <K, V> ImmutableMap<K, V> empty()
+    {
+        return Maps.immutable.empty();
+    }
+
+    static <K, V> ImmutableMap<K, V> of()
+    {
+        return Maps.immutable.of();
+    }
+
+    static <K, V> ImmutableMap<K, V> of(K key, V value)
+    {
+        return Maps.immutable.of(key, value);
+    }
+
+    static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return Maps.immutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return Maps.immutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return Maps.immutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> ImmutableMap<K, V> ofMap(Map<K, V> map)
+    {
+        return Maps.immutable.ofMap(map);
+    }
+
+    static <K, V> ImmutableMap<K, V> ofAll(Map<K, V> map)
+    {
+        return Maps.immutable.ofAll(map);
+    }
+
     @Override
     ImmutableMap<K, V> newWithKeyValue(K key, V value);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.map;
 
+import java.util.Map;
+
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.bag.primitive.MutableByteBag;
@@ -34,6 +36,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -48,6 +51,51 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableMap<K, V>
         extends MutableMapIterable<K, V>, UnsortedMapIterable<K, V>, Cloneable
 {
+    static <K, V> MutableMap<K, V> empty()
+    {
+        return Maps.mutable.empty();
+    }
+
+    static <K, V> MutableMap<K, V> of()
+    {
+        return Maps.mutable.of();
+    }
+
+    static <K, V> MutableMap<K, V> ofInitialCapacity(int capacity)
+    {
+        return Maps.mutable.ofInitialCapacity(capacity);
+    }
+
+    static <K, V> MutableMap<K, V> of(K key, V value)
+    {
+        return Maps.mutable.of(key, value);
+    }
+
+    static <K, V> MutableMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return Maps.mutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> MutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return Maps.mutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> MutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return Maps.mutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> MutableMap<K, V> ofMap(Map<? extends K, ? extends V> map)
+    {
+        return Maps.mutable.ofMap(map);
+    }
+
+    static <K, V> MutableMap<K, V> ofMapIterable(MapIterable<? extends K, ? extends V> mapIterable)
+    {
+        return Maps.mutable.ofMapIterable(mapIterable);
+    }
+
     /**
      * Adds all the entries derived from {@code iterable} to {@code this}. The key and value for each entry
      * is determined by applying the {@code keyFunction} and {@code valueFunction} to each item in

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.map.sorted;
 
+import java.util.Comparator;
 import java.util.SortedMap;
 
 import org.eclipse.collections.api.block.function.Function;
@@ -28,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.SortedMaps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -51,6 +53,66 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableSortedMap<K, V>
         extends SortedMapIterable<K, V>, ImmutableMapIterable<K, V>
 {
+    static <K, V> ImmutableSortedMap<K, V> empty()
+    {
+        return SortedMaps.immutable.empty();
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of()
+    {
+        return SortedMaps.immutable.of();
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(K key, V value)
+    {
+        return SortedMaps.immutable.of(key, value);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return SortedMaps.immutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return SortedMaps.immutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return SortedMaps.immutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(Comparator<? super K> comparator)
+    {
+        return SortedMaps.immutable.of(comparator);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(Comparator<? super K> comparator, K key, V value)
+    {
+        return SortedMaps.immutable.of(comparator, key, value);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2)
+    {
+        return SortedMaps.immutable.of(comparator, key1, value1, key2, value2);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return SortedMaps.immutable.of(comparator, key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return SortedMaps.immutable.of(comparator, key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> ImmutableSortedMap<K, V> ofSortedMap(SortedMap<K, V> map)
+    {
+        return SortedMaps.immutable.ofSortedMap(map);
+    }
+
     @Override
     SortedMap<K, V> castToMap();
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.map.sorted;
 
+import java.util.Comparator;
+import java.util.Map;
 import java.util.SortedMap;
 
 import org.eclipse.collections.api.block.function.Function;
@@ -27,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.MutableCollection;
+import org.eclipse.collections.api.factory.SortedMaps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
@@ -51,6 +54,66 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableSortedMap<K, V>
         extends MutableMapIterable<K, V>, SortedMapIterable<K, V>, SortedMap<K, V>, Cloneable
 {
+    static <K, V> MutableSortedMap<K, V> empty()
+    {
+        return SortedMaps.mutable.empty();
+    }
+
+    static <K, V> MutableSortedMap<K, V> of()
+    {
+        return SortedMaps.mutable.of();
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(K key, V value)
+    {
+        return SortedMaps.mutable.of(key, value);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(K key1, V value1, K key2, V value2)
+    {
+        return SortedMaps.mutable.of(key1, value1, key2, value2);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return SortedMaps.mutable.of(key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return SortedMaps.mutable.of(key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(Comparator<? super K> comparator)
+    {
+        return SortedMaps.mutable.of(comparator);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(Comparator<? super K> comparator, K key, V value)
+    {
+        return SortedMaps.mutable.of(comparator, key, value);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2)
+    {
+        return SortedMaps.mutable.of(comparator, key1, value1, key2, value2);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2, K key3, V value3)
+    {
+        return SortedMaps.mutable.of(comparator, key1, value1, key2, value2, key3, value3);
+    }
+
+    static <K, V> MutableSortedMap<K, V> of(Comparator<? super K> comparator, K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4)
+    {
+        return SortedMaps.mutable.of(comparator, key1, value1, key2, value2, key3, value3, key4, value4);
+    }
+
+    static <K, V> MutableSortedMap<K, V> ofSortedMap(Map<? extends K, ? extends V> map)
+    {
+        return SortedMaps.mutable.ofSortedMap(map);
+    }
+
     /**
      * Creates a new instance of the same type with the same internal Comparator.
      */

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/FixedSizeSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/FixedSizeSet.java
@@ -10,8 +10,11 @@
 
 package org.eclipse.collections.api.set;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.FixedSizeCollection;
+import org.eclipse.collections.api.factory.Sets;
 
 /**
  * A FixedSizeSet is a set that may be mutated, but cannot grow or shrink in size.
@@ -19,6 +22,46 @@ import org.eclipse.collections.api.collection.FixedSizeCollection;
 public interface FixedSizeSet<T>
         extends MutableSet<T>, FixedSizeCollection<T>
 {
+    static <T> FixedSizeSet<T> empty()
+    {
+        return Sets.fixedSize.empty();
+    }
+
+    static <T> FixedSizeSet<T> of()
+    {
+        return Sets.fixedSize.of();
+    }
+
+    static <T> FixedSizeSet<T> of(T one)
+    {
+        return Sets.fixedSize.of(one);
+    }
+
+    static <T> FixedSizeSet<T> of(T one, T two)
+    {
+        return Sets.fixedSize.of(one, two);
+    }
+
+    static <T> FixedSizeSet<T> of(T one, T two, T three)
+    {
+        return Sets.fixedSize.of(one, two, three);
+    }
+
+    static <T> FixedSizeSet<T> of(T one, T two, T three, T four)
+    {
+        return Sets.fixedSize.of(one, two, three, four);
+    }
+
+    static <T> MutableSet<T> ofAll(Iterable<? extends T> items)
+    {
+        return Sets.fixedSize.ofAll(items);
+    }
+
+    static <T> MutableSet<T> fromStream(Stream<? extends T> stream)
+    {
+        return Sets.fixedSize.fromStream(stream);
+    }
+
     @Override
     FixedSizeSet<T> tap(Procedure<? super T> procedure);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/ImmutableSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/ImmutableSet.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.set;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -25,6 +26,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
@@ -47,6 +49,51 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableSet<T>
         extends UnsortedSetIterable<T>, ImmutableSetIterable<T>
 {
+    static <T> ImmutableSet<T> empty()
+    {
+        return Sets.immutable.empty();
+    }
+
+    static <T> ImmutableSet<T> of()
+    {
+        return Sets.immutable.of();
+    }
+
+    static <T> ImmutableSet<T> of(T one)
+    {
+        return Sets.immutable.of(one);
+    }
+
+    static <T> ImmutableSet<T> of(T one, T two)
+    {
+        return Sets.immutable.of(one, two);
+    }
+
+    static <T> ImmutableSet<T> of(T one, T two, T three)
+    {
+        return Sets.immutable.of(one, two, three);
+    }
+
+    static <T> ImmutableSet<T> of(T one, T two, T three, T four)
+    {
+        return Sets.immutable.of(one, two, three, four);
+    }
+
+    static <T> ImmutableSet<T> of(T... items)
+    {
+        return Sets.immutable.of(items);
+    }
+
+    static <T> ImmutableSet<T> ofAll(Iterable<? extends T> items)
+    {
+        return Sets.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableSet<T> fromStream(Stream<? extends T> stream)
+    {
+        return Sets.immutable.fromStream(stream);
+    }
+
     @Override
     ImmutableSet<T> newWith(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/MutableSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/MutableSet.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.set;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
@@ -23,6 +25,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
@@ -42,6 +45,36 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableSet<T>
         extends UnsortedSetIterable<T>, MutableSetIterable<T>, Cloneable
 {
+    static <T> MutableSet<T> empty()
+    {
+        return Sets.mutable.empty();
+    }
+
+    static <T> MutableSet<T> of()
+    {
+        return Sets.mutable.of();
+    }
+
+    static <T> MutableSet<T> of(T... items)
+    {
+        return Sets.mutable.of(items);
+    }
+
+    static <T> MutableSet<T> ofInitialCapacity(int capacity)
+    {
+        return Sets.mutable.ofInitialCapacity(capacity);
+    }
+
+    static <T> MutableSet<T> ofAll(Iterable<? extends T> items)
+    {
+        return Sets.mutable.ofAll(items);
+    }
+
+    static <T> MutableSet<T> fromStream(Stream<? extends T> stream)
+    {
+        return Sets.mutable.fromStream(stream);
+    }
+
     @Override
     MutableSet<T> with(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/ImmutableSortedSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/ImmutableSortedSet.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.set.sorted;
 
+import java.util.Comparator;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -27,6 +28,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -51,6 +53,51 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface ImmutableSortedSet<T>
         extends SortedSetIterable<T>, ImmutableSetIterable<T>
 {
+    static <T> ImmutableSortedSet<T> empty()
+    {
+        return SortedSets.immutable.empty();
+    }
+
+    static <T> ImmutableSortedSet<T> empty(Comparator<? super T> comparator)
+    {
+        return SortedSets.immutable.empty(comparator);
+    }
+
+    static <T> ImmutableSortedSet<T> of()
+    {
+        return SortedSets.immutable.of();
+    }
+
+    static <T> ImmutableSortedSet<T> of(T... items)
+    {
+        return SortedSets.immutable.of(items);
+    }
+
+    static <T> ImmutableSortedSet<T> ofAll(Iterable<? extends T> items)
+    {
+        return SortedSets.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableSortedSet<T> of(Comparator<? super T> comparator)
+    {
+        return SortedSets.immutable.of(comparator);
+    }
+
+    static <T> ImmutableSortedSet<T> of(Comparator<? super T> comparator, T... items)
+    {
+        return SortedSets.immutable.of(comparator, items);
+    }
+
+    static <T> ImmutableSortedSet<T> ofAll(Comparator<? super T> comparator, Iterable<? extends T> items)
+    {
+        return SortedSets.immutable.ofAll(comparator, items);
+    }
+
+    static <T> ImmutableSortedSet<T> ofSortedSet(SortedSet<T> set)
+    {
+        return SortedSets.immutable.ofSortedSet(set);
+    }
+
     @Override
     ImmutableSortedSet<T> newWith(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/MutableSortedSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/sorted/MutableSortedSet.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.set.sorted;
 
+import java.util.Comparator;
 import java.util.SortedSet;
 
 import org.eclipse.collections.api.block.function.Function;
@@ -26,6 +27,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
@@ -50,6 +52,41 @@ import org.eclipse.collections.api.tuple.Pair;
 public interface MutableSortedSet<T>
         extends MutableSetIterable<T>, SortedSetIterable<T>, SortedSet<T>, Cloneable
 {
+    static <T> MutableSortedSet<T> empty()
+    {
+        return SortedSets.mutable.empty();
+    }
+
+    static <T> MutableSortedSet<T> of()
+    {
+        return SortedSets.mutable.of();
+    }
+
+    static <T> MutableSortedSet<T> of(T... items)
+    {
+        return SortedSets.mutable.of(items);
+    }
+
+    static <T> MutableSortedSet<T> ofAll(Iterable<? extends T> items)
+    {
+        return SortedSets.mutable.ofAll(items);
+    }
+
+    static <T> MutableSortedSet<T> of(Comparator<? super T> comparator)
+    {
+        return SortedSets.mutable.of(comparator);
+    }
+
+    static <T> MutableSortedSet<T> of(Comparator<? super T> comparator, T... items)
+    {
+        return SortedSets.mutable.of(comparator, items);
+    }
+
+    static <T> MutableSortedSet<T> ofAll(Comparator<? super T> comparator, Iterable<? extends T> items)
+    {
+        return SortedSets.mutable.ofAll(comparator, items);
+    }
+
     @Override
     MutableSortedSet<T> with(T element);
 

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.stack;
 
+import java.util.stream.Stream;
+
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
@@ -27,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
@@ -44,6 +47,46 @@ import org.eclipse.collections.api.tuple.Pair;
 
 public interface ImmutableStack<T> extends StackIterable<T>
 {
+    static <T> ImmutableStack<T> empty()
+    {
+        return Stacks.immutable.empty();
+    }
+
+    static <T> ImmutableStack<T> of()
+    {
+        return Stacks.immutable.of();
+    }
+
+    static <T> ImmutableStack<T> of(T element)
+    {
+        return Stacks.immutable.of(element);
+    }
+
+    static <T> ImmutableStack<T> of(T... elements)
+    {
+        return Stacks.immutable.of(elements);
+    }
+
+    static <T> ImmutableStack<T> ofAll(Iterable<? extends T> items)
+    {
+        return Stacks.immutable.ofAll(items);
+    }
+
+    static <T> ImmutableStack<T> fromStream(Stream<? extends T> stream)
+    {
+        return Stacks.immutable.fromStream(stream);
+    }
+
+    static <T> ImmutableStack<T> ofReversed(T... elements)
+    {
+        return Stacks.immutable.ofReversed(elements);
+    }
+
+    static <T> ImmutableStack<T> ofAllReversed(Iterable<? extends T> items)
+    {
+        return Stacks.immutable.ofAllReversed(items);
+    }
+
     ImmutableStack<T> push(T item);
 
     ImmutableStack<T> pop();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.api.stack;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -29,6 +30,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
@@ -47,6 +49,41 @@ import org.eclipse.collections.api.tuple.Pair;
 
 public interface MutableStack<T> extends StackIterable<T>
 {
+    static <T> MutableStack<T> empty()
+    {
+        return Stacks.mutable.empty();
+    }
+
+    static <T> MutableStack<T> of()
+    {
+        return Stacks.mutable.of();
+    }
+
+    static <T> MutableStack<T> of(T... elements)
+    {
+        return Stacks.mutable.of(elements);
+    }
+
+    static <T> MutableStack<T> ofAll(Iterable<? extends T> elements)
+    {
+        return Stacks.mutable.ofAll(elements);
+    }
+
+    static <T> MutableStack<T> fromStream(Stream<? extends T> stream)
+    {
+        return Stacks.mutable.fromStream(stream);
+    }
+
+    static <T> MutableStack<T> ofReversed(T... elements)
+    {
+        return Stacks.mutable.ofReversed(elements);
+    }
+
+    static <T> MutableStack<T> ofAllReversed(Iterable<? extends T> items)
+    {
+        return Stacks.mutable.ofAllReversed(items);
+    }
+
     /**
      * Adds an item to the top of the stack.
      */

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/ImmutableBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/ImmutableBagsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.bag;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableBagsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(HashBag.newBag(), ImmutableBag.of());
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of());
+        Assert.assertEquals(HashBag.newBagWith(1), ImmutableBag.of(1));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1));
+        Assert.assertEquals(HashBag.newBagWith(1, 2), ImmutableBag.of(1, 2));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3), ImmutableBag.of(1, 2, 3));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4), ImmutableBag.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5), ImmutableBag.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6), ImmutableBag.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7), ImmutableBag.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(HashBag.newBagWith(3, 2, 1), ImmutableBag.ofAll(HashBag.newBagWith(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.ofAll(HashBag.newBagWith(1, 2, 3)));
+        Assert.assertEquals(HashBag.newBagWith(3, 2, 1), ImmutableBag.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableBag.class, ImmutableBag.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 11; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(HashBag.newBag(interval), ImmutableBag.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(HashBag.newBag(interval), ImmutableBag.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void emptyBag()
+    {
+        Assert.assertTrue(ImmutableBag.of().isEmpty());
+        Assert.assertSame(ImmutableBag.of(), ImmutableBag.of());
+        Verify.assertPostSerializedIdentity(ImmutableBag.of());
+    }
+
+    @Test
+    public void newBagWith()
+    {
+        ImmutableBag<String> bag = ImmutableBag.of();
+        Assert.assertEquals(bag, ImmutableBag.of(bag.toArray()));
+        Assert.assertEquals(bag = bag.newWith("1"), ImmutableBag.of("1"));
+        Assert.assertEquals(bag = bag.newWith("2"), ImmutableBag.of("1", "2"));
+        Assert.assertEquals(bag = bag.newWith("3"), ImmutableBag.of("1", "2", "3"));
+        Assert.assertEquals(bag = bag.newWith("4"), ImmutableBag.of("1", "2", "3", "4"));
+        Assert.assertEquals(bag = bag.newWith("5"), ImmutableBag.of("1", "2", "3", "4", "5"));
+        Assert.assertEquals(bag = bag.newWith("6"), ImmutableBag.of("1", "2", "3", "4", "5", "6"));
+        Assert.assertEquals(bag = bag.newWith("7"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7"));
+        Assert.assertEquals(bag = bag.newWith("8"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        Assert.assertEquals(bag = bag.newWith("9"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        Assert.assertEquals(bag = bag.newWith("10"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        Assert.assertEquals(bag = bag.newWith("11"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        Assert.assertEquals(bag = bag.newWith("12"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+    }
+
+    @Test
+    public void newBagWithArray()
+    {
+        ImmutableBag<String> bag = ImmutableBag.of();
+        Assert.assertEquals(bag = bag.newWith("1"), ImmutableBag.of(new String[]{"1"}));
+        Assert.assertEquals(bag = bag.newWith("2"), ImmutableBag.of(new String[]{"1", "2"}));
+        Assert.assertEquals(bag = bag.newWith("3"), ImmutableBag.of(new String[]{"1", "2", "3"}));
+        Assert.assertEquals(bag = bag.newWith("4"), ImmutableBag.of(new String[]{"1", "2", "3", "4"}));
+        Assert.assertEquals(bag = bag.newWith("5"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5"}));
+        Assert.assertEquals(bag = bag.newWith("6"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        Assert.assertEquals(bag = bag.newWith("7"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        Assert.assertEquals(bag = bag.newWith("8"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        Assert.assertEquals(bag = bag.newWith("9"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        Assert.assertEquals(bag = bag.newWith("10"), ImmutableBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        Assert.assertEquals(bag = bag.newWith("11"), ImmutableBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+    }
+
+    @Test
+    public void newBagWithWithBag()
+    {
+        Assert.assertEquals(HashBag.newBag(), ImmutableBag.ofAll(HashBag.newBag()));
+        for (int i = 0; i < 12; i++)
+        {
+            List<Integer> interval = Interval.fromTo(0, i);
+            Assert.assertEquals(HashBag.newBag(interval), ImmutableBag.ofAll(interval));
+        }
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/MutableBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/MutableBagsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.bag;
+
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableBagsTest
+{
+    @Test
+    public void of()
+    {
+        Verify.assertBagsEqual(HashBag.newBag(), MutableBag.of());
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of());
+        Verify.assertBagsEqual(HashBag.newBagWith(1), MutableBag.of(1));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of(1));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2), MutableBag.of(1, 2));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of(1, 2));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 3), MutableBag.of(1, 2, 3));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of(1, 2, 3));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 3, 4), MutableBag.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of(1, 2, 3, 4));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 3, 4, 5), MutableBag.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.of(1, 2, 3, 4, 5));
+
+        Bag<Integer> bag = HashBag.newBagWith(1, 2, 2, 3, 3, 3);
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), MutableBag.ofAll(bag));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.ofAll(bag));
+        Assert.assertNotSame(MutableBag.ofAll(bag), bag);
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), MutableBag.ofAll(FastList.newListWith(1, 2, 2, 3, 3, 3)));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.ofAll(FastList.newListWith(1, 2, 2, 3, 3, 3)));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 3, 4, 5), MutableBag.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), MutableBag.fromStream(Stream.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertInstanceOf(MutableBag.class, MutableBag.fromStream(Stream.of(1, 2, 2, 3, 3, 3)));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/sorted/ImmutableSortedBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/sorted/ImmutableSortedBagsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.bag.sorted;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
+import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
+import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableSortedBagsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(TreeBag.newBag(), ImmutableSortedBag.of());
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of());
+        Assert.assertEquals(TreeBag.newBagWith(1), ImmutableSortedBag.of(1));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2), ImmutableSortedBag.of(1, 2));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3), ImmutableSortedBag.of(1, 2, 3));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4), ImmutableSortedBag.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5), ImmutableSortedBag.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6), ImmutableSortedBag.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7), ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(TreeBag.newBagWith(3, 2, 1), ImmutableSortedBag.ofAll(TreeBag.newBagWith(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.ofAll(TreeBag.newBagWith(1, 2, 3)));
+
+        Assert.assertEquals(TreeBag.newBag(), ImmutableSortedBag.of(Comparator.reverseOrder()));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder()));
+        Assert.assertEquals(TreeBag.newBagWith(1), ImmutableSortedBag.of(Comparator.reverseOrder(), 1));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(TreeBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(TreeBag.newBagWith(3, 2, 1), ImmutableSortedBag.ofAll(Comparator.reverseOrder(), MutableSortedBag.of(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableSortedBag.class, ImmutableSortedBag.ofAll(Comparator.reverseOrder(), MutableSortedBag.of(1, 2, 3)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 11; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(TreeBag.newBag(interval), ImmutableSortedBag.ofAll(interval));
+            Verify.assertEqualsAndHashCode(TreeBag.newBag(interval), ImmutableSortedBag.ofAll(Comparator.reverseOrder(), interval));
+        }
+    }
+
+    @Test
+    public void emptyBag()
+    {
+        Assert.assertTrue(ImmutableSortedBag.of().isEmpty());
+        Assert.assertSame(ImmutableSortedBag.of(), ImmutableSortedBag.of());
+        Verify.assertPostSerializedIdentity(ImmutableSortedBag.of());
+    }
+
+    @Test
+    public void newBagWith()
+    {
+        ImmutableSortedBag<String> bag = ImmutableSortedBag.of();
+        Assert.assertEquals(bag, ImmutableSortedBag.of(bag.toArray()));
+        Assert.assertEquals(bag = bag.newWith("1"), ImmutableSortedBag.of("1"));
+        Assert.assertEquals(bag = bag.newWith("2"), ImmutableSortedBag.of("1", "2"));
+        Assert.assertEquals(bag = bag.newWith("3"), ImmutableSortedBag.of("1", "2", "3"));
+        Assert.assertEquals(bag = bag.newWith("4"), ImmutableSortedBag.of("1", "2", "3", "4"));
+        Assert.assertEquals(bag = bag.newWith("5"), ImmutableSortedBag.of("1", "2", "3", "4", "5"));
+        Assert.assertEquals(bag = bag.newWith("6"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6"));
+        Assert.assertEquals(bag = bag.newWith("7"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7"));
+        Assert.assertEquals(bag = bag.newWith("8"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        Assert.assertEquals(bag = bag.newWith("9"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        Assert.assertEquals(bag = bag.newWith("10"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        Assert.assertEquals(bag = bag.newWith("11"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        Assert.assertEquals(bag = bag.newWith("12"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+    }
+
+    @Test
+    public void newBagWithArray()
+    {
+        ImmutableSortedBag<String> bag = ImmutableSortedBag.of();
+        Assert.assertEquals(bag = bag.newWith("1"), ImmutableSortedBag.of(new String[]{"1"}));
+        Assert.assertEquals(bag = bag.newWith("2"), ImmutableSortedBag.of(new String[]{"1", "2"}));
+        Assert.assertEquals(bag = bag.newWith("3"), ImmutableSortedBag.of(new String[]{"1", "2", "3"}));
+        Assert.assertEquals(bag = bag.newWith("4"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4"}));
+        Assert.assertEquals(bag = bag.newWith("5"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5"}));
+        Assert.assertEquals(bag = bag.newWith("6"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        Assert.assertEquals(bag = bag.newWith("7"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        Assert.assertEquals(bag = bag.newWith("8"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        Assert.assertEquals(bag = bag.newWith("9"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        Assert.assertEquals(bag = bag.newWith("10"), ImmutableSortedBag.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        Assert.assertEquals(bag = bag.newWith("11"), ImmutableSortedBag.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+    }
+
+    @Test
+    public void newBagWithWithBag()
+    {
+        Assert.assertEquals(TreeBag.newBag(), ImmutableSortedBag.ofAll(TreeBag.newBag()));
+        Assert.assertEquals(TreeBag.newBag(), ImmutableSortedBag.ofAll(Comparator.<String>reverseOrder(), TreeBag.newBag()));
+        for (int i = 0; i < 12; i++)
+        {
+            List<Integer> interval = Interval.fromTo(0, i);
+            Assert.assertEquals(TreeBag.newBag(interval), ImmutableSortedBag.ofAll(interval));
+            Assert.assertEquals(TreeBag.newBag(interval), ImmutableSortedBag.ofAll(Comparator.reverseOrder(), interval));
+        }
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/sorted/MutableSortedBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/bag/sorted/MutableSortedBagsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.bag.sorted;
+
+import java.util.Comparator;
+
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableSortedBagsTest
+{
+    @Test
+    public void of()
+    {
+        Verify.assertBagsEqual(TreeBag.newBag(), MutableSortedBag.of());
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of());
+        Verify.assertBagsEqual(TreeBag.newBagWith(1), MutableSortedBag.of(1));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(1));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2), MutableSortedBag.of(1, 2));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(1, 2));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3), MutableSortedBag.of(1, 2, 3));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(1, 2, 3));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4), MutableSortedBag.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(1, 2, 3, 4));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4, 5), MutableSortedBag.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(1, 2, 3, 4, 5));
+
+        Verify.assertBagsEqual(TreeBag.newBag(), MutableSortedBag.of(Comparator.reverseOrder()));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder()));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1), MutableSortedBag.of(Comparator.reverseOrder(), 1));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder(), 1));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2), MutableSortedBag.of(Comparator.reverseOrder(), 1, 2));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder(), 1, 2));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3), MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4), MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4, 5), MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5));
+
+        Bag<Integer> bag1 = TreeBag.newBagWith(1, 2, 2, 3, 3, 3);
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), MutableSortedBag.ofAll(bag1));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(bag1));
+        Assert.assertNotSame(MutableSortedBag.ofAll(bag1), bag1);
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), MutableSortedBag.ofAll(MutableList.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(MutableList.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4, 5), MutableSortedBag.ofAll(MutableSet.of(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(MutableSet.of(1, 2, 3, 4, 5)));
+
+        Bag<Integer> bag2 = TreeBag.newBagWith(Comparator.reverseOrder(), 1, 2, 2, 3, 3, 3);
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), MutableSortedBag.ofAll(bag2));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(bag2));
+        Assert.assertNotSame(MutableSortedBag.ofAll(bag2), bag2);
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), MutableSortedBag.ofAll(Comparator.reverseOrder(), MutableList.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(Comparator.reverseOrder(), MutableList.of(1, 2, 2, 3, 3, 3)));
+        Verify.assertBagsEqual(TreeBag.newBagWith(1, 2, 3, 4, 5), MutableSortedBag.ofAll(Comparator.reverseOrder(), MutableSet.of(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(MutableSortedBag.class, MutableSortedBag.ofAll(Comparator.reverseOrder(), MutableSet.of(1, 2, 3, 4, 5)));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/FixedSizeListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/FixedSizeListsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.list;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.list.FixedSizeList;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FixedSizeListsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(FastList.newList(), FixedSizeList.of());
+        Assert.assertEquals(FastList.newList(), FixedSizeList.empty());
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of());
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.empty());
+        Assert.assertEquals(FastList.newListWith(1), FixedSizeList.of(1));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1));
+        Assert.assertEquals(FastList.newListWith(1, 2), FixedSizeList.of(1, 2));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), FixedSizeList.of(1, 2, 3));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), FixedSizeList.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), FixedSizeList.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), FixedSizeList.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), FixedSizeList.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), FixedSizeList.ofAll(FastList.newListWith(1, 2, 3)));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.ofAll(FastList.newListWith(1, 2, 3)));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), FixedSizeList.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(FixedSizeList.class, FixedSizeList.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 11; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(interval, FixedSizeList.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(interval, FixedSizeList.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void emptyList()
+    {
+        Assert.assertTrue(FixedSizeList.of().isEmpty());
+        Assert.assertSame(FixedSizeList.of(), FixedSizeList.of());
+        Verify.assertPostSerializedIdentity(FixedSizeList.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/ImmutableListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/ImmutableListsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.list;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableListsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(FastList.newList(), ImmutableList.of());
+        Assert.assertEquals(FastList.newList(), ImmutableList.empty());
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of());
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.empty());
+        Assert.assertEquals(FastList.newListWith(1), ImmutableList.of(1));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1));
+        Assert.assertEquals(FastList.newListWith(1, 2), ImmutableList.of(1, 2));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), ImmutableList.of(1, 2, 3));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), ImmutableList.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), ImmutableList.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), ImmutableList.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), ImmutableList.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), ImmutableList.ofAll(FastList.newListWith(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.ofAll(FastList.newListWith(1, 2, 3)));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), ImmutableList.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @Test
+    public void castToList()
+    {
+        List<Object> list = ImmutableList.of().castToList();
+        Assert.assertNotNull(list);
+        Assert.assertSame(ImmutableList.of(), list);
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 11; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(interval, ImmutableList.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(interval, ImmutableList.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void copyList()
+    {
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.ofAll(Lists.fixedSize.of()));
+        MutableList<Integer> list = Lists.fixedSize.of(1);
+        ImmutableList<Integer> immutableList = list.toImmutable();
+        Verify.assertInstanceOf(ImmutableList.class, ImmutableList.ofAll(list));
+        Assert.assertSame(ImmutableList.ofAll(immutableList.castToList()), immutableList);
+    }
+
+    @Test
+    public void emptyList()
+    {
+        Assert.assertTrue(ImmutableList.of().isEmpty());
+        Assert.assertSame(ImmutableList.of(), ImmutableList.of());
+        Verify.assertPostSerializedIdentity(ImmutableList.of());
+    }
+
+    @Test
+    public void newListWith()
+    {
+        ImmutableList<String> list = ImmutableList.of();
+        Assert.assertEquals(list, ImmutableList.of(list.toArray()));
+        Assert.assertEquals(list = list.newWith("1"), ImmutableList.of("1"));
+        Assert.assertEquals(list = list.newWith("2"), ImmutableList.of("1", "2"));
+        Assert.assertEquals(list = list.newWith("3"), ImmutableList.of("1", "2", "3"));
+        Assert.assertEquals(list = list.newWith("4"), ImmutableList.of("1", "2", "3", "4"));
+        Assert.assertEquals(list = list.newWith("5"), ImmutableList.of("1", "2", "3", "4", "5"));
+        Assert.assertEquals(list = list.newWith("6"), ImmutableList.of("1", "2", "3", "4", "5", "6"));
+        Assert.assertEquals(list = list.newWith("7"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7"));
+        Assert.assertEquals(list = list.newWith("8"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        Assert.assertEquals(list = list.newWith("9"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        Assert.assertEquals(list = list.newWith("10"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        Assert.assertEquals(list = list.newWith("11"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        Assert.assertEquals(list = list.newWith("12"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+    }
+
+    @Test
+    public void newListWithArray()
+    {
+        ImmutableList<String> list = ImmutableList.of();
+        Assert.assertEquals(list = list.newWith("1"), ImmutableList.of(new String[]{"1"}));
+        Assert.assertEquals(list = list.newWith("2"), ImmutableList.of(new String[]{"1", "2"}));
+        Assert.assertEquals(list = list.newWith("3"), ImmutableList.of(new String[]{"1", "2", "3"}));
+        Assert.assertEquals(list = list.newWith("4"), ImmutableList.of(new String[]{"1", "2", "3", "4"}));
+        Assert.assertEquals(list = list.newWith("5"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5"}));
+        Assert.assertEquals(list = list.newWith("6"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        Assert.assertEquals(list = list.newWith("7"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        Assert.assertEquals(list = list.newWith("8"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        Assert.assertEquals(list = list.newWith("9"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        Assert.assertEquals(list = list.newWith("10"), ImmutableList.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        Assert.assertEquals(list = list.newWith("11"), ImmutableList.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+    }
+
+    @Test
+    public void newListWithWithList()
+    {
+        Assert.assertEquals(FastList.newList(), ImmutableList.ofAll(FastList.newList()));
+        for (int i = 0; i < 12; i++)
+        {
+            List<Integer> list = Interval.fromTo(0, i);
+            Assert.assertEquals(list, ImmutableList.ofAll(list));
+        }
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/MutableListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/list/MutableListsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.list;
+
+import java.lang.reflect.Field;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.list.primitive.IntInterval;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableListsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(FastList.newList(), MutableList.of());
+        Assert.assertEquals(FastList.newList(), MutableList.empty());
+        Verify.assertInstanceOf(MutableList.class, MutableList.of());
+        Verify.assertInstanceOf(MutableList.class, MutableList.empty());
+        Assert.assertEquals(FastList.newListWith(1), MutableList.of(1));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1));
+        Assert.assertEquals(FastList.newListWith(1, 2), MutableList.of(1, 2));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), MutableList.of(1, 2, 3));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), MutableList.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), MutableList.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), MutableList.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), MutableList.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), MutableList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), MutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), MutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(MutableList.class, MutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), MutableList.ofAll(FastList.newListWith(1, 2, 3)));
+        Verify.assertInstanceOf(MutableList.class, MutableList.ofAll(FastList.newListWith(1, 2, 3)));
+        Assert.assertEquals(FastList.newListWith(1, 2, 3), MutableList.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(MutableList.class, MutableList.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 11; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(interval, MutableList.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(interval, MutableList.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void ofInitialCapacity()
+    {
+        MutableList<String> list1 = MutableList.ofInitialCapacity(0);
+        this.assertPresizedListEquals(0, (FastList<String>) list1);
+
+        MutableList<String> list2 = MutableList.ofInitialCapacity(5);
+        this.assertPresizedListEquals(5, (FastList<String>) list2);
+
+        MutableList<String> list3 = MutableList.ofInitialCapacity(20);
+        this.assertPresizedListEquals(20, (FastList<String>) list3);
+
+        MutableList<String> list4 = MutableList.ofInitialCapacity(60);
+        this.assertPresizedListEquals(60, (FastList<String>) list4);
+
+        MutableList<String> list5 = MutableList.ofInitialCapacity(64);
+        this.assertPresizedListEquals(64, (FastList<String>) list5);
+
+        MutableList<String> list6 = MutableList.ofInitialCapacity(65);
+        this.assertPresizedListEquals(65, (FastList<String>) list6);
+
+        Verify.assertThrows(IllegalArgumentException.class, () -> MutableList.ofInitialCapacity(-12));
+    }
+
+    private void assertPresizedListEquals(int initialCapacity, FastList<String> list)
+    {
+        try
+        {
+            Field itemsField = FastList.class.getDeclaredField("items");
+            itemsField.setAccessible(true);
+            Object[] items = (Object[]) itemsField.get(list);
+            Assert.assertEquals(initialCapacity, items.length);
+        }
+        catch (SecurityException ignored)
+        {
+            Assert.fail("Unable to modify the visibility of the field 'items' on FastList");
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            Assert.fail("No field named 'items' in FastList");
+        }
+        catch (IllegalAccessException ignored)
+        {
+            Assert.fail("No access to the field 'items' in FastList");
+        }
+    }
+
+    @Test
+    public void withNValues()
+    {
+        ImmutableList<Integer> expected =
+                IntInterval.oneTo(10).collect(each -> new Integer(1));
+        MutableList<Integer> mutable =
+                MutableList.withNValues(10, () -> new Integer(1));
+        Assert.assertEquals(expected, mutable);
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/FixedSizeMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/FixedSizeMapsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.map;
+
+import org.eclipse.collections.api.map.FixedSizeMap;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.domain.Key;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FixedSizeMapsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), FixedSizeMap.of());
+        Verify.assertInstanceOf(FixedSizeMap.class, FixedSizeMap.of());
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), FixedSizeMap.of(1, 2));
+        Verify.assertInstanceOf(FixedSizeMap.class, FixedSizeMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), FixedSizeMap.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(FixedSizeMap.class, FixedSizeMap.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), FixedSizeMap.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(FixedSizeMap.class, FixedSizeMap.of(1, 2, 3, 4, 5, 6));
+
+        FixedSizeMap<String, String> map1 = FixedSizeMap.of("key1", "value1");
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue("key1", "value1", map1);
+
+        FixedSizeMap<String, String> map2 = FixedSizeMap.of("key1", "value1", "key2", "value2");
+        Verify.assertSize(2, map2);
+        Verify.assertContainsAllKeyValues(map2, "key1", "value1", "key2", "value2");
+
+        FixedSizeMap<String, String> map3 = FixedSizeMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+        Verify.assertSize(3, map3);
+        Verify.assertContainsAllKeyValues(map3, "key1", "value1", "key2", "value2", "key3", "value3");
+    }
+
+    @Test
+    public void ofDuplicateKeys()
+    {
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), FixedSizeMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), FixedSizeMap.of(1, 2, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), FixedSizeMap.of(1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), FixedSizeMap.of(1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), FixedSizeMap.of(1, 2, 3, 4, 3, 4));
+    }
+
+    @Test
+    public void ofDuplicates()
+    {
+        Assert.assertEquals(FixedSizeMap.of(0, 0), FixedSizeMap.of(0, 0, 0, 0));
+        Assert.assertEquals(FixedSizeMap.of(0, 0), FixedSizeMap.of(0, 0, 0, 0, 0, 0));
+
+        Assert.assertEquals(FixedSizeMap.of(0, 0, 1, 1), FixedSizeMap.of(1, 1, 0, 0, 0, 0));
+        Assert.assertEquals(FixedSizeMap.of(0, 0, 2, 2), FixedSizeMap.of(0, 0, 2, 2, 0, 0));
+        Assert.assertEquals(FixedSizeMap.of(0, 0, 3, 3), FixedSizeMap.of(0, 0, 0, 0, 3, 3));
+    }
+
+    @Test
+    public void mapKeyPreservation()
+    {
+        Key key = new Key("key");
+
+        Key duplicateKey1 = new Key("key");
+        FixedSizeMap<Key, Integer> map1 = FixedSizeMap.of(key, 1, duplicateKey1, 2);
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue(key, 2, map1);
+        Assert.assertSame(key, map1.keysView().getFirst());
+
+        Key duplicateKey2 = new Key("key");
+        FixedSizeMap<Key, Integer> map2 = FixedSizeMap.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
+        Verify.assertSize(1, map2);
+        Verify.assertContainsKeyValue(key, 3, map2);
+        Assert.assertSame(key, map2.keysView().getFirst());
+
+        Key duplicateKey3 = new Key("key");
+        FixedSizeMap<Key, Integer> map3 = FixedSizeMap.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
+        Verify.assertSize(2, map3);
+        Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
+        Assert.assertSame(key, map3.keysView().detect(key::equals));
+    }
+
+    @Test
+    public void emptyMap()
+    {
+        Assert.assertTrue(FixedSizeMap.of().isEmpty());
+        Assert.assertSame(FixedSizeMap.of(), FixedSizeMap.of());
+        Verify.assertPostSerializedIdentity(FixedSizeMap.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/ImmutableMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/ImmutableMapsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.map;
+
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.domain.Key;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableMapsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), ImmutableMap.of());
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.of());
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), ImmutableMap.of(1, 2));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), ImmutableMap.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), ImmutableMap.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), ImmutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        ImmutableMap<String, String> map1 = ImmutableMap.of("key1", "value1");
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue("key1", "value1", map1);
+
+        ImmutableMap<String, String> map2 = ImmutableMap.of("key1", "value1", "key2", "value2");
+        Verify.assertSize(2, map2);
+        Verify.assertContainsAllKeyValues(map2, "key1", "value1", "key2", "value2");
+
+        ImmutableMap<String, String> map3 = ImmutableMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+        Verify.assertSize(3, map3);
+        Verify.assertContainsAllKeyValues(map3, "key1", "value1", "key2", "value2", "key3", "value3");
+
+        ImmutableMap<String, String> map4 = ImmutableMap.of("key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+        Verify.assertSize(4, map4);
+        Verify.assertContainsAllKeyValues(map4, "key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+    }
+
+    @Test
+    public void ofDuplicateKeys()
+    {
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), ImmutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), ImmutableMap.of(1, 2, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), ImmutableMap.of(1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), ImmutableMap.of(1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), ImmutableMap.of(1, 2, 3, 4, 3, 4));
+    }
+
+    @Test
+    public void ofAllMap()
+    {
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(ImmutableMap.class, ImmutableMap.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofDuplicates()
+    {
+        Assert.assertEquals(ImmutableMap.of(0, 0), ImmutableMap.of(0, 0, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0), ImmutableMap.of(0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0), ImmutableMap.of(0, 0, 0, 0, 0, 0, 0, 0));
+
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1), ImmutableMap.of(1, 1, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 2, 2), ImmutableMap.of(0, 0, 2, 2, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 3, 3), ImmutableMap.of(0, 0, 0, 0, 3, 3));
+
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1), ImmutableMap.of(1, 1, 0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 2, 2), ImmutableMap.of(0, 0, 2, 2, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 3, 3), ImmutableMap.of(0, 0, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 4, 4), ImmutableMap.of(0, 0, 0, 0, 0, 0, 4, 4));
+
+        Assert.assertEquals(ImmutableMap.of(0, 0, 2, 2, 3, 3, 4, 4), ImmutableMap.of(0, 0, 2, 2, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 3, 3, 4, 4), ImmutableMap.of(1, 1, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 2, 2, 4, 4), ImmutableMap.of(1, 1, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 2, 2, 3, 3), ImmutableMap.of(1, 1, 2, 2, 3, 3, 0, 0));
+
+        Assert.assertEquals(ImmutableMap.of(0, 0, 3, 3, 4, 4), ImmutableMap.of(0, 0, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 2, 2, 4, 4), ImmutableMap.of(0, 0, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 2, 2, 3, 3), ImmutableMap.of(0, 0, 2, 2, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 4, 4), ImmutableMap.of(1, 1, 0, 0, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 3, 3), ImmutableMap.of(1, 1, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableMap.of(0, 0, 1, 1, 2, 2), ImmutableMap.of(1, 1, 2, 2, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void mapKeyPreservation()
+    {
+        Key key = new Key("key");
+
+        Key duplicateKey1 = new Key("key");
+        ImmutableMap<Key, Integer> map1 = ImmutableMap.of(key, 1, duplicateKey1, 2);
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue(key, 2, map1);
+        Assert.assertSame(key, map1.keysView().getFirst());
+
+        Key duplicateKey2 = new Key("key");
+        ImmutableMap<Key, Integer> map2 = ImmutableMap.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
+        Verify.assertSize(1, map2);
+        Verify.assertContainsKeyValue(key, 3, map2);
+        Assert.assertSame(key, map2.keysView().getFirst());
+
+        Key duplicateKey3 = new Key("key");
+        ImmutableMap<Key, Integer> map3 = ImmutableMap.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
+        Verify.assertSize(2, map3);
+        Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
+        Assert.assertSame(key, map3.keysView().detect(key::equals));
+    }
+
+    @Test
+    public void emptyMap()
+    {
+        Assert.assertTrue(ImmutableMap.of().isEmpty());
+        Assert.assertSame(ImmutableMap.of(), ImmutableMap.of());
+        Verify.assertPostSerializedIdentity(ImmutableMap.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/MutableMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/MutableMapsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.map;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.domain.Key;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableMapsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.of());
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of());
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), MutableMap.of(1, 2));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), MutableMap.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), MutableMap.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), MutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        MutableMap<String, String> map1 = MutableMap.of("key1", "value1");
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue("key1", "value1", map1);
+
+        MutableMap<String, String> map2 = MutableMap.of("key1", "value1", "key2", "value2");
+        Verify.assertSize(2, map2);
+        Verify.assertContainsAllKeyValues(map2, "key1", "value1", "key2", "value2");
+
+        MutableMap<String, String> map3 = MutableMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+        Verify.assertSize(3, map3);
+        Verify.assertContainsAllKeyValues(map3, "key1", "value1", "key2", "value2", "key3", "value3");
+
+        MutableMap<String, String> map4 = MutableMap.of("key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+        Verify.assertSize(4, map4);
+        Verify.assertContainsAllKeyValues(map4, "key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+    }
+
+    @Test
+    public void ofDuplicateKeys()
+    {
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), MutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), MutableMap.of(1, 2, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), MutableMap.of(1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), MutableMap.of(1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), MutableMap.of(1, 2, 3, 4, 3, 4));
+    }
+
+    @Test
+    public void ofMap()
+    {
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofMapIterable()
+    {
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofDuplicates()
+    {
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0, 0, 0, 0, 0));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1), MutableMap.of(1, 1, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2), MutableMap.of(0, 0, 2, 2, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3), MutableMap.of(0, 0, 0, 0, 3, 3));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1), MutableMap.of(1, 1, 0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2), MutableMap.of(0, 0, 2, 2, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3), MutableMap.of(0, 0, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 4, 4), MutableMap.of(0, 0, 0, 0, 0, 0, 4, 4));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 3, 3, 4, 4), MutableMap.of(0, 0, 2, 2, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 3, 3, 4, 4), MutableMap.of(1, 1, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2, 4, 4), MutableMap.of(1, 1, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2, 3, 3), MutableMap.of(1, 1, 2, 2, 3, 3, 0, 0));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3, 4, 4), MutableMap.of(0, 0, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 4, 4), MutableMap.of(0, 0, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 3, 3), MutableMap.of(0, 0, 2, 2, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 4, 4), MutableMap.of(1, 1, 0, 0, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 3, 3), MutableMap.of(1, 1, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2), MutableMap.of(1, 1, 2, 2, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void mapKeyPreservation()
+    {
+        Key key = new Key("key");
+
+        Key duplicateKey1 = new Key("key");
+        MutableMap<Key, Integer> map1 = MutableMap.of(key, 1, duplicateKey1, 2);
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue(key, 2, map1);
+        Assert.assertSame(key, map1.keysView().getFirst());
+
+        Key duplicateKey2 = new Key("key");
+        MutableMap<Key, Integer> map2 = MutableMap.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
+        Verify.assertSize(1, map2);
+        Verify.assertContainsKeyValue(key, 3, map2);
+        Assert.assertSame(key, map2.keysView().getFirst());
+
+        Key duplicateKey3 = new Key("key");
+        MutableMap<Key, Integer> map3 = MutableMap.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
+        Verify.assertSize(2, map3);
+        Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
+        Assert.assertSame(key, map3.keysView().detect(key::equals));
+    }
+
+    @Test
+    public void ofInitialCapacity()
+    {
+        MutableMap<String, String> map1 = MutableMap.ofInitialCapacity(0);
+        this.assertPresizedMapSizeEquals(0, (UnifiedMap<String, String>) map1);
+
+        MutableMap<String, String> map2 = MutableMap.ofInitialCapacity(5);
+        this.assertPresizedMapSizeEquals(5, (UnifiedMap<String, String>) map2);
+
+        MutableMap<String, String> map3 = MutableMap.ofInitialCapacity(20);
+        this.assertPresizedMapSizeEquals(20, (UnifiedMap<String, String>) map3);
+
+        Verify.assertThrows(IllegalArgumentException.class, () -> MutableMap.ofInitialCapacity(-12));
+    }
+
+    private void assertPresizedMapSizeEquals(int initialCapacity, UnifiedMap<String, String> map)
+    {
+        try
+        {
+            Field tableField = UnifiedMap.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            Object[] table = (Object[]) tableField.get(map);
+
+            int size = (int) Math.ceil(initialCapacity / 0.75);
+            int capacity = 1;
+            while (capacity < size)
+            {
+                capacity <<= 1;
+            }
+            capacity <<= 1;
+
+            Assert.assertEquals(capacity, table.length);
+        }
+        catch (SecurityException ignored)
+        {
+            Assert.fail("Unable to modify the visibility of the table on UnifiedMap");
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            Assert.fail("No field named table UnifiedMap");
+        }
+        catch (IllegalAccessException ignored)
+        {
+            Assert.fail("No access the field table in UnifiedMap");
+        }
+    }
+
+    @Test
+    public void ofAll()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.ofMap(new HashMap<>()));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMap(new HashMap<>()));
+
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.ofMapIterable(Maps.immutable.with()));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMapIterable(Maps.immutable.with()));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), MutableMap.ofMap(MutableMap.of(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMap(MutableMap.of(1, 1)));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), MutableMap.ofMapIterable(MutableMap.of(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMapIterable(MutableMap.of(1, 1)));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/sorted/ImmutableSortedMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/sorted/ImmutableSortedMapsTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.map.sorted;
+
+import java.util.Comparator;
+
+import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.domain.Key;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableSortedMapsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(TreeSortedMap.newMap(), ImmutableSortedMap.of());
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of());
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2), ImmutableSortedMap.of(1, 2));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4), ImmutableSortedMap.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(1, 2, 3, 4));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 5, 6), ImmutableSortedMap.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        Assert.assertEquals(TreeSortedMap.newMap(), ImmutableSortedMap.of(Comparator.reverseOrder()));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(Comparator.reverseOrder()));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 5, 6), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+
+        ImmutableSortedMap<String, String> map1 = ImmutableSortedMap.of("key1", "value1");
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue("key1", "value1", map1);
+
+        ImmutableSortedMap<String, String> map2 = ImmutableSortedMap.of("key1", "value1", "key2", "value2");
+        Verify.assertSize(2, map2);
+        Verify.assertContainsAllKeyValues(map2, "key1", "value1", "key2", "value2");
+
+        ImmutableSortedMap<String, String> map3 = ImmutableSortedMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+        Verify.assertSize(3, map3);
+        Verify.assertContainsAllKeyValues(map3, "key1", "value1", "key2", "value2", "key3", "value3");
+
+        ImmutableSortedMap<String, String> map4 = ImmutableSortedMap.of("key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+        Verify.assertSize(4, map4);
+        Verify.assertContainsAllKeyValues(map4, "key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+    }
+
+    @Test
+    public void ofDuplicateKeys()
+    {
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2), ImmutableSortedMap.of(1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 1, 2), ImmutableSortedMap.of(1, 2, 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 1, 2), ImmutableSortedMap.of(1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 1, 2, 3, 4), ImmutableSortedMap.of(1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 3, 4), ImmutableSortedMap.of(1, 2, 3, 4, 3, 4));
+
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 1, 2), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 1, 2), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 1, 2, 3, 4), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, 2, 3, 4, 3, 4), ImmutableSortedMap.of(Comparator.reverseOrder(), 1, 2, 3, 4, 3, 4));
+    }
+
+    @Test
+    public void ofAllMap()
+    {
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, "One"), ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One")));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One")));
+
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, "One", 2, "Dos"), ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei"), ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(ImmutableSortedMap.class, ImmutableSortedMap.ofSortedMap(TreeSortedMap.newMapWith(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofDuplicates()
+    {
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0), ImmutableSortedMap.of(0, 0, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0), ImmutableSortedMap.of(0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0), ImmutableSortedMap.of(0, 0, 0, 0, 0, 0, 0, 0));
+
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1), ImmutableSortedMap.of(1, 1, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 2, 2), ImmutableSortedMap.of(0, 0, 2, 2, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 3, 3), ImmutableSortedMap.of(0, 0, 0, 0, 3, 3));
+
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1), ImmutableSortedMap.of(1, 1, 0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 2, 2), ImmutableSortedMap.of(0, 0, 2, 2, 0, 0, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 3, 3), ImmutableSortedMap.of(0, 0, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 4, 4), ImmutableSortedMap.of(0, 0, 0, 0, 0, 0, 4, 4));
+
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 2, 2, 3, 3, 4, 4), ImmutableSortedMap.of(0, 0, 2, 2, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 3, 3, 4, 4), ImmutableSortedMap.of(1, 1, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2, 4, 4), ImmutableSortedMap.of(1, 1, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2, 3, 3), ImmutableSortedMap.of(1, 1, 2, 2, 3, 3, 0, 0));
+
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 3, 3, 4, 4), ImmutableSortedMap.of(0, 0, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 2, 2, 4, 4), ImmutableSortedMap.of(0, 0, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 2, 2, 3, 3), ImmutableSortedMap.of(0, 0, 2, 2, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 4, 4), ImmutableSortedMap.of(1, 1, 0, 0, 0, 0, 4, 4));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 3, 3), ImmutableSortedMap.of(1, 1, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2), ImmutableSortedMap.of(1, 1, 2, 2, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void mapKeyPreservation()
+    {
+        Key key = new Key("key");
+
+        Key duplicateKey1 = new Key("key");
+        ImmutableSortedMap<Key, Integer> map1 = ImmutableSortedMap.of(key, 1, duplicateKey1, 2);
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue(key, 2, map1);
+        Assert.assertSame(key, map1.keysView().getFirst());
+
+        Key duplicateKey2 = new Key("key");
+        ImmutableSortedMap<Key, Integer> map2 = ImmutableSortedMap.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
+        Verify.assertSize(1, map2);
+        Verify.assertContainsKeyValue(key, 3, map2);
+        Assert.assertSame(key, map2.keysView().getFirst());
+
+        Key duplicateKey3 = new Key("key");
+        ImmutableSortedMap<Key, Integer> map3 = ImmutableSortedMap.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
+        Verify.assertSize(2, map3);
+        Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
+        Assert.assertSame(key, map3.keysView().detect(key::equals));
+    }
+
+    @Test
+    public void emptyMap()
+    {
+        Assert.assertTrue(ImmutableSortedMap.of().isEmpty());
+        Assert.assertSame(ImmutableSortedMap.of(), ImmutableSortedMap.of());
+        Verify.assertPostSerializedIdentity(ImmutableSortedMap.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/sorted/MutableSortedMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/map/sorted/MutableSortedMapsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.map.sorted;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.domain.Key;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableSortedMapsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.of());
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of());
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), MutableMap.of(1, 2));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), MutableMap.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), MutableMap.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), MutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        MutableMap<String, String> map1 = MutableMap.of("key1", "value1");
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue("key1", "value1", map1);
+
+        MutableMap<String, String> map2 = MutableMap.of("key1", "value1", "key2", "value2");
+        Verify.assertSize(2, map2);
+        Verify.assertContainsAllKeyValues(map2, "key1", "value1", "key2", "value2");
+
+        MutableMap<String, String> map3 = MutableMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+        Verify.assertSize(3, map3);
+        Verify.assertContainsAllKeyValues(map3, "key1", "value1", "key2", "value2", "key3", "value3");
+
+        MutableMap<String, String> map4 = MutableMap.of("key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+        Verify.assertSize(4, map4);
+        Verify.assertContainsAllKeyValues(map4, "key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4");
+    }
+
+    @Test
+    public void ofDuplicateKeys()
+    {
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), MutableMap.of(1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), MutableMap.of(1, 2, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), MutableMap.of(1, 2, 3, 4, 1, 2));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), MutableMap.of(1, 2, 1, 2, 3, 4));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), MutableMap.of(1, 2, 3, 4, 3, 4));
+    }
+
+    @Test
+    public void ofMap()
+    {
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofMapIterable()
+    {
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(MutableMap.class, MutableMap.ofMapIterable(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+    }
+
+    @Test
+    public void ofDuplicates()
+    {
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0), MutableMap.of(0, 0, 0, 0, 0, 0, 0, 0));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1), MutableMap.of(1, 1, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2), MutableMap.of(0, 0, 2, 2, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3), MutableMap.of(0, 0, 0, 0, 3, 3));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1), MutableMap.of(1, 1, 0, 0, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2), MutableMap.of(0, 0, 2, 2, 0, 0, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3), MutableMap.of(0, 0, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 4, 4), MutableMap.of(0, 0, 0, 0, 0, 0, 4, 4));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 3, 3, 4, 4), MutableMap.of(0, 0, 2, 2, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 3, 3, 4, 4), MutableMap.of(1, 1, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2, 4, 4), MutableMap.of(1, 1, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2, 3, 3), MutableMap.of(1, 1, 2, 2, 3, 3, 0, 0));
+
+        Assert.assertEquals(MutableMap.of(0, 0, 3, 3, 4, 4), MutableMap.of(0, 0, 0, 0, 3, 3, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 4, 4), MutableMap.of(0, 0, 2, 2, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 2, 2, 3, 3), MutableMap.of(0, 0, 2, 2, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 4, 4), MutableMap.of(1, 1, 0, 0, 0, 0, 4, 4));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 3, 3), MutableMap.of(1, 1, 0, 0, 3, 3, 0, 0));
+        Assert.assertEquals(MutableMap.of(0, 0, 1, 1, 2, 2), MutableMap.of(1, 1, 2, 2, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void mapKeyPreservation()
+    {
+        Key key = new Key("key");
+
+        Key duplicateKey1 = new Key("key");
+        MutableMap<Key, Integer> map1 = MutableMap.of(key, 1, duplicateKey1, 2);
+        Verify.assertSize(1, map1);
+        Verify.assertContainsKeyValue(key, 2, map1);
+        Assert.assertSame(key, map1.keysView().getFirst());
+
+        Key duplicateKey2 = new Key("key");
+        MutableMap<Key, Integer> map2 = MutableMap.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
+        Verify.assertSize(1, map2);
+        Verify.assertContainsKeyValue(key, 3, map2);
+        Assert.assertSame(key, map2.keysView().getFirst());
+
+        Key duplicateKey3 = new Key("key");
+        MutableMap<Key, Integer> map3 = MutableMap.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
+        Verify.assertSize(2, map3);
+        Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
+        Assert.assertSame(key, map3.keysView().detect(key::equals));
+    }
+
+    @Test
+    public void ofInitialCapacity()
+    {
+        MutableMap<String, String> map1 = MutableMap.ofInitialCapacity(0);
+        this.assertPresizedMapSizeEquals(0, (UnifiedMap<String, String>) map1);
+
+        MutableMap<String, String> map2 = MutableMap.ofInitialCapacity(5);
+        this.assertPresizedMapSizeEquals(5, (UnifiedMap<String, String>) map2);
+
+        MutableMap<String, String> map3 = MutableMap.ofInitialCapacity(20);
+        this.assertPresizedMapSizeEquals(20, (UnifiedMap<String, String>) map3);
+
+        Verify.assertThrows(IllegalArgumentException.class, () -> MutableMap.ofInitialCapacity(-12));
+    }
+
+    private void assertPresizedMapSizeEquals(int initialCapacity, UnifiedMap<String, String> map)
+    {
+        try
+        {
+            Field tableField = UnifiedMap.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            Object[] table = (Object[]) tableField.get(map);
+
+            int size = (int) Math.ceil(initialCapacity / 0.75);
+            int capacity = 1;
+            while (capacity < size)
+            {
+                capacity <<= 1;
+            }
+            capacity <<= 1;
+
+            Assert.assertEquals(capacity, table.length);
+        }
+        catch (SecurityException ignored)
+        {
+            Assert.fail("Unable to modify the visibility of the table on UnifiedMap");
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            Assert.fail("No field named table UnifiedMap");
+        }
+        catch (IllegalAccessException ignored)
+        {
+            Assert.fail("No access the field table in UnifiedMap");
+        }
+    }
+
+    @Test
+    public void ofAll()
+    {
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.ofMap(new HashMap<>()));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMap(new HashMap<>()));
+
+        Assert.assertEquals(UnifiedMap.newMap(), MutableMap.ofMapIterable(Maps.immutable.with()));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMapIterable(Maps.immutable.with()));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), MutableMap.ofMap(MutableMap.of(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMap(MutableMap.of(1, 1)));
+
+        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), MutableMap.ofMapIterable(MutableMap.of(1, 1)));
+        Verify.assertInstanceOf(UnifiedMap.class, MutableMap.ofMapIterable(MutableMap.of(1, 1)));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/FixedSizeSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/FixedSizeSetsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.set;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.set.FixedSizeSet;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FixedSizeSetsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedSet.newSet(), FixedSizeSet.of());
+        Assert.assertEquals(UnifiedSet.newSet(), FixedSizeSet.empty());
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.of());
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.empty());
+        Assert.assertEquals(UnifiedSet.newSetWith(1), FixedSizeSet.of(1));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.of(1));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), FixedSizeSet.of(1, 2));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.of(1, 2));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), FixedSizeSet.of(1, 2, 3));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.of(1, 2, 3));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), FixedSizeSet.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), FixedSizeSet.ofAll(Sets.mutable.of(1, 2, 3, 4)));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.ofAll(Sets.mutable.of(1, 2, 3, 4)));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), FixedSizeSet.fromStream(Stream.of(1, 2, 3, 4)));
+        Verify.assertInstanceOf(FixedSizeSet.class, FixedSizeSet.fromStream(Stream.of(1, 2, 3, 4)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(UnifiedSet.newSet(interval), FixedSizeSet.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(UnifiedSet.newSet(interval), FixedSizeSet.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void emptyMap()
+    {
+        Assert.assertTrue(FixedSizeSet.of().isEmpty());
+        Assert.assertSame(FixedSizeSet.of(), FixedSizeSet.of());
+        Verify.assertPostSerializedIdentity(FixedSizeSet.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/ImmutableSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/ImmutableSetsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.set;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableSetsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedSet.newSet(), ImmutableSet.empty());
+        Assert.assertEquals(UnifiedSet.newSet(), ImmutableSet.of());
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of());
+        Assert.assertEquals(UnifiedSet.newSetWith(1), ImmutableSet.of(1));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of(1));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), ImmutableSet.of(1, 2));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of(1, 2));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), ImmutableSet.of(1, 2, 3));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of(1, 2, 3));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), ImmutableSet.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), ImmutableSet.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), ImmutableSet.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), ImmutableSet.fromStream(Stream.of(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.fromStream(Stream.of(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void castToSet()
+    {
+        Set<Object> set = ImmutableSet.of().castToSet();
+        Assert.assertNotNull(set);
+        Assert.assertSame(ImmutableSet.of(), set);
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(UnifiedSet.newSet(interval), ImmutableSet.ofAll(interval));
+        }
+    }
+
+    @Test
+    public void copySet()
+    {
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.ofAll(Sets.fixedSize.of()));
+        MutableSet<Integer> set = Sets.fixedSize.of(1);
+        ImmutableSet<Integer> immutableSet = set.toImmutable();
+        Verify.assertInstanceOf(ImmutableSet.class, ImmutableSet.ofAll(set));
+        Assert.assertSame(ImmutableSet.ofAll(immutableSet.castToSet()), immutableSet);
+    }
+
+    @Test
+    public void emptySet()
+    {
+        Assert.assertTrue(ImmutableSet.of().isEmpty());
+        Assert.assertSame(ImmutableSet.of(), ImmutableSet.of());
+        Verify.assertPostSerializedIdentity(ImmutableSet.of());
+    }
+
+    @Test
+    public void newSetWith()
+    {
+        Assert.assertSame(ImmutableSet.empty(), ImmutableSet.of(ImmutableSet.empty().toArray()));
+        Verify.assertSize(1, ImmutableSet.of(1).castToSet());
+        Verify.assertSize(1, ImmutableSet.of(1, 1).castToSet());
+        Verify.assertSize(1, ImmutableSet.of(1, 1, 1).castToSet());
+        Verify.assertSize(1, ImmutableSet.of(1, 1, 1, 1).castToSet());
+        Verify.assertSize(1, ImmutableSet.of(1, 1, 1, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 1, 1, 2).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(2, 1, 1, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 2, 1, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 2, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 1, 2, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 1, 2).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(2, 1, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 2, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 2, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 1, 2).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(2, 1, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 2, 1).castToSet());
+        Verify.assertSize(2, ImmutableSet.of(1, 2).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(1, 2, 3).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(1, 2, 3, 1).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(2, 1, 3, 1).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(2, 3, 1, 1).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(2, 1, 1, 3).castToSet());
+        Verify.assertSize(3, ImmutableSet.of(1, 1, 2, 3).castToSet());
+        Verify.assertSize(4, ImmutableSet.of(1, 2, 3, 4).castToSet());
+        Verify.assertSize(4, ImmutableSet.of(1, 2, 3, 4, 1).castToSet());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/MutableSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/MutableSetsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.set;
+
+import java.lang.reflect.Field;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableSetsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedSet.newSet(), MutableSet.empty());
+        Assert.assertEquals(UnifiedSet.newSet(), MutableSet.of());
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of());
+        Assert.assertEquals(UnifiedSet.newSetWith(1), MutableSet.of(1));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of(1));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), MutableSet.of(1, 2));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of(1, 2));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), MutableSet.of(1, 2, 3));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of(1, 2, 3));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), MutableSet.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), MutableSet.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), MutableSet.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), MutableSet.fromStream(Stream.of(1, 2, 3, 4, 5)));
+        Verify.assertInstanceOf(MutableSet.class, MutableSet.fromStream(Stream.of(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void ofAll()
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            Interval interval = Interval.oneTo(i);
+            Verify.assertEqualsAndHashCode(UnifiedSet.newSet(interval), MutableSet.ofAll(interval));
+            Stream<Integer> stream = IntStream.rangeClosed(1, i).boxed();
+            Verify.assertEqualsAndHashCode(UnifiedSet.newSet(interval), MutableSet.fromStream(stream));
+        }
+    }
+
+    @Test
+    public void ofInitialCapacity()
+    {
+        MutableSet<String> set1 = MutableSet.ofInitialCapacity(0);
+        this.assertPresizedSetSizeEquals(0, (UnifiedSet<String>) set1);
+
+        MutableSet<String> set2 = MutableSet.ofInitialCapacity(5);
+        this.assertPresizedSetSizeEquals(5, (UnifiedSet<String>) set2);
+
+        MutableSet<String> set3 = MutableSet.ofInitialCapacity(20);
+        this.assertPresizedSetSizeEquals(20, (UnifiedSet<String>) set3);
+
+        MutableSet<String> set4 = MutableSet.ofInitialCapacity(60);
+        this.assertPresizedSetSizeEquals(60, (UnifiedSet<String>) set4);
+
+        MutableSet<String> set5 = MutableSet.ofInitialCapacity(64);
+        this.assertPresizedSetSizeEquals(60, (UnifiedSet<String>) set5);
+
+        MutableSet<String> set6 = MutableSet.ofInitialCapacity(65);
+        this.assertPresizedSetSizeEquals(65, (UnifiedSet<String>) set6);
+
+        Verify.assertThrows(IllegalArgumentException.class, () -> MutableSet.ofInitialCapacity(-12));
+    }
+
+    private void assertPresizedSetSizeEquals(int initialCapacity, UnifiedSet<String> set)
+    {
+        try
+        {
+            Field tableField = UnifiedSet.class.getDeclaredField("table");
+            tableField.setAccessible(true);
+            Object[] table = (Object[]) tableField.get(set);
+
+            int size = (int) Math.ceil(initialCapacity / 0.75f);
+            int capacity = 1;
+            while (capacity < size)
+            {
+                capacity <<= 1;
+            }
+            Assert.assertEquals(capacity, table.length);
+        }
+        catch (SecurityException ignored)
+        {
+            Assert.fail("Unable to modify the visibility of the field 'table' on UnifiedSet");
+        }
+        catch (NoSuchFieldException ignored)
+        {
+            Assert.fail("No field named 'table' in UnifiedSet");
+        }
+        catch (IllegalAccessException ignored)
+        {
+            Assert.fail("No access to the field 'table' in UnifiedSet");
+        }
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/sorted/ImmutableSortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/sorted/ImmutableSortedSetsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.set.sorted;
+
+import java.util.Comparator;
+import java.util.SortedSet;
+
+import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
+import org.eclipse.collections.impl.block.factory.Comparators;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.SortedSets;
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableSortedSetsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(UnifiedSet.newSet(), ImmutableSortedSet.of());
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of());
+        Assert.assertEquals(TreeSortedSet.newSet(Comparators.reverseNaturalOrder()), ImmutableSortedSet.empty(Comparators.reverseNaturalOrder()));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.empty(Comparators.reverseNaturalOrder()));
+        Assert.assertSame(ImmutableSortedSet.empty(), ImmutableSortedSet.of(new Integer[0]));
+        Assert.assertSame(ImmutableSortedSet.empty(), ImmutableSortedSet.of((Object[]) null));
+        Assert.assertEquals(UnifiedSet.newSetWith(), ImmutableSortedSet.of(Comparators.reverseNaturalOrder()));
+        Assert.assertEquals(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder()).comparator(), ImmutableSortedSet.of(Comparators.reverseNaturalOrder()).comparator());
+        Assert.assertEquals(TreeSortedSet.newSetWith().comparator(), ImmutableSortedSet.of((Comparator<Integer>) null).comparator());
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), ImmutableSortedSet.of(1, 2, 2));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(1, 2));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), ImmutableSortedSet.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(1, 2, 3, 4));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), ImmutableSortedSet.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(
+                SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8),
+                ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableSortedSet.class, ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8).comparator(), ImmutableSortedSet.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).comparator(), ImmutableSortedSet.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofAll(ImmutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofAll(ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofSortedSet(ImmutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofSortedSet(ImmutableSortedSet.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        Assert.assertEquals(SortedSets.mutable.empty(), ImmutableSortedSet.ofSortedSet(SortedSets.mutable.with()));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofSortedSet(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), ImmutableSortedSet.ofSortedSet(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(ImmutableSortedSet.empty(), ImmutableSortedSet.ofAll(null, Lists.mutable.empty()));
+    }
+
+    @Test
+    public void castToSet()
+    {
+        SortedSet<Object> set = ImmutableSortedSet.of().castToSortedSet();
+        Assert.assertNotNull(set);
+        Assert.assertSame(ImmutableSortedSet.of(), set);
+    }
+
+    @Test
+    public void emptySet()
+    {
+        Assert.assertTrue(ImmutableSortedSet.of().isEmpty());
+        Assert.assertSame(ImmutableSortedSet.of(), ImmutableSortedSet.of());
+        Verify.assertPostSerializedIdentity(ImmutableSortedSet.of());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/sorted/MutableSortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/set/sorted/MutableSortedSetsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.set.sorted;
+
+import org.eclipse.collections.api.set.sorted.MutableSortedSet;
+import org.eclipse.collections.impl.block.factory.Comparators;
+import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableSortedSetsTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(TreeSortedSet.newSet(), MutableSortedSet.of());
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of());
+        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2), MutableSortedSet.of(1, 2, 2));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of(1, 2));
+        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4), MutableSortedSet.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of(1, 2, 3, 4));
+        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6), MutableSortedSet.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), MutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), MutableSortedSet.ofAll(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.ofAll(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        Assert.assertEquals(TreeSortedSet.newSet(Comparators.naturalOrder()), MutableSortedSet.of(Comparators.naturalOrder()));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.of(Comparators.naturalOrder()));
+        Assert.assertEquals(TreeSortedSet.newSetWith(8, 7, 6, 5, 4, 3, 2, 1), MutableSortedSet.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        Verify.assertInstanceOf(MutableSortedSet.class, MutableSortedSet.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/stack/ImmutableStacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/stack/ImmutableStacksTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.stack;
+
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.stack.ImmutableStack;
+import org.eclipse.collections.impl.stack.mutable.ArrayStack;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutableStacksTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(ArrayStack.newStack(), ImmutableStack.of());
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of());
+        Assert.assertEquals(ArrayStack.newStackWith(1), ImmutableStack.of(1));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2), ImmutableStack.of(1, 2));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), ImmutableStack.of(1, 2, 3));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), ImmutableStack.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), ImmutableStack.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), ImmutableStack.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), ImmutableStack.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(ArrayStack.newStackWith(3, 2, 1), ImmutableStack.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), ImmutableStack.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(ImmutableStack.class, ImmutableStack.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @Test
+    public void emptyStack()
+    {
+        Assert.assertTrue(ImmutableStack.of().isEmpty());
+    }
+
+    @Test
+    public void newStackWith()
+    {
+        ImmutableStack<String> stack = ImmutableStack.of();
+        Assert.assertEquals(stack, ImmutableStack.of(stack.toArray()));
+        Assert.assertEquals(stack = stack.push("1"), ImmutableStack.of("1"));
+        Assert.assertEquals(stack = stack.push("2"), ImmutableStack.of("1", "2"));
+        Assert.assertEquals(stack = stack.push("3"), ImmutableStack.of("1", "2", "3"));
+        Assert.assertEquals(stack = stack.push("4"), ImmutableStack.of("1", "2", "3", "4"));
+        Assert.assertEquals(stack = stack.push("5"), ImmutableStack.of("1", "2", "3", "4", "5"));
+        Assert.assertEquals(stack = stack.push("6"), ImmutableStack.of("1", "2", "3", "4", "5", "6"));
+        Assert.assertEquals(stack = stack.push("7"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7"));
+        Assert.assertEquals(stack = stack.push("8"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        Assert.assertEquals(stack = stack.push("9"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        Assert.assertEquals(stack = stack.push("10"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        Assert.assertEquals(stack = stack.push("11"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        Assert.assertEquals(stack = stack.push("12"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+    }
+
+    @SuppressWarnings("RedundantArrayCreation")
+    @Test
+    public void newStackWithArray()
+    {
+        ImmutableStack<String> stack = ImmutableStack.of();
+        Assert.assertEquals(stack = stack.push("1"), ImmutableStack.of(new String[]{"1"}));
+        Assert.assertEquals(stack = stack.push("2"), ImmutableStack.of(new String[]{"1", "2"}));
+        Assert.assertEquals(stack = stack.push("3"), ImmutableStack.of(new String[]{"1", "2", "3"}));
+        Assert.assertEquals(stack = stack.push("4"), ImmutableStack.of(new String[]{"1", "2", "3", "4"}));
+        Assert.assertEquals(stack = stack.push("5"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5"}));
+        Assert.assertEquals(stack = stack.push("6"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        Assert.assertEquals(stack = stack.push("7"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        Assert.assertEquals(stack = stack.push("8"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        Assert.assertEquals(stack = stack.push("9"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        Assert.assertEquals(stack = stack.push("10"), ImmutableStack.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        Assert.assertEquals(stack = stack.push("11"), ImmutableStack.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+    }
+
+    @Test
+    public void newStackWithStack()
+    {
+        ImmutableStack<String> stack = ImmutableStack.of();
+        ArrayStack<String> arrayStack = ArrayStack.newStackWith("1");
+        Assert.assertEquals(stack = stack.push("1"), arrayStack.toImmutable());
+        arrayStack.push("2");
+        Assert.assertEquals(stack = stack.push("2"), arrayStack.toImmutable());
+        arrayStack.push("3");
+        Assert.assertEquals(stack = stack.push("3"), arrayStack.toImmutable());
+        arrayStack.push("4");
+        Assert.assertEquals(stack = stack.push("4"), arrayStack.toImmutable());
+        arrayStack.push("5");
+        Assert.assertEquals(stack = stack.push("5"), arrayStack.toImmutable());
+        arrayStack.push("6");
+        Assert.assertEquals(stack = stack.push("6"), arrayStack.toImmutable());
+        arrayStack.push("7");
+        Assert.assertEquals(stack = stack.push("7"), arrayStack.toImmutable());
+        arrayStack.push("8");
+        Assert.assertEquals(stack = stack.push("8"), arrayStack.toImmutable());
+        arrayStack.push("9");
+        Assert.assertEquals(stack = stack.push("9"), arrayStack.toImmutable());
+        arrayStack.push("10");
+        Assert.assertEquals(stack = stack.push("10"), arrayStack.toImmutable());
+        arrayStack.push("11");
+        Assert.assertEquals(stack = stack.push("11"), arrayStack.toImmutable());
+    }
+}

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/stack/MutableStacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/stack/MutableStacksTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.factory.stack;
+
+import java.util.stream.Stream;
+
+import org.eclipse.collections.api.stack.ImmutableStack;
+import org.eclipse.collections.api.stack.MutableStack;
+import org.eclipse.collections.impl.factory.Stacks;
+import org.eclipse.collections.impl.stack.mutable.ArrayStack;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MutableStacksTest
+{
+    @Test
+    public void of()
+    {
+        Assert.assertEquals(ArrayStack.newStack(), MutableStack.of());
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of());
+        Assert.assertEquals(ArrayStack.newStackWith(1), MutableStack.of(1));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2), MutableStack.of(1, 2));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), MutableStack.of(1, 2, 3));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), MutableStack.of(1, 2, 3, 4));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), MutableStack.of(1, 2, 3, 4, 5));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), MutableStack.of(1, 2, 3, 4, 5, 6));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5, 6));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), MutableStack.of(1, 2, 3, 4, 5, 6, 7));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5, 6, 7));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Assert.assertEquals(ArrayStack.newStackWith(3, 2, 1), MutableStack.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), MutableStack.fromStream(Stream.of(1, 2, 3)));
+        Verify.assertInstanceOf(MutableStack.class, MutableStack.fromStream(Stream.of(1, 2, 3)));
+    }
+
+    @SuppressWarnings("RedundantArrayCreation")
+    @Test
+    public void newStackWithArray()
+    {
+        ImmutableStack<String> stack = Stacks.immutable.of();
+        Assert.assertEquals(stack = stack.push("1"), Stacks.immutable.of(new String[]{"1"}));
+        Assert.assertEquals(stack = stack.push("2"), Stacks.immutable.of(new String[]{"1", "2"}));
+        Assert.assertEquals(stack = stack.push("3"), Stacks.immutable.of(new String[]{"1", "2", "3"}));
+        Assert.assertEquals(stack = stack.push("4"), Stacks.immutable.of(new String[]{"1", "2", "3", "4"}));
+        Assert.assertEquals(stack = stack.push("5"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
+        Assert.assertEquals(stack = stack.push("6"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        Assert.assertEquals(stack = stack.push("7"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        Assert.assertEquals(stack = stack.push("8"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        Assert.assertEquals(stack = stack.push("9"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        Assert.assertEquals(stack = stack.push("10"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        Assert.assertEquals(stack = stack.push("11"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+    }
+
+    @Test
+    public void newStackWithWithStack()
+    {
+        ArrayStack<Object> expected = ArrayStack.newStack();
+        Assert.assertEquals(expected, MutableStack.ofAll(ArrayStack.newStack()));
+        expected.push(1);
+        Assert.assertEquals(ArrayStack.newStackWith(1), MutableStack.ofAll(expected));
+        expected.push(2);
+        Assert.assertEquals(ArrayStack.newStackWith(2, 1), MutableStack.ofAll(expected));
+    }
+}


### PR DESCRIPTION
Since we use ServiceLoaders to have factories in the api module, and since Java 8 supports static methods on interfaces, we can support factory methods on interfaces.

This PR just adds the factory methods, but you can start to see what it will look like when we use these methods in my work-in-progress commit: e7476bee1dc2f1113194c0a93d04c96108fd168b

Before:
```java
Lists.immutable.with(1, 2, 3)
```

After:
```java
ImmutableList.of(1, 2, 3)
```

Where we support both of() and with(), I only added the *of* methods. This is because the static method withAll() clashes with the non-static method with the same name. I think this is ok though since JDK interfaces consistently use "of"