### PR TITLE
feat: Add 15-ea as an experimental build in GitHub actions

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Beta Tests
+
+on: [push, pull_request]
+
+jobs:
+  applications:
+    name: Unit Test ${{ matrix.java-version }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: [15-ea]
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+
+    env:
+      JAVA_VERSION: ${{ matrix.java-version }}
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Set Maven Wrapper
+        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+      - name: Set JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Unit-Test
+        run: ./mvnw verify
+        env:
+          MAVEN_OPTS: "-Xmx1g"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ jobs:
         - DESC="unit tests oraclejdk14"
         - CMD="./mvnw install --no-transfer-progress"
 
-    - jdk: openjdk-ea
-      env:
-        - DESC="unit tests openjdk-ea"
-        - CMD="./mvnw install --no-transfer-progress"
-
     - jdk: oraclejdk8
       env:
         - DESC="unit tests Java15-EA"
@@ -44,10 +39,6 @@ jobs:
         - CMD="./.travis-command-ea-builds.sh"
 
   allow_failures:
-    - jdk: openjdk-ea
-      env:
-        - DESC="unit tests openjdk-ea"
-        - CMD="./mvnw install --no-transfer-progress"
     - jdk: oraclejdk8
       env:
         - DESC="unit tests Java15-EA"


### PR DESCRIPTION
Signed-off-by: sendilkumarn <sendilkumarn@live.com>


This removes 15-ea build from the Travis and adds it to the GitHub Actions. These tests are allowed to fail.

Part of #821

cc: @donraab 