### PR TITLE
Expose the allocateTable method as protected

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
@@ -1296,7 +1296,7 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
         return false;
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new Object[sizeToAllocate];
         this.values = new <type>[sizeToAllocate];

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
@@ -1322,7 +1322,7 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
         return false;
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new Object[sizeToAllocate];
         this.values = new <type>[sizeToAllocate];

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
@@ -283,7 +283,7 @@ public class <name>BooleanHashMap extends AbstractMutableBooleanValuesMap implem
         return !isEmptyKey(key) && !isRemovedKey(key);
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new <type>[sizeToAllocate];
         this.values = new BitSet(sizeToAllocate);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -2999,7 +2999,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return spread & (this.keys.length - 1);
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new <type>[sizeToAllocate];
         this.values = (V[]) new Object[sizeToAllocate];

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -959,7 +959,7 @@ public class <name1><name2>HashMap extends AbstractMutable<name2>ValuesMap imple
         return spread & (<if(sameTwoPrimitives)>(<endif>this.<keyArray>.length<if(sameTwoPrimitives)> \>> 1)<endif> - 1);
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.<keyArray> = new <type1>[sizeToAllocate<if(sameTwoPrimitives)> \<\< 1<endif>];
         <if(!sameTwoPrimitives)>

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -946,7 +946,7 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
         }
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.table = new <type>[sizeToAllocate];
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
@@ -1106,7 +1106,7 @@ public class ObjectBooleanHashMap<K> implements MutableObjectBooleanMap<K>, Exte
         }
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new Object[sizeToAllocate];
         this.values = new BitSet(sizeToAllocate);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
@@ -1117,7 +1117,7 @@ public class ObjectBooleanHashMapWithHashingStrategy<K> implements MutableObject
         }
     }
 
-    private void allocateTable(int sizeToAllocate)
+    protected void allocateTable(int sizeToAllocate)
     {
         this.keys = new Object[sizeToAllocate];
         this.values = new BitSet(sizeToAllocate);


### PR DESCRIPTION
This will provide a way to dynamically restrict the growth of the backing arrays. See #787 for reference.
