### PR TITLE
#882 Fix Eclipse compiler complaints

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveSingletonBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/immutable/immutablePrimitiveSingletonBag.stg
@@ -214,9 +214,10 @@ final class Immutable<name>SingletonBag implements Immutable<name>Bag, Serializa
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public \<V> ImmutableBag\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        return HashBag.newBagWith(function.valueOf(this.element1)).toImmutable();
+        return (ImmutableBag\<V>) HashBag.newBagWith(function.valueOf(this.element1)).toImmutable();
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
@@ -173,9 +173,10 @@ final class Immutable<name>SingletonList implements Immutable<name>List, Seriali
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public \<V> ImmutableList\<V> collect(<name>ToObjectFunction\<? extends V> function)
     {
-        return FastList.newListWith(function.valueOf(this.element1)).toImmutable();
+        return (ImmutableList\<V>) FastList.newListWith(function.valueOf(this.element1)).toImmutable();
     }
 
     <(arithmeticMethods.(type))(name, type)>


### PR DESCRIPTION
Fix Eclipse compiler complaints

Fixes two autogenerated classes for compiling errors when using Eclipse Compiler to compile.

The fix doesn't affect normal usage. I don't this fix is harmful. It benefits people that want to contribute using Eclipse IDE (and Eclipse compiler).

Signed-off-by: Leonardo de Moura Rocha Lima <leomrlima@gmail.com>