### PR TITLE
Implement swap() method on mutable primitive lists

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
@@ -42,6 +42,13 @@ public interface Mutable<name>List extends Mutable<name>Collection, <name>List
 
     <type> set(int index, <type> element);
 
+    default void swap(int index1, int index2)
+    {
+        <type> value = this.get(index1);
+        this.set(index1, this.get(index2));
+        this.set(index2, value);
+    }
+
     <sharedAPI(fileName(primitive), name)>
 
     <mutableAPI(fileName(primitive), type, name)>

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -505,6 +505,14 @@ public class <name>ArrayList extends Abstract<name>Iterable
     }
 
     @Override
+    public void swap(int index1, int index2)
+    {
+        <type> value = this.get(index1);
+        this.items[index1] = this.items[index2];
+        this.items[index2] = value;
+    }
+
+    @Override
     public <name>ArrayList with(<type> element)
     {
         this.add(element);

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -255,6 +255,16 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(this.newMutableCollectionWith(<["1", "4", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
+    @Test
+    public void swap()
+    {
+        Mutable<name>List list = this.classUnderTest();
+        list.swap(1, 2);
+        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
+        list.swap(1, 1);
+        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void subList()
     {

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -125,6 +125,13 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
+    public void swap()
+    {
+        this.list.swap(0, 1);
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
     public void clear()
     {
         this.classUnderTest().clear();


### PR DESCRIPTION
Implement `swap(index1, index2)` method for swapping two list elements. Add corresponding tests on mutable primitive list tests and default implementations on the respective primitive list interfaces. 

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>