### PR TITLE
use implementation instead of deprecated compile when declaring depen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ Eclipse Collections is a comprehensive collections library for Java. The library
 <dependency>
   <groupId>org.eclipse.collections</groupId>
   <artifactId>eclipse-collections-api</artifactId>
-  <version>10.0.0</version>
+  <version>10.1.0</version>
 </dependency>
 
 <dependency>
   <groupId>org.eclipse.collections</groupId>
   <artifactId>eclipse-collections</artifactId>
-  <version>10.0.0</version>
+  <version>10.1.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-compile 'org.eclipse.collections:eclipse-collections-api:10.0.0'
-compile 'org.eclipse.collections:eclipse-collections:10.0.0'
+implementation 'org.eclipse.collections:eclipse-collections-api:10.1.0'
+implementation 'org.eclipse.collections:eclipse-collections:10.1.0'
 ```
 
 ### OSGi Bundle


### PR DESCRIPTION
…dcy with gradle.
and bump to 10.1.0 in readme for both maven and gradle.

Signed-off-by: Lars Eckart <lars.eckart@gmail.com>

I hope i completed the registration and contributor agreement steps correctly.