### PR TITLE
feat: remove redundant travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,43 +18,13 @@ jobs:
         - CMD="./mvnw install --projects acceptance-tests --also-make --activate-profiles all --no-transfer-progress"
 
     - jdk: oraclejdk8
-      env:
-        - DESC="findbugs"
-        - CMD="./mvnw install findbugs:check --projects '!scala-unit-tests,!jmh-scala-tests,!jmh-tests,!jcstress-tests,!p2-repository' --activate-profiles all -DskipTests=true --no-transfer-progress"
-
-    - jdk: oraclejdk8
-      env:
-        - DESC="checkstyle"
-        - CMD="./mvnw install checkstyle:check --activate-profiles all -DskipTests=true --no-transfer-progress"
-
-    - jdk: oraclejdk8
-      env:
-        - DESC="unit tests"
+      env:		
+        - DESC="unit tests"		
         - CMD="./mvnw install"
-
-    - jdk: oraclejdk8
-      env:
-        - DESC="compile performance-tests"
-        - CMD="./mvnw install --projects performance-tests --also-make --activate-profiles all -DskipTests=true --no-transfer-progress"
-
-    - jdk: oraclejdk11
-      env:
-        - DESC="compile javadoc"
-        - CMD="./mvnw install javadoc:jar --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin,eclipse-collections-api,eclipse-collections,eclipse-collections-testutils,eclipse-collections-forkjoin' --activate-profiles all -DskipTests=true --no-transfer-progress"
-
-    - jdk: openjdk11
-      env:
-        - DESC="unit tests openjdk11"
-        - CMD="./mvnw install --no-transfer-progress"
 
     - jdk: oraclejdk11
       env:
         - DESC="unit tests oraclejdk11"
-        - CMD="./mvnw install --no-transfer-progress"
-
-    - jdk: openjdk14
-      env:
-        - DESC="unit tests openjdk14"
         - CMD="./mvnw install --no-transfer-progress"
 
     - jdk: oraclejdk14


### PR DESCRIPTION
This cleans up some travis build, since we have the GitHub Actions 


Part of #821 