### PR TITLE
Closes #890: Implements Null Safe Comparators by Function

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Comparators.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Comparators.java
@@ -360,6 +360,20 @@ public final class Comparators
         return Comparators.byFunction(function, naturalOrder());
     }
 
+    public static <T, V extends Comparable<? super V>> SerializableComparator<T> byFunctionNullsLast(Function<? super T, ? extends V> function)
+    {
+        return Comparators.byFunction(
+                function,
+                Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    public static <T, V extends Comparable<? super V>> SerializableComparator<T> byFunctionNullsFirst(Function<? super T, ? extends V> function)
+    {
+        return Comparators.byFunction(
+                function,
+                Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
     public static <T> SerializableComparator<T> byBooleanFunction(BooleanFunction<T> function)
     {
         return Functions.toBooleanComparator(function);

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsSerializationTest.java
@@ -201,4 +201,34 @@ public class ComparatorsSerializationTest
                         + "TGphdmEvdXRpbC9Db21wYXJhdG9yO3hwcA==",
                 Comparators.bySecondOfPair(null));
     }
+
+    @Test
+    public void compareByFunctionNullsLast()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEBvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLmNvbXBhcmF0b3IuRnVu\n"
+                        + "Y3Rpb25Db21wYXJhdG9yAAAAAAAAAAECAAJMAApjb21wYXJhdG9ydAAWTGphdmEvdXRpbC9Db21w\n"
+                        + "YXJhdG9yO0wACGZ1bmN0aW9udAA1TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9ibG9jay9m\n"
+                        + "dW5jdGlvbi9GdW5jdGlvbjt4cHNyACRqYXZhLnV0aWwuQ29tcGFyYXRvcnMkTnVsbENvbXBhcmF0\n"
+                        + "b3KW851NtwreSAIAAloACW51bGxGaXJzdEwABHJlYWxxAH4AAXhwAH5yACxqYXZhLnV0aWwuQ29t\n"
+                        + "cGFyYXRvcnMkTmF0dXJhbE9yZGVyQ29tcGFyYXRvcgAAAAAAAAAAEgAAeHIADmphdmEubGFuZy5F\n"
+                        + "bnVtAAAAAAAAAAASAAB4cHQACElOU1RBTkNFcA==",
+                Comparators.byFunctionNullsLast(null));
+    }
+
+    @Test
+    public void compareByFunctionNullsFirst()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEBvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLmNvbXBhcmF0b3IuRnVu\n"
+                        + "Y3Rpb25Db21wYXJhdG9yAAAAAAAAAAECAAJMAApjb21wYXJhdG9ydAAWTGphdmEvdXRpbC9Db21w\n"
+                        + "YXJhdG9yO0wACGZ1bmN0aW9udAA1TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9ibG9jay9m\n"
+                        + "dW5jdGlvbi9GdW5jdGlvbjt4cHNyACRqYXZhLnV0aWwuQ29tcGFyYXRvcnMkTnVsbENvbXBhcmF0\n"
+                        + "b3KW851NtwreSAIAAloACW51bGxGaXJzdEwABHJlYWxxAH4AAXhwAX5yACxqYXZhLnV0aWwuQ29t\n"
+                        + "cGFyYXRvcnMkTmF0dXJhbE9yZGVyQ29tcGFyYXRvcgAAAAAAAAAAEgAAeHIADmphdmEubGFuZy5F\n"
+                        + "bnVtAAAAAAAAAAASAAB4cHQACElOU1RBTkNFcA==",
+                Comparators.byFunctionNullsFirst(null));
+    }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.block.function.primitive.FloatFunction;
 import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.Interval;
@@ -194,6 +195,44 @@ public class ComparatorsTest
         Verify.assertNegative(personComparator.compare(raab, white));
         Verify.assertPositive(personComparator.compare(white, raab));
         Verify.assertZero(personComparator.compare(raab, raab));
+    }
+
+    @Test
+    public void fromFunctionsSafeNullsHigh()
+    {
+        Person bob = new Person("Bob", null, 0);
+        Person dan = new Person("Dan", "Witwicky", 0);
+        Person alice = new Person("Alice", "Liddell", 0);
+        Person carol = new Person("Carol", null, 0);
+
+        Comparator<Person> personComparator = Comparators.byFunctionNullsLast(Person::getLastName);
+        Verify.assertNegative(personComparator.compare(alice, bob));
+        Verify.assertPositive(personComparator.compare(carol, alice));
+        Verify.assertNegative(personComparator.compare(alice, dan));
+        Verify.assertZero(personComparator.compare(bob, carol));
+
+        MutableList<Person> people = Lists.mutable.of(bob, dan, carol, alice);
+        people.sortThis(personComparator);
+        Assert.assertEquals(Lists.immutable.of(alice, dan, bob, carol), people);
+    }
+
+    @Test
+    public void fromFunctionsSafeNullsLow()
+    {
+        Person bob = new Person("Bob", null, 0);
+        Person dan = new Person("Dan", "Witwicky", 0);
+        Person alice = new Person("Alice", "Liddell", 0);
+        Person carol = new Person("Carol", null, 0);
+
+        Comparator<Person> personComparator = Comparators.byFunctionNullsFirst(Person::getLastName);
+        Verify.assertPositive(personComparator.compare(alice, bob));
+        Verify.assertNegative(personComparator.compare(carol, alice));
+        Verify.assertNegative(personComparator.compare(alice, dan));
+        Verify.assertZero(personComparator.compare(bob, carol));
+
+        MutableList<Person> people = Lists.mutable.of(bob, dan, carol, alice);
+        people.sortThis(personComparator);
+        Assert.assertEquals(Lists.immutable.of(bob, carol, alice, dan), people);
     }
 
     @Test


### PR DESCRIPTION
Added two factory methods for byFunction comparators that handle null values. They use null safe comparators from java.util.Comparator and follow a similar naming convention.

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>