### PR TITLE
Add covariant overrides for sortThis().

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/FixedSizeList.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.list;
 
+import java.util.Comparator;
+
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.FixedSizeCollection;
 
@@ -38,4 +40,17 @@ public interface FixedSizeList<T>
 
     @Override
     FixedSizeList<T> tap(Procedure<? super T> procedure);
+
+    @Override
+    default FixedSizeList<T> sortThis(Comparator<? super T> comparator)
+    {
+        this.sort(comparator);
+        return this;
+    }
+
+    @Override
+    default FixedSizeList<T> sortThis()
+    {
+        return this.sortThis(null);
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MultiReaderList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MultiReaderList.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.api.list;
 
+import java.util.Comparator;
+
 import org.eclipse.collections.api.block.procedure.Procedure;
 
 /**
@@ -23,4 +25,17 @@ public interface MultiReaderList<T>
     void withReadLockAndDelegate(Procedure<? super MutableList<T>> procedure);
 
     void withWriteLockAndDelegate(Procedure<? super MutableList<T>> procedure);
+
+    @Override
+    default MultiReaderList<T> sortThis(Comparator<? super T> comparator)
+    {
+        this.sort(comparator);
+        return this;
+    }
+
+    @Override
+    default MultiReaderList<T> sortThis()
+    {
+        return this.sortThis(null);
+    }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
@@ -452,7 +452,7 @@ public final class MultiReaderFastList<T>
     }
 
     @Override
-    public MutableList<T> sortThis()
+    public MultiReaderList<T> sortThis()
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
         {
@@ -462,7 +462,7 @@ public final class MultiReaderFastList<T>
     }
 
     @Override
-    public MutableList<T> sortThis(Comparator<? super T> comparator)
+    public MultiReaderList<T> sortThis(Comparator<? super T> comparator)
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireWriteLock())
         {


### PR DESCRIPTION
While reviewing #801, I wanted to point out that methods that return `this` need covariant overrides on all sub-interfaces. I wanted to point to sortThis() as an example and was surprised to find that it's missing overrides.

While unlikely to cause problems for users, I believe this is a breaking change and can wait for the next major version.