### PR TITLE
Implementation for 3-tuple, Triple and Triplet

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triple.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triple.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.tuple;
+
+import java.io.Serializable;
+
+public interface Triple<T1, T2, T3>
+        extends Serializable, Comparable<Triple<T1, T2, T3>>
+{
+    T1 getOne();
+
+    T2 getTwo();
+
+    T3 getThree();
+
+    Triple<T3, T2, T1> reverse();
+}
+

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triplet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/tuple/Triplet.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.tuple;
+
+public interface Triplet<T> extends Triple<T, T, T>
+{
+    Triplet<T> reverse();
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/TripleImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/TripleImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.tuple;
+
+import java.util.Objects;
+
+import org.eclipse.collections.api.tuple.Triple;
+
+class TripleImpl<T1, T2, T3> implements Triple<T1, T2, T3>
+{
+    private static final long serialVersionUID = 1L;
+
+    private final T1 one;
+    private final T2 two;
+    private final T3 three;
+
+    TripleImpl(T1 one, T2 two, T3 three)
+    {
+        this.one = one;
+        this.two = two;
+        this.three = three;
+    }
+
+    @Override
+    public T1 getOne()
+    {
+        return this.one;
+    }
+
+    @Override
+    public T2 getTwo()
+    {
+        return this.two;
+    }
+
+    @Override
+    public T3 getThree()
+    {
+        return this.three;
+    }
+
+    @Override
+    public TripleImpl<T3, T2, T1> reverse()
+    {
+        return new TripleImpl<>(this.three, this.two, this.one);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof Triple))
+        {
+            return false;
+        }
+
+        Triple<?, ?, ?> that = (Triple<?, ?, ?>) o;
+
+        return Objects.equals(this.one, that.getOne())
+                && Objects.equals(this.two, that.getTwo())
+                && Objects.equals(this.three, that.getThree());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = this.one == null ? 0 : this.one.hashCode();
+        result = 29 * result + (this.two == null ? 0 : this.two.hashCode());
+        result = 43 * result + (this.three == null ? 0 : this.three.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.one + ":" + this.two + ":" + this.three;
+    }
+
+    @Override
+    public int compareTo(Triple<T1, T2, T3> other)
+    {
+        int i = ((Comparable<T1>) this.one).compareTo(other.getOne());
+        if (i != 0)
+        {
+            return i;
+        }
+        int j = ((Comparable<T2>) this.two).compareTo(other.getTwo());
+        if (j != 0)
+        {
+            return j;
+        }
+        return ((Comparable<T3>) this.three).compareTo(other.getThree());
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/TripletImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/TripletImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.tuple;
+
+import org.eclipse.collections.api.tuple.Triplet;
+
+class TripletImpl<T> extends TripleImpl<T, T, T> implements Triplet<T>
+{
+    private static final long serialVersionUID = 1L;
+
+    TripletImpl(T newOne, T newTwo, T newThree)
+    {
+        super(newOne, newTwo, newThree);
+    }
+
+    @Override
+    public TripletImpl<T> reverse()
+    {
+        return new TripletImpl<>(this.getThree(), this.getTwo(), this.getOne());
+    }
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/Tuples.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/tuple/Tuples.java
@@ -13,12 +13,17 @@ package org.eclipse.collections.impl.tuple;
 import java.util.Map;
 
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.api.tuple.Triple;
+import org.eclipse.collections.api.tuple.Triplet;
 import org.eclipse.collections.api.tuple.Twin;
 
 /**
  * A Pair is a container that holds two related objects. It is the equivalent of an Association in Smalltalk, or an
  * implementation of Map.Entry in the JDK. A Twin is a Pair with the same types. This class is a factory class
  * for Pairs and Twins.
+ *
+ * A Triple is a container that holds three related objects. Similar to Haskell a Tuple is container that can contain 2 or more objects.
+ * The Triple is the implementation of the 3-tuple. A Triplet is a Triple with the same types. This class holds factory methods for Triples and Triplets
  *
  * The equivalent class for primitive and object combinations is {@link org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples}
  */
@@ -41,5 +46,15 @@ public final class Tuples
     public static <T> Twin<T> twin(T one, T two)
     {
         return new TwinImpl<>(one, two);
+    }
+
+    public static <T1, T2, T3> Triple<T1, T2, T3> triple(T1 one, T2 two, T3 three)
+    {
+        return new TripleImpl<>(one, two, three);
+    }
+
+    public static <T> Triplet<T> triplet(T one, T two, T three)
+    {
+        return new TripletImpl<>(one, two, three);
     }
 }

--- a/java.header
+++ b/java.header
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) 201\d .*\.$
+^ \* Copyright \(c\) 20(1|2)\d .*\.$
 ^ \* All rights reserved\. This program and the accompanying materials$
 ^ \* are made available under the terms of the Eclipse Public License v1\.0$
 ^ \* and Eclipse Distribution License v\. 1\.0 which accompany this distribution\.$

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.api.tuple.Triple;
+import org.eclipse.collections.api.tuple.Triplet;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
@@ -49,6 +51,24 @@ public class TuplesTest
     }
 
     @Test
+    public void triple()
+    {
+        Triple<String, String, String> triple = Tuples.triple("1", "2", "3");
+        Assert.assertEquals("1", triple.getOne());
+        Assert.assertEquals("2", triple.getTwo());
+        Assert.assertEquals("3", triple.getThree());
+    }
+
+    @Test
+    public void triplet()
+    {
+        Triplet<String> triplet = Tuples.triplet("1", "2", "3");
+        Assert.assertEquals("1", triplet.getOne());
+        Assert.assertEquals("2", triplet.getTwo());
+        Assert.assertEquals("3", triplet.getThree());
+    }
+
+    @Test
     public void equalsHashCode()
     {
         Twin<String> pair1 = Tuples.twin("1", "1");
@@ -59,6 +79,19 @@ public class TuplesTest
         Verify.assertEqualsAndHashCode(pair1, pair1a);
         Assert.assertNotEquals(pair1, pair2);
         Assert.assertNotEquals(pair1, new Object());
+    }
+
+    @Test
+    public void equalsHashCodeTriple()
+    {
+        Triplet<String> triple1 = Tuples.triplet("1", "1", "1");
+        Triple<String, String, String> triple1a = Tuples.triple("1", "1", "1");
+        Triple<String, String, String> triple2 = Tuples.triple("2", "2", "2");
+
+        Verify.assertEqualsAndHashCode(triple1, triple1);
+        Verify.assertEqualsAndHashCode(triple1, triple1a);
+        Assert.assertNotEquals(triple1, triple2);
+        Assert.assertNotEquals(triple1, new Object());
     }
 
     @Test
@@ -75,8 +108,10 @@ public class TuplesTest
     public void testToString()
     {
         Pair<String, String> pair1 = Tuples.pair("1", "1");
-
         Assert.assertEquals("1:1", pair1.toString());
+
+        Triple<String, String, String> triple = Tuples.triple("1", "2",  "3");
+        Assert.assertEquals("1:2:3", triple.toString());
     }
 
     @Test
@@ -104,5 +139,25 @@ public class TuplesTest
         Assert.assertEquals("1", swappedTwin.getOne());
         Assert.assertEquals("One", swappedTwin.getTwo());
         Assert.assertEquals(expectedTwin, swappedTwin);
+    }
+
+    @Test
+    public void reverse()
+    {
+        Triple<String, Integer, Boolean> triple = Tuples.triple("One",  2,  true);
+        Triple<Boolean, Integer, String> reversedTriple = triple.reverse();
+        Triple<Boolean, Integer, String> expectedTriple = Tuples.triple(true, 2, "One");
+        Assert.assertEquals(true, reversedTriple.getOne());
+        Assert.assertEquals(Integer.valueOf(2), reversedTriple.getTwo());
+        Assert.assertEquals("One", reversedTriple.getThree());
+        Assert.assertEquals(expectedTriple, reversedTriple);
+
+        Triplet<String> triplet = Tuples.triplet("One", "2", "true");
+        Triplet<String> reversedTriplet = triplet.reverse();
+        Triplet<String> expectedTriplet = Tuples.triplet("true", "2", "One");
+        Assert.assertEquals("true", reversedTriplet.getOne());
+        Assert.assertEquals("2", reversedTriplet.getTwo());
+        Assert.assertEquals("One", reversedTriplet.getThree());
+        Assert.assertEquals(expectedTriplet, reversedTriplet);
     }
 }


### PR DESCRIPTION
An implementation similar to tuple for 3 elements like in Haskell
I use this sometimes and was not part of this great collections framework.

Other frameworks do have this kind of implementations like apache commons lang3
Tuples with more than 2 elements are also a common datatype in a language like Python, .Net and bunch of functional languages.
