### PR TITLE
(Partially) Closes #351: Javadocs for map APIs

### DIFF
--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/configuration_1_2.dtd">
 
 <!--
   ~ Copyright (c) 2016 Goldman Sachs.

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -334,9 +334,4 @@
         <property name="format" value="\n\n\n" />
         <property name="message" value="Extra newline." />
     </module>
-
-    <module name="RegexpMultiline">
-        <property name="format" value="\r" />
-        <property name="message" value="Carriage return." />
-    </module>
 </module>

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.1//EN"
+    "https://checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <!--
   ~ Copyright (c) 2015 Goldman Sachs.

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -116,5 +116,8 @@
     <suppress checks="RedundantModifier" files="ImmutableIntArrayStack.java" />
     <suppress checks="RedundantModifier" files="ImmutableLongArrayStack.java" />
     <suppress checks="RedundantModifier" files="ImmutableShortArrayStack.java" />
+	
+	<!-- Runs outside of a plugin Mojo and has no logging API on classpath -->
+	<suppress checks="RegexpSinglelineJava" files="JavadocUtil.java" />
 
 </suppressions>

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutableObjectPrimitiveMap.stg
@@ -51,10 +51,30 @@ public interface ImmutableObject<name>Map\<K> extends Object<name>Map\<K>
     @Override
     \<V> ImmutableCollection\<V> collect(<name>ToObjectFunction\<? extends V> function);
 
+    /**
+     * Copy this map, associate the value with the key (replacing the value if one
+     * already exists for {@code key}), and return the copy as new immutable map.
+     * A copy is always made even if {@code key} is already associated with {@code value}.
+     * @param key the key to add
+     * @param value the value to associate with the key in the copy
+     * @return an immutable copy of this map with {@code value} associated with {@code key}
+     */
     ImmutableObject<name>Map\<K> newWithKeyValue(K key, <type> value);
 
+    /**
+     * Copy this map, remove any associated value with the key (if one exists), and
+     * return the copy as a new immutable map.
+     * @param key the key to remove
+     * @return an immutable copy of this map with {@code key} removed
+     */
     ImmutableObject<name>Map\<K> newWithoutKey(K key);
 
+    /**
+     * Copy this map, remove any associated values with the specified keys (if any exist),
+     * and return the copy as a new immutable map.
+     * @param keys the keys to remove
+     * @return an immutable copy of this map with all keys in {@code keys} removed
+     */
     ImmutableObject<name>Map\<K> newWithoutAllKeys(Iterable\<? extends K> keys);
     <if(!primitive.booleanPrimitive)><(flipUniqueValues.(name))(name)><endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutableObjectPrimitiveMap.stg
@@ -42,6 +42,7 @@ public interface ImmutableObject<name>Map\<K> extends Object<name>Map\<K>
     /**
      * @since 9.0.
      */
+    @Override
     default ImmutableObject<name>Map\<K> tap(<name>Procedure procedure)
     {
         this.forEach(procedure);

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitiveObjectMap.stg
@@ -35,10 +35,30 @@ public interface Immutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Immut
     @Override
     Immutable<name>ObjectMap\<V> reject(<name>ObjectPredicate\<? super V> predicate);
 
+    /**
+     * Copy this map, associate the value with the key (replacing the value if one
+     * already exists for {@code key}), and return the copy as new immutable map.
+     * A copy is always made even if {@code key} is already associated with {@code value}.
+     * @param key the key to add
+     * @param value the value to associate with the key in the copy
+     * @return an immutable copy of this map with {@code value} associated with {@code key}
+     */
     Immutable<name>ObjectMap\<V> newWithKeyValue(<type> key, V value);
 
+    /**
+     * Copy this map, remove any associated value with the key (if one exists), and
+     * return the copy as a new immutable map.
+     * @param key the key to remove
+     * @return an immutable copy of this map with {@code key} removed
+     */
     Immutable<name>ObjectMap\<V> newWithoutKey(<type> key);
 
+    /**
+     * Copy this map, remove any associated values with the specified keys (if any exist),
+     * and return the copy as a new immutable map.
+     * @param keys the keys to remove
+     * @return an immutable copy of this map with all keys in {@code keys} removed
+     */
     Immutable<name>ObjectMap\<V> newWithoutAllKeys(<name>Iterable keys);
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/immutablePrimitivePrimitiveMap.stg
@@ -46,10 +46,30 @@ public interface Immutable<name1><name2>Map extends <name1><name2>Map
     @Override
     \<V> ImmutableBag\<V> collect(<name2>ToObjectFunction\<? extends V> function);
 
+    /**
+     * Copy this map, associate the value with the key (replacing the value if one
+     * already exists for {@code key}), and return the copy as new immutable map.
+     * A copy is always made even if {@code key} is already associated with {@code value}.
+     * @param key the key to add
+     * @param value the value to associate with the key in the copy
+     * @return an immutable copy of this map with {@code value} associated with {@code key}
+     */
     Immutable<name1><name2>Map newWithKeyValue(<type1> key, <type2> value);
 
+    /**
+     * Copy this map, remove any associated value with the key (if one exists), and
+     * return the copy as a new immutable map.
+     * @param key the key to remove
+     * @return an immutable copy of this map with {@code key} removed
+     */
     Immutable<name1><name2>Map newWithoutKey(<type1> key);
 
+    /**
+     * Copy this map, remove any associated values with the specified keys (if any exist),
+     * and return the copy as a new immutable map.
+     * @param keys the keys to remove
+     * @return an immutable copy of this map with all keys in {@code keys} removed
+     */
     Immutable<name1><name2>Map newWithoutAllKeys(<name1>Iterable keys);
     <if(!primitive2.booleanPrimitive)><(flipUniqueValues.(name2))(name1, name2)><endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
@@ -176,6 +176,7 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
     /**
      * @since 9.0.
      */
+    @Override
     default MutableObject<name>Map\<K> tap(<name>Procedure procedure)
     {
         this.forEach(procedure);

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
@@ -36,8 +36,17 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
     @Override
     Mutable<name>Iterator <type>Iterator();
 
+    /**
+     * Removes all entries from this map.
+     */
     void clear();
 
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     */
     void put(K key, <type> value);
 
     /**
@@ -51,6 +60,12 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
         this.put(keyValuePair.getOne(), keyValuePair.getTwo());
     }
 
+    /**
+     * Puts all of the key/value mappings from the specified map into this map. If this
+     * map already has a value associated with one of the keys in the map, it will be
+     * replaced with the value in {@code map}.
+     * @param map the map to copy into this map
+     */
     void putAll(Object<name>Map\<? extends K> map);
 
     /**
@@ -61,20 +76,88 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
      */
     void updateValues(Object<name>To<name>Function\<? super K> function);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #remove(Object)
+     */
     void removeKey(K key);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #removeKey(K)
+     */
     void remove(Object key);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map,
+     * returning the previously associated value with the key. If no mapping
+     * existed for the key, the specified default value is returned.
+     * @param key the key to remove
+     * @param value the default value to return if no mapping for the key exists
+     * @return the value previously associated with the key, if one existed,
+     * or {@code value} if not
+     */
     <type> removeKeyIfAbsent(K key, <type> value);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates a value with the key.
+     * a new value with they key
+     * @param key the key
+     * @param value the value to associate with {@code key} if no such mapping exists
+     * @return the value associated with key, if one exists, or {@code value} if not
+     */
     <type> getIfAbsentPut(K key, <type> value);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value supplier with the key.
+     * @param key the key
+     * @param function the supplier that provides the value if no mapping exists for {@code key}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} if not
+     */
     <type> getIfAbsentPut(K key, <name>Function0 function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The {@code key} will be passed as the argument to the function.
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code key} if not
+     */
     <type> getIfAbsentPutWithKey(K key, <name>Function\<? super K> function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The specified {@code parameter} will be passed as the argument to the function.
+     * @param parameter the parameter to provide to {@code function} if no value
+     * exists for {@code key}
+     * @param \<P> the type of the value function's {@code parameter}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code parameter} if not
+     */
     \<P> <type> getIfAbsentPutWith(K key, <name>Function\<? super P> function, P parameter);
 
+    /**
+     * Updates or sets the value associated with the key by applying the function to the
+     * existing value, if one exists, or to the specified initial value if one does not.
+     * @param key the key
+     * @param initialValueIfAbsent the initial value to supply to the function if no
+     * mapping exists for the key
+     * @param function the function that returns the updated value based on the current
+     * value or the initial value, if no value exists
+     * @return the new value associated with the key, either as a result of applying
+     * {@code function} to the value already associated with the key or as a result of
+     * applying it to {@code initialValueIfAbsent} and associating the result with {@code key}
+     */
     <type> updateValue(K key, <type> initialValueIfAbsent, <name>To<name>Function function);
     <if(!primitive.booleanPrimitive)><(flipUniqueValues.(name))(name)><endif>
 
@@ -102,10 +185,30 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
     @Override
     \<V> MutableCollection\<V> collect(<name>ToObjectFunction\<? extends V> function);
 
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     * @return this map
+     * @see #put(K, <type>)
+     */
     MutableObject<name>Map\<K> withKeyValue(K key, <type> value);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from this map.
+     * @param key the key to remove
+     * @return this map
+     * @see #remove(Object)
+     */
     MutableObject<name>Map\<K> withoutKey(K key);
 
+    /**
+     * Removes the mappings associated with all the keys, if they exist, from this map.
+     * @param keys the keys to remove
+     * @return this map
+     * @see #remove(Object)
+     */
     MutableObject<name>Map\<K> withoutAllKeys(Iterable\<? extends K> keys);
 
     default MutableObject<name>Map\<K> withAllKeyValues(Iterable\<Object<name>Pair\<K>\> keyValuePairs)

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutableObjectPrimitiveMap.stg
@@ -113,7 +113,7 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value supplier with the key.
+     * invokes the supplier and associates the result with the key.
      * @param key the key
      * @param function the supplier that provides the value if no mapping exists for {@code key}
      * @return the value associated with the key, if one exists, or the result of
@@ -134,7 +134,7 @@ public interface MutableObject<name>Map\<K> extends Object<name>Map\<K>
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value function with the key.
+     * invokes the value function with the parameter and associates the result with the key.
      * @param key the key
      * @param function the function that provides the value if no mapping exists.
      * The specified {@code parameter} will be passed as the argument to the function.

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
@@ -78,7 +78,6 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
      * associates a value with the key.
-     * a new value with they key
      * @param key the key
      * @param value the value to associate with {@code key} if no such mapping exists
      * @return the value associated with key, if one exists, or {@code value} if not
@@ -87,7 +86,7 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value supplier with the key.
+     * invokes the supplier and associates the result with the key.
      * @param key the key
      * @param function the supplier that provides the value if no mapping exists for {@code key}
      * @return the value associated with the key, if one exists, or the result of
@@ -108,7 +107,7 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value function with the key.
+     * invokes the value function with the parameter and associates the result with the key.
      * @param key the key
      * @param function the function that provides the value if no mapping exists.
      * The specified {@code parameter} will be passed as the argument to the function.

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveObjectMap.stg
@@ -31,6 +31,14 @@ import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
  */
 public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, MutablePrimitiveObjectMap\<V>
 {
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     * @return the value previously associated with {@code key} if one existed, or
+     * {@code null} if not
+     */
     V put(<type> key, V value);
 
     /**
@@ -45,20 +53,71 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
     }
 
     /**
+     * Puts all of the key/value mappings from the specified map into this map. If this
+     * map already has a value associated with one of the keys in the map, it will be
+     * replaced with the value in {@code map}.
+     * @param map the map to copy into this map
      * @since 5.0.
      */
     void putAll(<name>ObjectMap\<? extends V> map);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #remove(<type>)
+     */
     V removeKey(<type> key);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #removeKey(<type>)
+     */
     V remove(<type> key);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates a value with the key.
+     * a new value with they key
+     * @param key the key
+     * @param value the value to associate with {@code key} if no such mapping exists
+     * @return the value associated with key, if one exists, or {@code value} if not
+     */
     V getIfAbsentPut(<type> key, V value);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value supplier with the key.
+     * @param key the key
+     * @param function the supplier that provides the value if no mapping exists for {@code key}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} if not
+     */
     V getIfAbsentPut(<type> key, Function0\<? extends V> function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The {@code key} will be passed as the argument to the function.
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code key} if not
+     */
     V getIfAbsentPutWithKey(<type> key, <name>ToObjectFunction\<? extends V> function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The specified {@code parameter} will be passed as the argument to the function.
+     * @param parameter the parameter to provide to {@code function} if no value
+     * exists for {@code key}
+     * @param \<P> the type of the value function's {@code parameter}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code parameter} if not
+     */
     \<P> V getIfAbsentPutWith(<type> key, Function\<? super P, ? extends V> function, P parameter);
 
     /**
@@ -68,8 +127,21 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
     V updateValue(<type> key, Function0\<? extends V> factory, Function\<? super V, ? extends V> function);
 
     /**
-     * Same as {@link #updateValue(<type>, Function0, Function)} with a Function2 and specified parameter which is
-     * passed to the function.
+     * Updates or sets the value associated with the key by applying the function to the
+     * existing value, if one exists, or the initial value supplied by the factory if one does not.
+     * @param key the key
+     * @param factory the supplier providing the initial value to the function if no
+     * mapping exists for the key
+     * @param function the function that returns the updated value based on the current
+     * value or the initial value, if no value exists. The specified {@code parameter}
+     * will also be passed as the second argument to the function.
+     * @param parameter the parameter to provide to {@code function} if no value
+     * exists for {@code key}
+     * @param \<P> the type of the value function's {@code parameter}
+     * @return the new value associated with the key, either as a result of applying
+     * {@code function} to the value already associated with the key or as a result of
+     * applying it to the value returned by {@code factory} and associating the result
+     * with {@code key}
      */
     \<P> V updateValueWith(<type> key, Function0\<? extends V> factory, Function2\<? super V, ? super P, ? extends V> function, P parameter);
 
@@ -85,12 +157,40 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
     @Override
     Mutable<name>ObjectMap\<V> reject(<name>ObjectPredicate\<? super V> predicate);
 
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     * @return this map
+     * @see #put(<type>, V)
+     */
     Mutable<name>ObjectMap\<V> withKeyValue(<type> key, V value);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from this map.
+     * @param key the key to remove
+     * @return this map
+     * @see #remove(<type>)
+     */
     Mutable<name>ObjectMap\<V> withoutKey(<type> key);
 
+    /**
+     * Removes the mappings associated with all the keys, if they exist, from this map.
+     * @param keys the keys to remove
+     * @return this map
+     * @see #remove(<type>)
+     */
     Mutable<name>ObjectMap\<V> withoutAllKeys(<name>Iterable keys);
 
+    /**
+     * Puts all of the key/value mappings from the specified pairs into this map. If this
+     * map already has a value associated with one of the keys in the pairs, it will be
+     * replaced with the value in the pair.
+     * @param iterable the pairs to put into this map
+     * @return this map
+     * @see #putPair(<name>ObjectPair)
+     */
     default Mutable<name>ObjectMap\<V> withAllKeyValues(Iterable\<<name>ObjectPair\<V>\> keyValuePairs)
     {
         for (<name>ObjectPair\<V> keyValuePair : keyValuePairs)
@@ -100,8 +200,20 @@ public interface Mutable<name>ObjectMap\<V> extends <name>ObjectMap\<V>, Mutable
         return this;
     }
 
+    /**
+     * Returns an unmodifiable view of this map, delegating all read-only operations to this
+     * map and throwing an {@link UnsupportedOperationException} for all mutating operations.
+     * This avoids the overhead of copying the map when calling {@link #toImmutable()} while
+     * still providing immutability.
+     * @return an unmodifiable view of this map
+     */
     Mutable<name>ObjectMap\<V> asUnmodifiable();
 
+    /**
+     * Returns a synchronized view of this map, delegating all operations to this map but
+     * ensuring only one caller has access to the map at a time.
+     * @return a synchronized view of this map
+     */
     Mutable<name>ObjectMap\<V> asSynchronized();
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitivePrimitiveMap.stg
@@ -33,6 +33,12 @@ import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
  */
 public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<name2>ValuesMap
 {
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     */
     void put(<type1> key, <type2> value);
 
     /**
@@ -46,6 +52,12 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
         this.put(keyValuePair.getOne(), keyValuePair.getTwo());
     }
 
+    /**
+     * Puts all of the key/value mappings from the specified map into this map. If this
+     * map already has a value associated with one of the keys in the map, it will be
+     * replaced with the value in {@code map}.
+     * @param map the map to copy into this map
+     */
     void putAll(<name1><name2>Map map);
 
     /**
@@ -56,20 +68,88 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
      */
     void updateValues(<name1><name2>To<name2>Function function);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #remove(<type1>)
+     */
     void removeKey(<type1> key);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map.
+     * @param key the key to remove
+     * @see #removeKey(<type1>)
+     */
     void remove(<type1> key);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from the map,
+     * returning the previously associated value with the key. If no mapping
+     * existed for the key, the specified default value is returned.
+     * @param key the key to remove
+     * @param value the default value to return if no mapping for the key exists
+     * @return the value previously associated with the key, if one existed,
+     * or {@code value} if not
+     */
     <type2> removeKeyIfAbsent(<type1> key, <type2> value);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates a value with the key.
+     * a new value with they key
+     * @param key the key
+     * @param value the value to associate with {@code key} if no such mapping exists
+     * @return the value associated with key, if one exists, or {@code value} if not
+     */
     <type2> getIfAbsentPut(<type1> key, <type2> value);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value supplier with the key.
+     * @param key the key
+     * @param function the supplier that provides the value if no mapping exists for {@code key}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} if not
+     */
     <type2> getIfAbsentPut(<type1> key, <name2>Function0 function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The {@code key} will be passed as the argument to the function.
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code key} if not
+     */
     <type2> getIfAbsentPutWithKey(<type1> key, <name1>To<name2>Function function);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * associates the result of invoking the value function with the key.
+     * @param key the key
+     * @param function the function that provides the value if no mapping exists.
+     * The specified {@code parameter} will be passed as the argument to the function.
+     * @param parameter the parameter to provide to {@code function} if no value
+     * exists for {@code key}
+     * @param \<P> the type of the value function's {@code parameter}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code function} with {@code parameter} if not
+     */
     \<P> <type2> getIfAbsentPutWith(<type1> key, <name2>Function\<? super P> function, P parameter);
 
+    /**
+     * Updates or sets the value associated with the key by applying the function to the
+     * existing value, if one exists, or to the specified initial value if one does not.
+     * @param key the key
+     * @param initialValueIfAbsent the initial value to supply to the function if no
+     * mapping exists for the key
+     * @param function the function that returns the updated value based on the current
+     * value or the initial value, if no value exists
+     * @return the new value associated with the key, either as a result of applying
+     * {@code function} to the value already associated with the key or as a result of
+     * applying it to {@code initialValueIfAbsent} and associating the result with {@code key}
+     */
     <type2> updateValue(<type1> key, <type2> initialValueIfAbsent, <name2>To<name2>Function function);
     <if(!primitive2.booleanPrimitive)><(flipUniqueValues.(name2))(name1, name2)><endif>
 
@@ -79,12 +159,40 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
     @Override
     Mutable<name1><name2>Map reject(<name1><name2>Predicate predicate);
 
+    /**
+     * Associates a value with the specified key. If a value is already associated
+     * with the key in this map, it will be replaced with {@code value}.
+     * @param key the key
+     * @param value the value to associate with {@code value}
+     * @return this map
+     * @see #put(<type1>, <type2>)
+     */
     Mutable<name1><name2>Map withKeyValue(<type1> key, <type2> value);
 
+    /**
+     * Removes the mapping associated with the key, if one exists, from this map.
+     * @param key the key to remove
+     * @return this map
+     * @see #remove(<type1>)
+     */
     Mutable<name1><name2>Map withoutKey(<type1> key);
 
+    /**
+     * Removes the mappings associated with all the keys, if they exist, from this map.
+     * @param keys the keys to remove
+     * @return this map
+     * @see #remove(<type1>)
+     */
     Mutable<name1><name2>Map withoutAllKeys(<name1>Iterable keys);
 
+    /**
+     * Puts all of the key/value mappings from the specified pairs into this map. If this
+     * map already has a value associated with one of the keys in the pairs, it will be
+     * replaced with the value in the pair.
+     * @param iterable the pairs to put into this map
+     * @return this map
+     * @see #putPair(<name1><name2>Pair)
+     */
     default Mutable<name1><name2>Map withAllKeyValues(Iterable\<<name1><name2>Pair> keyValuePairs)
     {
         for (<name1><name2>Pair keyValuePair : keyValuePairs)
@@ -94,8 +202,20 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
         return this;
     }
 
+    /**
+     * Returns an unmodifiable view of this map, delegating all read-only operations to this
+     * map and throwing an {@link UnsupportedOperationException} for all mutating operations.
+     * This avoids the overhead of copying the map when calling {@link #toImmutable()} while
+     * still providing immutability.
+     * @return an unmodifiable view of this map
+     */
     Mutable<name1><name2>Map asUnmodifiable();
 
+    /**
+     * Returns a synchronized view of this map, delegating all operations to this map but
+     * ensuring only one caller has access to the map at a time.
+     * @return a synchronized view of this map
+     */
     Mutable<name1><name2>Map asSynchronized();
     <(arithmeticMethods.(type2))(type1, type2)>
 }
@@ -116,6 +236,15 @@ arithmeticMethods ::= [
 allMethods(type1, type2) ::= <<
 
 
+/**
+ * Increments and updates the value associated with the key, if a value exists, or
+ * sets the value to be the specified value if one does not.
+ * @param key the key
+ * @param toBeAdded the amount to increment the existing value, if one exists, or
+ * to use as the initial value if one does not
+ * @return the value after incrementing {@code toBeAdded} to the existing value
+ * associated with {@code key} or {@code toBeAdded} if one does not
+ */
 <type2> addToValue(<type1> key, <type2> toBeAdded);
 >>
 

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitivePrimitiveMap.stg
@@ -96,7 +96,6 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
      * associates a value with the key.
-     * a new value with they key
      * @param key the key
      * @param value the value to associate with {@code key} if no such mapping exists
      * @return the value associated with key, if one exists, or {@code value} if not
@@ -105,7 +104,7 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value supplier with the key.
+     * invokes the supplier and associates the result with the key.
      * @param key the key
      * @param function the supplier that provides the value if no mapping exists for {@code key}
      * @return the value associated with the key, if one exists, or the result of
@@ -126,7 +125,7 @@ public interface Mutable<name1><name2>Map extends <name1><name2>Map, Mutable<nam
 
     /**
      * Retrieves the value associated with the key if one exists; if it does not,
-     * associates the result of invoking the value function with the key.
+     * invokes the value function with the parameter and associates the result with the key.
      * @param key the key
      * @param function the function that provides the value if no mapping exists.
      * The specified {@code parameter} will be passed as the argument to the function.

--- a/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/mutablePrimitiveValuesMap.stg
@@ -38,6 +38,9 @@ public interface Mutable<name>ValuesMap extends <name>ValuesMap
     @Override
     \<V> MutableBag\<V> collect(<name>ToObjectFunction\<? extends V> function);
 
+    /**
+     * Removes all entries from this map.
+     */
     void clear();
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
@@ -113,6 +113,7 @@ public interface Object<name>Map\<K> extends <name>Iterable
     /**
      * @since 9.0.
      */
+    @Override
     default Object<name>Map\<K> tap(<name>Procedure procedure)
     {
         this.forEach(procedure);
@@ -124,6 +125,7 @@ public interface Object<name>Map\<K> extends <name>Iterable
      *
      * @return a string representation of this Object<name>Map
      */
+    @Override
     String toString();
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
@@ -32,25 +32,82 @@ import org.eclipse.collections.api.tuple.primitive.Object<name>Pair;
  */
 public interface Object<name>Map\<K> extends <name>Iterable
 {
+    /**
+     * Retrieves the value associated with the key. If no mapping exists for the key,
+     * the default value (usually {@code 0}) is returned.
+     * @param key the key
+     * @return the value associated with the key, or the default value if no such
+     * mapping exists
+     */
     <type> get(Object key);
 
+    /**
+     * Retrieves the value associated with the key, throwing an {@link IllegalStateException}
+     * if no such mapping exists.
+     * @param key the key
+     * @return the value associated with the key
+     * @throws IllegalStateException if no mapping exists for the key
+     */
     <type> getOrThrow(Object key);
 
+    /**
+     * Retrieves the value associated with the key, returning the specified default
+     * value if no such mapping exists.
+     * @param key the key
+     * @param ifAbsent the default value to return if no mapping exists for {@code key}
+     * @return the value associated with the key, or {@code ifAbsent} if no such
+     * mapping exists.
+     */
     <type> getIfAbsent(Object key, <type> ifAbsent);
 
+    /**
+     * Returns whether or not the key is present in the map.
+     * @param key the key
+     * @return if a mapping exists in this map for the key
+     */
     boolean containsKey(Object key);
 
+    /**
+     * Returns whether or not this map contains the value.
+     * @param value the value to test
+     * @return if this collection contains the value
+     */
     boolean containsValue(<type> value);
 
+    /**
+     * Iterates through each value in this map.
+     * @param procedure the procedure to invoke for each value in this map.
+     */
     void forEachValue(<name>Procedure procedure);
 
+    /**
+     * Iterates through each key in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key
+     */
     void forEachKey(Procedure\<? super K> procedure);
 
+    /**
+     * Iterates through each key/value pair in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key/value pair
+     */
     void forEachKeyValue(Object<name>Procedure\<? super K> procedure);
     <if(!primitive.booleanPrimitive)><(flipUniqueValues.(name))(name)><endif>
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that match the predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * included in the returned map
+     * @return a copy of this map with the matching key/value pairs
+     */
     Object<name>Map\<K> select(Object<name>Predicate\<? super K> predicate);
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that do not match the
+     * predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * excluded from the returned map
+     * @return a copy of this map without the matching key/value pairs
+     */
     Object<name>Map\<K> reject(Object<name>Predicate\<? super K> predicate);
 
     /**
@@ -69,18 +126,41 @@ public interface Object<name>Map\<K> extends <name>Iterable
      */
     String toString();
 
+    /**
+     * Returns a copy of this map that is immutable (if this map is mutable) or
+     * itself if it is already immutable.
+     * @return an immutable map that is equivalent to this one
+     */
     ImmutableObject<name>Map\<K> toImmutable();
 
+    /**
+     * Returns a set containing all the keys in this map. The set is backed by the
+     * map, so any modifications to the returned set will affect this map.
+     * @return a mutable set containing the keys in this map
+     */
     Set\<K> keySet();
 
+    /**
+     * Returns the values in this map as a separate collection. The returned collection is backed by the map, so any
+     * changes made to the returned collection will affect the state of this map.
+     * @return the values as a collection backed by this map
+     */
     Mutable<name>Collection values();
 
     /**
+     * Returns a view of the keys in this map. This iterable is backed by the map, so
+     * any modifications to the underlying map will be reflected in the keys returned
+     * by the iterable.
+     * @return a view of the keys in this map
      * @since 5.0
      */
     LazyIterable\<K> keysView();
 
     /**
+     * Returns a view of the key/value pairs in this map. This iterable is backed by
+     * the map, so any modifications to the underlying map will be reflected in the
+     * pairs returned by the iterable.
+     * @return a view of the keys in this map
      * @since 5.0
      */
     RichIterable\<Object<name>Pair\<K>\> keyValuesView();

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveObjectMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveObjectMap.stg
@@ -32,33 +32,92 @@ import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
  */
 public interface <name>ObjectMap\<V> extends PrimitiveObjectMap\<V>
 {
+    /**
+     * Retrieves the value associated with the key. If no mapping exists for the key,
+     * {@code null} is returned.
+     * @param key the key
+     * @return the value associated with the key, or the default value if no such
+     * mapping exists
+     */
     V get(<type> key);
 
+    /**
+     * Retrieves the value associated with the key if one exists; if it does not,
+     * returns the result of invoking the value supplier.
+     * @param key the key
+     * @param function the supplier that provides the value if no mapping exists for {@code key}
+     * @return the value associated with the key, if one exists, or the result of
+     * invoking {@code ifAbsent} if not
+     */
     V getIfAbsent(<type> key, Function0\<? extends V> ifAbsent);
 
+    /**
+     * Returns whether or not the key is present in the map.
+     * @param key the key
+     * @return if a mapping exists in this map for the key
+     */
     boolean containsKey(<type> key);
 
     @Override
     <name>ObjectMap\<V> tap(Procedure\<? super V> procedure);
 
+    /**
+     * Iterates through each key in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key
+     */
     void forEachKey(<name>Procedure procedure);
 
+    /**
+     * Iterates through each key/value pair in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key/value pair
+     */
     void forEachKeyValue(<name>ObjectProcedure\<? super V> procedure);
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that match the predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * included in the returned map
+     * @return a copy of this map with the matching key/value pairs
+     */
     <name>ObjectMap\<V> select(<name>ObjectPredicate\<? super V> predicate);
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that do not match the
+     * predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * excluded from the returned map
+     * @return a copy of this map without the matching key/value pairs
+     */
     <name>ObjectMap\<V> reject(<name>ObjectPredicate\<? super V> predicate);
 
+    /**
+     * Returns a copy of this map that is immutable (if this map is mutable) or
+     * itself if it is already immutable.
+     * @return an immutable map that is equivalent to this one
+     */
     Immutable<name>ObjectMap\<V> toImmutable();
 
+    /**
+     * Returns a set containing all the keys in this map. The set is backed by the
+     * map, so any modifications to the returned set will affect this map.
+     * @return a mutable set containing the keys in this map
+     */
     Mutable<name>Set keySet();
 
     /**
+     * Returns a view of the keys in this map. This iterable is backed by the map, so
+     * any modifications to the underlying map will be reflected in the keys returned
+     * by the iterable.
+     * @return a view of the keys in this map
      * @since 5.0
      */
     Lazy<name>Iterable keysView();
 
     /**
+     * Returns a view of the key/value pairs in this map. This iterable is backed by
+     * the map, so any modifications to the underlying map will be reflected in the
+     * pairs returned by the iterable.
+     * @return a view of the keys in this map
      * @since 5.0
      */
     RichIterable\<<name>ObjectPair\<V>\> keyValuesView();

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
@@ -34,28 +34,86 @@ import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
  */
 public interface <name1><name2>Map extends <name2>ValuesMap
 {
+	/**
+	 * Retrieves the value associated with the key. If no mapping exists for the key,
+	 * the default value (usually {@code 0}) is returned.
+	 * @param key the key
+	 * @return the value associated with the key, or the default value if no such
+	 * mapping exists
+	 */
     <type2> get(<type1> key);
 
+    /**
+     * Retrieves the value associated with the key, returning the specified default
+     * value if no such mapping exists.
+     * @param key the key
+     * @param ifAbsent the default value to return if no mapping exists for {@code key}
+     * @return the value associated with the key, or {@code ifAbsent} if no such
+     * mapping exists.
+     */
     <type2> getIfAbsent(<type1> key, <type2> ifAbsent);
 
+    /**
+     * Retrieves the value associated with the key, throwing an {@link IllegalStateException}
+     * if no such mapping exists.
+     * @param key the key
+     * @return the value associated with the key
+     * @throws IllegalStateException if no mapping exists for the key
+     */
     <type2> getOrThrow(<type1> key);
 
+    /**
+     * Returns whether or not the key is present in the map.
+     * @param key the key
+     * @return if a mapping exists in this map for the key
+     */
     boolean containsKey(<type1> key);
 
+    /**
+     * Iterates through each key in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key
+     */
     void forEachKey(<name1>Procedure procedure);
 
+    /**
+     * Iterates through each key/value pair in the map, invoking the procedure for each.
+     * @param procedure the procedure to invoke for each key/value pair
+     */
     void forEachKeyValue(<name1><name2>Procedure procedure);
 
+    /**
+     * Returns a view of the keys in this map. This iterable is backed by the map, so
+     * any modifications to the underlying map will be reflected in the keys returned
+     * by the iterable.
+     * @return a view of the keys in this map
+     */
     Lazy<name1>Iterable keysView();
 
     /**
+     * Returns a view of the key/value pairs in this map. This iterable is backed by
+     * the map, so any modifications to the underlying map will be reflected in the
+     * pairs returned by the iterable.
+     * @return a view of the keys in this map
      * @since 5.0
      */
     RichIterable\<<name1><name2>Pair> keyValuesView();
     <if(!primitive2.booleanPrimitive)><(flipUniqueValues.(name2))(name1, name2)><endif>
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that match the predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * included in the returned map
+     * @return a copy of this map with the matching key/value pairs
+     */
     <name1><name2>Map select(<name1><name2>Predicate predicate);
 
+    /**
+     * Return a copy of this map containing only the key/value pairs that do not match the
+     * predicate.
+     * @param predicate the predicate to determine which key/value pairs in this map should be
+     * excluded from the returned map
+     * @return a copy of this map without the matching key/value pairs
+     */
     <name1><name2>Map reject(<name1><name2>Predicate predicate);
 
     /**
@@ -78,8 +136,18 @@ public interface <name1><name2>Map extends <name2>ValuesMap
     @Override
     String toString();
 
+    /**
+     * Returns a copy of this map that is immutable (if this map is mutable) or 
+     * itself if it is already immutable.
+     * @return an immutable map that is equivalent to this one
+     */
     Immutable<name1><name2>Map toImmutable();
 
+    /**
+     * Returns a set containing all the keys in this map. The set is backed by the
+     * map, so any modifications to the returned set will affect this map. 
+     * @return a mutable set containing the keys in this map
+     */
     Mutable<name1>Set keySet();
 }
 
@@ -99,11 +167,11 @@ flipUniqueValues ::= [
 noMethods(name1, name2) ::= ""
 
 flipUniqueValues(name1, name2) ::= <<<\n>/**
- * Return the <name2><name1>Map that is obtained by flipping the direction of this map and making the associations
- * from value to key.
- *
- * @throws IllegalStateException if the <name2><name1>Map contains duplicate values.
- * @since 9.0
- */
+     * Return the <name2><name1>Map that is obtained by flipping the direction of this map and making the associations
+     * from value to key.
+     *
+     * @throws IllegalStateException if the <name2><name1>Map contains duplicate values.
+     * @since 9.0
+     */
 <name2><name1>Map flipUniqueValues();
 >>

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
@@ -34,13 +34,13 @@ import org.eclipse.collections.api.tuple.primitive.<name1><name2>Pair;
  */
 public interface <name1><name2>Map extends <name2>ValuesMap
 {
-	/**
-	 * Retrieves the value associated with the key. If no mapping exists for the key,
-	 * the default value (usually {@code 0}) is returned.
-	 * @param key the key
-	 * @return the value associated with the key, or the default value if no such
-	 * mapping exists
-	 */
+    /**
+     * Retrieves the value associated with the key. If no mapping exists for the key,
+     * the default value (usually {@code 0}) is returned.
+     * @param key the key
+     * @return the value associated with the key, or the default value if no such
+     * mapping exists
+     */
     <type2> get(<type1> key);
 
     /**
@@ -86,6 +86,7 @@ public interface <name1><name2>Map extends <name2>ValuesMap
      * any modifications to the underlying map will be reflected in the keys returned
      * by the iterable.
      * @return a view of the keys in this map
+     * @since 5.0
      */
     Lazy<name1>Iterable keysView();
 
@@ -137,7 +138,7 @@ public interface <name1><name2>Map extends <name2>ValuesMap
     String toString();
 
     /**
-     * Returns a copy of this map that is immutable (if this map is mutable) or 
+     * Returns a copy of this map that is immutable (if this map is mutable) or
      * itself if it is already immutable.
      * @return an immutable map that is equivalent to this one
      */
@@ -145,7 +146,7 @@ public interface <name1><name2>Map extends <name2>ValuesMap
 
     /**
      * Returns a set containing all the keys in this map. The set is backed by the
-     * map, so any modifications to the returned set will affect this map. 
+     * map, so any modifications to the returned set will affect this map.
      * @return a mutable set containing the keys in this map
      */
     Mutable<name1>Set keySet();

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
@@ -31,10 +31,24 @@ import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
  */
 public interface <name>ValuesMap extends <name>Iterable
 {
+	/**
+	 * Returns whether or not this map contains the value.
+	 * @param value the value to test
+	 * @return if this collection contains the value
+	 */
     boolean containsValue(<type> value);
 
+    /**
+     * Iterates through each value in this map.
+     * @param procedure the procedure to invoke for each value in this map.
+     */
     void forEachValue(<name>Procedure procedure);
 
+    /**
+     * Returns the values in this map as a separate collection. The returned collection is backed by the map, so any
+     * changes made to the returned collection will affect the state of this map.
+     * @return the values as a collection backed by this map
+     */
     Mutable<name>Collection values();
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
@@ -60,6 +60,7 @@ public interface <name>ValuesMap extends <name>Iterable
     /**
      * @since 9.0.
      */
+    @Override
     default <name>ValuesMap tap(<name>Procedure procedure)
     {
         this.forEach(procedure);

--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitiveValuesMap.stg
@@ -31,11 +31,11 @@ import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
  */
 public interface <name>ValuesMap extends <name>Iterable
 {
-	/**
-	 * Returns whether or not this map contains the value.
-	 * @param value the value to test
-	 * @return if this collection contains the value
-	 */
+    /**
+     * Returns whether or not this map contains the value.
+     * @param value the value to test
+     * @return if this collection contains the value
+     */
     boolean containsValue(<type> value);
 
     /**

--- a/eclipse-collections-code-generator/src/test/java/org/eclipse/collections/codegenerator/tools/JavadocUtil.java
+++ b/eclipse-collections-code-generator/src/test/java/org/eclipse/collections/codegenerator/tools/JavadocUtil.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.codegenerator.tools;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.regex.Pattern;
+
+import org.eclipse.collections.codegenerator.EclipseCollectionsCodeGenerator;
+import org.eclipse.collections.codegenerator.model.Primitive;
+
+/**
+ * <p>This class copies the Javadocs from a generated class back to the template.
+ * This is helpful for writing the Javadocs on a "real" class to benefit from IDE
+ * support (auto complete of parameter names, for example) that you don't get
+ * when directly editing the template.</p>
+ *
+ * <p>This class is in the test classpath to keep it out of public API, but it is
+ * not a test.</p>
+ *
+ * <p>This assumes it is running in the same folder as the code generator and the
+ * API folder with the templates is a sibling folder. You can specify any number
+ * of pairs of arguments, for example:
+ * <blockquote><code>
+ * org.eclipse.collections.api.map.primitive.IntValuesMap
+ * api/map/primitiveValuesMap
+ * org.eclipse.collections.api.map.primitive.CharIntMap
+ * api/map/primitivePrimitiveMap
+ * </code></blockquote>
+ * </p>
+ *
+ * @author <a href="dimeo@elderresearch.com">John Dimeo</a>
+ * @since May 8, 2020
+ */
+public class JavadocUtil
+{
+    private static final Path TEMPLATE_ROOT = Paths.get("src", "main", "resources");
+    private static final Path API_ROOT = Paths.get("..", "eclipse-collections-api");
+
+    private String generatedClass;
+    private String template;
+
+    public JavadocUtil generatedClass(String gc)
+    {
+        this.generatedClass = gc;
+        return this;
+    }
+
+    public JavadocUtil template(String t)
+    {
+        this.template = t;
+        return this;
+    }
+
+    public void process() throws IOException
+    {
+        generatedClass = generatedClass.replace('.', File.separatorChar);
+        if (!generatedClass.endsWith(".java"))
+        {
+            generatedClass += ".java";
+        }
+        if (!template.endsWith(".stg"))
+        {
+            template  += ".stg";
+        }
+
+        Path src = API_ROOT.resolve(EclipseCollectionsCodeGenerator.GENERATED_SOURCES_LOCATION.replace('/', File.separatorChar) + generatedClass);
+        Path dest = TEMPLATE_ROOT.resolve(template.replace('/', File.separatorChar));
+
+        if (!Files.isRegularFile(src) || !Files.isRegularFile(dest))
+        {
+            throw new IllegalArgumentException("Specified files are not readable");
+        }
+
+        List<String> srcLines = Files.readAllLines(src);
+        List<String> destLines = Files.readAllLines(dest);
+        Deque<String> javadocLines = new LinkedList<>();
+
+        boolean inJavadoc = false;
+        boolean matchNextLine = false;
+        for (String srcLine : srcLines)
+        {
+            String srcLineNorm = normalizeGeneratedClassLine(srcLine);
+            String srcLineTrimmed = srcLineNorm.trim();
+            if (srcLineTrimmed.isEmpty())
+            {
+                continue;
+            }
+
+            // Annotations belong with the javadoc
+            if (srcLineTrimmed.startsWith("@"))
+            {
+                javadocLines.add(srcLineNorm);
+                continue;
+            }
+
+            if (matchNextLine)
+            {
+                findLineReplacingJavadoc(destLines, srcLineTrimmed, javadocLines);
+                matchNextLine = false;
+                continue;
+            }
+
+            if (srcLineTrimmed.startsWith("/**"))
+            {
+                inJavadoc = true;
+                javadocLines.clear();
+            }
+            if (inJavadoc)
+            {
+                javadocLines.add(srcLineNorm);
+                if (srcLineTrimmed.startsWith("*/") || srcLineTrimmed.endsWith("*/"))
+                {
+                    inJavadoc = false;
+                    matchNextLine = true;
+                }
+            }
+        }
+
+        Files.write(dest, destLines);
+
+        System.out.println("Copied Javadocs from " + generatedClass + " back to " + template);
+    }
+
+    private static void findLineReplacingJavadoc(List<String> lines, String matchLine, Deque<String> javadoc)
+    {
+        ListIterator<String> iter = lines.listIterator();
+        while (iter.hasNext())
+        {
+            String line = normalizeTemplateLine(iter.next().trim());
+            // Definitions aren't candidates for matches
+            if (line.isEmpty() || line.contains("::="))
+            {
+                continue;
+            }
+
+            if (line.equals(matchLine))
+            {
+                // Remove existing javadoc
+                iter.previous();
+                while (iter.hasPrevious()
+                    && (line = iter.previous().trim()).startsWith("@")
+                    || line.startsWith("*/")
+                    || line.startsWith("*")
+                    || line.startsWith("/**"))
+                {
+                    iter.remove();
+                }
+                iter.next();
+                javadoc.forEach(iter::add);
+                return;
+            }
+        }
+        System.err.println("Could not match line " + matchLine);
+        return;
+    }
+
+    // Remove all types and type placeholders so lines will exactly match
+    private static String normalizeTemplateLine(String s)
+    {
+        s = s.replace("<type1>", "<type>").replace("<type2>", "<type>");
+        s = s.replace("<name1>", "<name>").replace("<name2>", "<name>");
+        // boolean is a common return value for is...() methods - normalize
+        // it to match normalized lines from the generated class. Also remove \
+        return s.replace("boolean", "<type>").replaceAll(Pattern.quote("\\"), "");
+    }
+
+    // TODO: Multiple types/names not properly supported
+    private static String normalizeGeneratedClassLine(String s)
+    {
+        for (Primitive p : Primitive.values())
+        {
+            s = s.replace(p.type, "<type>").replace(p.getName(), "<name>");
+        }
+        // ... but "interface" gets erroneously replaced
+        return s.replace("<type>erface", "interface");
+    }
+
+    public static void main(String... args) throws IOException
+    {
+        if (args.length < 2 || args.length % 2 > 0)
+        {
+            throw new IllegalArgumentException("You must specify pairs of file paths: a generated class followed by its template");
+        }
+
+        for (int i = 0; i < args.length; i += 2)
+        {
+            new JavadocUtil().generatedClass(args[i]).template(args[i + 1]).process();
+        }
+    }
+}


### PR DESCRIPTION
I have completed Javadocs on the API's `map` package. I am opening a PR to being the review process now before I (or someone else!) moves on to the other packages (`list`, `set`, `bag`, etc.).  In my view, `map` was the highest priority with methods like `getIfAbsentPutWith` that benefited most from Javadocs. Additionally, I'm envisioning many Javadocs in those packages will be copy-paste from what I have here, so I want to confirm the verbiage is right before doing so.

Some non-Javadoc changes included in this PR (which can be taken out if needed):
- Update checkstyle DTD (now content assist works in Eclipse when editing the configs)
- Remove `\r` checkstyle check. I don't see what benefit it provides (from what I can tell, my commits still have just `\n` even from Windows) while just making it a lot harder to contribute from Windows and get a clean build
- Remove a redundant `tap()` declaration in `immutableObjectPrimitiveMap.stg`

Additionally, this includes a helper `JavadocUtil` that will copy Javadocs back _from_ a generated class _to_ a template. It's not perfect but it saved me a ton of time, so that I could edit the Javadocs on an example concrete class and benefit from Eclipse's Javadoc assists that would otherwise be unavailable when directly editing the template.