### PR TITLE
Pull up RichIterable.groupByUniqueKey() as default methods.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/ImmutableBiMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/ImmutableBiMap.java
@@ -16,6 +16,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.BiMaps;
 import org.eclipse.collections.api.map.ImmutableMapIterable;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -118,7 +119,11 @@ public interface ImmutableBiMap<K, V> extends BiMap<K, V>, ImmutableMapIterable<
     <V1> ImmutableSetMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
     @Override
-    <VV> ImmutableBiMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> ImmutableBiMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        MutableBiMap<VV, V> target = BiMaps.mutable.empty();
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     /**
      * @deprecated in 8.0. Use {@link OrderedIterable#zip(Iterable)} instead.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/MutableBiMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bimap/MutableBiMap.java
@@ -17,6 +17,7 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.factory.BiMaps;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -122,7 +123,10 @@ public interface MutableBiMap<K, V> extends BiMap<K, V>, MutableMapIterable<K, V
     <V1> MutableSetMultimap<V1, V> groupByEach(Function<? super V, ? extends Iterable<V1>> function);
 
     @Override
-    <VV> MutableBiMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> MutableBiMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, BiMaps.mutable.empty());
+    }
 
     @Override
     MutableBiMap<K, V> withKeyValue(K key, V value);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/ImmutableCollection.java
@@ -41,7 +41,9 @@ import org.eclipse.collections.api.collection.primitive.ImmutableFloatCollection
 import org.eclipse.collections.api.collection.primitive.ImmutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.ImmutableShortCollection;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.multimap.ImmutableMultimap;
@@ -195,7 +197,11 @@ public interface ImmutableCollection<T>
     <V> ImmutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+    default <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        MutableMap<V, T> target = Maps.mutable.withInitialCapacity(this.size());
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     @Override
     <S> ImmutableCollection<Pair<T, S>> zip(Iterable<S> that);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/collection/MutableCollection.java
@@ -38,6 +38,7 @@ import org.eclipse.collections.api.collection.primitive.MutableFloatCollection;
 import org.eclipse.collections.api.collection.primitive.MutableIntCollection;
 import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
@@ -525,7 +526,10 @@ public interface MutableCollection<T>
     <V> MutableMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+    default <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        return this.groupByUniqueKey(function, Maps.mutable.withInitialCapacity(this.size()));
+    }
 
     /**
      * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ImmutableMap.java
@@ -34,6 +34,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.ImmutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -170,7 +171,11 @@ public interface ImmutableMap<K, V>
     <VV> ImmutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
     @Override
-    <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
+    default <V1> ImmutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
+    {
+        MutableMap<V1, V> target = Maps.mutable.withInitialCapacity(this.size());
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     @Override
     <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMap.java
@@ -36,6 +36,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -177,7 +178,10 @@ public interface MutableMap<K, V>
     <VV> MutableBagMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
     @Override
-    <V1> MutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function);
+    default <V1> MutableMap<V1, V> groupByUniqueKey(Function<? super V, ? extends V1> function)
+    {
+        return this.groupByUniqueKey(function, Maps.mutable.withInitialCapacity(this.size()));
+    }
 
     @Override
     <K2, V2> MutableMap<K2, V2> aggregateInPlaceBy(

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/ImmutablePrimitiveObjectMap.java
@@ -33,7 +33,9 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.ImmutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
 import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
@@ -58,7 +60,11 @@ public interface ImmutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
     <VV> ImmutableBagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function);
 
     @Override
-    <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        MutableMap<VV, V> target = Maps.mutable.withInitialCapacity(this.size());
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     @Override
     <VV> ImmutableBag<VV> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends VV> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/primitive/MutablePrimitiveObjectMap.java
@@ -33,6 +33,7 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.ordered.OrderedIterable;
@@ -57,7 +58,10 @@ public interface MutablePrimitiveObjectMap<V> extends PrimitiveObjectMap<V>
     <VV> MutableBagMultimap<VV, V> groupBy(Function<? super V, ? extends VV> function);
 
     @Override
-    <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, Maps.mutable.withInitialCapacity(this.size()));
+    }
 
     @Override
     <VV> MutableBag<VV> collectIf(Predicate<? super V> predicate, Function<? super V, ? extends VV> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/ImmutableSortedMap.java
@@ -28,6 +28,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableByteList;
@@ -39,6 +40,7 @@ import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.ImmutableShortList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.ImmutableMapIterable;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
 import org.eclipse.collections.api.multimap.sortedset.ImmutableSortedSetMultimap;
 import org.eclipse.collections.api.partition.list.PartitionImmutableList;
@@ -186,7 +188,11 @@ public interface ImmutableSortedMap<K, V>
     <VV> ImmutableListMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
     @Override
-    <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> ImmutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        MutableMap<VV, V> target = Maps.mutable.withInitialCapacity(this.size());
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     @Override
     <K2, V2> ImmutableMap<K2, V2> aggregateInPlaceBy(

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/sorted/MutableSortedMap.java
@@ -28,6 +28,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.collection.MutableCollection;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableByteList;
@@ -237,7 +238,10 @@ public interface MutableSortedMap<K, V>
     <VV> MutableListMultimap<VV, V> groupByEach(Function<? super V, ? extends Iterable<VV>> function);
 
     @Override
-    <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function);
+    default <VV> MutableMap<VV, V> groupByUniqueKey(Function<? super V, ? extends VV> function)
+    {
+        return this.groupByUniqueKey(function, Maps.mutable.withInitialCapacity(this.size()));
+    }
 
     // TODO: When we have implementations of linked hash maps
     // MutableOrderedMap<V, K> flipUniqueValues();

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/ImmutableStack.java
@@ -27,7 +27,9 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
@@ -175,7 +177,11 @@ public interface ImmutableStack<T> extends StackIterable<T>
     <V> ImmutableListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+    default <V> ImmutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        MutableMap<V, T> target = Maps.mutable.withInitialCapacity(this.size());
+        return this.groupByUniqueKey(function, target).toImmutable();
+    }
 
     @Override
     <S> ImmutableStack<Pair<T, S>> zip(Iterable<S> that);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/stack/MutableStack.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectDoubleMap;
@@ -217,7 +218,10 @@ public interface MutableStack<T> extends StackIterable<T>
     <V> MutableListMultimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     @Override
-    <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
+    default <V> MutableMap<V, T> groupByUniqueKey(Function<? super T, ? extends V> function)
+    {
+        return this.groupByUniqueKey(function, Maps.mutable.withInitialCapacity(this.size()));
+    }
 
     @Override
     <S> MutableStack<Pair<T, S>> zip(Iterable<S> that);


### PR DESCRIPTION
Based on the conversation here: https://github.com/eclipse/eclipse-collections/pull/865#discussion_r419031392 I decided to try to pull up another method that we found, without removing any implementations. This was partially an experiment to see how fast it can be.