### PR TITLE
Added to primitive iterables toArray() method which takes an array parameter

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -64,6 +64,16 @@ public interface <name>Iterable extends PrimitiveIterable
     <type>[] toArray();
 
     /**
+     * Converts the <name>Iterable to a primitive <type> array. If the collection fits into the provided array it is used
+     * to store its elements and is returned from the method, otherwise a new array of the appropriate size is allocated
+     * and returned. If the iterable is empty, the target array is returned unchanged.
+     */
+    default <type>[] toArray(<type>[] target)
+    {
+        return this.toList().toArray(target);
+    }
+
+    /**
      * Returns true if the value is contained in the <name>Iterable, and false if it is not.
      */
     boolean contains(<type> value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveEmptyBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveEmptyBag.stg
@@ -305,6 +305,12 @@ final class Immutable<name>EmptyBag implements Immutable<name>Bag, Serializable
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public String toString()
     {
         return "[]";

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveHashBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveHashBag.stg
@@ -347,6 +347,12 @@ final class Immutable<name>HashBag implements Immutable<name>Bag, Serializable
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.delegate.toArray(target);
+    }
+
+    @Override
     public String toString()
     {
         return this.delegate.toString();

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveSingletonBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveSingletonBag.stg
@@ -347,6 +347,20 @@ final class Immutable<name>SingletonBag implements Immutable<name>Bag, Serializa
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type>[]{this.element1};
+        }
+        else
+        {
+            target[0] = this.element1;
+        }
+        return target;
+    }
+
+    @Override
     public String toString()
     {
         return '[' + this.makeString() + ']';

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
@@ -746,6 +746,28 @@ public class <name>HashBag
     }
 
     @Override
+    public <type>[] toArray(<type>[] array)
+    {
+        if (array.length \< this.size())
+        {
+            array = new <type>[this.size()];
+        }
+
+        int[] index = {0};
+
+        <type>[] finalBypass = array;
+        this.forEachWithOccurrences((<type> each, int occurrences) ->
+        {
+            for (int i = 0; i \< occurrences; i++)
+            {
+                finalBypass[index[0]] = each;
+                index[0]++;
+            }
+        });
+        return array;
+    }
+
+    @Override
     public Mutable<name>Bag asUnmodifiable()
     {
         return new Unmodifiable<name>Bag(this);

--- a/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractSynchronizedPrimitiveCollection.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractSynchronizedPrimitiveCollection.stg
@@ -394,6 +394,15 @@ public abstract class AbstractSynchronized<name>Collection
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        synchronized (this.lock)
+        {
+            return this.collection.toArray(target);
+        }
+    }
+
+    @Override
     public String toString()
     {
         synchronized (this.lock)

--- a/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractUnmodifiablePrimitiveCollection.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/collection/mutable/abstractUnmodifiablePrimitiveCollection.stg
@@ -287,6 +287,12 @@ public abstract class AbstractUnmodifiable<name>Collection
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.collection.toArray(target);
+    }
+
+    @Override
     public String toString()
     {
         return this.collection.toString();

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
@@ -430,6 +430,17 @@ final class Immutable<name>ArrayList
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< this.items.length)
+        {
+            target = new <type>[this.items.length];
+        }
+        System.arraycopy(this.items, 0, target, 0, this.items.length);
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         for (<type> item : this.items)

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveEmptyList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveEmptyList.stg
@@ -173,6 +173,12 @@ final class Immutable<name>EmptyList implements Immutable<name>List, Serializabl
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return false;

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
@@ -186,6 +186,20 @@ final class Immutable<name>SingletonList implements Immutable<name>List, Seriali
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type>[]{this.element1};
+        }
+        else
+        {
+            target[0] = this.element1;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return <(equals.(type))("this.element1", "value")>;

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -863,6 +863,17 @@ public class <name>ArrayList extends Abstract<name>Iterable
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< this.size)
+        {
+            target = new <type>[this.size];
+        }
+        System.arraycopy(this.items, 0, target, 0, this.size);
+        return target;
+    }
+
+    @Override
     public boolean equals(Object otherList)
     {
         if (otherList == this)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveKeySet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveKeySet.stg
@@ -596,6 +596,30 @@ public abstract class AbstractMutable<name>KeySet implements Mutable<name>Set
     }
 
     @Override
+    public <type>[] toArray(<type>[] result)
+    {
+        int size = this.getOuter().size();
+        if (result.length \< size)
+        {
+            result = new <type>[size];
+        }
+
+        <type>[] finalBypass = result;
+
+        this.getOuter().forEachKey(new <name>Procedure()
+        {
+            private int index;
+
+            public void value(<type> each)
+            {
+                finalBypass[this.index] = each;
+                this.index++;
+            }
+        });
+        return result;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.getOuter().containsKey(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveValuesMap.stg
@@ -251,6 +251,20 @@ public abstract class AbstractMutable<name>ValuesMap extends Abstract<name>Itera
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< this.size())
+        {
+            target = new <type>[this.size()];
+        }
+        int index = 0;
+
+        <forEachValue(template = {target[index] = <value>;<\n>index++})>
+
+        return target;
+    }
+
+    @Override
     public Mutable<name>Bag select(<name>Predicate predicate)
     {
         return this.select(predicate, new <name>HashBag());
@@ -747,6 +761,12 @@ result = nextSum})>
         public <type>[] toArray()
         {
             return AbstractMutable<name>ValuesMap.this.toArray();
+        }
+
+        @Override
+        public <type>[] toArray(<type>[] target)
+        {
+            return AbstractMutable<name>ValuesMap.this.toArray(target);
         }
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveEmptyMap.stg
@@ -148,6 +148,12 @@ final class ImmutableObject<name>EmptyMap\<K> implements ImmutableObject<name>Ma
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return false;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
@@ -178,6 +178,12 @@ final class ImmutableObject<name>HashMap\<K> extends AbstractImmutableObject<nam
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.delegate.toArray(target);
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.delegate.contains(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveSingletonMap.stg
@@ -168,6 +168,20 @@ final class ImmutableObject<name>SingletonMap\<K> extends AbstractImmutableObjec
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type>[]{this.value1};
+        }
+        else
+        {
+            target[0] = this.value1;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return <(equals.(type))("this.value1", "value")>;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
@@ -251,6 +251,12 @@ final class Immutable<name1><name2>EmptyMap implements Immutable<name1><name2>Ma
     }
 
     @Override
+    public <type2>[] toArray(<type2>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public boolean contains(<type2> value)
     {
         return false;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
@@ -283,6 +283,12 @@ final class Immutable<name1><name2>HashMap implements Immutable<name1><name2>Map
     }
 
     @Override
+    public <type2>[] toArray(<type2>[] target)
+    {
+        return this.delegate.toArray(target);
+    }
+
+    @Override
     public boolean contains(<type2> value)
     {
         return this.delegate.contains(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
@@ -268,6 +268,20 @@ final class Immutable<name1><name2>SingletonMap implements Immutable<name1><name
     }
 
     @Override
+    public <type2>[] toArray(<type2>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type2>[]{this.value1};
+        }
+        else
+        {
+            target[0] = this.value1;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type2> value)
     {
         return <(equals.(type2))("this.value1", "value")>;

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
@@ -373,6 +373,26 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< this.size())
+        {
+            target = new <type>[this.size()];
+        }
+        int index = 0;
+
+        for (int i = 0; i \< this.keys.length; i++)
+        {
+            if (isNonSentinel(this.keys[i]))
+            {
+                target[index] = this.values[i];
+                index++;
+            }
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.containsValue(value);
@@ -1821,6 +1841,12 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
         public <type>[] toArray()
         {
             return Object<name>HashMap.this.toArray();
+        }
+
+        @Override
+        public <type>[] toArray(<type>[] target)
+        {
+            return Object<name>HashMap.this.toArray(target);
         }
 
         @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
@@ -396,6 +396,26 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< this.size())
+        {
+            target = new <type>[this.size()];
+        }
+        int index = 0;
+
+        for (int i = 0; i \< this.keys.length; i++)
+        {
+            if (isNonSentinel(this.keys[i]))
+            {
+                target[index] = this.values[i];
+                index++;
+            }
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.containsValue(value);
@@ -1847,6 +1867,12 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
         public <type>[] toArray()
         {
             return Object<name>HashMapWithHashingStrategy.this.toArray();
+        }
+
+        @Override
+        public <type>[] toArray(<type>[] target)
+        {
+            return Object<name>HashMapWithHashingStrategy.this.toArray(target);
         }
 
         @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveImmutableKeySets.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveImmutableKeySets.stg
@@ -138,6 +138,18 @@ class <className> extends AbstractImmutable<name>Set implements Serializable
     }
 
     @Override
+    public <type>[] toArray(<type>[] array)
+    {
+        if (array.length \< this.size())
+        {
+            array = new <type>[this.size()];
+        }
+        int index = 0;
+        <forEachKey("toArray")>
+        return array;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         if (<(equals.(type))("value", "EMPTY_KEY")>)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -3611,6 +3611,29 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         }
 
         @Override
+        public <type>[] toArray(<type>[] result)
+        {
+            int size = <name>ObjectHashMap.this.size();
+            if (result.length \< size)
+            {
+                result = new <type>[size];
+            }
+            final <type>[] finalBypass = result;
+            <name>ObjectHashMap.this.forEachKey(new <name>Procedure()
+            {
+                private int index;
+
+                @Override
+                public void value(<type> each)
+                {
+                    finalBypass[this.index] = each;
+                    this.index++;
+                }
+            });
+            return result;
+        }
+
+        @Override
         public boolean contains(<type> value)
         {
             return <name>ObjectHashMap.this.containsKey(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedObjectPrimitiveMap.stg
@@ -404,6 +404,15 @@ public class SynchronizedObject<name>Map\<K>
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        synchronized (this.lock)
+        {
+            return this.map.toArray(target);
+        }
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         synchronized (this.lock)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
@@ -438,6 +438,15 @@ public class Synchronized<name1><name2>Map
     }
 
     @Override
+    public <type2>[] toArray(<type2>[] target)
+    {
+        synchronized (this.lock)
+        {
+            return this.map.toArray(target);
+        }
+    }
+
+    @Override
     public boolean contains(<type2> value)
     {
         synchronized (this.lock)

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiableObjectPrimitiveMap.stg
@@ -306,6 +306,12 @@ public class UnmodifiableObject<name>Map\<K>
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.map.toArray(target);
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.map.contains(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/unmodifiablePrimitivePrimitiveMap.stg
@@ -316,6 +316,12 @@ public class Unmodifiable<name1><name2>Map
     }
 
     @Override
+    public <type2>[] toArray(<type2>[] target)
+    {
+        return this.map.toArray(target);
+    }
+
+    @Override
     public boolean contains(<type2> value)
     {
         return this.map.contains(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveEmptySet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveEmptySet.stg
@@ -258,6 +258,12 @@ final class Immutable<name>EmptySet implements Immutable<name>Set, Serializable
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public String toString()
     {
         return "[]";

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveSingletonSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveSingletonSet.stg
@@ -302,6 +302,20 @@ final class Immutable<name>SingletonSet implements Immutable<name>Set, Serializa
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type>[]{this.element};
+        }
+        else
+        {
+            target[0] = this.element;
+        }
+        return target;
+    }
+
+    @Override
     public String toString()
     {
         return '[' + this.makeString() + ']';

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -500,6 +500,35 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
     }
 
     @Override
+    public <type>[] toArray(<type>[] array)
+    {
+        if (array.length \< this.size())
+        {
+            array = new <type>[this.size()];
+        }
+
+        int j = 0;
+        int zeroToThirtyOne = this.zeroToThirtyOne;
+        while (zeroToThirtyOne != 0)
+        {
+            <type> value = <(castFromInt.(type))("Integer.numberOfTrailingZeros(zeroToThirtyOne)")>;
+            array[j] = value;
+            j++;
+            zeroToThirtyOne &= ~(1 \<\< <(castRealTypeToInt.(type))("value")>);
+        }
+
+        for (int i = 0; i \< this.table.length && j \< this.size(); i++)
+        {
+            if (isNonSentinel(this.table[i]))
+            {
+                array[j] = this.table[i];
+                j++;
+            }
+        }
+        return array;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         if (isBetweenZeroAndThirtyOne(value))
@@ -1168,6 +1197,35 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
         public <type>[] toArray()
         {
             <type>[] array = new <type>[this.size()];
+
+            int j = 0;
+            int zeroToThirtyOne = this.zeroToThirtyOne;
+            while (zeroToThirtyOne != 0)
+            {
+                <type> value = <(castFromInt.(type))("Integer.numberOfTrailingZeros(zeroToThirtyOne)")>;
+                array[j] = value;
+                j++;
+                zeroToThirtyOne &= ~(1 \<\< <(castRealTypeToInt.(type))("value")>);
+            }
+
+            for (int i = 0; i \< this.table.length && j \< this.size(); i++)
+            {
+                if (isNonSentinel(this.table[i]))
+                {
+                    array[j] = this.table[i];
+                    j++;
+                }
+            }
+            return array;
+        }
+
+        @Override
+        public <type>[] toArray(<type>[] array)
+        {
+            if (array.length \< this.size())
+            {
+                array = new <type>[this.size()];
+            }
 
             int j = 0;
             int zeroToThirtyOne = this.zeroToThirtyOne;

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/abstractPrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/abstractPrimitiveStack.stg
@@ -167,6 +167,12 @@ public abstract class Abstract<name>Stack implements <name>Stack
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.getDelegate().asReversed().toArray(target);
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return this.getDelegate().asReversed().contains(value);

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
@@ -158,6 +158,12 @@ final class Immutable<name>EmptyStack implements Immutable<name>Stack, Serializa
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return false;

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
@@ -171,6 +171,20 @@ final class Immutable<name>SingletonStack implements Immutable<name>Stack, Seria
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        if (target.length \< 1)
+        {
+            target = new <type>[]{this.element1};
+        }
+        else
+        {
+            target[0] = this.element1;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         return <(equals.(type))("this.element1", "value")>;

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
@@ -297,6 +297,15 @@ public class Synchronized<name>Stack
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        synchronized (this.lock)
+        {
+            return this.stack.toArray(target);
+        }
+    }
+
+    @Override
     public String toString()
     {
         synchronized (this.lock)

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
@@ -213,6 +213,12 @@ public class Unmodifiable<name>Stack
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        return this.stack.toArray(target);
+    }
+
+    @Override
     public String toString()
     {
         return this.stack.toString();

--- a/eclipse-collections-code-generator/src/main/resources/impl/synchronizedPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/synchronizedPrimitiveIterable.stg
@@ -84,6 +84,15 @@ public class Synchronized<name>Iterable implements <name>Iterable, Serializable
     }
 
     @Override
+    public <type>[] toArray(<type>[] target)
+    {
+        synchronized (this.lock)
+        {
+            return this.iterable.toArray(target);
+        }
+    }
+
+    @Override
     public boolean contains(<type> value)
     {
         synchronized (this.lock)

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -707,6 +707,36 @@ public void sumConsistentRounding()
     }
 
     @Test
+    public void toArrayWithTargetArray()
+    {
+        <type>[] originalAsSortedArray = this.classUnderTest().toSortedArray();
+
+        <type>[] target = new <type>[this.classUnderTest().size()];
+
+        Assert.assertSame(target, this.classUnderTest().toArray(target));
+        Arrays.sort(target);
+        Assert.assertTrue(Arrays.equals(originalAsSortedArray, target));
+
+        if (this.classUnderTest().size() > 0)
+        {
+            <type>[] targetTooSmall = new <type>[this.classUnderTest().size() - 1];
+            <type>[] result = this.classUnderTest().toArray(targetTooSmall);
+            Assert.assertNotSame(targetTooSmall, result);
+            Arrays.sort(result);
+            Assert.assertTrue(Arrays.equals(this.classUnderTest().toSortedArray(), result));
+        }
+
+        <type>[] targetTooBig = new <type>[this.classUnderTest().size() + 1];
+        <type>[] bigResult = this.classUnderTest().toArray(targetTooBig);
+        Assert.assertSame(targetTooBig, bigResult);
+        Arrays.sort(targetTooBig);
+        for (int i = 0; i \< originalAsSortedArray.length; i++)
+        {
+            Assert.assertEquals(originalAsSortedArray[i], bigResult[i + 1]<(delta.(type))>);
+        }
+    }
+
+    @Test
     public void toSortedArray()
     {
         <name>Iterable iterable = this.classUnderTest();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBag.java
@@ -839,6 +839,28 @@ public final class BooleanHashBag implements MutableBooleanBag, Externalizable
     }
 
     @Override
+    public boolean[] toArray(boolean[] array)
+    {
+        if (array.length < this.size())
+        {
+            array = new boolean[this.size()];
+        }
+        int[] index = {0};
+
+        boolean[] finalBypass = array;
+
+        this.forEachWithOccurrences((each, occurrences) ->
+        {
+            for (int i = 0; i < occurrences; i++)
+            {
+                finalBypass[index[0]] = each;
+                index[0]++;
+            }
+        });
+        return array;
+    }
+
+    @Override
     public MutableBooleanList toList()
     {
         return BooleanArrayList.newList(this);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
@@ -296,6 +296,20 @@ final class ImmutableBooleanArrayList
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        if (target.length < this.size)
+        {
+            target = new boolean[this.size];
+        }
+        for (int i = 0; i < this.size; i++)
+        {
+            target[i] = this.items.get(i);
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         for (int i = 0; i < this.size; i++)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
@@ -799,6 +799,17 @@ public final class BooleanArrayList
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        if (target.length < this.size)
+        {
+            target = new boolean[this.size];
+        }
+        System.arraycopy(this.items, 0, target, 0, this.size);
+        return target;
+    }
+
+    @Override
     public boolean equals(Object otherList)
     {
         if (otherList == this)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -605,6 +605,18 @@ public final class IntInterval
     }
 
     @Override
+    public int[] toArray(int[] result)
+    {
+        if (result.length < this.size())
+        {
+            result = new int[this.size()];
+        }
+        int[] finalBypass = result;
+        this.forEachWithIndex((each, index) -> finalBypass[index] = each);
+        return result;
+    }
+
+    @Override
     public <T> T injectInto(T injectedValue, ObjectIntToObjectFunction<? super T, ? extends T> function)
     {
         T result = injectedValue;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableBooleanValuesMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableBooleanValuesMap.java
@@ -470,6 +470,40 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
         return array;
     }
 
+    @Override
+    public boolean[] toArray(boolean[] array)
+    {
+        if (array.length < this.size())
+        {
+            array = new boolean[this.size()];
+        }
+        int index = 0;
+
+        if (this.getSentinelValues() != null)
+        {
+            if (this.getSentinelValues().containsZeroKey)
+            {
+                array[index] = this.getSentinelValues().zeroValue;
+                index++;
+            }
+            if (this.getSentinelValues().containsOneKey)
+            {
+                array[index] = this.getSentinelValues().oneValue;
+                index++;
+            }
+        }
+        for (int i = 0; i < this.getTableSize(); i++)
+        {
+            if (this.isNonSentinelAtIndex(i))
+            {
+                array[index] = this.getValueAtIndex(i);
+                index++;
+            }
+        }
+
+        return array;
+    }
+
     protected static class SentinelValues extends AbstractSentinelValues
     {
         protected boolean zeroValue;
@@ -748,6 +782,12 @@ public abstract class AbstractMutableBooleanValuesMap extends AbstractBooleanIte
         public boolean[] toArray()
         {
             return AbstractMutableBooleanValuesMap.this.toArray();
+        }
+
+        @Override
+        public boolean[] toArray(boolean[] target)
+        {
+            return AbstractMutableBooleanValuesMap.this.toArray(target);
         }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
@@ -378,6 +378,25 @@ public class ObjectBooleanHashMap<K> implements MutableObjectBooleanMap<K>, Exte
     }
 
     @Override
+    public boolean[] toArray(boolean[] result)
+    {
+        if (result.length < this.size())
+        {
+            result = new boolean[this.size()];
+        }
+        int index = 0;
+        for (int i = 0; i < this.keys.length; i++)
+        {
+            if (ObjectBooleanHashMap.isNonSentinel(this.keys[i]))
+            {
+                result[index] = this.values.get(i);
+                index++;
+            }
+        }
+        return result;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return this.containsValue(value);
@@ -1515,6 +1534,12 @@ public class ObjectBooleanHashMap<K> implements MutableObjectBooleanMap<K>, Exte
         public boolean[] toArray()
         {
             return ObjectBooleanHashMap.this.toArray();
+        }
+
+        @Override
+        public boolean[] toArray(boolean[] target)
+        {
+            return ObjectBooleanHashMap.this.toArray(target);
         }
 
         @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
@@ -394,6 +394,25 @@ public class ObjectBooleanHashMapWithHashingStrategy<K> implements MutableObject
     }
 
     @Override
+    public boolean[] toArray(boolean[] result)
+    {
+        if (result.length < this.size())
+        {
+            result = new boolean[this.size()];
+        }
+        int index = 0;
+        for (int i = 0; i < this.keys.length; i++)
+        {
+            if (ObjectBooleanHashMapWithHashingStrategy.isNonSentinel(this.keys[i]))
+            {
+                result[index] = this.values.get(i);
+                index++;
+            }
+        }
+        return result;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return this.containsValue(value);
@@ -1530,6 +1549,12 @@ public class ObjectBooleanHashMapWithHashingStrategy<K> implements MutableObject
         public boolean[] toArray()
         {
             return ObjectBooleanHashMapWithHashingStrategy.this.toArray();
+        }
+
+        @Override
+        public boolean[] toArray(boolean[] target)
+        {
+            return ObjectBooleanHashMapWithHashingStrategy.this.toArray(target);
         }
 
         @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySet.java
@@ -162,6 +162,12 @@ final class ImmutableBooleanEmptySet implements ImmutableBooleanSet, Serializabl
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        return target;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return false;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableFalseSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableFalseSet.java
@@ -166,6 +166,20 @@ final class ImmutableFalseSet implements ImmutableBooleanSet, Serializable
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        if (target.length < 1)
+        {
+            target = new boolean[]{false};
+        }
+        else
+        {
+            target[0] = false;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return !value;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableTrueFalseSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableTrueFalseSet.java
@@ -203,6 +203,21 @@ final class ImmutableTrueFalseSet implements ImmutableBooleanSet, Serializable
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        if (target.length < 2)
+        {
+            target = new boolean[]{false, true};
+        }
+        else
+        {
+            target[0] = false;
+            target[1] = true;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return true;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableTrueSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableTrueSet.java
@@ -166,6 +166,20 @@ final class ImmutableTrueSet implements ImmutableBooleanSet, Serializable
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        if (target.length < 1)
+        {
+            target = new boolean[]{true};
+        }
+        else
+        {
+            target[0] = true;
+        }
+        return target;
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return value;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSet.java
@@ -605,6 +605,43 @@ public class BooleanHashSet implements MutableBooleanSet, Externalizable
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        int requiredSize = 0;
+        if (this.state == 1 || this.state == 2)
+        {
+            requiredSize = 1;
+        }
+        else if (this.state == 3)
+        {
+            requiredSize = 2;
+        }
+
+        if (target.length < requiredSize)
+        {
+            target = new boolean[requiredSize];
+        }
+
+        switch (this.state)
+        {
+            case 0:
+                return target;
+            case 1:
+                target[0] = false;
+                return target;
+            case 2:
+                target[0] = true;
+                return target;
+            case 3:
+                target[0] = false;
+                target[1] = true;
+                return target;
+            default:
+                throw new AssertionError("Invalid state");
+        }
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         if (this.state == 3)

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSet.java
@@ -559,6 +559,27 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
     }
 
     @Override
+    public byte[] toArray(byte[] array)
+    {
+        if (array.length < this.size())
+        {
+            array = new byte[this.size()];
+        }
+        int index = 0;
+
+        ByteIterator iterator = this.byteIterator();
+
+        while (iterator.hasNext())
+        {
+            byte nextByte = iterator.next();
+            array[index] = nextByte;
+            index++;
+        }
+
+        return array;
+    }
+
+    @Override
     public boolean containsAll(byte... source)
     {
         for (byte item : source)
@@ -1168,6 +1189,27 @@ public final class ByteHashSet implements MutableByteSet, Externalizable
         public byte[] toArray()
         {
             byte[] array = new byte[this.size()];
+            int index = 0;
+
+            ByteIterator iterator = this.byteIterator();
+
+            while (iterator.hasNext())
+            {
+                byte nextByte = iterator.next();
+                array[index] = nextByte;
+                index++;
+            }
+
+            return array;
+        }
+
+        @Override
+        public byte[] toArray(byte[] array)
+        {
+            if (array.length < this.size())
+            {
+                array = new byte[this.size()];
+            }
             int index = 0;
 
             ByteIterator iterator = this.byteIterator();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStack.java
@@ -315,6 +315,12 @@ public final class BooleanArrayStack implements MutableBooleanStack, Externaliza
     }
 
     @Override
+    public boolean[] toArray(boolean[] target)
+    {
+        return this.delegate.asReversed().toArray(target);
+    }
+
+    @Override
     public boolean contains(boolean value)
     {
         return this.delegate.asReversed().contains(value);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
@@ -130,6 +130,23 @@ public class CharAdapter
     }
 
     @Override
+    public char[] toArray(char[] target)
+    {
+        int size = this.adapted.length();
+        if (target.length < size)
+        {
+            target = new char[size];
+        }
+
+        for (int i = 0; i < size; i++)
+        {
+            target[i] = this.adapted.charAt(i);
+        }
+
+        return target;
+    }
+
+    @Override
     public boolean contains(char expected)
     {
         return StringIterate.anySatisfyChar(this.adapted, value -> expected == value);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
@@ -134,6 +134,12 @@ public class CodePointAdapter
     }
 
     @Override
+    public int[] toArray(int[] target)
+    {
+        return this.toList().toArray(target);
+    }
+
+    @Override
     public boolean contains(int expected)
     {
         int length = this.adapted.length();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
@@ -171,6 +171,12 @@ public class CodePointList extends AbstractIntIterable implements CharSequence, 
     }
 
     @Override
+    public int[] toArray(int[] target)
+    {
+        return this.codePoints.toArray(target);
+    }
+
+    @Override
     public boolean contains(int expected)
     {
         return this.codePoints.contains(expected);


### PR DESCRIPTION
 If the collection fits into the provided array it is used to store its elements and is returned from the method, otherwise a new array of the appropriate size is allocated and returned. If the iterable is empty, the target array is returned unchanged.

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>