### PR TITLE
Add GitHub Action Workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,5 +20,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Enable Maven Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Maven
+      run: mvn install
+      env:
+        MAVEN_OPTS: "-Xmx1g"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,8 @@ jobs:
   project-build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         java-version: [8, 11, 14-ea, 15-ea]
 
     runs-on: ${{ matrix.os }}
@@ -22,7 +23,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.1
+        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,24 +10,31 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  project-build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        java-version: [8, 11, 14-ea, 15-ea]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Enable Maven Cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Maven
-      run: mvn install
-      env:
-        MAVEN_OPTS: "-Xmx1g"
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Set Maven Wrapper
+        run: mvn -N io.takari:maven:wrapper -Dmaven=3.6.1
+      - name: Set JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Enable Maven Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Maven
+        run: ./mvnw verify
+        env:
+          MAVEN_OPTS: "-Xmx1g"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Eclipse Collections CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Eclipse Collections CI
+name: Eclipse Collections CI Build
 
 on:
   push:


### PR DESCRIPTION
Builds on Ubuntu and for the following versions of Java:

- 8
- 11
- 14-EA
- 15-EA

Since it uses the Setup Java action from GitHub, it leverages Azul Zulu builds by default. If needed, it is possible to download (wget) and then use the parameter `jdkFile` to tell Setup Java where to get the JDK.