### PR TITLE
toImmutable() method on FastList avoids creating a redundant array copy

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableListFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableListFactoryImpl.java
@@ -229,7 +229,7 @@ public class ImmutableListFactoryImpl implements ImmutableListFactory
                 return this.of(items.get(0), items.get(1), items.get(2), items.get(3), items.get(4), items.get(5), items.get(6), items.get(7), items.get(8), items.get(9));
 
             default:
-                return ImmutableArrayList.newListWith((T[]) items.toArray());
+                return ImmutableArrayList.newList(items);
         }
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -24,6 +24,7 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Twin;
@@ -1201,6 +1202,15 @@ public class FastListTest extends AbstractListTestCase
         Assert.assertEquals(
                 FastList.newListWith(42, 10, 11, 12),
                 FastList.newListWith(42).withAll(Interval.from(10).to(12).toList()));
+    }
+
+    @Test
+    public void unoptimizedListToImmutable()
+    {
+        FastList<String> list = FastList.newListWith(
+                "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15");
+        ImmutableList<String> immutableList = list.toImmutable();
+        Verify.assertIterablesEqual(immutableList, list);
     }
 
     @Test(expected = NoSuchElementException.class)


### PR DESCRIPTION
The toImmutable() call chain now invokes the ImmutableArrayList factory method that takes an iterable rather than an array
Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>