### PR TITLE
Closes #895: Implement subList() on IntInterval

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -501,7 +501,7 @@ public final class IntInterval
     @Override
     public ImmutableIntList subList(int fromIndex, int toIndex)
     {
-        throw new UnsupportedOperationException("subList not yet implemented!");
+        return IntInterval.fromToBy(this.get(fromIndex), this.get(toIndex - 1), this.step);
     }
 
     /**

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -351,10 +351,11 @@ public class IntIntervalTest
         Verify.assertSize(200_000_001, IntInterval.fromTo(1_000_000_000, -1_000_000_000).by(-10));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void subList()
     {
-        this.intInterval.subList(0, 1);
+        IntInterval interval = IntInterval.fromToBy(1, 10, 2);
+        Assert.assertEquals(IntLists.immutable.with(3, 5, 7), interval.subList(1, 4));
     }
 
     @Test


### PR DESCRIPTION
Closes #895: replaces `...UnsupportedOperationException...` with the implementation that follows the pattern in the `Interval` class

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>