### PR TITLE
Closes #892: Uses direct formulas to calculate sum(), mean(), and average() on IntInterval

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -790,12 +790,7 @@ public final class IntInterval
     @Override
     public long sum()
     {
-        long sum = 0L;
-        for (IntIterator intIterator = this.intIterator(); intIterator.hasNext(); )
-        {
-            sum += intIterator.next();
-        }
-        return sum;
+        return (long) this.size() * ((long) this.getFirst() + (long) this.getLast()) / 2L;
     }
 
     @Override
@@ -833,21 +828,14 @@ public final class IntInterval
     @Override
     public double average()
     {
-        return (double) this.sum() / (double) this.size();
+        // for an arithmetic sequence its median and its average are the same
+        return this.median();
     }
 
     @Override
     public double median()
     {
-        int[] sortedArray = this.toSortedArray();
-        int middleIndex = sortedArray.length >> 1;
-        if (sortedArray.length > 1 && (sortedArray.length & 1) == 0)
-        {
-            int first = sortedArray[middleIndex];
-            int second = sortedArray[middleIndex - 1];
-            return ((double) first + (double) second) / 2.0;
-        }
-        return (double) sortedArray[middleIndex];
+        return ((double) this.getFirst() + (double) this.getLast()) / 2.0;
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -560,19 +560,40 @@ public class IntIntervalTest
     public void sum()
     {
         Assert.assertEquals(10L, IntInterval.oneTo(4).sum());
+        Assert.assertEquals(5L, IntInterval.oneToBy(4, 3).sum());
+        Assert.assertEquals(4L, IntInterval.oneToBy(4, 2).sum());
+        Assert.assertEquals(-10L, IntInterval.fromTo(-1, -4).sum());
+        Assert.assertEquals(-15L, IntInterval.fromToBy(-2, -10, -3).sum());
+
+        Assert.assertEquals(-7L, IntInterval.fromToBy(-10, 10, 3).sum());
+
+        Assert.assertEquals(
+                3L * ((long) Integer.MAX_VALUE * 2L - 2L) / 2L,
+                IntInterval.fromTo(Integer.MAX_VALUE - 2, Integer.MAX_VALUE).sum());
     }
 
     @Test
     public void average()
     {
         Assert.assertEquals(2.5, IntInterval.oneTo(4).average(), 0.0);
+        Assert.assertEquals(5.0, IntInterval.oneToBy(9, 2).average(), 0.0);
+        Assert.assertEquals(5.0, IntInterval.oneToBy(10, 2).average(), 0.0);
+        Assert.assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).average(), 0.0);
+
+        Assert.assertEquals((double) Integer.MAX_VALUE - 1.5,
+                IntInterval.fromTo(Integer.MAX_VALUE - 3, Integer.MAX_VALUE).average(), 0.0);
     }
 
     @Test
     public void median()
     {
         Assert.assertEquals(2.5, IntInterval.oneTo(4).median(), 0.0);
-        Assert.assertEquals(3.0, IntInterval.oneTo(5).median(), 0.0);
+        Assert.assertEquals(5.0, IntInterval.oneToBy(9, 2).median(), 0.0);
+        Assert.assertEquals(5.0, IntInterval.oneToBy(10, 2).median(), 0.0);
+        Assert.assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).median(), 0.0);
+
+        Assert.assertEquals((double) Integer.MAX_VALUE - 1.5,
+                IntInterval.fromTo(Integer.MAX_VALUE - 3, Integer.MAX_VALUE).median(), 0.0);
     }
 
     @Test


### PR DESCRIPTION
Uses direct formulas for `mean()` and `average()`, e.g. (first + last)/2.0, and `sum()`, e.g. size * ((first + last) / 2.0) to eliminate unnecessary object creation (arrays and iterators) and improve performance.

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>