### PR TITLE
Closes #728: Adds shuffle operation to primitive lists

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
@@ -14,6 +14,7 @@ body(type, name) ::= <<
 
 package org.eclipse.collections.api.list.primitive;
 
+<(auxiliaryImports.(type))(type)>
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.block.function.primitive.<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
@@ -151,6 +152,52 @@ allMethods(type) ::= <<
  */
 Mutable<name>List sortThis();
 
+/**
+ * Randomly permutes this list mutating its contents and returns the same list (this).
+ *
+ * Uses {@code java.util.Random} as the source of randomness.
+ */
+default Mutable<name>List shuffleThis()
+{
+    return this.shuffleThis(new Random());
+}
+
+/**
+ * Randomly permutes this list mutating its contents and returns the same list (this).
+ *
+ * Implements the Fisher-Yates shuffle algorithm using the provided source of randomness.
+ */
+default Mutable<name>List shuffleThis(Random rnd)
+{
+    for (int j = this.size() - 1; j > 0; j--)
+    {
+        int k = rnd.nextInt(j + 1);
+        <type> selected  = this.get(j);
+        this.set(j, this.get(k));
+        this.set(k, selected);
+    }
+
+    return this;
+}
+
 >>
 
 noMethods(type) ::= ""
+
+auxiliaryImports ::= [
+    "byte": "allAuxiliaryImports",
+    "short": "allAuxiliaryImports",
+    "char": "allAuxiliaryImports",
+    "int": "allAuxiliaryImports",
+    "long": "allAuxiliaryImports",
+    "float": "allAuxiliaryImports",
+    "double": "allAuxiliaryImports",
+    "boolean": "noAuxiliaryImports"
+]
+
+allAuxiliaryImports(type) ::= <<
+import java.util.Random;
+
+>>
+
+noAuxiliaryImports(type) ::= ""

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
@@ -448,6 +448,16 @@ public Mutable<name>List sortThis()
 }
 
 @Override
+public Mutable<name>List shuffleThis()
+{
+    synchronized (this.getLock())
+    {
+        this.getMutable<name>List().shuffleThis();
+    }
+    return this;
+}
+
+@Override
 public int binarySearch(<type> value)
 {
     synchronized (this.getLock())

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/unmodifiablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/unmodifiablePrimitiveList.stg
@@ -323,6 +323,12 @@ public Mutable<name>List sortThis()
 }
 
 @Override
+public Mutable<name>List shuffleThis()
+{
+    throw new UnsupportedOperationException("Cannot call shuffleThis() on " + this.getClass().getSimpleName());
+}
+
+@Override
 public int binarySearch(<type> value)
 {
     return this.getMutable<name>List().binarySearch(value);

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -19,6 +19,7 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.list.primitive.<name>List;
 import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.MutableSet;
@@ -318,6 +319,24 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         list.add(<(literal.(type))("1")>);
         list.sortThis();
         Assert.assertEquals(<(literal.(type))("1")>, list.get(0)<(wideDelta.(type))>);
+    }
+
+    @Test
+    public void shuffleThis()
+    {
+        <name>List checkList = this.newWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"]:(literal.(type))(); separator=", ">).toImmutable();
+
+        Mutable<name>List list = checkList.toList();
+
+        <name>List shuffleOne = list.shuffleThis().toImmutable();
+        <name>List shuffleTwo = list.shuffleThis().toImmutable();
+
+        Assert.assertNotEquals(checkList, shuffleOne);
+        Assert.assertNotEquals(checkList, shuffleTwo);
+        Assert.assertNotEquals(shuffleOne, shuffleTwo);
+
+        Assert.assertEquals(checkList, shuffleOne.toSortedList());
+        Assert.assertEquals(checkList, shuffleTwo.toSortedList());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -236,6 +236,13 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     }
 
     @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void shuffleThis()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).shuffleThis();
+    }
+
+    @Override
     @Test
     public void contains()
     {


### PR DESCRIPTION
Adds `shuffleThis()` method to mutable primitive lists (excluding boolean list).  The method randomly permutes the list in place and returns the same list (this). 

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>