### PR TITLE
Turn on CheckStyle check TrailingComment and fix violations.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,7 @@
     <option name="CLASS_BRACE_STYLE" value="2" />
     <option name="METHOD_BRACE_STYLE" value="2" />
     <JavaCodeStyleSettings>
+      <option name="REPLACE_INSTANCEOF_AND_CAST" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
       <option name="IMPORT_LAYOUT_TABLE">
@@ -60,6 +61,9 @@
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     </codeStyleSettings>
     <codeStyleSettings language="JAVA">
+      <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="LINE_COMMENT_ADD_SPACE" value="true" />
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
@@ -142,6 +146,8 @@
       <option name="FOR_BRACE_FORCE" value="3" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">
+      <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/concurrent/MultiReaderUnifiedSetAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/concurrent/MultiReaderUnifiedSetAcceptanceTest.java
@@ -303,7 +303,8 @@ public class MultiReaderUnifiedSetAcceptanceTest
         Assert.assertTrue(set.retainAll(toRetain));
         Assert.assertTrue(set.containsAll(toRetain));
 
-        Assert.assertFalse(set.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.retainAll(toRetain));
 
         Verify.assertSize(size / 2, set);
 
@@ -343,7 +344,8 @@ public class MultiReaderUnifiedSetAcceptanceTest
         Assert.assertTrue(set.retainAll(toRetain));
         Assert.assertTrue(set.containsAll(toRetain));
 
-        Assert.assertFalse(set.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.retainAll(toRetain));
 
         Verify.assertSize(size / 2, set);
 
@@ -486,7 +488,8 @@ public class MultiReaderUnifiedSetAcceptanceTest
 
         Assert.assertTrue(set.removeAll(toRemove));
 
-        Assert.assertFalse(set.removeAll(toRemove)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.removeAll(toRemove));
 
         Verify.assertSize(size / 2, set);
 

--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapAcceptanceTest.java
@@ -593,7 +593,8 @@ public class UnifiedMapAcceptanceTest
         Assert.assertTrue(keySet.retainAll(toRetain));
         Assert.assertTrue(keySet.containsAll(toRetain));
 
-        Assert.assertFalse(keySet.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(keySet.retainAll(toRetain));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, keySet);
@@ -635,7 +636,8 @@ public class UnifiedMapAcceptanceTest
 
         Assert.assertTrue(keySet.removeAll(toRemove));
 
-        Assert.assertFalse(keySet.removeAll(toRemove)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(keySet.removeAll(toRemove));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, keySet);
@@ -895,7 +897,8 @@ public class UnifiedMapAcceptanceTest
         Assert.assertTrue(entrySet.retainAll(toRetain));
         Assert.assertTrue(entrySet.containsAll(toRetain));
 
-        Assert.assertFalse(entrySet.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(entrySet.retainAll(toRetain));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, entrySet);
@@ -937,7 +940,8 @@ public class UnifiedMapAcceptanceTest
 
         Assert.assertTrue(entrySet.removeAll(toRemove));
 
-        Assert.assertFalse(entrySet.removeAll(toRemove)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(entrySet.removeAll(toRemove));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, entrySet);
@@ -1237,7 +1241,8 @@ public class UnifiedMapAcceptanceTest
         Assert.assertTrue(values.retainAll(toRetain));
         Assert.assertTrue(values.containsAll(toRetain));
 
-        Assert.assertFalse(values.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(values.retainAll(toRetain));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, values);
@@ -1279,7 +1284,8 @@ public class UnifiedMapAcceptanceTest
 
         Assert.assertTrue(values.removeAll(toRemove));
 
-        Assert.assertFalse(values.removeAll(toRemove)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(values.removeAll(toRemove));
 
         Verify.assertSize(size / 2, map);
         Verify.assertSize(size / 2, values);

--- a/acceptance-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAcceptanceTest.java
@@ -52,7 +52,9 @@ public class UnifiedSetAcceptanceTest
     {
         UnifiedSet<CollidingInt> set = UnifiedSet.newSet();
 
-        int size = 84000; // divisible by every integer between 2 and 8
+        // divisible by every integer between 2 and 8
+        int size = 84_000;
+
         for (int i = 0; i < size; i++)
         {
             Assert.assertTrue(set.add(new CollidingInt(i, shift)));
@@ -418,7 +420,8 @@ public class UnifiedSetAcceptanceTest
         Assert.assertTrue(set.retainAll(toRetain));
         Assert.assertTrue(set.containsAll(toRetain));
 
-        Assert.assertFalse(set.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.retainAll(toRetain));
 
         Verify.assertSize(size / 2, set);
 
@@ -458,7 +461,8 @@ public class UnifiedSetAcceptanceTest
         Assert.assertTrue(set.retainAll(toRetain));
         Assert.assertTrue(set.containsAll(toRetain));
 
-        Assert.assertFalse(set.retainAll(toRetain)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.retainAll(toRetain));
 
         Verify.assertSize(size / 2, set);
 
@@ -735,7 +739,8 @@ public class UnifiedSetAcceptanceTest
 
         Assert.assertTrue(set.removeAll(toRemove));
 
-        Assert.assertFalse(set.removeAll(toRemove)); // a second call should not modify the set
+        // a second call should not modify the set
+        Assert.assertFalse(set.removeAll(toRemove));
 
         Verify.assertSize(size / 2, set);
 

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -238,9 +238,10 @@
         <module name="EqualsHashCode" />
 
         <module name="HiddenField">
-            <property name="severity" value="warning" />
-            <property name="ignoreSetter" value="true" />
             <property name="ignoreConstructorParameter" value="true" />
+            <property name="ignoreSetter" value="true" />
+            <property name="setterCanReturnItsClass" value="true" />
+            <property name="severity" value="warning" />
         </module>
 
         <!-- Effective Java Item 4 - Avoid creating duplicate objects -->

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -250,6 +250,14 @@
             <property name="tokens" value="VARIABLE_DEF" />
             <property name="allowSamelineMultipleAnnotations" value="true" />
         </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="ANNOTATION_DEF" />
+            <property name="tokens" value="ANNOTATION_FIELD_DEF" />
+            <property name="tokens" value="PACKAGE_DEF" />
+            <property name="tokens" value="ENUM_CONSTANT_DEF" />
+            <property name="tokens" value="VARIABLE_DEF" />
+            <property name="allowSamelineSingleParameterlessAnnotation" value="false" />
+        </module>
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="ignored" />
         </module>

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -97,12 +97,46 @@
         <module name="NoWhitespaceBefore" />
 
         <module name="OperatorWrap">
-            <property name="tokens" value="ASSIGN, DIV_ASSIGN, PLUS_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN, SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN" />
+            <property name="tokens" value="ASSIGN" />
+            <property name="tokens" value="DIV_ASSIGN" />
+            <property name="tokens" value="PLUS_ASSIGN" />
+            <property name="tokens" value="MINUS_ASSIGN" />
+            <property name="tokens" value="STAR_ASSIGN" />
+            <property name="tokens" value="MOD_ASSIGN" />
+            <property name="tokens" value="SR_ASSIGN" />
+            <property name="tokens" value="BSR_ASSIGN" />
+            <property name="tokens" value="SL_ASSIGN" />
+            <property name="tokens" value="BXOR_ASSIGN" />
+            <property name="tokens" value="BOR_ASSIGN" />
+            <property name="tokens" value="BAND_ASSIGN" />
             <property name="option" value="eol" />
         </module>
 
         <module name="OperatorWrap">
-            <property name="tokens" value="QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD, SR, BSR, GE, GT, SL, LE, LT, BXOR, BOR, LOR, BAND, LAND, LITERAL_INSTANCEOF, TYPE_EXTENSION_AND, METHOD_REF" />
+            <property name="tokens" value="QUESTION" />
+            <property name="tokens" value="COLON" />
+            <property name="tokens" value="EQUAL" />
+            <property name="tokens" value="NOT_EQUAL" />
+            <property name="tokens" value="DIV" />
+            <property name="tokens" value="PLUS" />
+            <property name="tokens" value="MINUS" />
+            <property name="tokens" value="STAR" />
+            <property name="tokens" value="MOD" />
+            <property name="tokens" value="SR" />
+            <property name="tokens" value="BSR" />
+            <property name="tokens" value="GE" />
+            <property name="tokens" value="GT" />
+            <property name="tokens" value="SL" />
+            <property name="tokens" value="LE" />
+            <property name="tokens" value="LT" />
+            <property name="tokens" value="BXOR" />
+            <property name="tokens" value="BOR" />
+            <property name="tokens" value="LOR" />
+            <property name="tokens" value="BAND" />
+            <property name="tokens" value="LAND" />
+            <property name="tokens" value="TYPE_EXTENSION_AND" />
+            <property name="tokens" value="LITERAL_INSTANCEOF" />
+            <property name="tokens" value="METHOD_REF" />
             <property name="option" value="nl" />
         </module>
 

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -195,6 +195,21 @@
             <property name="tokens" value="LITERAL_DEFAULT" />
         </module>
         <module name="RightCurly">
+            <property name="tokens" value="METHOD_DEF" />
+            <property name="tokens" value="CTOR_DEF" />
+            <property name="tokens" value="CLASS_DEF" />
+            <property name="tokens" value="INSTANCE_INIT" />
+            <property name="tokens" value="LITERAL_FOR" />
+            <property name="tokens" value="STATIC_INIT" />
+            <property name="tokens" value="LITERAL_WHILE" />
+            <property name="tokens" value="LITERAL_CATCH" />
+            <property name="tokens" value="LITERAL_ELSE" />
+            <property name="tokens" value="LITERAL_FINALLY" />
+            <property name="tokens" value="LITERAL_IF" />
+            <property name="tokens" value="LITERAL_TRY" />
+            <property name="tokens" value="LITERAL_DO" />
+            <property name="tokens" value="ANNOTATION_DEF" />
+            <property name="tokens" value="ENUM_DEF" />
             <property name="option" value="alone" />
         </module>
 

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -219,7 +219,8 @@
         <module name="EmptyStatement" />
         <module name="EmptyBlock">
             <property name="tokens" value="LITERAL_CATCH"/>
-            <property name="tokens" value="ARRAY_INIT"/>      <property name="tokens" value="LITERAL_DEFAULT" />
+            <property name="tokens" value="ARRAY_INIT"/>
+            <property name="tokens" value="LITERAL_DEFAULT" />
             <property name="tokens" value="LITERAL_CASE" />
             <property name="tokens" value="INSTANCE_INIT" />
             <property name="tokens" value="LITERAL_DO" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -191,8 +191,8 @@
             <property name="tokens" value="LITERAL_FOR" />
             <property name="tokens" value="LITERAL_IF" />
             <property name="tokens" value="LITERAL_WHILE" />
-            <property name="tokens" value="LITERAL_CASE" />
-            <property name="tokens" value="LITERAL_DEFAULT" />
+            <!--<property name="tokens" value="LITERAL_CASE" />-->
+            <!--<property name="tokens" value="LITERAL_DEFAULT" />-->
         </module>
         <module name="RightCurly">
             <property name="tokens" value="METHOD_DEF" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -151,9 +151,15 @@
             <!--TODO: Remove this, to include the LAMBDA token-->
             <property name="tokens" value="INTERFACE_DEF, CLASS_DEF, ANNOTATION_DEF, ENUM_DEF, CTOR_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, LITERAL_WHILE, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, STATIC_INIT, OBJBLOCK"/>
         </module>
-
-        <module name="NeedBraces" />
-
+        <module name="NeedBraces">
+            <property name="tokens" value="LITERAL_DO" />
+            <property name="tokens" value="LITERAL_ELSE" />
+            <property name="tokens" value="LITERAL_FOR" />
+            <property name="tokens" value="LITERAL_IF" />
+            <property name="tokens" value="LITERAL_WHILE" />
+            <property name="tokens" value="LITERAL_CASE" />
+            <property name="tokens" value="LITERAL_DEFAULT" />
+        </module>
         <module name="RightCurly">
             <property name="option" value="alone" />
         </module>

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -268,6 +268,7 @@
 
         <module name="HideUtilityClassConstructor" />
 
+        <module name="InnerTypeLast" />
         <!-- Effective Java Item 17 - Use interfaces only to define types -->
         <module name="InterfaceIsType">
             <property name="severity" value="warning" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -254,7 +254,7 @@
         </module>
 
         <module name="IllegalThrows" />
-
+        <module name="TrailingComment" />
         <module name="UpperEll" />
 
         <module name="SuperFinalize" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -163,8 +163,20 @@
         <module name="ArrayTrailingComma" />
         <module name="EmptyStatement" />
         <module name="EmptyBlock">
-            <property name="tokens"
-                value="LITERAL_WHILE, LITERAL_TRY, LITERAL_FINALLY, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, INSTANCE_INIT, STATIC_INIT, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_CASE, LITERAL_DEFAULT" />
+            <property name="tokens" value="LITERAL_CATCH"/>
+            <property name="tokens" value="ARRAY_INIT"/>      <property name="tokens" value="LITERAL_DEFAULT" />
+            <property name="tokens" value="LITERAL_CASE" />
+            <property name="tokens" value="INSTANCE_INIT" />
+            <property name="tokens" value="LITERAL_DO" />
+            <property name="tokens" value="LITERAL_ELSE" />
+            <property name="tokens" value="LITERAL_FINALLY" />
+            <property name="tokens" value="LITERAL_FOR" />
+            <property name="tokens" value="LITERAL_IF" />
+            <property name="tokens" value="LITERAL_SWITCH" />
+            <property name="tokens" value="LITERAL_SYNCHRONIZED" />
+            <property name="tokens" value="LITERAL_TRY" />
+            <property name="tokens" value="LITERAL_WHILE" />
+            <property name="tokens" value="STATIC_INIT" />
         </module>
 
         <!-- Effective Java Item 8 - Always override hashCode when you override equals -->

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -160,6 +160,7 @@
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <module name="ArrayTrailingComma" />
         <module name="EmptyStatement" />
         <module name="EmptyBlock">
             <property name="tokens"

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -247,9 +247,16 @@
         <!-- Effective Java Item 4 - Avoid creating duplicate objects -->
         <module name="IllegalInstantiation">
             <property name="severity" value="warning" />
-            <property
-                name="classes"
-                value="java.lang.Boolean,java.lang.Integer,java.lang.Long,java.lang.Short,java.lang.Character,java.lang.Byte,java.util.Timer,java.util.TimerTask" />
+            <property name="classes" value="java.lang.Boolean" />
+            <property name="classes" value="java.lang.Byte" />
+            <property name="classes" value="java.lang.Character" />
+            <property name="classes" value="java.lang.Integer" />
+            <property name="classes" value="java.lang.Long" />
+            <property name="classes" value="java.lang.Short" />
+            <property name="classes" value="java.lang.StringBuffer" />
+            <property name="classes" value="java.lang.String" />
+            <property name="classes" value="java.util.Timer" />
+            <property name="classes" value="java.util.TimerTask" />
         </module>
 
         <module name="SimplifyBooleanExpression" />

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
@@ -89,7 +89,9 @@ public class <name>BooleanHashMap extends AbstractMutableBooleanValuesMap implem
     private static final int DEFAULT_INITIAL_CAPACITY = 8;
     private static final int CACHE_LINE_SIZE = 64;
     private static final int KEY_SIZE = <keySize.(type)>;
-    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2; /* half a cache line */
+
+    // half a cache line
+    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2;
 
     private <type>[] keys;
     private BitSet values;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveImmutableKeySets.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveImmutableKeySets.stg
@@ -37,7 +37,9 @@ class <className> extends AbstractImmutable<name>Set implements Serializable
     private static final <type> REMOVED_KEY = <(literal.(type))("1")>;
     private static final int CACHE_LINE_SIZE = 64;
     private static final int KEY_SIZE = <keySize.(type)>;
-    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2; /* half a cache line */
+
+    // half a cache line
+    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2;
 
     private final <type>[] <keyArray>;
     private final int occupiedWithData;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -190,7 +190,9 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
     private static final <type> REMOVED_KEY = <(literal.(type))("1")>;
     private static final int CACHE_LINE_SIZE = 64;
     private static final int KEY_SIZE = <keySize.(type)>;
-    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2; /* half a cache line */
+
+    // half a cache line
+    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2;
 
     private <type>[] keys;
     private V[] values;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -99,7 +99,9 @@ public class <name1><name2>HashMap extends AbstractMutable<name2>ValuesMap imple
     private static final <type1> REMOVED_KEY = <(literal.(type1))("1")>;
     private static final int CACHE_LINE_SIZE = 64;
     private static final int KEY_SIZE = <keySize.(type1)>;
-    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2; /* half a cache line */
+
+    // half a cache line
+    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2;
 
     private static final int DEFAULT_INITIAL_CAPACITY = 8;
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -61,7 +61,9 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
     private static final <type> REMOVED = <(literal.(type))("1")>;
     private static final int CACHE_LINE_SIZE = 64;
     private static final int KEY_SIZE = <keySize.(type)>;
-    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2; /* half a cache line */
+
+    // half a cache line
+    private static final int INITIAL_LINEAR_PROBE = CACHE_LINE_SIZE / KEY_SIZE / 2;
 
     private <type>[] table;
     private int occupiedWithData;

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
@@ -168,7 +168,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
 
-        hashMap.updateValue(2.0f, <(literal.(type))("0")>, function); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.updateValue(2.0f, <(literal.(type))("0")>, function);
+
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
     }
@@ -195,7 +197,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.put(2.0f, <(literal.(type))("9")>); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.put(2.0f, <(literal.(type))("9")>);
+
         Assert.assertEquals(8, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -221,7 +225,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(2.0f, <(literal.(type))("5")>); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(2.0f, <(literal.(type))("5")>);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -249,7 +255,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(2.0f, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(2.0f, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -277,7 +285,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWith(2.0f, function, Integer.valueOf(5)); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWith(2.0f, function, Integer.valueOf(5));
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -305,7 +315,9 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWithKey(2.0f, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWithKey(2.0f, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -330,7 +342,8 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
 
-        hashMap.put(2.0f, <(literal.(type))("3")>); //putting in a slot marked as REMOVED
+        // putting in a slot marked as REMOVED
+        hashMap.put(2.0f, <(literal.(type))("3")>);
 
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(8, occupiedWithData.get(hashMap));

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
@@ -289,7 +289,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
 
-        hashMap.updateValue(<(literal.(type))("2")>, function0, function); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.updateValue(<(literal.(type))("2")>, function0, function);
+
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
     }
@@ -322,7 +324,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
 
-        hashMap.updateValueWith(<(literal.(type))("2")>, function0, function, 0.0f); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.updateValueWith(<(literal.(type))("2")>, function0, function, 0.0f);
+
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
     }
@@ -349,7 +353,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.put(<(literal.(type))("2")>, 9.0f); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.put(<(literal.(type))("2")>, 9.0f);
+
         Assert.assertEquals(8, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -375,7 +381,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(<(literal.(type))("2")>, 5.0f); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(<(literal.(type))("2")>, 5.0f);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -403,7 +411,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(<(literal.(type))("2")>, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(<(literal.(type))("2")>, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -431,7 +441,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWith(<(literal.(type))("2")>, function, Float.valueOf(5.0f)); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWith(<(literal.(type))("2")>, function, Float.valueOf(5.0f));
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -459,7 +471,9 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWithKey(<(literal.(type))("2")>, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWithKey(<(literal.(type))("2")>, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -484,7 +498,8 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
 
-        hashMap.put(<(literal.(type))("2")>, 3.0f); //putting in a slot marked as REMOVED
+        // putting in a slot marked as REMOVED
+        hashMap.put(<(literal.(type))("2")>, 3.0f);
 
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(8, occupiedWithData.get(hashMap));

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
@@ -303,7 +303,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
 
-        hashMap.updateValue(<(literal.(type1))("2")>, <(literal.(type2))("0")>, function); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.updateValue(<(literal.(type1))("2")>, <(literal.(type2))("0")>, function);
+
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
     }
@@ -331,7 +333,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("9")>); // putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("9")>);
+
         Assert.assertEquals(8, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -357,7 +361,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(<(literal.(type1))("2")>, <(literal.(type2))("5")>);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -385,7 +391,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPut(<(literal.(type1))("2")>, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPut(<(literal.(type1))("2")>, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -413,7 +421,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWith(<(literal.(type1))("2")>, function, <wrapperName2>.valueOf(<(literal.(type2))("5")>)); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWith(<(literal.(type1))("2")>, function, <wrapperName2>.valueOf(<(literal.(type2))("5")>));
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -441,7 +451,9 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(3, occupiedWithData.get(hashMap));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
 
-        hashMap.getIfAbsentPutWithKey(<(literal.(type1))("2")>, function); //putting in a slot marked REMOVED
+        // putting in a slot marked REMOVED
+        hashMap.getIfAbsentPutWithKey(<(literal.(type1))("2")>, function);
+
         Assert.assertEquals(4, occupiedWithData.get(hashMap));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
     }
@@ -468,7 +480,8 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         Assert.assertEquals(1, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(7, occupiedWithData.get(hashMap));
 
-        hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("3")>); //putting in a slot marked as REMOVED
+        // putting in a slot marked as REMOVED
+        hashMap.put(<(literal.(type1))("2")>, <(literal.(type2))("3")>);
 
         Assert.assertEquals(0, occupiedWithSentinels.get(hashMap));
         Assert.assertEquals(8, occupiedWithData.get(hashMap));

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
@@ -130,7 +130,9 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         Assert.assertEquals(7, occupiedWithData.get(hashSet));
         Assert.assertEquals(1, occupiedWithSentinels.get(hashSet));
 
-        hashSet.add(<(literal.(type))("32")>); //adding to a REMOVED slot
+        // adding to a REMOVED slot
+        hashSet.add(<(literal.(type))("32")>);
+
         Assert.assertEquals(8, occupiedWithData.get(hashSet));
         Assert.assertEquals(0, occupiedWithSentinels.get(hashSet));
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
@@ -85,36 +85,6 @@ public final class Interval
     }
 
     /**
-     * This instance {@code to} method allows Interval to act as a fluent builder for itself.
-     * It works in conjunction with the static method {@link #from(int)} and instance method {@link #by(int)}.
-     * <p>
-     * Usage Example:
-     * <pre>
-     * Interval interval1 = Interval.from(1).to(5);         // results in: 1, 2, 3, 4, 5.
-     * Interval interval2 = Interval.from(1).to(10).by(2);  // results in: 1, 3, 5, 7, 9.
-     * </pre>
-     */
-    public Interval to(int newTo)
-    {
-        return Interval.fromToBy(this.from, newTo, this.step);
-    }
-
-    /**
-     * This instance {@code by} method allows Interval to act as a fluent builder for itself.
-     * It works in conjunction with the static method {@link #from(int)} and instance method {@link #to(int)}.
-     * <p>
-     * Usage Example:
-     * <pre>
-     * Interval interval1 = Interval.from(1).to(5);         // results in: 1, 2, 3, 4, 5.
-     * Interval interval2 = Interval.from(1).to(10).by(2);  // results in: 1, 3, 5, 7, 9.
-     * </pre>
-     */
-    public Interval by(int newStep)
-    {
-        return Interval.fromToBy(this.from, this.to, newStep);
-    }
-
-    /**
      * Returns an Interval starting at zero.
      * <p>
      * Usage Example:
@@ -275,6 +245,36 @@ public final class Interval
     {
         IntervalUtils.checkArguments(from, to, stepBy);
         return new Interval(from, to, stepBy);
+    }
+
+    /**
+     * This instance {@code to} method allows Interval to act as a fluent builder for itself.
+     * It works in conjunction with the static method {@link #from(int)} and instance method {@link #by(int)}.
+     * <p>
+     * Usage Example:
+     * <pre>
+     * Interval interval1 = Interval.from(1).to(5);         // results in: 1, 2, 3, 4, 5.
+     * Interval interval2 = Interval.from(1).to(10).by(2);  // results in: 1, 3, 5, 7, 9.
+     * </pre>
+     */
+    public Interval to(int newTo)
+    {
+        return Interval.fromToBy(this.from, newTo, this.step);
+    }
+
+    /**
+     * This instance {@code by} method allows Interval to act as a fluent builder for itself.
+     * It works in conjunction with the static method {@link #from(int)} and instance method {@link #to(int)}.
+     * <p>
+     * Usage Example:
+     * <pre>
+     * Interval interval1 = Interval.from(1).to(5);         // results in: 1, 2, 3, 4, 5.
+     * Interval interval2 = Interval.from(1).to(10).by(2);  // results in: 1, 3, 5, 7, 9.
+     * </pre>
+     */
+    public Interval by(int newStep)
+    {
+        return Interval.fromToBy(this.from, this.to, newStep);
     }
 
     /**
@@ -772,39 +772,6 @@ public final class Interval
         return new IntegerIterator();
     }
 
-    private class IntegerIterator implements Iterator<Integer>
-    {
-        private long current = Interval.this.from;
-
-        @Override
-        public boolean hasNext()
-        {
-            if (Interval.this.from <= Interval.this.to)
-            {
-                return this.current <= (long) Interval.this.to;
-            }
-            return this.current >= (long) Interval.this.to;
-        }
-
-        @Override
-        public Integer next()
-        {
-            if (this.hasNext())
-            {
-                Integer result = (int) this.current;
-                this.current += Interval.this.step;
-                return result;
-            }
-            throw new NoSuchElementException();
-        }
-
-        @Override
-        public void remove()
-        {
-            throw new UnsupportedOperationException("Cannot remove a value from an Interval");
-        }
-    }
-
     @Override
     public Integer getFirst()
     {
@@ -1035,5 +1002,38 @@ public final class Interval
     public LazyIterable<Integer> distinct()
     {
         return this;
+    }
+
+    private class IntegerIterator implements Iterator<Integer>
+    {
+        private long current = Interval.this.from;
+
+        @Override
+        public boolean hasNext()
+        {
+            if (Interval.this.from <= Interval.this.to)
+            {
+                return this.current <= (long) Interval.this.to;
+            }
+            return this.current >= (long) Interval.this.to;
+        }
+
+        @Override
+        public Integer next()
+        {
+            if (this.hasNext())
+            {
+                Integer result = (int) this.current;
+                this.current += Interval.this.step;
+                return result;
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException("Cannot remove a value from an Interval");
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/AbstractMutableList.java
@@ -650,6 +650,193 @@ public abstract class AbstractMutableList<T>
         return new SubList<>(this, fromIndex, toIndex);
     }
 
+    @Override
+    public boolean contains(Object object)
+    {
+        return this.indexOf(object) > -1;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> source)
+    {
+        return Iterate.allSatisfyWith(source, Predicates2.in(), this);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collection)
+    {
+        int currentSize = this.size();
+        this.removeIfWith(Predicates2.in(), collection);
+        return currentSize != this.size();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collection)
+    {
+        int currentSize = this.size();
+        this.removeIfWith(Predicates2.notIn(), collection);
+        return currentSize != this.size();
+    }
+
+    @Override
+    public T getFirst()
+    {
+        return ListIterate.getFirst(this);
+    }
+
+    @Override
+    public T getLast()
+    {
+        return ListIterate.getLast(this);
+    }
+
+    @Override
+    public void appendString(Appendable appendable, String separator)
+    {
+        this.appendString(appendable, "", separator, "");
+    }
+
+    @Override
+    public void appendString(Appendable appendable, String start, String separator, String end)
+    {
+        ListIterate.appendString(this, appendable, start, separator, end);
+    }
+
+    @Override
+    public <V> FastListMultimap<V, T> groupBy(Function<? super T, ? extends V> function)
+    {
+        return ListIterate.groupBy(this, function);
+    }
+
+    @Override
+    public <V> FastListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
+    {
+        return ListIterate.groupByEach(this, function);
+    }
+
+    @Override
+    public <K> MutableMap<K, T> groupByUniqueKey(Function<? super T, ? extends K> function)
+    {
+        return ListIterate.groupByUniqueKey(this, function);
+    }
+
+    @Override
+    public <S> MutableList<Pair<T, S>> zip(Iterable<S> that)
+    {
+        return ListIterate.zip(this, that);
+    }
+
+    @Override
+    public MutableList<Pair<T, Integer>> zipWithIndex()
+    {
+        return ListIterate.zipWithIndex(this);
+    }
+
+    @Override
+    public MutableList<T> with(T element)
+    {
+        this.add(element);
+        return this;
+    }
+
+    @Override
+    public MutableList<T> without(T element)
+    {
+        this.remove(element);
+        return this;
+    }
+
+    @Override
+    public MutableList<T> withAll(Iterable<? extends T> elements)
+    {
+        this.addAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    public MutableList<T> withoutAll(Iterable<? extends T> elements)
+    {
+        this.removeAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    public ReverseIterable<T> asReversed()
+    {
+        return ReverseIterable.adapt(this);
+    }
+
+    @Override
+    public ParallelListIterable<T> asParallel(ExecutorService executorService, int batchSize)
+    {
+        return new ListIterableParallelIterable<>(this, executorService, batchSize);
+    }
+
+    @Override
+    public int binarySearch(T key, Comparator<? super T> comparator)
+    {
+        return Collections.binarySearch(this, key, comparator);
+    }
+
+    @Override
+    public RichIterable<RichIterable<T>> chunk(int size)
+    {
+        if (size <= 0)
+        {
+            throw new IllegalArgumentException("Size for groups must be positive but was: " + size);
+        }
+
+        if (this instanceof RandomAccess)
+        {
+            MutableList<RichIterable<T>> result = Lists.mutable.empty();
+            int i = 0;
+            while (i < this.size())
+            {
+                MutableList<T> batch = new FastList<>(Math.min(size, this.size() - i));
+
+                for (int j = 0; j < size && i < this.size(); j++)
+                {
+                    batch.add(this.get(i));
+                    i++;
+                }
+                result.add(batch);
+            }
+            return result;
+        }
+
+        return super.chunk(size);
+    }
+
+    @Override
+    public MutableList<T> take(int count)
+    {
+        return ListIterate.take(this, count);
+    }
+
+    @Override
+    public MutableList<T> takeWhile(Predicate<? super T> predicate)
+    {
+        return ListIterate.takeWhile(this, predicate);
+    }
+
+    @Override
+    public MutableList<T> drop(int count)
+    {
+        return ListIterate.drop(this, count);
+    }
+
+    @Override
+    public MutableList<T> dropWhile(Predicate<? super T> predicate)
+    {
+        return ListIterate.dropWhile(this, predicate);
+    }
+
+    @Override
+    public PartitionMutableList<T> partitionWhile(Predicate<? super T> predicate)
+    {
+        return ListIterate.partitionWhile(this, predicate);
+    }
+
     protected static class SubList<T>
             extends AbstractMutableList<T>
             implements Serializable, RandomAccess
@@ -895,192 +1082,5 @@ public abstract class AbstractMutableList<T>
         {
             ListIterate.forEachWith(this, procedure, parameter);
         }
-    }
-
-    @Override
-    public boolean contains(Object object)
-    {
-        return this.indexOf(object) > -1;
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> source)
-    {
-        return Iterate.allSatisfyWith(source, Predicates2.in(), this);
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> collection)
-    {
-        int currentSize = this.size();
-        this.removeIfWith(Predicates2.in(), collection);
-        return currentSize != this.size();
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> collection)
-    {
-        int currentSize = this.size();
-        this.removeIfWith(Predicates2.notIn(), collection);
-        return currentSize != this.size();
-    }
-
-    @Override
-    public T getFirst()
-    {
-        return ListIterate.getFirst(this);
-    }
-
-    @Override
-    public T getLast()
-    {
-        return ListIterate.getLast(this);
-    }
-
-    @Override
-    public void appendString(Appendable appendable, String separator)
-    {
-        this.appendString(appendable, "", separator, "");
-    }
-
-    @Override
-    public void appendString(Appendable appendable, String start, String separator, String end)
-    {
-        ListIterate.appendString(this, appendable, start, separator, end);
-    }
-
-    @Override
-    public <V> FastListMultimap<V, T> groupBy(Function<? super T, ? extends V> function)
-    {
-        return ListIterate.groupBy(this, function);
-    }
-
-    @Override
-    public <V> FastListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
-    {
-        return ListIterate.groupByEach(this, function);
-    }
-
-    @Override
-    public <K> MutableMap<K, T> groupByUniqueKey(Function<? super T, ? extends K> function)
-    {
-        return ListIterate.groupByUniqueKey(this, function);
-    }
-
-    @Override
-    public <S> MutableList<Pair<T, S>> zip(Iterable<S> that)
-    {
-        return ListIterate.zip(this, that);
-    }
-
-    @Override
-    public MutableList<Pair<T, Integer>> zipWithIndex()
-    {
-        return ListIterate.zipWithIndex(this);
-    }
-
-    @Override
-    public MutableList<T> with(T element)
-    {
-        this.add(element);
-        return this;
-    }
-
-    @Override
-    public MutableList<T> without(T element)
-    {
-        this.remove(element);
-        return this;
-    }
-
-    @Override
-    public MutableList<T> withAll(Iterable<? extends T> elements)
-    {
-        this.addAllIterable(elements);
-        return this;
-    }
-
-    @Override
-    public MutableList<T> withoutAll(Iterable<? extends T> elements)
-    {
-        this.removeAllIterable(elements);
-        return this;
-    }
-
-    @Override
-    public ReverseIterable<T> asReversed()
-    {
-        return ReverseIterable.adapt(this);
-    }
-
-    @Override
-    public ParallelListIterable<T> asParallel(ExecutorService executorService, int batchSize)
-    {
-        return new ListIterableParallelIterable<>(this, executorService, batchSize);
-    }
-
-    @Override
-    public int binarySearch(T key, Comparator<? super T> comparator)
-    {
-        return Collections.binarySearch(this, key, comparator);
-    }
-
-    @Override
-    public RichIterable<RichIterable<T>> chunk(int size)
-    {
-        if (size <= 0)
-        {
-            throw new IllegalArgumentException("Size for groups must be positive but was: " + size);
-        }
-
-        if (this instanceof RandomAccess)
-        {
-            MutableList<RichIterable<T>> result = Lists.mutable.empty();
-            int i = 0;
-            while (i < this.size())
-            {
-                MutableList<T> batch = new FastList<>(Math.min(size, this.size() - i));
-
-                for (int j = 0; j < size && i < this.size(); j++)
-                {
-                    batch.add(this.get(i));
-                    i++;
-                }
-                result.add(batch);
-            }
-            return result;
-        }
-
-        return super.chunk(size);
-    }
-
-    @Override
-    public MutableList<T> take(int count)
-    {
-        return ListIterate.take(this, count);
-    }
-
-    @Override
-    public MutableList<T> takeWhile(Predicate<? super T> predicate)
-    {
-        return ListIterate.takeWhile(this, predicate);
-    }
-
-    @Override
-    public MutableList<T> drop(int count)
-    {
-        return ListIterate.drop(this, count);
-    }
-
-    @Override
-    public MutableList<T> dropWhile(Predicate<? super T> predicate)
-    {
-        return ListIterate.dropWhile(this, predicate);
-    }
-
-    @Override
-    public PartitionMutableList<T> partitionWhile(Predicate<? super T> predicate)
-    {
-        return ListIterate.partitionWhile(this, predicate);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/CompositeFastList.java
@@ -624,6 +624,61 @@ public final class CompositeFastList<E>
         this.lists.add(list);
     }
 
+    @Override
+    public ParallelListIterable<E> asParallel(ExecutorService executorService, int batchSize)
+    {
+        return new NonParallelListIterable<>(this);
+    }
+
+    private static final class ProcedureToInnerListObjectIntProcedure<E> implements Procedure<FastList<E>>
+    {
+        private static final long serialVersionUID = 1L;
+        private final ObjectIntProcedure<? super E> objectIntProcedure;
+        private int index;
+
+        private ProcedureToInnerListObjectIntProcedure(ObjectIntProcedure<? super E> objectIntProcedure)
+        {
+            this.objectIntProcedure = objectIntProcedure;
+        }
+
+        @Override
+        public void value(FastList<E> list)
+        {
+            list.each(object ->
+            {
+                this.objectIntProcedure.value(
+                        object,
+                        this.index);
+                this.index++;
+            });
+        }
+    }
+
+    private static final class ProcedureToReverseInnerListObjectIntProcedure<E> implements Procedure<FastList<E>>
+    {
+        private static final long serialVersionUID = 1L;
+        private final ObjectIntProcedure<? super E> objectIntProcedure;
+        private int index;
+
+        private ProcedureToReverseInnerListObjectIntProcedure(ObjectIntProcedure<? super E> objectIntProcedure, int size)
+        {
+            this.objectIntProcedure = objectIntProcedure;
+            this.index = size;
+        }
+
+        @Override
+        public void value(FastList<E> list)
+        {
+            list.reverseForEach(object ->
+            {
+                this.objectIntProcedure.value(
+                        object,
+                        this.index);
+                this.index--;
+            });
+        }
+    }
+
     private final class CompositeIterator
             implements Iterator<E>
     {
@@ -678,62 +733,5 @@ public final class CompositeFastList<E>
             CompositeFastList.this.size--;
             this.currentIterator.remove();
         }
-    }
-
-    private static final class ProcedureToInnerListObjectIntProcedure<E> implements Procedure<FastList<E>>
-    {
-        private static final long serialVersionUID = 1L;
-
-        private int index;
-        private final ObjectIntProcedure<? super E> objectIntProcedure;
-
-        private ProcedureToInnerListObjectIntProcedure(ObjectIntProcedure<? super E> objectIntProcedure)
-        {
-            this.objectIntProcedure = objectIntProcedure;
-        }
-
-        @Override
-        public void value(FastList<E> list)
-        {
-            list.each(object ->
-            {
-                this.objectIntProcedure.value(
-                        object,
-                        this.index);
-                this.index++;
-            });
-        }
-    }
-
-    private static final class ProcedureToReverseInnerListObjectIntProcedure<E> implements Procedure<FastList<E>>
-    {
-        private static final long serialVersionUID = 1L;
-
-        private int index;
-        private final ObjectIntProcedure<? super E> objectIntProcedure;
-
-        private ProcedureToReverseInnerListObjectIntProcedure(ObjectIntProcedure<? super E> objectIntProcedure, int size)
-        {
-            this.objectIntProcedure = objectIntProcedure;
-            this.index = size;
-        }
-
-        @Override
-        public void value(FastList<E> list)
-        {
-            list.reverseForEach(object ->
-            {
-                this.objectIntProcedure.value(
-                        object,
-                        this.index);
-                this.index--;
-            });
-        }
-    }
-
-    @Override
-    public ParallelListIterable<E> asParallel(ExecutorService executorService, int batchSize)
-    {
-        return new NonParallelListIterable<>(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
@@ -837,6 +837,190 @@ public final class MultiReaderFastList<T>
 
     // Exposed for testing
 
+    @Override
+    public int detectIndex(Predicate<? super T> predicate)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.detectIndex(predicate);
+        }
+    }
+
+    @Override
+    public int detectLastIndex(Predicate<? super T> predicate)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.detectLastIndex(predicate);
+        }
+    }
+
+    @Override
+    public <V> MutableListMultimap<V, T> groupBy(Function<? super T, ? extends V> function)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.groupBy(function);
+        }
+    }
+
+    @Override
+    public <V> MutableListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.groupByEach(function);
+        }
+    }
+
+    @Override
+    public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.groupByUniqueKey(function);
+        }
+    }
+
+    @Override
+    public <S> MutableList<Pair<T, S>> zip(Iterable<S> that)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.zip(that);
+        }
+    }
+
+    @Override
+    public MutableList<Pair<T, Integer>> zipWithIndex()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.zipWithIndex();
+        }
+    }
+
+    @Override
+    public MutableList<T> toReversed()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.toReversed();
+        }
+    }
+
+    @Override
+    public MutableList<T> reverseThis()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
+        {
+            this.delegate.reverseThis();
+            return this;
+        }
+    }
+
+    @Override
+    public MutableList<T> shuffleThis()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
+        {
+            this.delegate.shuffleThis();
+            return this;
+        }
+    }
+
+    @Override
+    public MutableList<T> shuffleThis(Random rnd)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
+        {
+            this.delegate.shuffleThis(rnd);
+            return this;
+        }
+    }
+
+    @Override
+    public MutableStack<T> toStack()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.toStack();
+        }
+    }
+
+    @Override
+    public RichIterable<RichIterable<T>> chunk(int size)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.chunk(size);
+        }
+    }
+
+    @Override
+    public MutableList<T> take(int count)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.take(count);
+        }
+    }
+
+    @Override
+    public MutableList<T> takeWhile(Predicate<? super T> predicate)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.takeWhile(predicate);
+        }
+    }
+
+    @Override
+    public MutableList<T> drop(int count)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.drop(count);
+        }
+    }
+
+    @Override
+    public MutableList<T> dropWhile(Predicate<? super T> predicate)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.dropWhile(predicate);
+        }
+    }
+
+    @Override
+    public PartitionMutableList<T> partitionWhile(Predicate<? super T> predicate)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return this.delegate.partitionWhile(predicate);
+        }
+    }
+
+    @Override
+    public LazyIterable<T> asReversed()
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return ReverseIterable.adapt(this);
+        }
+    }
+
+    @Override
+    public ParallelListIterable<T> asParallel(ExecutorService executorService, int batchSize)
+    {
+        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
+        {
+            return new MultiReaderParallelListIterable<>(
+                    this.delegate.asParallel(executorService, batchSize), this.lock);
+        }
+    }
+
     static final class UntouchableMutableList<T>
             extends UntouchableMutableCollection<T>
             implements MutableList<T>
@@ -1511,190 +1695,6 @@ public final class MultiReaderFastList<T>
         public void becomeUseless()
         {
             this.delegate = null;
-        }
-    }
-
-    @Override
-    public int detectIndex(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.detectIndex(predicate);
-        }
-    }
-
-    @Override
-    public int detectLastIndex(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.detectLastIndex(predicate);
-        }
-    }
-
-    @Override
-    public <V> MutableListMultimap<V, T> groupBy(Function<? super T, ? extends V> function)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.groupBy(function);
-        }
-    }
-
-    @Override
-    public <V> MutableListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.groupByEach(function);
-        }
-    }
-
-    @Override
-    public <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.groupByUniqueKey(function);
-        }
-    }
-
-    @Override
-    public <S> MutableList<Pair<T, S>> zip(Iterable<S> that)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.zip(that);
-        }
-    }
-
-    @Override
-    public MutableList<Pair<T, Integer>> zipWithIndex()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.zipWithIndex();
-        }
-    }
-
-    @Override
-    public MutableList<T> toReversed()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.toReversed();
-        }
-    }
-
-    @Override
-    public MutableList<T> reverseThis()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
-        {
-            this.delegate.reverseThis();
-            return this;
-        }
-    }
-
-    @Override
-    public MutableList<T> shuffleThis()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
-        {
-            this.delegate.shuffleThis();
-            return this;
-        }
-    }
-
-    @Override
-    public MutableList<T> shuffleThis(Random rnd)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
-        {
-            this.delegate.shuffleThis(rnd);
-            return this;
-        }
-    }
-
-    @Override
-    public MutableStack<T> toStack()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.toStack();
-        }
-    }
-
-    @Override
-    public RichIterable<RichIterable<T>> chunk(int size)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.chunk(size);
-        }
-    }
-
-    @Override
-    public MutableList<T> take(int count)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.take(count);
-        }
-    }
-
-    @Override
-    public MutableList<T> takeWhile(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.takeWhile(predicate);
-        }
-    }
-
-    @Override
-    public MutableList<T> drop(int count)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.drop(count);
-        }
-    }
-
-    @Override
-    public MutableList<T> dropWhile(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.dropWhile(predicate);
-        }
-    }
-
-    @Override
-    public PartitionMutableList<T> partitionWhile(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.partitionWhile(predicate);
-        }
-    }
-
-    @Override
-    public LazyIterable<T> asReversed()
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return ReverseIterable.adapt(this);
-        }
-    }
-
-    @Override
-    public ParallelListIterable<T> asParallel(ExecutorService executorService, int batchSize)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return new MultiReaderParallelListIterable<>(
-                    this.delegate.asParallel(executorService, batchSize), this.lock);
         }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableList.java
@@ -600,6 +600,11 @@ public class UnmodifiableMutableList<T>
         throw new UnsupportedOperationException("Cannot call withoutAll() on " + this.getClass().getSimpleName());
     }
 
+    protected Object writeReplace()
+    {
+        return new UnmodifiableCollectionSerializationProxy<>(this.getMutableList());
+    }
+
     private static final class RandomAccessUnmodifiableMutableList<T> extends UnmodifiableMutableList<T> implements RandomAccess
     {
         private static final long serialVersionUID = 1L;
@@ -614,10 +619,5 @@ public class UnmodifiableMutableList<T>
         {
             return this;
         }
-    }
-
-    protected Object writeReplace()
-    {
-        return new UnmodifiableCollectionSerializationProxy<>(this.getMutableList());
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
@@ -328,6 +328,24 @@ public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterabl
         return this;
     }
 
+    @Override
+    public <VV> MutableBagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function)
+    {
+        return this.groupBy(function, HashBagMultimap.newMultimap());
+    }
+
+    @Override
+    public <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function)
+    {
+        return this.groupByEach(function, HashBagMultimap.newMultimap());
+    }
+
+    @Override
+    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
+    }
+
     /**
      * Trait-style class that is used to capture commonalities between ValuesCollection class implementations in order to
      * avoid code duplication.
@@ -345,23 +363,5 @@ public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterabl
         {
             throw new UnsupportedOperationException("Cannot call addAll() on " + this.getClass().getSimpleName());
         }
-    }
-
-    @Override
-    public <VV> MutableBagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function)
-    {
-        return this.groupBy(function, HashBagMultimap.newMultimap());
-    }
-
-    @Override
-    public <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function)
-    {
-        return this.groupByEach(function, HashBagMultimap.newMultimap());
-    }
-
-    @Override
-    public <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
-    {
-        return this.groupByUniqueKey(function, UnifiedMap.newMap(this.size()));
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -72,7 +72,10 @@ public final class ConcurrentHashMap<K, V>
     private static final AtomicIntegerFieldUpdater<ConcurrentHashMap> SIZE_UPDATER = AtomicIntegerFieldUpdater.newUpdater(ConcurrentHashMap.class, "size");
     private static final Object RESIZED = new Object();
     private static final Object RESIZING = new Object();
-    private static final int PARTITIONED_SIZE_THRESHOLD = 4096; // chosen to keep size below 1% of the total size of the map
+
+    // chosen to keep size below 1% of the total size of the map
+    private static final int PARTITIONED_SIZE_THRESHOLD = 4096;
+
     private static final int SIZE_BUCKETS = 7;
 
     /**
@@ -82,8 +85,9 @@ public final class ConcurrentHashMap<K, V>
 
     private AtomicIntegerArray partitionedSize;
 
+    // updated via atomic field updater
     @SuppressWarnings("UnusedDeclaration")
-    private volatile int size; // updated via atomic field updater
+    private volatile int size;
 
     public ConcurrentHashMap()
     {
@@ -102,7 +106,9 @@ public final class ConcurrentHashMap<K, V>
         }
 
         int threshold = initialCapacity;
-        threshold += threshold >> 1; // threshold = length * 0.75
+
+        // threshold = length * 0.75
+        threshold += threshold >> 1;
 
         int capacity = 1;
         while (capacity < threshold)
@@ -111,7 +117,8 @@ public final class ConcurrentHashMap<K, V>
         }
         if (capacity >= PARTITIONED_SIZE_THRESHOLD)
         {
-            this.partitionedSize = new AtomicIntegerArray(SIZE_BUCKETS * 16); // we want 7 extra slots and 64 bytes for each slot. int is 4 bytes, so 64 bytes is 16 ints.
+            // we want 7 extra slots and 64 bytes for each slot. int is 4 bytes, so 64 bytes is 16 ints.
+            this.partitionedSize = new AtomicIntegerArray(SIZE_BUCKETS * 16);
         }
         this.table = new AtomicReferenceArray(capacity + 1);
     }
@@ -161,7 +168,9 @@ public final class ConcurrentHashMap<K, V>
                 if (currentArray.compareAndSet(index, o, newEntry))
                 {
                     this.incrementSizeAndPossiblyResize(currentArray, length, o);
-                    return null; // per the contract of putIfAbsent, we return null when the map didn't have this key before
+
+                    // per the contract of putIfAbsent, we return null when the map didn't have this key before
+                    return null;
                 }
             }
         }
@@ -173,7 +182,10 @@ public final class ConcurrentHashMap<K, V>
         if (prev != null)
         {
             int localSize = this.size();
-            int threshold = (length >> 1) + (length >> 2); // threshold = length * 0.75
+
+            // threshold = length * 0.75
+            int threshold = (length >> 1) + (length >> 2);
+
             if (localSize + 1 > threshold)
             {
                 this.resize(currentArray);
@@ -242,7 +254,8 @@ public final class ConcurrentHashMap<K, V>
         boolean ownResize = false;
         if (last == null || last == RESIZE_SENTINEL)
         {
-            synchronized (oldTable) // allocating a new array is too expensive to make this an atomic operation
+            // allocating a new array is too expensive to make this an atomic operation
+            synchronized (oldTable)
             {
                 if (oldTable.get(end) == null)
                 {
@@ -387,7 +400,8 @@ public final class ConcurrentHashMap<K, V>
                 {
                     if (toCopyEntry.getNext() == null)
                     {
-                        newEntry = toCopyEntry; // no need to duplicate
+                        // no need to duplicate
+                        newEntry = toCopyEntry;
                     }
                     else
                     {
@@ -531,7 +545,8 @@ public final class ConcurrentHashMap<K, V>
                     newValue = factory.value(param1, param2, key);
                     if (newValue == null)
                     {
-                        return null; // null value means no mapping is required
+                        // null value means no mapping is required
+                        return null;
                     }
                     key = keyTransformer.value(key, newValue);
                 }
@@ -851,7 +866,9 @@ public final class ConcurrentHashMap<K, V>
         if (this.size() == 0)
         {
             int threshold = map.size();
-            threshold += threshold >> 1; // threshold = length * 0.75
+
+            // threshold = length * 0.75
+            threshold += threshold >> 1;
 
             int capacity = 1;
             while (capacity < threshold)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -1462,6 +1462,343 @@ public final class ConcurrentHashMap<K, V>
         }
     }
 
+    public static <NK, NV> ConcurrentHashMap<NK, NV> newMap(Map<NK, NV> map)
+    {
+        ConcurrentHashMap<NK, NV> result = new ConcurrentHashMap<>(map.size());
+        result.putAll(map);
+        return result;
+    }
+
+    @Override
+    public ConcurrentHashMap<K, V> withKeyValue(K key, V value)
+    {
+        return (ConcurrentHashMap<K, V>) super.withKeyValue(key, value);
+    }
+
+    @Override
+    public ConcurrentHashMap<K, V> withAllKeyValues(Iterable<? extends Pair<? extends K, ? extends V>> keyValues)
+    {
+        return (ConcurrentHashMap<K, V>) super.withAllKeyValues(keyValues);
+    }
+
+    @Override
+    public ConcurrentHashMap<K, V> withAllKeyValueArguments(Pair<? extends K, ? extends V>... keyValues)
+    {
+        return (ConcurrentHashMap<K, V>) super.withAllKeyValueArguments(keyValues);
+    }
+
+    @Override
+    public ConcurrentHashMap<K, V> withoutKey(K key)
+    {
+        return (ConcurrentHashMap<K, V>) super.withoutKey(key);
+    }
+
+    @Override
+    public ConcurrentHashMap<K, V> withoutAllKeys(Iterable<? extends K> keys)
+    {
+        return (ConcurrentHashMap<K, V>) super.withoutAllKeys(keys);
+    }
+
+    @Override
+    public MutableMap<K, V> clone()
+    {
+        return ConcurrentHashMap.newMap(this);
+    }
+
+    @Override
+    public <K, V> MutableMap<K, V> newEmpty(int capacity)
+    {
+        return ConcurrentHashMap.newMap();
+    }
+
+    @Override
+    public boolean notEmpty()
+    {
+        return !this.isEmpty();
+    }
+
+    @Override
+    public void forEachWithIndex(ObjectIntProcedure<? super V> objectIntProcedure)
+    {
+        Iterate.forEachWithIndex(this.values(), objectIntProcedure);
+    }
+
+    @Override
+    public Iterator<V> iterator()
+    {
+        return this.values().iterator();
+    }
+
+    @Override
+    public MutableMap<K, V> newEmpty()
+    {
+        return ConcurrentHashMap.newMap();
+    }
+
+    @Override
+    public ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure)
+    {
+        this.each(procedure);
+        return this;
+    }
+
+    @Override
+    public void forEachValue(Procedure<? super V> procedure)
+    {
+        IterableIterate.forEach(this.values(), procedure);
+    }
+
+    @Override
+    public void forEachKey(Procedure<? super K> procedure)
+    {
+        IterableIterate.forEach(this.keySet(), procedure);
+    }
+
+    @Override
+    public void forEachKeyValue(Procedure2<? super K, ? super V> procedure)
+    {
+        IterableIterate.forEach(this.entrySet(), new MapEntryToProcedure2<>(procedure));
+    }
+
+    @Override
+    public <E> MutableMap<K, V> collectKeysAndValues(
+            Iterable<E> iterable,
+            Function<? super E, ? extends K> keyFunction,
+            Function<? super E, ? extends V> valueFunction)
+    {
+        Iterate.addToMap(iterable, keyFunction, valueFunction, this);
+        return this;
+    }
+
+    @Override
+    public V removeKey(K key)
+    {
+        return this.remove(key);
+    }
+
+    @Override
+    public <P> V getIfAbsentPutWith(K key, Function<? super P, ? extends V> function, P parameter)
+    {
+        int hash = this.hash(key);
+        AtomicReferenceArray currentArray = this.table;
+        V newValue = null;
+        boolean createdValue = false;
+        while (true)
+        {
+            int length = currentArray.length();
+            int index = ConcurrentHashMap.indexFor(hash, length);
+            Object o = currentArray.get(index);
+            if (o == RESIZED || o == RESIZING)
+            {
+                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
+            }
+            else
+            {
+                Entry<K, V> e = (Entry<K, V>) o;
+                while (e != null)
+                {
+                    Object candidate = e.getKey();
+                    if (candidate.equals(key))
+                    {
+                        return e.getValue();
+                    }
+                    e = e.getNext();
+                }
+                if (!createdValue)
+                {
+                    createdValue = true;
+                    newValue = function.valueOf(parameter);
+                }
+                Entry<K, V> newEntry = new Entry<>(key, newValue, (Entry<K, V>) o);
+                if (currentArray.compareAndSet(index, o, newEntry))
+                {
+                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
+                    return newValue;
+                }
+            }
+        }
+    }
+
+    @Override
+    public V getIfAbsent(K key, Function0<? extends V> function)
+    {
+        V result = this.get(key);
+        if (result == null)
+        {
+            return function.value();
+        }
+        return result;
+    }
+
+    @Override
+    public <P> V getIfAbsentWith(
+            K key,
+            Function<? super P, ? extends V> function,
+            P parameter)
+    {
+        V result = this.get(key);
+        if (result == null)
+        {
+            return function.valueOf(parameter);
+        }
+        return result;
+    }
+
+    @Override
+    public <A> A ifPresentApply(K key, Function<? super V, ? extends A> function)
+    {
+        V result = this.get(key);
+        return result == null ? null : function.valueOf(result);
+    }
+
+    @Override
+    public <P> void forEachWith(Procedure2<? super V, ? super P> procedure, P parameter)
+    {
+        Iterate.forEachWith(this.values(), procedure, parameter);
+    }
+
+    @Override
+    public V updateValue(K key, Function0<? extends V> factory, Function<? super V, ? extends V> function)
+    {
+        int hash = this.hash(key);
+        AtomicReferenceArray currentArray = this.table;
+        int length = currentArray.length();
+        int index = ConcurrentHashMap.indexFor(hash, length);
+        Object o = currentArray.get(index);
+        if (o == null)
+        {
+            V result = function.valueOf(factory.value());
+            Entry<K, V> newEntry = new Entry<>(key, result, null);
+            if (currentArray.compareAndSet(index, null, newEntry))
+            {
+                this.addToSize(1);
+                return result;
+            }
+        }
+        return this.slowUpdateValue(key, factory, function, hash, currentArray);
+    }
+
+    private V slowUpdateValue(K key, Function0<? extends V> factory, Function<? super V, ? extends V> function, int hash, AtomicReferenceArray currentArray)
+    {
+        //noinspection LabeledStatement
+        outer:
+        while (true)
+        {
+            int length = currentArray.length();
+            int index = ConcurrentHashMap.indexFor(hash, length);
+            Object o = currentArray.get(index);
+            if (o == RESIZED || o == RESIZING)
+            {
+                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
+            }
+            else
+            {
+                Entry<K, V> e = (Entry<K, V>) o;
+                while (e != null)
+                {
+                    Object candidate = e.getKey();
+                    if (candidate.equals(key))
+                    {
+                        V oldValue = e.getValue();
+                        V newValue = function.valueOf(oldValue);
+                        Entry<K, V> newEntry = new Entry<>(e.getKey(), newValue, this.createReplacementChainForRemoval((Entry<K, V>) o, e));
+                        if (!currentArray.compareAndSet(index, o, newEntry))
+                        {
+                            //noinspection ContinueStatementWithLabel
+                            continue outer;
+                        }
+                        return newValue;
+                    }
+                    e = e.getNext();
+                }
+                V result = function.valueOf(factory.value());
+                Entry<K, V> newEntry = new Entry<>(key, result, (Entry<K, V>) o);
+                if (currentArray.compareAndSet(index, o, newEntry))
+                {
+                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
+                    return result;
+                }
+            }
+        }
+    }
+
+    @Override
+    public <P> V updateValueWith(K key, Function0<? extends V> factory, Function2<? super V, ? super P, ? extends V> function, P parameter)
+    {
+        int hash = this.hash(key);
+        AtomicReferenceArray currentArray = this.table;
+        int length = currentArray.length();
+        int index = ConcurrentHashMap.indexFor(hash, length);
+        Object o = currentArray.get(index);
+        if (o == null)
+        {
+            V result = function.value(factory.value(), parameter);
+            Entry<K, V> newEntry = new Entry<>(key, result, null);
+            if (currentArray.compareAndSet(index, null, newEntry))
+            {
+                this.addToSize(1);
+                return result;
+            }
+        }
+        return this.slowUpdateValueWith(key, factory, function, parameter, hash, currentArray);
+    }
+
+    private <P> V slowUpdateValueWith(
+            K key,
+            Function0<? extends V> factory,
+            Function2<? super V, ? super P, ? extends V> function,
+            P parameter,
+            int hash,
+            AtomicReferenceArray currentArray)
+    {
+        //noinspection LabeledStatement
+        outer:
+        while (true)
+        {
+            int length = currentArray.length();
+            int index = ConcurrentHashMap.indexFor(hash, length);
+            Object o = currentArray.get(index);
+            if (o == RESIZED || o == RESIZING)
+            {
+                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
+            }
+            else
+            {
+                Entry<K, V> e = (Entry<K, V>) o;
+                while (e != null)
+                {
+                    Object candidate = e.getKey();
+                    if (candidate.equals(key))
+                    {
+                        V oldValue = e.getValue();
+                        V newValue = function.value(oldValue, parameter);
+                        Entry<K, V> newEntry = new Entry<>(e.getKey(), newValue, this.createReplacementChainForRemoval((Entry<K, V>) o, e));
+                        if (!currentArray.compareAndSet(index, o, newEntry))
+                        {
+                            //noinspection ContinueStatementWithLabel
+                            continue outer;
+                        }
+                        return newValue;
+                    }
+                    e = e.getNext();
+                }
+                V result = function.value(factory.value(), parameter);
+                Entry<K, V> newEntry = new Entry<>(key, result, (Entry<K, V>) o);
+                if (currentArray.compareAndSet(index, o, newEntry))
+                {
+                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
+                    return result;
+                }
+            }
+        }
+    }
+
+    @Override
+    public ImmutableMap<K, V> toImmutable()
+    {
+        return Maps.immutable.ofMap(this);
+    }
+
     private static final class IteratorState
     {
         private AtomicReferenceArray currentTable;
@@ -1981,342 +2318,5 @@ public final class ConcurrentHashMap<K, V>
         {
             this.queuePosition.set(0);
         }
-    }
-
-    public static <NK, NV> ConcurrentHashMap<NK, NV> newMap(Map<NK, NV> map)
-    {
-        ConcurrentHashMap<NK, NV> result = new ConcurrentHashMap<>(map.size());
-        result.putAll(map);
-        return result;
-    }
-
-    @Override
-    public ConcurrentHashMap<K, V> withKeyValue(K key, V value)
-    {
-        return (ConcurrentHashMap<K, V>) super.withKeyValue(key, value);
-    }
-
-    @Override
-    public ConcurrentHashMap<K, V> withAllKeyValues(Iterable<? extends Pair<? extends K, ? extends V>> keyValues)
-    {
-        return (ConcurrentHashMap<K, V>) super.withAllKeyValues(keyValues);
-    }
-
-    @Override
-    public ConcurrentHashMap<K, V> withAllKeyValueArguments(Pair<? extends K, ? extends V>... keyValues)
-    {
-        return (ConcurrentHashMap<K, V>) super.withAllKeyValueArguments(keyValues);
-    }
-
-    @Override
-    public ConcurrentHashMap<K, V> withoutKey(K key)
-    {
-        return (ConcurrentHashMap<K, V>) super.withoutKey(key);
-    }
-
-    @Override
-    public ConcurrentHashMap<K, V> withoutAllKeys(Iterable<? extends K> keys)
-    {
-        return (ConcurrentHashMap<K, V>) super.withoutAllKeys(keys);
-    }
-
-    @Override
-    public MutableMap<K, V> clone()
-    {
-        return ConcurrentHashMap.newMap(this);
-    }
-
-    @Override
-    public <K, V> MutableMap<K, V> newEmpty(int capacity)
-    {
-        return ConcurrentHashMap.newMap();
-    }
-
-    @Override
-    public boolean notEmpty()
-    {
-        return !this.isEmpty();
-    }
-
-    @Override
-    public void forEachWithIndex(ObjectIntProcedure<? super V> objectIntProcedure)
-    {
-        Iterate.forEachWithIndex(this.values(), objectIntProcedure);
-    }
-
-    @Override
-    public Iterator<V> iterator()
-    {
-        return this.values().iterator();
-    }
-
-    @Override
-    public MutableMap<K, V> newEmpty()
-    {
-        return ConcurrentHashMap.newMap();
-    }
-
-    @Override
-    public ConcurrentMutableMap<K, V> tap(Procedure<? super V> procedure)
-    {
-        this.each(procedure);
-        return this;
-    }
-
-    @Override
-    public void forEachValue(Procedure<? super V> procedure)
-    {
-        IterableIterate.forEach(this.values(), procedure);
-    }
-
-    @Override
-    public void forEachKey(Procedure<? super K> procedure)
-    {
-        IterableIterate.forEach(this.keySet(), procedure);
-    }
-
-    @Override
-    public void forEachKeyValue(Procedure2<? super K, ? super V> procedure)
-    {
-        IterableIterate.forEach(this.entrySet(), new MapEntryToProcedure2<>(procedure));
-    }
-
-    @Override
-    public <E> MutableMap<K, V> collectKeysAndValues(
-            Iterable<E> iterable,
-            Function<? super E, ? extends K> keyFunction,
-            Function<? super E, ? extends V> valueFunction)
-    {
-        Iterate.addToMap(iterable, keyFunction, valueFunction, this);
-        return this;
-    }
-
-    @Override
-    public V removeKey(K key)
-    {
-        return this.remove(key);
-    }
-
-    @Override
-    public <P> V getIfAbsentPutWith(K key, Function<? super P, ? extends V> function, P parameter)
-    {
-        int hash = this.hash(key);
-        AtomicReferenceArray currentArray = this.table;
-        V newValue = null;
-        boolean createdValue = false;
-        while (true)
-        {
-            int length = currentArray.length();
-            int index = ConcurrentHashMap.indexFor(hash, length);
-            Object o = currentArray.get(index);
-            if (o == RESIZED || o == RESIZING)
-            {
-                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
-            }
-            else
-            {
-                Entry<K, V> e = (Entry<K, V>) o;
-                while (e != null)
-                {
-                    Object candidate = e.getKey();
-                    if (candidate.equals(key))
-                    {
-                        return e.getValue();
-                    }
-                    e = e.getNext();
-                }
-                if (!createdValue)
-                {
-                    createdValue = true;
-                    newValue = function.valueOf(parameter);
-                }
-                Entry<K, V> newEntry = new Entry<>(key, newValue, (Entry<K, V>) o);
-                if (currentArray.compareAndSet(index, o, newEntry))
-                {
-                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
-                    return newValue;
-                }
-            }
-        }
-    }
-
-    @Override
-    public V getIfAbsent(K key, Function0<? extends V> function)
-    {
-        V result = this.get(key);
-        if (result == null)
-        {
-            return function.value();
-        }
-        return result;
-    }
-
-    @Override
-    public <P> V getIfAbsentWith(
-            K key,
-            Function<? super P, ? extends V> function,
-            P parameter)
-    {
-        V result = this.get(key);
-        if (result == null)
-        {
-            return function.valueOf(parameter);
-        }
-        return result;
-    }
-
-    @Override
-    public <A> A ifPresentApply(K key, Function<? super V, ? extends A> function)
-    {
-        V result = this.get(key);
-        return result == null ? null : function.valueOf(result);
-    }
-
-    @Override
-    public <P> void forEachWith(Procedure2<? super V, ? super P> procedure, P parameter)
-    {
-        Iterate.forEachWith(this.values(), procedure, parameter);
-    }
-
-    @Override
-    public V updateValue(K key, Function0<? extends V> factory, Function<? super V, ? extends V> function)
-    {
-        int hash = this.hash(key);
-        AtomicReferenceArray currentArray = this.table;
-        int length = currentArray.length();
-        int index = ConcurrentHashMap.indexFor(hash, length);
-        Object o = currentArray.get(index);
-        if (o == null)
-        {
-            V result = function.valueOf(factory.value());
-            Entry<K, V> newEntry = new Entry<>(key, result, null);
-            if (currentArray.compareAndSet(index, null, newEntry))
-            {
-                this.addToSize(1);
-                return result;
-            }
-        }
-        return this.slowUpdateValue(key, factory, function, hash, currentArray);
-    }
-
-    private V slowUpdateValue(K key, Function0<? extends V> factory, Function<? super V, ? extends V> function, int hash, AtomicReferenceArray currentArray)
-    {
-        //noinspection LabeledStatement
-        outer:
-        while (true)
-        {
-            int length = currentArray.length();
-            int index = ConcurrentHashMap.indexFor(hash, length);
-            Object o = currentArray.get(index);
-            if (o == RESIZED || o == RESIZING)
-            {
-                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
-            }
-            else
-            {
-                Entry<K, V> e = (Entry<K, V>) o;
-                while (e != null)
-                {
-                    Object candidate = e.getKey();
-                    if (candidate.equals(key))
-                    {
-                        V oldValue = e.getValue();
-                        V newValue = function.valueOf(oldValue);
-                        Entry<K, V> newEntry = new Entry<>(e.getKey(), newValue, this.createReplacementChainForRemoval((Entry<K, V>) o, e));
-                        if (!currentArray.compareAndSet(index, o, newEntry))
-                        {
-                            //noinspection ContinueStatementWithLabel
-                            continue outer;
-                        }
-                        return newValue;
-                    }
-                    e = e.getNext();
-                }
-                V result = function.valueOf(factory.value());
-                Entry<K, V> newEntry = new Entry<>(key, result, (Entry<K, V>) o);
-                if (currentArray.compareAndSet(index, o, newEntry))
-                {
-                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
-                    return result;
-                }
-            }
-        }
-    }
-
-    @Override
-    public <P> V updateValueWith(K key, Function0<? extends V> factory, Function2<? super V, ? super P, ? extends V> function, P parameter)
-    {
-        int hash = this.hash(key);
-        AtomicReferenceArray currentArray = this.table;
-        int length = currentArray.length();
-        int index = ConcurrentHashMap.indexFor(hash, length);
-        Object o = currentArray.get(index);
-        if (o == null)
-        {
-            V result = function.value(factory.value(), parameter);
-            Entry<K, V> newEntry = new Entry<>(key, result, null);
-            if (currentArray.compareAndSet(index, null, newEntry))
-            {
-                this.addToSize(1);
-                return result;
-            }
-        }
-        return this.slowUpdateValueWith(key, factory, function, parameter, hash, currentArray);
-    }
-
-    private <P> V slowUpdateValueWith(
-            K key,
-            Function0<? extends V> factory,
-            Function2<? super V, ? super P, ? extends V> function,
-            P parameter,
-            int hash,
-            AtomicReferenceArray currentArray)
-    {
-        //noinspection LabeledStatement
-        outer:
-        while (true)
-        {
-            int length = currentArray.length();
-            int index = ConcurrentHashMap.indexFor(hash, length);
-            Object o = currentArray.get(index);
-            if (o == RESIZED || o == RESIZING)
-            {
-                currentArray = this.helpWithResizeWhileCurrentIndex(currentArray, index);
-            }
-            else
-            {
-                Entry<K, V> e = (Entry<K, V>) o;
-                while (e != null)
-                {
-                    Object candidate = e.getKey();
-                    if (candidate.equals(key))
-                    {
-                        V oldValue = e.getValue();
-                        V newValue = function.value(oldValue, parameter);
-                        Entry<K, V> newEntry = new Entry<>(e.getKey(), newValue, this.createReplacementChainForRemoval((Entry<K, V>) o, e));
-                        if (!currentArray.compareAndSet(index, o, newEntry))
-                        {
-                            //noinspection ContinueStatementWithLabel
-                            continue outer;
-                        }
-                        return newValue;
-                    }
-                    e = e.getNext();
-                }
-                V result = function.value(factory.value(), parameter);
-                Entry<K, V> newEntry = new Entry<>(key, result, (Entry<K, V>) o);
-                if (currentArray.compareAndSet(index, o, newEntry))
-                {
-                    this.incrementSizeAndPossiblyResize(currentArray, length, o);
-                    return result;
-                }
-            }
-        }
-    }
-
-    @Override
-    public ImmutableMap<K, V> toImmutable()
-    {
-        return Maps.immutable.ofMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -74,7 +74,9 @@ public class ConcurrentHashMapUnsafe<K, V>
     private static final AtomicReferenceFieldUpdater<ConcurrentHashMapUnsafe, Object[]> TABLE_UPDATER = AtomicReferenceFieldUpdater.newUpdater(ConcurrentHashMapUnsafe.class, Object[].class, "table");
     private static final Object RESIZED = new Object();
     private static final Object RESIZING = new Object();
-    private static final int PARTITIONED_SIZE_THRESHOLD = 4096; // chosen to keep size below 1% of the total size of the map
+
+    // chosen to keep size below 1% of the total size of the map
+    private static final int PARTITIONED_SIZE_THRESHOLD = 4096;
 
     private static final Unsafe UNSAFE;
     private static final long OBJECT_ARRAY_BASE;
@@ -123,8 +125,9 @@ public class ConcurrentHashMapUnsafe<K, V>
 
     private int[] partitionedSize;
 
+    // updated via atomic field updater
     @SuppressWarnings("UnusedDeclaration")
-    private volatile int size; // updated via atomic field updater
+    private volatile int size;
 
     public ConcurrentHashMapUnsafe()
     {
@@ -143,7 +146,9 @@ public class ConcurrentHashMapUnsafe<K, V>
         }
 
         int threshold = initialCapacity;
-        threshold += threshold >> 1; // threshold = length * 0.75
+
+        // threshold = length * 0.75
+        threshold += threshold >> 1;
 
         int capacity = 1;
         while (capacity < threshold)
@@ -152,7 +157,8 @@ public class ConcurrentHashMapUnsafe<K, V>
         }
         if (capacity >= PARTITIONED_SIZE_THRESHOLD)
         {
-            this.partitionedSize = new int[SIZE_BUCKETS * 16]; // we want 7 extra slots and 64 bytes for each slot. int is 4 bytes, so 64 bytes is 16 ints.
+            // we want 7 extra slots and 64 bytes for each slot. int is 4 bytes, so 64 bytes is 16 ints.
+            this.partitionedSize = new int[SIZE_BUCKETS * 16];
         }
         this.table = new Object[capacity + 1];
     }
@@ -217,7 +223,9 @@ public class ConcurrentHashMapUnsafe<K, V>
                 if (ConcurrentHashMapUnsafe.casArrayAt(currentArray, index, o, newEntry))
                 {
                     this.incrementSizeAndPossiblyResize(currentArray, length, o);
-                    return null; // per the contract of putIfAbsent, we return null when the map didn't have this key before
+
+                    // per the contract of putIfAbsent, we return null when the map didn't have this key before
+                    return null;
                 }
             }
         }
@@ -229,7 +237,10 @@ public class ConcurrentHashMapUnsafe<K, V>
         if (prev != null)
         {
             int localSize = this.size();
-            int threshold = (length >> 1) + (length >> 2); // threshold = length * 0.75
+
+            // threshold = length * 0.75
+            int threshold = (length >> 1) + (length >> 2);
+
             if (localSize + 1 > threshold)
             {
                 this.resize(currentArray);
@@ -300,7 +311,8 @@ public class ConcurrentHashMapUnsafe<K, V>
         boolean ownResize = false;
         if (last == null || last == RESIZE_SENTINEL)
         {
-            synchronized (oldTable) // allocating a new array is too expensive to make this an atomic operation
+            // allocating a new array is too expensive to make this an atomic operation
+            synchronized (oldTable)
             {
                 if (ConcurrentHashMapUnsafe.arrayAt(oldTable, end) == null)
                 {
@@ -446,7 +458,8 @@ public class ConcurrentHashMapUnsafe<K, V>
                 {
                     if (toCopyEntry.getNext() == null)
                     {
-                        newEntry = toCopyEntry; // no need to duplicate
+                        // no need to duplicate
+                        newEntry = toCopyEntry;
                     }
                     else
                     {
@@ -647,7 +660,8 @@ public class ConcurrentHashMapUnsafe<K, V>
                     newValue = factory.value(param1, param2, key);
                     if (newValue == null)
                     {
-                        return null; // null value means no mapping is required
+                        // null value means no mapping is required
+                        return null;
                     }
                     key = keyTransformer.value(key, newValue);
                 }
@@ -968,7 +982,9 @@ public class ConcurrentHashMapUnsafe<K, V>
         if (this.size() == 0)
         {
             int threshold = map.size();
-            threshold += threshold >> 1; // threshold = length * 0.75
+
+            // threshold = length * 0.75
+            threshold += threshold >> 1;
 
             int capacity = 1;
             while (capacity < threshold)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -2100,6 +2100,47 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         return this.shortCircuitWith(predicate, parameter, true, false, true);
     }
 
+    private static boolean nullSafeEquals(Object value, Object other)
+    {
+        if (value == null)
+        {
+            if (other == null)
+            {
+                return true;
+            }
+        }
+        else if (other == value || value.equals(other))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private K nonSentinel(Object key)
+    {
+        return key == NULL_KEY ? null : (K) key;
+    }
+
+    private static Object toSentinelIfNull(Object key)
+    {
+        if (key == null)
+        {
+            return NULL_KEY;
+        }
+        return key;
+    }
+
+    private boolean nonNullTableObjectEquals(Object cur, K key)
+    {
+        return cur == key || (cur == NULL_KEY ? key == null : cur.equals(key));
+    }
+
+    @Override
+    public ImmutableMap<K, V> toImmutable()
+    {
+        return Maps.immutable.withAll(this);
+    }
+
     protected class KeySet implements Set<K>, Serializable, BatchIterable<K>
     {
         private static final long serialVersionUID = 1L;
@@ -2531,22 +2572,6 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             this.lastReturned = true;
             return UnifiedMap.this.nonSentinel(cur);
         }
-    }
-
-    private static boolean nullSafeEquals(Object value, Object other)
-    {
-        if (value == null)
-        {
-            if (other == null)
-            {
-                return true;
-            }
-        }
-        else if (other == value || value.equals(other))
-        {
-            return true;
-        }
-        return false;
     }
 
     protected class EntrySet implements Set<Entry<K, V>>, Serializable, BatchIterable<Entry<K, V>>
@@ -3278,30 +3303,5 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             this.lastReturned = true;
             return (V) val;
         }
-    }
-
-    private K nonSentinel(Object key)
-    {
-        return key == NULL_KEY ? null : (K) key;
-    }
-
-    private static Object toSentinelIfNull(Object key)
-    {
-        if (key == null)
-        {
-            return NULL_KEY;
-        }
-        return key;
-    }
-
-    private boolean nonNullTableObjectEquals(Object cur, K key)
-    {
-        return cur == key || (cur == NULL_KEY ? key == null : cur.equals(key));
-    }
-
-    @Override
-    public ImmutableMap<K, V> toImmutable()
-    {
-        return Maps.immutable.withAll(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -297,7 +297,9 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
 
     protected int allocate(int capacity)
     {
-        this.allocateTable(capacity << 1); // the table size is twice the capacity to handle both keys and values
+        // the table size is twice the capacity to handle both keys and values
+        this.allocateTable(capacity << 1);
+
         this.computeMaxSize(capacity);
 
         return capacity;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -339,7 +339,9 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
 
     protected int allocate(int capacity)
     {
-        this.allocateTable(capacity << 1); // the table size is twice the capacity to handle both keys and values
+        // the table size is twice the capacity to handle both keys and values
+        this.allocateTable(capacity << 1);
+
         this.computeMaxSize(capacity);
 
         return capacity;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -1712,6 +1712,47 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         return target;
     }
 
+    private static boolean nullSafeEquals(Object value, Object other)
+    {
+        if (value == null)
+        {
+            if (other == null)
+            {
+                return true;
+            }
+        }
+        else if (other == value || value.equals(other))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private K nonSentinel(Object key)
+    {
+        return key == NULL_KEY ? null : (K) key;
+    }
+
+    private static Object toSentinelIfNull(Object key)
+    {
+        if (key == null)
+        {
+            return NULL_KEY;
+        }
+        return key;
+    }
+
+    private boolean nonNullTableObjectEquals(Object cur, K key)
+    {
+        return cur == key || (cur == NULL_KEY ? key == null : this.hashingStrategy.equals(this.nonSentinel(cur), key));
+    }
+
+    @Override
+    public ImmutableMap<K, V> toImmutable()
+    {
+        return HashingStrategyMaps.immutable.withAll(this);
+    }
+
     protected class KeySet implements Set<K>, Serializable, BatchIterable<K>
     {
         private static final long serialVersionUID = 1L;
@@ -2145,22 +2186,6 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             this.lastReturned = true;
             return UnifiedMapWithHashingStrategy.this.nonSentinel(cur);
         }
-    }
-
-    private static boolean nullSafeEquals(Object value, Object other)
-    {
-        if (value == null)
-        {
-            if (other == null)
-            {
-                return true;
-            }
-        }
-        else if (other == value || value.equals(other))
-        {
-            return true;
-        }
-        return false;
     }
 
     protected class EntrySet implements Set<Entry<K, V>>, Serializable, BatchIterable<Entry<K, V>>
@@ -2902,30 +2927,5 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             this.lastReturned = true;
             return (V) val;
         }
-    }
-
-    private K nonSentinel(Object key)
-    {
-        return key == NULL_KEY ? null : (K) key;
-    }
-
-    private static Object toSentinelIfNull(Object key)
-    {
-        if (key == null)
-        {
-            return NULL_KEY;
-        }
-        return key;
-    }
-
-    private boolean nonNullTableObjectEquals(Object cur, K key)
-    {
-        return cur == key || (cur == NULL_KEY ? key == null : this.hashingStrategy.equals(this.nonSentinel(cur), key));
-    }
-
-    @Override
-    public ImmutableMap<K, V> toImmutable()
-    {
-        return HashingStrategyMaps.immutable.withAll(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
@@ -233,24 +233,6 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
         return target;
     }
 
-    private static final class KeyValuePairFunction<V, K> implements Function<V, Pair<K, V>>
-    {
-        private static final long serialVersionUID = 1L;
-
-        private final K key;
-
-        private KeyValuePairFunction(K key)
-        {
-            this.key = key;
-        }
-
-        @Override
-        public Pair<K, V> valueOf(V value)
-        {
-            return Tuples.pair(this.key, value);
-        }
-    }
-
     @Override
     public <K2, V2, R extends MutableMultimap<K2, V2>> R collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function, R target)
     {
@@ -273,5 +255,23 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
     {
         this.getMap().forEachKeyValue((key, collection) -> target.putAll(key, collection.collect(function)));
         return target;
+    }
+
+    private static final class KeyValuePairFunction<V, K> implements Function<V, Pair<K, V>>
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final K key;
+
+        private KeyValuePairFunction(K key)
+        {
+            this.key = key;
+        }
+
+        @Override
+        public Pair<K, V> valueOf(V value)
+        {
+            return Tuples.pair(this.key, value);
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapImpl.java
@@ -83,29 +83,6 @@ public final class ImmutableListMultimapImpl<K, V>
         return new ImmutableListMultimapSerializationProxy<>(this.map);
     }
 
-    public static class ImmutableListMultimapSerializationProxy<K, V>
-            extends ImmutableMultimapSerializationProxy<K, V, ImmutableList<V>> implements Externalizable
-    {
-        private static final long serialVersionUID = 1L;
-
-        @SuppressWarnings("UnusedDeclaration")
-        public ImmutableListMultimapSerializationProxy()
-        {
-            // For Externalizable use only
-        }
-
-        public ImmutableListMultimapSerializationProxy(ImmutableMap<K, ImmutableList<V>> map)
-        {
-            super(map);
-        }
-
-        @Override
-        protected AbstractMutableMultimap<K, V, MutableList<V>> createEmptyMutableMultimap()
-        {
-            return new FastListMultimap<>();
-        }
-    }
-
     @Override
     public ImmutableListMultimap<K, V> newWith(K key, V value)
     {
@@ -177,5 +154,28 @@ public final class ImmutableListMultimapImpl<K, V>
     public <V2> ImmutableListMultimap<K, V2> collectValues(Function<? super V, ? extends V2> function)
     {
         return this.collectValues(function, FastListMultimap.<K, V2>newMultimap()).toImmutable();
+    }
+
+    public static class ImmutableListMultimapSerializationProxy<K, V>
+            extends ImmutableMultimapSerializationProxy<K, V, ImmutableList<V>> implements Externalizable
+    {
+        private static final long serialVersionUID = 1L;
+
+        @SuppressWarnings("UnusedDeclaration")
+        public ImmutableListMultimapSerializationProxy()
+        {
+            // For Externalizable use only
+        }
+
+        public ImmutableListMultimapSerializationProxy(ImmutableMap<K, ImmutableList<V>> map)
+        {
+            super(map);
+        }
+
+        @Override
+        protected AbstractMutableMultimap<K, V, MutableList<V>> createEmptyMutableMultimap()
+        {
+            return new FastListMultimap<>();
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapImpl.java
@@ -83,29 +83,6 @@ public final class ImmutableSetMultimapImpl<K, V>
         return new ImmutableSetMultimapSerializationProxy<>(this.map);
     }
 
-    private static final class ImmutableSetMultimapSerializationProxy<K, V>
-            extends ImmutableMultimapSerializationProxy<K, V, ImmutableSet<V>> implements Externalizable
-    {
-        private static final long serialVersionUID = 1L;
-
-        @SuppressWarnings("UnusedDeclaration")
-        public ImmutableSetMultimapSerializationProxy()
-        {
-            // For Externalizable use only
-        }
-
-        private ImmutableSetMultimapSerializationProxy(ImmutableMap<K, ImmutableSet<V>> map)
-        {
-            super(map);
-        }
-
-        @Override
-        protected AbstractMutableMultimap<K, V, MutableSet<V>> createEmptyMutableMultimap()
-        {
-            return new UnifiedSetMultimap<>();
-        }
-    }
-
     @Override
     public ImmutableSetMultimap<K, V> newWith(K key, V value)
     {
@@ -177,5 +154,28 @@ public final class ImmutableSetMultimapImpl<K, V>
     public <V2> ImmutableBagMultimap<K, V2> collectValues(Function<? super V, ? extends V2> function)
     {
         return this.collectValues(function, HashBagMultimap.<K, V2>newMultimap()).toImmutable();
+    }
+
+    private static final class ImmutableSetMultimapSerializationProxy<K, V>
+            extends ImmutableMultimapSerializationProxy<K, V, ImmutableSet<V>> implements Externalizable
+    {
+        private static final long serialVersionUID = 1L;
+
+        @SuppressWarnings("UnusedDeclaration")
+        public ImmutableSetMultimapSerializationProxy()
+        {
+            // For Externalizable use only
+        }
+
+        private ImmutableSetMultimapSerializationProxy(ImmutableMap<K, ImmutableSet<V>> map)
+        {
+            super(map);
+        }
+
+        @Override
+        protected AbstractMutableMultimap<K, V, MutableSet<V>> createEmptyMutableMultimap()
+        {
+            return new UnifiedSetMultimap<>();
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapImpl.java
@@ -111,45 +111,6 @@ public final class ImmutableSortedSetMultimapImpl<K, V>
         return new ImmutableSortedSetMultimapSerializationProxy<>(this.map, this.comparator());
     }
 
-    private static final class ImmutableSortedSetMultimapSerializationProxy<K, V>
-            extends ImmutableMultimapSerializationProxy<K, V, ImmutableSortedSet<V>> implements Externalizable
-    {
-        private static final long serialVersionUID = 1L;
-        private Comparator<? super V> comparator;
-
-        @SuppressWarnings("UnusedDeclaration")
-        public ImmutableSortedSetMultimapSerializationProxy()
-        {
-            // For Externalizable use only
-        }
-
-        private ImmutableSortedSetMultimapSerializationProxy(ImmutableMap<K, ImmutableSortedSet<V>> map, Comparator<? super V> comparator)
-        {
-            super(map);
-            this.comparator = comparator;
-        }
-
-        @Override
-        public void writeExternal(ObjectOutput out) throws IOException
-        {
-            out.writeObject(this.comparator);
-            super.writeExternal(out);
-        }
-
-        @Override
-        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
-        {
-            this.comparator = (Comparator<? super V>) in.readObject();
-            super.readExternal(in);
-        }
-
-        @Override
-        protected AbstractMutableMultimap<K, V, MutableSortedSet<V>> createEmptyMutableMultimap()
-        {
-            return new TreeSortedSetMultimap<>(this.comparator);
-        }
-    }
-
     @Override
     public ImmutableSortedSetMultimap<K, V> newWith(K key, V value)
     {
@@ -221,5 +182,44 @@ public final class ImmutableSortedSetMultimapImpl<K, V>
     public <V2> ImmutableListMultimap<K, V2> collectValues(Function<? super V, ? extends V2> function)
     {
         return this.collectValues(function, FastListMultimap.<K, V2>newMultimap()).toImmutable();
+    }
+
+    private static final class ImmutableSortedSetMultimapSerializationProxy<K, V>
+            extends ImmutableMultimapSerializationProxy<K, V, ImmutableSortedSet<V>> implements Externalizable
+    {
+        private static final long serialVersionUID = 1L;
+        private Comparator<? super V> comparator;
+
+        @SuppressWarnings("UnusedDeclaration")
+        public ImmutableSortedSetMultimapSerializationProxy()
+        {
+            // For Externalizable use only
+        }
+
+        private ImmutableSortedSetMultimapSerializationProxy(ImmutableMap<K, ImmutableSortedSet<V>> map, Comparator<? super V> comparator)
+        {
+            super(map);
+            this.comparator = comparator;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException
+        {
+            out.writeObject(this.comparator);
+            super.writeExternal(out);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
+        {
+            this.comparator = (Comparator<? super V>) in.readObject();
+            super.readExternal(in);
+        }
+
+        @Override
+        protected AbstractMutableMultimap<K, V, MutableSortedSet<V>> createEmptyMutableMultimap()
+        {
+            return new TreeSortedSetMultimap<>(this.comparator);
+        }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSet.java
@@ -123,7 +123,8 @@ abstract class AbstractMemoryEfficientMutableSet<T>
     protected abstract class MemoryEfficientSetIterator
             implements Iterator<T>
     {
-        private int next;    // next entry to return, defaults to 0
+        // next entry to return, defaults to 0
+        private int next;
 
         protected abstract T getElement(int i);
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSet.java
@@ -316,7 +316,8 @@ public abstract class AbstractImmutableSet<T> extends AbstractImmutableCollectio
     protected abstract class ImmutableSetIterator
             implements Iterator<T>
     {
-        private int next;    // next entry to return, defaults to 0
+        // next entry to return, defaults to 0
+        private int next;
 
         protected abstract T getElement(int i);
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/UnifiedSet.java
@@ -1923,7 +1923,8 @@ public class UnifiedSet<T>
                         }
                         return bucket.three;
                     case 4:
-                        return null; // this happens when a bucket is exactly full and we're iterating
+                        // this happens when a bucket is exactly full and we're iterating
+                        return null;
                     default:
                         throw new AssertionError();
                 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSet.java
@@ -50,10 +50,16 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
     private static final byte MAX_BYTE_GROUP_1 = -65;
     private static final byte MAX_BYTE_GROUP_2 = -1;
     private static final byte MAX_BYTE_GROUP_3 = 63;
-    private long bitGroup1; // -128 to -65
-    private long bitGroup2; //-64 to -1
-    private long bitGroup3; //0 to 63
-    private long bitGroup4; // 64 to 127
+
+    // -128 to -65
+    private long bitGroup1;
+    // -64 to -1
+    private long bitGroup2;
+    // 0 to 63
+    private long bitGroup3;
+    // 64 to 127
+    private long bitGroup4;
+
     private short size;
 
     public ByteHashSet()
@@ -843,7 +849,7 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
 
         if (this.bitGroup1 != 0L)
         {
-            //the minimum has to be from this
+            // the minimum has to be from this
             min = (byte) (128 - Long.numberOfLeadingZeros(this.bitGroup1));
             min *= -1;
         }
@@ -1005,10 +1011,16 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
     private static final class ImmutableByteHashSet implements ImmutableByteSet, Serializable
     {
         private static final long serialVersionUID = 1L;
-        private final long bitGroup1; // -128 to -65
-        private final long bitGroup2; //-64 to -1
-        private final long bitGroup3; //0 to 63
-        private final long bitGroup4; // 64 to 127
+
+        // -128 to -65
+        private final long bitGroup1;
+        // -64 to -1
+        private final long bitGroup2;
+        // 0 to 63
+        private final long bitGroup3;
+        // 64 to 127
+        private final long bitGroup4;
+
         private final short size;
 
         private ImmutableByteHashSet(
@@ -1470,7 +1482,7 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
 
             if (this.bitGroup1 != 0L)
             {
-                //the minimum has to be from this
+                // the minimum has to be from this
                 min = (byte) (128 - Long.numberOfLeadingZeros(this.bitGroup1));
                 min *= -1;
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/strategy/mutable/UnifiedSetWithHashingStrategy.java
@@ -1993,7 +1993,8 @@ public class UnifiedSetWithHashingStrategy<T>
                         }
                         return bucket.three;
                     case 4:
-                        return null; // this happens when a bucket is exactly full and we're iterating
+                        // this happens when a bucket is exactly full and we're iterating
+                        return null;
                     default:
                         throw new AssertionError();
                 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ArrayIterate.java
@@ -120,11 +120,13 @@ public final class ArrayIterate
     {
         if (comparator == null)
         {
-            Arrays.sort(array, 0, size); // handles case size < 2 in Java 8 ComparableTimSort
+            // handles case size < 2 in Java 8 ComparableTimSort
+            Arrays.sort(array, 0, size);
         }
         else
         {
-            Arrays.sort(array, 0, size, comparator); // handles case size < 2 in Java 8 TimSort
+            // handles case size < 2 in Java 8 TimSort
+            Arrays.sort(array, 0, size, comparator);
         }
     }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/ListIterate.java
@@ -95,7 +95,8 @@ public final class ListIterate
 
     public static boolean equals(List<?> one, List<?> two)
     {
-        if (one.size() != two.size())   // we assume that size() is a constant time operation in most lists
+        // we assume that size() is a constant time operation in most lists
+        if (one.size() != two.size())
         {
             return false;
         }

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapSmallStressTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapSmallStressTest.java
@@ -151,7 +151,10 @@ public class IntIntMapSmallStressTest extends AbstractJMHTestRunner
     protected MutableList<Integer> getJDKSequenceCollisions(int lower, int upper)
     {
         MutableList<Integer> jdkCollidingNumbers = FastList.newList();
-        int slots = 1; // slots = KEY_COUNT / (1 << 32) / (1 << MAP_SIZE) + 1;
+
+        // slots = KEY_COUNT / (1 << 32) / (1 << MAP_SIZE) + 1;
+        int slots = 1;
+
         MutableIntSet indices = new IntHashSet();
         for (int i = lower; i < upper && jdkCollidingNumbers.size() < KEY_COUNT; i++)
         {

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/map/KolobokeMapPutTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/map/KolobokeMapPutTest.java
@@ -40,8 +40,11 @@ public class KolobokeMapPutTest extends AbstractJMHTestRunner
     public int size;
     @Param({"true", "false"})
     public boolean isPresized;
+
+    // Adding a loadFactor for only ease of data plots
     @Param("0.75")
-    public float loadFactor; //Adding a loadFactor for only ease of data plots
+    public float loadFactor;
+
     private String[] elements;
 
     @Setup

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/map/ScalaAnyRefMapPutTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/map/ScalaAnyRefMapPutTest.java
@@ -40,8 +40,11 @@ public class ScalaAnyRefMapPutTest extends AbstractJMHTestRunner
     public int size;
     @Param({"true", "false"})
     public boolean isPresized;
+
+    //Adding a loadFactor for only ease of data plots
     @Param("0.75")
-    public float loadFactor; //Adding a loadFactor for only ease of data plots
+    public float loadFactor;
+
     private String[] elements;
 
     @Setup

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <scala.version>2.12.6</scala.version>
         <guava.version>25.1-jre</guava.version>
         <trove4j.version>3.0.3</trove4j.version>
-        <checkstyle.version>8.18</checkstyle.version>
+        <checkstyle.version>8.29</checkstyle.version>
         <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
         <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
         <jacoco.plugin.version>0.8.5</jacoco.plugin.version>

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
@@ -2060,7 +2060,7 @@ public interface RichIterableTestCase extends IterableTestCase
                         Tuples.pair("11", 1),
                         Tuples.pair("3", 3),
                         Tuples.pair("2", 2),
-                        Tuples.pair("1", 1)
+                        Tuples.pair("1", 1),
                 };
         assertEquals(
                 TreeSortedMap.newMapWith(pairs),

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
@@ -1054,7 +1054,7 @@ public interface RichIterableUniqueTestCase extends RichIterableTestCase
                         Tuples.pair("11", 1),
                         Tuples.pair("3", 3),
                         Tuples.pair("2", 2),
-                        Tuples.pair("1", 1)
+                        Tuples.pair("1", 1),
                 };
         assertEquals(
                 TreeSortedMap.newMapWith(pairs),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/NonInstantiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/NonInstantiableTest.java
@@ -88,7 +88,7 @@ public class NonInstantiableTest
             SetIterables.class,
             SetIterate.class,
             SortedMaps.class,
-            SortedSetIterables.class
+            SortedSetIterables.class,
     };
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -1033,8 +1033,11 @@ public class IntervalTest
         MutableList<Integer> tapResult = Lists.mutable.of();
         Interval interval = Interval.fromTo(10, -10).by(-5);
         LazyIterable<Integer> lazyTapIterable = interval.tap(tapResult::add);
+
+        // force evaluation
         lazyTapIterable.each(x -> {
-        }); //force evaluation
+        });
+
         Assert.assertEquals(interval, tapResult);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
@@ -126,9 +126,15 @@ public class FixedSizeListFactoryTest
     {
         String[] content = {"one", "two"};
 
-        //List<Object>   list1 = Lists.fixedSize.of(content);  // incompatible types: List<Object> vs List<String>
-        //List<String[]> list2 = Lists.fixedSize.of(content);  // incompatible types: List<String[]> vs List<String>
-        List<String[]> list3 = Lists.fixedSize.<String[]>of(content);  // correct!
+        // fails with "incompatible types: List<Object> vs List<String>"
+        // List<Object> list1 = Lists.fixedSize.of(content);
+
+        // fails with "incompatible types: List<String[]> vs List<String>"
+        // List<String[]> list2 = Lists.fixedSize.of(content);
+
+        // successfully compiles
+        List<String[]> list3 = Lists.fixedSize.<String[]>of(content);
+
         Verify.assertSize(1, list3);
 
         MutableList<String> list4 = Lists.fixedSize.of(content);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -506,17 +506,26 @@ public class FastListTest extends AbstractListTestCase
     @Test
     public void testRemoveAllWithWeakReference()
     {
-        String fred = new String("Fred");    // Deliberate String copy for unit test purpose
-        String wilma = new String("Wilma");  // Deliberate String copy for unit test purpose
+        // Deliberate String copy for unit test purpose
+        String fred = new String("Fred");
+
+        // Deliberate String copy for unit test purpose
+        String wilma = new String("Wilma");
+
         FastList<String> objects = FastList.<String>newList().with(fred, wilma);
         objects.removeAll(mList("Fred"));
         objects.remove(0);
         Verify.assertSize(0, objects);
         WeakReference<String> ref = new WeakReference<>(wilma);
+
+        // Deliberate null of a local variable for unit test purpose
         //noinspection ReuseOfLocalVariable
-        fred = null;   // Deliberate null of a local variable for unit test purpose
+        fred = null;
+
+        // Deliberate null of a local variable for unit test purpose
         //noinspection ReuseOfLocalVariable
-        wilma = null;  // Deliberate null of a local variable for unit test purpose
+        wilma = null;
+
         System.gc();
         Thread.yield();
         System.gc();
@@ -1191,7 +1200,9 @@ public class FastListTest extends AbstractListTestCase
         Assert.assertEquals(
                 Bags.mutable.of("A", "1", "2", "3", "4"),
                 list.toBag());
-        Verify.assertStartsWith(list, "A", "1", "2");  // "3" and "4" are from a set, so may not be in order
+
+        // "3" and "4" are from a set, so may not be in order
+        Verify.assertStartsWith(list, "A", "1", "2");
 
         Assert.assertEquals(
                 FastList.newListWith(42, 10, 11, 12),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
@@ -487,17 +487,26 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     @Test
     public void removeAllWithWeakReference()
     {
-        String fred = new String("Fred");    // Deliberate String copy for unit test purpose
-        String wilma = new String("Wilma");  // Deliberate String copy for unit test purpose
+        // Deliberate String copy for unit test purpose
+        String fred = new String("Fred");
+
+        // Deliberate String copy for unit test purpose
+        String wilma = new String("Wilma");
+
         MutableList<String> objects = MultiReaderFastList.newListWith(fred, wilma);
         objects.removeAll(Lists.fixedSize.of("Fred"));
         objects.remove(0);
         Verify.assertEmpty(objects);
         WeakReference<String> ref = new WeakReference<>(wilma);
+
+        // Deliberate null of a local variable for unit test purpose
         //noinspection ReuseOfLocalVariable
-        fred = null;   // Deliberate null of a local variable for unit test purpose
+        fred = null;
+
+        // Deliberate null of a local variable for unit test purpose
         //noinspection ReuseOfLocalVariable
-        wilma = null;  // Deliberate null of a local variable for unit test purpose
+        wilma = null;
+
         System.gc();
         Thread.yield();
         System.gc();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
@@ -250,8 +250,10 @@ public abstract class MapIterableTestCase
         Verify.assertSize(8, result);
         Verify.assertContainsAll(
                 result,
-                "One", "Two", "Three", "Four", // Map values
-                "0", "1", "2", "3");  // Stringified index values
+                // Map values
+                "One", "Two", "Three", "Four",
+                // Stringified index values
+                "0", "1", "2", "3");
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
@@ -367,7 +367,9 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         multi.forEachKey(each -> Verify.assertContains(each, values));
 
         Assert.assertEquals(multi.size(), map.size());
-        Assert.assertTrue(multi.sizeDistinct() <= map.size()); // should be the same or less since values are degenerate
+
+        // should be the same or less since values are degenerate
+        Assert.assertTrue(multi.sizeDistinct() <= map.size());
 
         MutableMap<String, Integer> siMap = this.mixedTypeClassUnderTest();
         MutableMultimap<Integer, String> siMulti = siMap.flip();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
@@ -142,7 +142,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void keySet_toArray_withSmallTarget()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Integer[] destination = new Integer[2]; // deliberately to small to force the method to allocate one of the correct size
+
+        // deliberately to small to force the method to allocate one of the correct size
+        Integer[] destination = new Integer[2];
+
         Integer[] result = map.keySet().toArray(destination);
         Arrays.sort(result);
         Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
@@ -152,7 +155,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void keySet_ToArray_withLargeTarget()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Integer[] target = new Integer[6]; // deliberately large to force the extra to be set to null
+
+        // deliberately large to force the extra to be set to null
+        Integer[] target = new Integer[6];
+
         target[4] = 42;
         target[5] = 42;
         Integer[] result = map.keySet().toArray(target);
@@ -310,7 +316,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void valuesCollection_PostSerializedEquality_chainedMapWithEmptySlot()
     {
         MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(4);
-        map.put(42, 42); // add non-colliding key
+
+        // add non-colliding key
+        map.put(42, 42);
+
         Collection<Integer> values = map.values();
         // This test is not using Verify.assertPostSerializedEqualsAndHashCode b/c the deserialized form of the values view is a FastList, which will not be equals to the orginal view (a Collection).
         Collection<Integer> revived = SerializeTestHelper.serializeDeserialize(values);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
@@ -215,7 +215,10 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     public void keySet_toArray_withSmallTarget()
     {
         ImmutableTreeMap<Integer, String> immutableSortedMap = new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4"));
-        Integer[] destination = new Integer[2]; // deliberately to small to force the method to allocate one of the correct size
+
+        // deliberately to small to force the method to allocate one of the correct size
+        Integer[] destination = new Integer[2];
+
         Integer[] result = immutableSortedMap.keySet().toArray(destination);
         Arrays.sort(result);
         Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
@@ -225,7 +228,10 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     public void keySet_ToArray_withLargeTarget()
     {
         ImmutableTreeMap<Integer, String> immutableSortedMap = new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4"));
-        Integer[] target = new Integer[6]; // deliberately large to force the extra to be set to null
+
+        // deliberately large to force the extra to be set to null
+        Integer[] target = new Integer[6];
+
         target[4] = 42;
         target[5] = 42;
         Integer[] result = immutableSortedMap.keySet().toArray(target);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
@@ -38,7 +38,10 @@ public class UnifiedSetAsPoolTest
         UnifiedSet<AlwaysEqual> pool = UnifiedSet.newSet();
         AlwaysEqual firstObject = new AlwaysEqual();
         pool.put(firstObject);
-        AlwaysEqual equalObject = new AlwaysEqual();  // deliberate new instance
+
+        // deliberate new instance
+        AlwaysEqual equalObject = new AlwaysEqual();
+
         Assert.assertSame(firstObject, pool.get(equalObject));
     }
 
@@ -71,7 +74,10 @@ public class UnifiedSetAsPoolTest
         AlwaysEqual firstObject = new AlwaysEqual();
         UnifiedSet<AlwaysEqual> pool = UnifiedSet.newSet();
         pool.put(firstObject);
-        AlwaysEqual secondObject = new AlwaysEqual();  // deliberate new instance
+
+        // deliberate new instance
+        AlwaysEqual secondObject = new AlwaysEqual();
+
         Object returnedObject = pool.put(secondObject);
 
         Assert.assertSame(returnedObject, firstObject);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
@@ -48,8 +48,12 @@ public class LongHashSetExtraTest
                 }
             }
         }
-        interestingHashes.contains(1840593613821121L); // this is a test that the operation doesn't go into an infinite loop
-        interestingHashes.add(1840593613821121L); // this is a test that the operation doesn't go into an infinite loop
+
+        // this is a test that the operation doesn't go into an infinite loop
+        interestingHashes.contains(1840593613821121L);
+
+        // this is a test that the operation doesn't go into an infinite loop
+        interestingHashes.add(1840593613821121L);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
@@ -830,9 +830,12 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.getIntegerList();
         Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detect(list, Integer.valueOf(1)::equals));
+
+        // test relies on having a unique instance of "2"
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         ArrayList<Integer> list2 =
-                this.newArrayList(1, new Integer(2), 2);  // test relies on having a unique instance of "2"
+                this.newArrayList(1, new Integer(2), 2);
+
         Assert.assertSame(list2.get(1), ArrayListIterate.detect(list2, Integer.valueOf(2)::equals));
     }
 
@@ -848,9 +851,12 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.getIntegerList();
         Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detectWith(list, Object::equals, 1));
-        //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
+
+        // test relies on having a unique instance of "2"
+        // noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         ArrayList<Integer> list2 =
-                this.newArrayList(1, new Integer(2), 2);  // test relies on having a unique instance of "2"
+                this.newArrayList(1, new Integer(2), 2);
+
         Assert.assertSame(list2.get(1), ArrayListIterate.detectWith(list2, Object::equals, 2));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -585,7 +585,7 @@ public class IterateTest
                 Tuples.pair("Key2", "2"),
                 Tuples.pair("Key3", "3"),
                 Tuples.pair("Key3", "3"),
-                Tuples.pair("Key3", "3")
+                Tuples.pair("Key3", "3"),
         };
         Function<Integer, String> keyFunction = each -> "Key" + each;
         Function<Integer, String> valueFunction = String::valueOf;
@@ -855,7 +855,7 @@ public class IterateTest
                 Tuples.pair("Key3", "1"),
                 Tuples.pair("Key3", "3"),
                 Tuples.pair("Key3", "1"),
-                Tuples.pair("Key3", "3")
+                Tuples.pair("Key3", "3"),
         };
 
         Function<Integer, String> keyFunction = each -> "Key" + each;


### PR DESCRIPTION
We were about 10 versions behind on CheckStyle. I upgraded locally to the latest and I've been experimenting with getting our configuration to be closer to CheckStyle's own configuration for its own GitHub project [here](https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-8.28/config/checkstyle_checks.xml). This check was already available in the older version and only had a few violations. If this rule is controversial we can skip it. There are other new rules I also plan on turning on as I have time.