### PR TITLE
Closes #908: Support sorting of primitive lists by indirect comparison

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/block/function/primitiveComparator.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/block/function/primitiveComparator.stg
@@ -1,0 +1,34 @@
+import "copyright.stg"
+
+targetPath() ::= "org/eclipse/collections/api/block/comparator/primitive"
+
+fileName(primitive) ::= "<primitive.name>Comparator"
+
+class(primitive) ::= <<
+<body(primitive.type, primitive.name, primitive.wrapperName)>
+>>
+
+body(type, name, wrapperName) ::= <<
+<copyright()>
+
+package org.eclipse.collections.api.block.comparator.primitive;
+
+import java.io.Serializable;
+
+/**
+ * <name>Comparator is a primitive Comparator that takes two arguments of type <type> and
+ * otherwise follows the contract of {@code java.util.Comparator}.
+ * This comparator can be used to sort primitive collections, which support indirect sorting,
+ * if a sort order other thant the natural one of the collection elements is required.
+ *
+ * This file was automatically generated from template file primitiveComparator.stg.
+ *
+ */
+@FunctionalInterface
+public interface <name>Comparator\<T>
+        extends Serializable
+{
+    int compare(<type> value1, <type> value2);
+}
+
+>>

--- a/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
@@ -160,6 +160,32 @@ allMethods(type) ::= <<
 Mutable<name>List sortThis();
 
 /**
+ * Sorts the internal data structure of this list and returns the list itself as a convenience.
+ */
+default Mutable<name>List sortThis(<name>Comparator comparator)
+{
+    throw new UnsupportedOperationException("sortThis(<name>Comparator comparator) is not supported on " + this.getClass());
+}
+
+/**
+ * Sorts the internal data structure of this list based on the natural order of the key returned by {@code
+ * function}.
+ */
+default \<T> Mutable<name>List sortThisBy(<name>ToObjectFunction\<T> function)
+{
+    return sortThisBy(function, (Comparator\<? super T>) Comparator.naturalOrder());
+}
+
+/**
+ * Sorts the internal data structure of this list based on the key returned by {@code
+ * function} using the provided {@code comparator}.
+ */
+default \<T> Mutable<name>List sortThisBy(<name>ToObjectFunction\<T> function, Comparator\<? super T> comparator)
+{
+    return this.sortThis((i1, i2) -> comparator.compare(function.valueOf(i1), function.valueOf(i2)));
+}
+
+/**
  * Randomly permutes this list mutating its contents and returns the same list (this).
  *
  * Uses {@code java.util.Random} as the source of randomness.
@@ -203,7 +229,9 @@ auxiliaryImports ::= [
 ]
 
 allAuxiliaryImports(type) ::= <<
+import java.util.Comparator;
 import java.util.Random;
+import org.eclipse.collections.api.block.comparator.primitive.<name>Comparator;
 
 >>
 

--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveSort.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveSort.stg
@@ -1,0 +1,154 @@
+import "copyright.stg"
+
+targetPath() ::= "org/eclipse/collections/impl/utility/primitive"
+
+fileName(primitive) ::= "<primitive.name>QuickSort"
+
+class(primitive) ::= <<
+<body(primitive.type, primitive.name, primitive.wrapperName)>
+>>
+
+body(type, name, wrapperName) ::= <<
+<copyright()>
+
+package org.eclipse.collections.impl.utility.primitive;
+
+import org.eclipse.collections.api.block.comparator.primitive.<name>Comparator;
+
+/**
+ * <name>QuickSort is an implementation of the Quick Sort algorithm as described in Donald Knuth's TAOCP with some
+ * optimizations. It supports indirect array sorting based on primitive comparators and/or key values extracted from
+ * the array values if a sort order other thant the natural one of the array elements is required.
+ *
+ * This file was automatically generated from template file primitiveSort.stg.
+ *
+ */
+
+public final class <name>QuickSort
+{
+    private static final int SORT_SMALL_SIZE = 9;
+
+    private <name>QuickSort()
+    {
+    }
+
+    public static void sort(<type>[] array, int left, int right, <name>Comparator comparator)
+    {
+        int size = right - left + 1;
+
+        if (size \<= <name>QuickSort.SORT_SMALL_SIZE)
+        {
+            <name>QuickSort.insertionSort(array, left, right, comparator);
+        }
+        else
+        {
+            // Initialize new stage
+            int mid = (right - (right / 2)) + (left / 2);
+            <type> leftVal = array[left];
+            <type> rightVal = array[right];
+            <type> midVal = array[mid];
+
+            int swapIndex = -1;
+
+            if (comparator.compare(leftVal, midVal) > 0 && comparator.compare(leftVal, rightVal) > 0)
+            {
+                swapIndex = (comparator.compare(midVal, rightVal) \< 0) ? right : mid;
+            }
+            else if (comparator.compare(leftVal, midVal) \< 0 && comparator.compare(leftVal, rightVal) \< 0)
+            {
+                swapIndex = (comparator.compare(midVal, rightVal) \< 0) ? mid : right;
+            }
+
+            if (swapIndex > 0)
+            {
+                swap(array, left, swapIndex);
+            }
+
+            <type> pivot = array[left];
+
+            int i = left + 1;
+            int j = right;
+
+            while (i \< j)
+            {
+                // Compare: Key(i) : Key, skip all which are \<= pivot or until hit j
+                while (comparator.compare(array[i], pivot) \<= 0 && i \< j)
+                {
+                    i++;
+                }
+
+                // Compare Key : Key(j), skip all which are > pivot or until hit i
+                while (comparator.compare(pivot, array[j]) \< 0 && j > i - 1)
+                {
+                    j--;
+                }
+
+                if (i \< j)
+                {
+                    swap(array, i, j);
+                }
+                else
+                {
+                    swap(array, left, j);
+                }
+            }
+
+            // Sort partitions, skipping sequences of elements equal to the pivot
+            if (right > j + 1)
+            {
+                int from = j + 1;
+                while (right > from && comparator.compare(pivot, array[from]) == 0)
+                {
+                    from++;
+                }
+                if (right > from)
+                {
+                    <name>QuickSort.sort(array, from, right, comparator);
+                }
+            }
+
+            if (left \< j - 1)
+            {
+                int to = j - 1;
+                while (to > left && comparator.compare(pivot, array[to]) == 0)
+                {
+                    to--;
+                }
+                if (left \< to)
+                {
+                    <name>QuickSort.sort(array, left, to, comparator);
+                }
+            }
+        }
+    }
+
+    private static void insertionSort(<type>[] array, int left, int right, <name>Comparator comparator)
+    {
+        for (int j = left + 1; j \<= right; j++)
+        {
+            if (comparator.compare(array[j - 1], array[j]) > 0)
+            {
+                <type> key = array[j];
+                int i = j - 1;
+
+                do
+                {
+                    array[i + 1] = array[i];
+                    i--;
+                }
+                while (i > -1 && comparator.compare(key, array[i]) \< 0);
+
+                array[i + 1] = key;
+            }
+        }
+    }
+    
+    private static void swap(<type>[] array, int i1, int i2)
+    {
+        <type> value = array[i1];
+        array[i1] = array[i2];
+        array[i2] = value;
+    }
+}
+
+>>

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -28,6 +28,7 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.comparator.primitive.<name>Comparator;
 import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
@@ -53,6 +54,7 @@ import org.eclipse.collections.impl.primitive.Abstract<name>Iterable;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
+import org.eclipse.collections.impl.utility.primitive.<name>QuickSort;
 <if(primitive.specializedStream)>
 import java.util.Spliterator;
 import java.util.Spliterators;<endif>
@@ -1008,6 +1010,13 @@ public class <name>ArrayList extends Abstract<name>Iterable
     public <name>ArrayList sortThis()
     {
         Arrays.sort(this.items, 0, this.size);
+        return this;
+    }
+
+    @Override
+    public <name>ArrayList sortThis(<name>Comparator comparator)
+    {
+        <name>QuickSort.sort(this.items, 0, this.size() - 1, comparator);
         return this;
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
@@ -17,9 +17,11 @@ body(type, name) ::= <<
 package org.eclipse.collections.impl.list.mutable.primitive;
 
 import java.util.Collection;
+<if(!primitive.booleanPrimitive)>import java.util.Comparator;<endif>
 
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
+<if(!primitive.booleanPrimitive)>import org.eclipse.collections.api.block.comparator.primitive.<name>Comparator;<endif>
 import org.eclipse.collections.api.block.function.primitive.<name>IntToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObjectFunction;
@@ -443,6 +445,36 @@ public Mutable<name>List sortThis()
     synchronized (this.getLock())
     {
         this.getMutable<name>List().sortThis();
+    }
+    return this;
+}
+
+@Override
+public Mutable<name>List sortThis(<name>Comparator comparator)
+{
+    synchronized (this.getLock())
+    {
+        this.getMutable<name>List().sortThis(comparator);
+    }
+    return this;
+}
+
+@Override
+public \<T> Mutable<name>List sortThisBy(<name>ToObjectFunction\<T> function)
+{
+    synchronized (this.getLock())
+    {
+        this.getMutable<name>List().sortThisBy(function);
+    }
+    return this;
+}
+
+@Override
+public \<T> Mutable<name>List sortThisBy(<name>ToObjectFunction\<T> function, Comparator\<? super T> comparator)
+{
+    synchronized (this.getLock())
+    {
+        this.getMutable<name>List().sortThisBy(function, comparator);
     }
     return this;
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -26,6 +26,7 @@ import org.eclipse.collections.api.set.MutableSet;
 <if(!primitive.intPrimitive)>import org.eclipse.collections.api.tuple.primitive.<name>IntPair;<endif>
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
+import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable<name>CollectionTestCase;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Sets;
@@ -50,6 +51,9 @@ import java.util.Arrays;<endif>
  */
 public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>CollectionTestCase
 {
+    private static final <name>List SORTED_LONGER_LIST = <name>ArrayList.newListWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]:(literal.(type))(); separator=", ">);
+    private static final <name>List SORTED_SHORTER_LIST = <name>ArrayList.newListWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
+
     @Override
     protected abstract Mutable<name>List classUnderTest();
 
@@ -329,6 +333,95 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         list.add(<(literal.(type))("1")>);
         list.sortThis();
         Assert.assertEquals(<(literal.(type))("1")>, list.get(0)<(wideDelta.(type))>);
+    }
+
+    @Test
+    public void sortWithPrimitiveComparator()
+    {
+        Mutable<name>List index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">); // sin: 0, 0.841, 0.909, 0.141, -0.757
+
+        index.sortThis((i1, i2) -> Double.compare(Math.sin(i1), Math.sin(i2)));
+
+        Assert.assertEquals(<name>ArrayList.newListWith(<["4", "0", "3", "1", "2"]:(literal.(type))(); separator=", ">), index);
+    }
+
+    @Test
+    public void sortWithOddEvenComparator()
+    {
+        Mutable<name>List index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">);
+
+        index.sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1)));
+
+        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "2", "4", "6", "8", "1", "3", "5", "7", "9"]:(literal.(type))(); separator=", ">), index);
+    }
+
+    @Test
+    public void sortWithKeyExtractorNaturalComparator()
+    {
+        MutableList\<String> list = Lists.mutable.of("Foo", "Bar", "Baz", "Waldo", "Qux");
+        Mutable<name>List index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
+
+        index.sortThisBy(i -> list.get((int) i));
+
+        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), index);
+    }
+
+    @Test
+    public void sortWithKeyExtractorUnnaturalComparator()
+    {
+        MutableList\<String> list = Lists.mutable.of("Foo", "Bar", "Baz", "Waldo", "Qux");
+        Mutable<name>List index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
+
+        index.sortThisBy(i -> list.get((int) i), Comparators.naturalOrder().reversed());
+
+        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), index);
+    }
+
+    @Test
+    public void sortShuffledInputWithDupes()
+    {
+        Assert.assertEquals(
+                <name>ArrayList.newListWith(<["0", "1", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">),
+                this.newMutableCollectionWith(<["3", "2", "1", "0", "1", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+        Assert.assertEquals(
+                <name>ArrayList.newListWith(<["1", "2", "2", "2", "3", "4", "6", "7", "8", "10", "11", "12", "13", "14", "15", "15", "15", "17", "18", "19"]:(literal.(type))(); separator=", ">),
+                this.newMutableCollectionWith(<["17", "1", "15", "12", "10", "4", "2", "19", "2", "8", "18", "15", "15", "13", "3", "11", "7", "2", "14", "6"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+    }
+
+    @Test
+    public void sortShuffledInput()
+    {
+        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "2", "1", "0", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+
+        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["3", "0", "1", "2", "5", "4"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+
+        Assert.assertEquals(
+                SORTED_LONGER_LIST,
+                this.newMutableCollectionWith(<["17", "1", "16", "12", "10", "4", "2", "19", "5", "8", "18", "15", "20", "13", "3", "11", "7", "9", "14", "6"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+
+        Assert.assertEquals(
+                SORTED_LONGER_LIST,
+                this.newMutableCollectionWith(<["12", "3", "17", "20", "5", "2", "4", "9", "16", "19", "10", "14", "6", "7", "15", "11", "13", "18", "8", "1"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+    }
+
+    @Test
+    public void sortSortedInput()
+    {
+        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+
+        Assert.assertEquals(
+                SORTED_LONGER_LIST,
+                this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+    }
+
+    @Test
+    public void sortReversedSortedInput()
+    {
+        Assert.assertEquals(SORTED_SHORTER_LIST, this.newMutableCollectionWith(<["5", "4", "3", "2", "1", "0"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
+
+        Assert.assertEquals(
+                SORTED_LONGER_LIST,
+                this.newMutableCollectionWith(<["20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1"]:(literal.(type))(); separator=", ">).sortThis(<wrapperName>::compare));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
+<if(!primitive.booleanPrimitive)>import org.eclipse.collections.impl.block.factory.Comparators;<endif>
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -238,6 +239,62 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     @Override
     @Test(expected = UnsupportedOperationException.class)
     public void sortThis()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortWithPrimitiveComparator()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis(<wrapperName>::compare);
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortWithOddEvenComparator()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1)));
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortWithKeyExtractorNaturalComparator()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString);
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortWithKeyExtractorUnnaturalComparator()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString, Comparators.naturalOrder().reversed());
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortShuffledInputWithDupes()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortShuffledInput()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortSortedInput()
+    {
+        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void sortReversedSortedInput()
     {
         new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
     }


### PR DESCRIPTION
Adds indirect sorting methods to primitive collections, which are in addition to the existing `sortThis()`. Unlike `sortThis()`, which uses natural ordering of the primitives, the new methods take a function to generate sort keys with an optional key comparator,  or they can take a primitive comparator.

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>