### PR TITLE
Closes #914: Synchronized primitive lists adds override for shuffleThis(Random rnd)

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
@@ -17,7 +17,10 @@ body(type, name) ::= <<
 package org.eclipse.collections.impl.list.mutable.primitive;
 
 import java.util.Collection;
-<if(!primitive.booleanPrimitive)>import java.util.Comparator;<endif>
+<if(!primitive.booleanPrimitive)>
+import java.util.Comparator;
+import java.util.Random;
+<endif>
 
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
@@ -485,6 +488,16 @@ public Mutable<name>List shuffleThis()
     synchronized (this.getLock())
     {
         this.getMutable<name>List().shuffleThis();
+    }
+    return this;
+}
+
+@Override
+public Mutable<name>List shuffleThis(Random rnd)
+{
+    synchronized (this.getLock())
+    {
+        this.getMutable<name>List().shuffleThis(rnd);
     }
     return this;
 }


### PR DESCRIPTION
Ensures that direct calls to `shuffleThis(Random rnd)` are synchronized

Signed-off-by: vmzakharov <zakharov.vladimir.m@gmail.com>