### PR TITLE
Fixes #793: optimizes removeIf() implementation on BooleanArrayList

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
@@ -351,18 +351,29 @@ public final class BooleanArrayList
     @Override
     public boolean removeIf(BooleanPredicate predicate)
     {
-        boolean changed = false;
+        int currentFilledIndex = 0;
         for (int i = 0; i < this.size; i++)
         {
             boolean item = this.items.get(i);
-            if (predicate.accept(item))
+            if (!predicate.accept(item))
             {
-                this.removeAtIndex(i);
-                i--;
-                changed = true;
+                // keep it
+                if (currentFilledIndex != i)
+                {
+                    this.items.set(currentFilledIndex, item);
+                }
+                currentFilledIndex++;
             }
         }
+        boolean changed = currentFilledIndex < this.size;
+        this.wipeAndResetTheEnd(currentFilledIndex);
         return changed;
+    }
+
+    private void wipeAndResetTheEnd(int newCurrentFilledIndex)
+    {
+        this.items.clear(newCurrentFilledIndex, this.size);
+        this.size = newCurrentFilledIndex;
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
@@ -217,9 +217,15 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void removeIf()
     {
         Assert.assertFalse(this.newWith(true, true).removeIf(b -> !b));
-        MutableBooleanList list = this.classUnderTest();
-        Assert.assertTrue(list.removeIf(b -> b));
-        Assert.assertEquals(BooleanArrayList.newListWith(false), list);
+
+        MutableBooleanList list1 = this.classUnderTest();
+        Assert.assertTrue(list1.removeIf(b -> b));
+        Assert.assertEquals(BooleanArrayList.newListWith(false), list1);
+
+        MutableBooleanList list2 = this.classUnderTest();
+        Assert.assertTrue(list2.removeIf(b -> !b));
+
+        Assert.assertEquals(BooleanArrayList.newListWith(true, true), list2);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
@@ -13,6 +13,8 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 import java.lang.reflect.Field;
 import java.util.BitSet;
 
+import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
+import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
@@ -93,5 +95,29 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
         Assert.assertEquals(BooleanArrayList.newListWith(true, true, false), arrayList1);
         Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true), arrayList2);
         Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true, false), arrayList3);
+    }
+
+    private static class LastValueBeforeFalseWasFalse
+            implements BooleanPredicate
+    {
+        private static final long serialVersionUID = 1L;
+        private boolean value = true;
+
+        @Override
+        public boolean accept(boolean currentValue)
+        {
+            boolean oldValue = this.value;
+            this.value = currentValue;
+            return !currentValue && !oldValue;
+        }
+    }
+
+    @Test
+    public void removeIfWithStatefulPredicate()
+    {
+        MutableBooleanList list = this.newWith(true, true, false, false, true, false, true, false, false, false);
+
+        Assert.assertTrue(list.removeIf(new LastValueBeforeFalseWasFalse()));
+        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true, false, true, false), list);
     }
 }


### PR DESCRIPTION
Made removeIf() on BooleanArrayList follow the same implementation approach as on the other primitive lists and FastList

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>