### PR TITLE
Closes #894: Memoizes size() value on IntInterval and Interval

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.collections.impl.list;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -61,12 +63,14 @@ public final class Interval
     private final int from;
     private final int to;
     private final int step;
+    private transient int size;
 
     private Interval(int from, int to, int step)
     {
         this.from = from;
         this.to = to;
         this.step = step;
+        this.size = IntervalUtils.intSize(this.from, this.to, this.step);
     }
 
     /**
@@ -757,12 +761,12 @@ public final class Interval
     }
 
     /**
-     * Calculates and returns the size of the interval.
+     * Returns the size of the interval.
      */
     @Override
     public int size()
     {
-        return IntervalUtils.intSize(this.from, this.to, this.step);
+        return this.size;
     }
 
     @Override
@@ -774,7 +778,7 @@ public final class Interval
     }
 
     /**
-     * Converts the interval to an Integer array
+     * Converts the interval to an Integer array.
      */
     public int[] toIntArray()
     {
@@ -1058,5 +1062,12 @@ public final class Interval
     public LazyIterable<Integer> distinct()
     {
         return this;
+    }
+
+    private void readObject(ObjectInputStream ois)
+            throws IOException, ClassNotFoundException
+    {
+        ois.defaultReadObject();
+        this.size = IntervalUtils.intSize(this.from, this.to, this.step);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl.list.primitive;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -63,12 +64,14 @@ public final class IntInterval
     private final int from;
     private final int to;
     private final int step;
+    private transient int size;
 
     private IntInterval(int from, int to, int step)
     {
         this.from = from;
         this.to = to;
         this.step = step;
+        this.size = IntervalUtils.intSize(this.from, this.to, this.step);
     }
 
     /**
@@ -502,12 +505,12 @@ public final class IntInterval
     }
 
     /**
-     * Calculates and returns the size of the interval.
+     * Returns the size of the interval.
      */
     @Override
     public int size()
     {
-        return IntervalUtils.intSize(this.from, this.to, this.step);
+        return this.size;
     }
 
     @Override
@@ -1050,5 +1053,12 @@ public final class IntInterval
             }
             return this.current >= this.to;
         }
+    }
+
+    private void readObject(ObjectInputStream ois)
+            throws IOException, ClassNotFoundException
+    {
+        ois.defaultReadObject();
+        this.size = IntervalUtils.intSize(this.from, this.to, this.step);
     }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/list/IntervalSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/list/IntervalSerializationTest.java
@@ -15,13 +15,20 @@ import org.junit.Test;
 
 public class IntervalSerializationTest
 {
+    public static final String EXPECTED_BASE_64_FORM =
+            "rO0ABXNyACpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmxpc3QuSW50ZXJ2YWwAAAAAAAAA\n"
+                    + "AQIAA0kABGZyb21JAARzdGVwSQACdG94cAAAAAAAAAABAAAACg==";
+
     @Test
     public void serializedForm()
     {
-        Verify.assertSerializedForm(
-                1L,
-                "rO0ABXNyACpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmxpc3QuSW50ZXJ2YWwAAAAAAAAA\n"
-                        + "AQIAA0kABGZyb21JAARzdGVwSQACdG94cAAAAAAAAAABAAAAAA==",
-                Interval.fromToBy(0, 0, 1));
+        Verify.assertSerializedForm(1L, EXPECTED_BASE_64_FORM, Interval.fromToBy(0, 10, 1));
+    }
+
+    // Testing deserialization because readObject() is overridden in Interval
+    @Test
+    public void deserialization()
+    {
+        Verify.assertDeserializedForm(EXPECTED_BASE_64_FORM, Interval.fromToBy(0, 10, 1));
     }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalSerializationTest.java
@@ -15,13 +15,20 @@ import org.junit.Test;
 
 public class IntIntervalSerializationTest
 {
+    public static final String EXPECTED_BASE_64_FORM =
+            "rO0ABXNyADdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmxpc3QucHJpbWl0aXZlLkludElu\n"
+                    + "dGVydmFsAAAAAAAAAAECAANJAARmcm9tSQAEc3RlcEkAAnRveHAAAAAAAAAAAQAAAAo=";
+
     @Test
     public void serializedForm()
     {
-        Verify.assertSerializedForm(
-                1L,
-                "rO0ABXNyADdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmxpc3QucHJpbWl0aXZlLkludElu\n"
-                        + "dGVydmFsAAAAAAAAAAECAANJAARmcm9tSQAEc3RlcEkAAnRveHAAAAAAAAAAAQAAAAA=",
-                IntInterval.fromToBy(0, 0, 1));
+        Verify.assertSerializedForm(1L, EXPECTED_BASE_64_FORM, IntInterval.fromToBy(0, 10, 1));
+    }
+
+    // Testing deserialization because readObject() is overridden in IntInterval
+    @Test
+    public void deserialization()
+    {
+        Verify.assertDeserializedForm(EXPECTED_BASE_64_FORM, IntInterval.fromToBy(0, 10, 1));
     }
 }


### PR DESCRIPTION
The value of size is calculated once on object instantiation rather than every time `size()` is called. The property `size` is transient to preserve serialization compatibility, thus requiring calculating size in the `readObject()` method as well.

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>