### PR TITLE
toImmutable() method on primitive lists avoids a redundant array creation

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveListFactoryImpl.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveListFactoryImpl.stg
@@ -92,7 +92,15 @@ public enum Immutable<name>ListFactoryImpl implements Immutable<name>ListFactory
         {
             return (Immutable<name>List) items;
         }
-        return this.with(items.toArray());
+        if (items == null || items.size() == 0)
+        {
+            return this.with();
+        }
+        if (items.size() == 1)
+        {
+            return this.with(items.toArray()[0]);
+        }
+        return Immutable<name>ArrayList.newList(items);
     }
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -953,15 +953,7 @@ public class <name>ArrayList extends Abstract<name>Iterable
     @Override
     public Immutable<name>List toImmutable()
     {
-        if (this.size == 0)
-        {
-            return <name>Lists.immutable.empty();
-        }
-        if (this.size == 1)
-        {
-            return <name>Lists.immutable.with(this.items[0]);
-        }
-        return <name>Lists.immutable.with(this.toArray());
+        return <name>Lists.immutable.withAll(this);
     }
 
     @Override


### PR DESCRIPTION
toImmutable() method on primitive lists avoids a redundant array creation. The method invokes the withAll(...) immutable factory method, which now also does the check to see if an optimized collection can be instantiated (moved the logic from toImmutable())
Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>