### PR TITLE
Make primitive*HashMap.keySet() serializable

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -116,7 +116,15 @@
     <suppress checks="RedundantModifier" files="ImmutableIntArrayStack.java" />
     <suppress checks="RedundantModifier" files="ImmutableLongArrayStack.java" />
     <suppress checks="RedundantModifier" files="ImmutableShortArrayStack.java" />
-	
+    <suppress checks="RedundantModifier" files="AbstractMutableBooleanKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableByteKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableCharKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableDoubleKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableFloatKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableIntKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableShortKeySet.java" />
+    <suppress checks="RedundantModifier" files="AbstractMutableLongKeySet.java" />
+
 	<!-- Runs outside of a plugin Mojo and has no logging API on classpath -->
 	<suppress checks="RegexpSinglelineJava" files="JavadocUtil.java" />
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveKeySet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/abstractMutablePrimitiveKeySet.stg
@@ -19,6 +19,10 @@ body(type, name) ::= <<
 package org.eclipse.collections.impl.map.mutable.primitive;
 
 import java.io.IOException;
+import java.io.Externalizable;
+import java.io.ObjectInput;
+import java.io.ObjectStreamException;
+import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 
@@ -52,8 +56,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name>Set;
  *
  * @since 6.0.
  */
-public abstract class AbstractMutable<name>KeySet implements Mutable<name>Set
+public abstract class AbstractMutable<name>KeySet implements Mutable<name>Set, Externalizable
 {
+    private static final long serialVersionUID = 1L;
     private static final <type> EMPTY_KEY = <(literal.(type))("0")>;
     private static final <type> REMOVED_KEY = <(literal.(type))("1")>;
 
@@ -880,6 +885,68 @@ public abstract class AbstractMutable<name>KeySet implements Mutable<name>Set
             }
         }
         return result;
+    }
+
+    public Object writeReplace() throws ObjectStreamException
+    {
+        return new SerRep(this);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException
+    {
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
+    {
+    }
+
+    private static class SerRep implements Externalizable
+    {
+        private static final long serialVersionUID = 1L;
+
+        private transient AbstractMutable<name>KeySet original;
+        private transient <name>HashSet deserialized;
+
+        @SuppressWarnings("RedundantModifier")
+        public SerRep()
+        {
+            // for Externalizable
+        }
+
+        private SerRep(AbstractMutable<name>KeySet original)
+        {
+            this.original = original;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException
+        {
+            out.writeInt(this.original.size());
+            <name>Iterator it = this.original.<type>Iterator();
+            while (it.hasNext())
+            {
+                out.write<name>(it.next());
+            }
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
+        {
+            int unread = in.readInt();
+            this.deserialized = new <name>HashSet(unread);
+            while (unread > 0)
+            {
+                this.deserialized.add(in.read<name>());
+                unread--;
+            }
+        }
+
+        private Object readResolve() throws ObjectStreamException
+        {
+            return this.deserialized;
+        }
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -64,7 +64,6 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
-import org.eclipse.collections.api.block.function.primitive.Object<name>ToObjectFunction;
 import org.eclipse.collections.api.block.function.primitive.BooleanFunction;
 import org.eclipse.collections.api.block.function.primitive.ByteFunction;
 import org.eclipse.collections.api.block.function.primitive.CharFunction;
@@ -80,7 +79,6 @@ import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.predicate.primitive.<name>ObjectPredicate;
-import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.block.procedure.primitive.<name>ObjectProcedure;
@@ -97,7 +95,6 @@ import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.primitive.<name>ObjectMap;
@@ -111,7 +108,6 @@ import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.multimap.bag.MutableBagMultimap;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
@@ -151,8 +147,6 @@ import org.eclipse.collections.impl.block.procedure.primitive.CollectShortProced
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.impl.factory.primitive.<name>ObjectMaps;
 <if(!primitive.longPrimitive)><if(!primitive.doublePrimitive)>import org.eclipse.collections.impl.factory.primitive.Object<name>Maps;<endif><endif>
 import org.eclipse.collections.impl.factory.primitive.ObjectDoubleMaps;
@@ -160,17 +154,13 @@ import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
 import org.eclipse.collections.impl.iterator.Unmodifiable<name>Iterator;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterable;
 import org.eclipse.collections.impl.lazy.primitive.AbstractLazy<name>Iterable;
-import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
-import org.eclipse.collections.impl.set.mutable.primitive.Synchronized<name>Set;
-import org.eclipse.collections.impl.set.mutable.primitive.Unmodifiable<name>Set;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -2825,10 +2815,8 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         this.copyKeysOnWrite = false;
     }
 
-    private static final class SentinelValues\<V>
+    private static final class SentinelValues\<V> extends AbstractSentinelValues
     {
-        private boolean containsZeroKey;
-        private boolean containsOneKey;
         private V zeroValue;
         private V oneValue;
 
@@ -3021,8 +3009,79 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return Math.min(capacity - 1, capacity >\> 1);
     }
 
-    private class KeySet implements Mutable<name>Set
+    private class KeysMapWrapper implements Mutable<name>KeysMap
     {
+        @Override
+        public int size()
+        {
+            return <name>ObjectHashMap.this.size();
+        }
+
+        @Override
+        public boolean containsKey(<type> key)
+        {
+            return <name>ObjectHashMap.this.containsKey(key);
+        }
+
+        @Override
+        public void forEachKey(<name>Procedure procedure)
+        {
+            <name>ObjectHashMap.this.forEachKey(procedure);
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return <name>ObjectHashMap.this.isEmpty();
+        }
+
+        @Override
+        public boolean notEmpty()
+        {
+            return <name>ObjectHashMap.this.notEmpty();
+        }
+
+        @Override
+        public void removeKey(<type> key)
+        {
+            <name>ObjectHashMap.this.removeKey(key);
+        }
+
+        @Override
+        public void clear()
+        {
+            <name>ObjectHashMap.this.clear();
+        }
+    }
+
+    private class KeySet extends AbstractMutable<name>KeySet
+    {
+        private KeysMapWrapper outer = new KeysMapWrapper();
+
+        @Override
+        protected Mutable<name>KeysMap getOuter()
+        {
+            return outer;
+        }
+
+        @Override
+        protected SentinelValues getSentinelValues()
+        {
+            return <name>ObjectHashMap.this.sentinelValues;
+        }
+
+        @Override
+        protected <type> getKeyAtIndex(int index)
+        {
+            return <name>ObjectHashMap.this.keys[index];
+        }
+
+        @Override
+        protected int getTableSize()
+        {
+            return <name>ObjectHashMap.this.keys.length;
+        }
+
         @Override
         public Mutable<name>Iterator <type>Iterator()
         {
@@ -3030,203 +3089,9 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         }
 
         @Override
-        public void forEach(<name>Procedure procedure)
-        {
-            this.each(procedure);
-        }
-
-        /**
-         * @since 7.0.
-         */
-        @Override
-        public void each(<name>Procedure procedure)
-        {
-            <name>ObjectHashMap.this.forEachKey(procedure);
-        }
-
-        @Override
-        public int count(<name>Predicate predicate)
-        {
-            int count = 0;
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && predicate.accept(EMPTY_KEY))
-                {
-                    count++;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && predicate.accept(REMOVED_KEY))
-                {
-                    count++;
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && predicate.accept(key))
-                {
-                    count++;
-                }
-            }
-            return count;
-        }
-
-        @Override
-        public boolean anySatisfy(<name>Predicate predicate)
-        {
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && predicate.accept(EMPTY_KEY))
-                {
-                    return true;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && predicate.accept(REMOVED_KEY))
-                {
-                    return true;
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && predicate.accept(key))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public \<T> T injectInto(T injectedValue, Object<name>ToObjectFunction\<? super T, ? extends T> function)
-        {
-            T result = injectedValue;
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                {
-                    result = function.valueOf(result, EMPTY_KEY);
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-                {
-                    result = function.valueOf(result, REMOVED_KEY);
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key))
-                {
-                    result = function.valueOf(result, key);
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public RichIterable\<<name>Iterable> chunk(int size)
-        {
-            if (size \<= 0)
-            {
-                throw new IllegalArgumentException("Size for groups must be positive but was: " + size);
-            }
-            if (this.isEmpty())
-            {
-                return Lists.mutable.empty();
-            }
-
-            <name>Iterator iterator = this.<type>Iterator();
-            MutableList\<<name>Iterable> result = Lists.mutable.empty();
-            while (iterator.hasNext())
-            {
-                Mutable<name>Set batch =  <name>Sets.mutable.empty();
-                for (int i = 0; i \< size && iterator.hasNext(); i++)
-                {
-                    batch.add(iterator.next());
-                }
-                result.add(batch);
-            }
-            return result;
-        }
-
-        @Override
-        public boolean allSatisfy(<name>Predicate predicate)
-        {
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && !predicate.accept(EMPTY_KEY))
-                {
-                    return false;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && !predicate.accept(REMOVED_KEY))
-                {
-                    return false;
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && !predicate.accept(key))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public boolean noneSatisfy(<name>Predicate predicate)
-        {
-            return !this.anySatisfy(predicate);
-        }
-
-        @Override
-        public boolean add(<type> element)
-        {
-            throw new UnsupportedOperationException("Cannot call add() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public boolean addAll(<type>... source)
-        {
-            throw new UnsupportedOperationException("Cannot call addAll() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public boolean addAll(<name>Iterable source)
-        {
-            throw new UnsupportedOperationException("Cannot call addAll() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public boolean remove(<type> key)
-        {
-            int oldSize = <name>ObjectHashMap.this.size();
-            <name>ObjectHashMap.this.removeKey(key);
-            return oldSize != <name>ObjectHashMap.this.size();
-        }
-
-        @Override
-        public boolean removeAll(<name>Iterable source)
-        {
-            int oldSize = <name>ObjectHashMap.this.size();
-            <name>Iterator iterator = source.<type>Iterator();
-            while (iterator.hasNext())
-            {
-                <name>ObjectHashMap.this.removeKey(iterator.next());
-            }
-            return oldSize != <name>ObjectHashMap.this.size();
-        }
-
-        @Override
-        public boolean removeAll(<type>... source)
-        {
-            int oldSize = <name>ObjectHashMap.this.size();
-            for (<type> item : source)
-            {
-                <name>ObjectHashMap.this.removeKey(item);
-            }
-            return oldSize != <name>ObjectHashMap.this.size();
-        }
-
-        @Override
         public boolean retainAll(<name>Iterable source)
         {
-            int oldSize = this.size();
+            int oldSize = <name>ObjectHashMap.this.size();
             final <name>Set sourceSet = source instanceof <name>Set ? (<name>Set) source : source.toSet();
             <name>ObjectHashMap\<V> retained = <name>ObjectHashMap.this.select((<type> key, V value) -> sourceSet.contains(key));
             if (retained.size() != oldSize)
@@ -3248,449 +3113,6 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         }
 
         @Override
-        public void clear()
-        {
-            <name>ObjectHashMap.this.clear();
-        }
-
-        @Override
-        public Mutable<name>Set select(<name>Predicate predicate)
-        {
-            Mutable<name>Set result = new <name>HashSet();
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && predicate.accept(EMPTY_KEY))
-                {
-                    result.add(EMPTY_KEY);
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && predicate.accept(REMOVED_KEY))
-                {
-                    result.add(REMOVED_KEY);
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && predicate.accept(key))
-                {
-                    result.add(key);
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public Mutable<name>Set reject(<name>Predicate predicate)
-        {
-            Mutable<name>Set result = new <name>HashSet();
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && !predicate.accept(EMPTY_KEY))
-                {
-                    result.add(EMPTY_KEY);
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && !predicate.accept(REMOVED_KEY))
-                {
-                    result.add(REMOVED_KEY);
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && !predicate.accept(key))
-                {
-                    result.add(key);
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public Mutable<name>Set with(<type> element)
-        {
-            throw new UnsupportedOperationException("Cannot call with() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public Mutable<name>Set without(<type> element)
-        {
-            throw new UnsupportedOperationException("Cannot call without() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public Mutable<name>Set withAll(<name>Iterable elements)
-        {
-            throw new UnsupportedOperationException("Cannot call withAll() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public Mutable<name>Set withoutAll(<name>Iterable elements)
-        {
-            throw new UnsupportedOperationException("Cannot call withoutAll() on " + this.getClass().getSimpleName());
-        }
-
-        @Override
-        public <type> detectIfNone(<name>Predicate predicate, <type> ifNone)
-        {
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey && predicate.accept(EMPTY_KEY))
-                {
-                    return EMPTY_KEY;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && predicate.accept(REMOVED_KEY))
-                {
-                    return REMOVED_KEY;
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key) && predicate.accept(key))
-                {
-                    return key;
-                }
-            }
-            return ifNone;
-        }
-
-        @Override
-        public \<V> MutableSet\<V> collect(<name>ToObjectFunction\<? extends V> function)
-        {
-            MutableSet\<V> result = Sets.mutable.with();
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                {
-                    result.add(function.valueOf(EMPTY_KEY));
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-                {
-                    result.add(function.valueOf(REMOVED_KEY));
-                }
-            }
-            for (<type> key : <name>ObjectHashMap.this.keys)
-            {
-                if (isNonSentinel(key))
-                {
-                    result.add(function.valueOf(key));
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public Mutable<name>Set asUnmodifiable()
-        {
-            return Unmodifiable<name>Set.of(this);
-        }
-
-        @Override
-        public Mutable<name>Set asSynchronized()
-        {
-            return Synchronized<name>Set.of(this);
-        }
-
-        /**
-         * @since 9.2.
-         */
-        @Override
-        public Mutable<name>Set newEmpty()
-        {
-            return new <name>HashSet();
-        }
-
-        @Override
-        <if(primitive.floatingPoint)>public <wideType.(type)> sum()
-{
-    <wideType.(type)> result = <wideZero.(type)>;
-    <wideType.(type)> compensation = <wideZero.(type)>;
-    if (<name>ObjectHashMap.this.sentinelValues != null)
-    {
-        if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-        {
-            <wideType.(type)> adjustedValue = EMPTY_KEY - compensation;
-            <wideType.(type)> nextSum = result + adjustedValue;
-            compensation = nextSum - result - adjustedValue;
-            result = nextSum;
-        }
-        if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-        {
-            <wideType.(type)> adjustedValue = REMOVED_KEY - compensation;
-            <wideType.(type)> nextSum = result + adjustedValue;
-            compensation = nextSum - result - adjustedValue;
-            result = nextSum;
-        }
-    }
-    for (<type> key : <name>ObjectHashMap.this.keys)
-    {
-        if (isNonSentinel(key))
-        {
-            <wideType.(type)> adjustedValue = key - compensation;
-            <wideType.(type)> nextSum = result + adjustedValue;
-            compensation = nextSum - result - adjustedValue;
-            result = nextSum;
-        }
-    }
-    return result;
-}
-
-        <else>public <wideType.(type)> sum()
-{
-    <wideType.(type)> result = <wideZero.(type)>;
-    if (<name>ObjectHashMap.this.sentinelValues != null)
-    {
-        if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-        {
-            result += EMPTY_KEY;
-        }
-        if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-        {
-            result += REMOVED_KEY;
-        }
-    }
-    for (<type> key : <name>ObjectHashMap.this.keys)
-    {
-        if (isNonSentinel(key))
-        {
-            result += key;
-        }
-    }
-    return result;
-}
-
-        <endif>
-        @Override
-        public <type> max()
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                throw new NoSuchElementException();
-            }
-
-            <type> max = <zero.(type)>;
-            boolean isMaxSet = false;
-
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                {
-                    max = EMPTY_KEY;
-                    isMaxSet = true;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-                {
-                    max = REMOVED_KEY;
-                    isMaxSet = true;
-                }
-            }
-            for (int i = 0; i \< <name>ObjectHashMap.this.keys.length; i++)
-            {
-                if (isNonSentinel(<name>ObjectHashMap.this.keys[i]) && (!isMaxSet || <(lessThan.(type))({max}, {<name>ObjectHashMap.this.keys[i]})>))
-                {
-                    max = <name>ObjectHashMap.this.keys[i];
-                    isMaxSet = true;
-                }
-            }
-            return max;
-        }
-
-        @Override
-        public <type> maxIfEmpty(<type> defaultValue)
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                return defaultValue;
-            }
-
-            return this.max();
-        }
-
-        @Override
-        public <type> min()
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                throw new NoSuchElementException();
-            }
-
-            <type> min = <zero.(type)>;
-            boolean isMinSet = false;
-
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                {
-                    min = EMPTY_KEY;
-                    isMinSet = true;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey && !isMinSet)
-                {
-                    min = REMOVED_KEY;
-                    isMinSet = true;
-                }
-            }
-            for (int i = 0; i \< <name>ObjectHashMap.this.keys.length; i++)
-            {
-                if (isNonSentinel(<name>ObjectHashMap.this.keys[i]) && (!isMinSet || <(lessThan.(type))({<name>ObjectHashMap.this.keys[i]}, {min})>))
-                {
-                    min = <name>ObjectHashMap.this.keys[i];
-                    isMinSet = true;
-                }
-            }
-            return min;
-        }
-
-        @Override
-        public <type> minIfEmpty(<type> defaultValue)
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                return defaultValue;
-            }
-
-            return this.min();
-        }
-
-        @Override
-        public double average()
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                throw new ArithmeticException();
-            }
-            return (double) this.sum() / (double) this.size();
-        }
-
-        @Override
-        public double median()
-        {
-            if (<name>ObjectHashMap.this.isEmpty())
-            {
-                throw new ArithmeticException();
-            }
-            <type>[] sortedArray = this.toSortedArray();
-            int middleIndex = sortedArray.length >\> 1;
-            if (sortedArray.length > 1 && (sortedArray.length & 1) == 0)
-            {
-                <type> first = sortedArray[middleIndex];
-                <type> second = sortedArray[middleIndex - 1];
-                return ((double) first + (double) second) / 2.0;
-            }
-            return (double) sortedArray[middleIndex];
-        }
-
-        @Override
-        public <type>[] toSortedArray()
-        {
-            <type>[] array = this.toArray();
-            Arrays.sort(array);
-            return array;
-        }
-
-        @Override
-        public Mutable<name>List toSortedList()
-        {
-            return <name>ArrayList.newList(this).sortThis();
-        }
-
-        @Override
-        public <type>[] toArray()
-        {
-            int size = <name>ObjectHashMap.this.size();
-            final <type>[] result = new <type>[size];
-            <name>ObjectHashMap.this.forEachKey(new <name>Procedure()
-            {
-                private int index;
-
-                @Override
-                public void value(<type> each)
-                {
-                    result[this.index] = each;
-                    this.index++;
-                }
-            });
-            return result;
-        }
-
-        @Override
-        public <type>[] toArray(<type>[] result)
-        {
-            int size = <name>ObjectHashMap.this.size();
-            if (result.length \< size)
-            {
-                result = new <type>[size];
-            }
-            final <type>[] finalBypass = result;
-            <name>ObjectHashMap.this.forEachKey(new <name>Procedure()
-            {
-                private int index;
-
-                @Override
-                public void value(<type> each)
-                {
-                    finalBypass[this.index] = each;
-                    this.index++;
-                }
-            });
-            return result;
-        }
-
-        @Override
-        public boolean contains(<type> value)
-        {
-            return <name>ObjectHashMap.this.containsKey(value);
-        }
-
-        @Override
-        public boolean containsAll(<type>... source)
-        {
-            for (<type> item : source)
-            {
-                if (!<name>ObjectHashMap.this.containsKey(item))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public boolean containsAll(<name>Iterable source)
-        {
-            <name>Iterator iterator = source.<type>Iterator();
-            while (iterator.hasNext())
-            {
-                if (!<name>ObjectHashMap.this.containsKey(iterator.next()))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public Mutable<name>List toList()
-        {
-            return <name>ArrayList.newList(this);
-        }
-
-        @Override
-        public Mutable<name>Set toSet()
-        {
-            return <name>HashSet.newSet(this);
-        }
-
-        @Override
-        public Mutable<name>Bag toBag()
-        {
-            return <name>HashBag.newBag(this);
-        }
-
-        @Override
-        public Lazy<name>Iterable asLazy()
-        {
-            return new Lazy<name>IterableAdapter(this);
-        }
-
-        @Override
         public <name>Set freeze()
         {
             <name>ObjectHashMap.this.copyKeysOnWrite = true;
@@ -3704,154 +3126,13 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             return new Immutable<name>MapKeySet(<name>ObjectHashMap.this.keys, <name>ObjectHashMap.this.occupiedWithData, containsZeroKey, containsOneKey);
         }
 
+        /**
+         * @since 9.2.
+         */
         @Override
-        public Immutable<name>Set toImmutable()
+        public Mutable<name>Set newEmpty()
         {
-            return <name>Sets.immutable.withAll(this);
-        }
-
-        @Override
-        public int size()
-        {
-            return <name>ObjectHashMap.this.size();
-        }
-
-        @Override
-        public boolean isEmpty()
-        {
-            return <name>ObjectHashMap.this.isEmpty();
-        }
-
-        @Override
-        public boolean notEmpty()
-        {
-            return <name>ObjectHashMap.this.notEmpty();
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj)
-            {
-                return true;
-            }
-
-            if (!(obj instanceof <name>Set))
-            {
-                return false;
-            }
-
-            <name>Set other = (<name>Set) obj;
-            return this.size() == other.size() && this.containsAll(other.toArray());
-        }
-
-        @Override
-        public int hashCode()
-        {
-            int result = 0;
-
-            if (<name>ObjectHashMap.this.sentinelValues != null)
-            {
-                if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                {
-                    result += <(hashCode.(type))("EMPTY_KEY")>;
-                }
-                if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-                {
-                    result += <(hashCode.(type))("REMOVED_KEY")>;
-                }
-            }
-            for (int i = 0; i \< <name>ObjectHashMap.this.keys.length; i++)
-            {
-                if (isNonSentinel(<name>ObjectHashMap.this.keys[i]))
-                {
-                    result += <(hashCode.(type))({<name>ObjectHashMap.this.keys[i]})>;
-                }
-            }
-
-            return result;
-        }
-
-        @Override
-        public String toString()
-        {
-            return this.makeString("[", ", ", "]");
-        }
-
-        @Override
-        public String makeString()
-        {
-            return this.makeString(", ");
-        }
-
-        @Override
-        public String makeString(String separator)
-        {
-            return this.makeString("", separator, "");
-        }
-
-        @Override
-        public String makeString(String start, String separator, String end)
-        {
-            Appendable stringBuilder = new StringBuilder();
-            this.appendString(stringBuilder, start, separator, end);
-            return stringBuilder.toString();
-        }
-
-        @Override
-        public void appendString(Appendable appendable)
-        {
-            this.appendString(appendable, ", ");
-        }
-
-        @Override
-        public void appendString(Appendable appendable, String separator)
-        {
-            this.appendString(appendable, "", separator, "");
-        }
-
-        @Override
-        public void appendString(Appendable appendable, String start, String separator, String end)
-        {
-            try
-            {
-                appendable.append(start);
-                boolean first = true;
-                if (<name>ObjectHashMap.this.sentinelValues != null)
-                {
-                    if (<name>ObjectHashMap.this.sentinelValues.containsZeroKey)
-                    {
-                        appendable.append(String.valueOf(EMPTY_KEY));
-                        first = false;
-                    }
-                    if (<name>ObjectHashMap.this.sentinelValues.containsOneKey)
-                    {
-                        if (!first)
-                        {
-                            appendable.append(separator);
-                        }
-                        appendable.append(String.valueOf(REMOVED_KEY));
-                        first = false;
-                    }
-                }
-                for (<type> key : <name>ObjectHashMap.this.keys)
-                {
-                    if (isNonSentinel(key))
-                    {
-                        if (!first)
-                        {
-                            appendable.append(separator);
-                        }
-                        appendable.append(String.valueOf(key));
-                        first = false;
-                    }
-                }
-                appendable.append(end);
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
+            return new <name>HashSet();
         }
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/abstractMutablePrimitivePrimitiveMapTestCase.stg
@@ -39,6 +39,7 @@ import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
 import org.eclipse.collections.impl.map.primitive.Abstract<name1><name2>MapTestCase;
 import org.eclipse.collections.impl.set.mutable.primitive.<name1>HashSet;
 import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.junit.Assert;
 import org.junit.Test;
@@ -834,6 +835,22 @@ public abstract class AbstractMutable<name1><name2>MapTestCase extends Abstract<
         Verify.assertThrows(
                 IllegalStateException.class,
                 () -> this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("1")>, <(literal.(type1))("2")>, <(literal.(type2))("1")>).flipUniqueValues());
+    }
+
+    @Test
+    public void serialize()
+    {
+        Mutable<name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
+        Mutable<name1><name2>Map map2 = SerializeTestHelper.serializeDeserialize(map);
+        Assert.assertEquals(map, map2);
+    }
+
+    @Test
+    public void serializeKeySet()
+    {
+        Mutable<name1><name2>Map map = this.newWithKeysValues(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>, <(literal.(type1))("4")>, <(literal.(type2))("5")>);
+        <name1>Set set = SerializeTestHelper.serializeDeserialize(map.keySet());
+        Assert.assertEquals(map.keySet(), set);
     }
 }
 

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -400,4 +400,72 @@
             <Class name="org.eclipse.collections.impl.utility.ArrayListIterate" />
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="SE_NO_SUITABLE_CONSTRUCTOR_FOR_EXTERNALIZATION" />
+        <Or>
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ByteShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.CharShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.DoubleShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.FloatShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.IntShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.LongShortHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortBooleanHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortByteHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortCharHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortDoubleHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortFloatHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortIntHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortLongHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortObjectHashMap$KeySet" />
+            <Class name="org.eclipse.collections.impl.map.mutable.primitive.ShortShortHashMap$KeySet" />
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteBooleanHashMapSerializationTest
                         + "ZS5CeXRlQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new ByteBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteByteHashMapSerializationTest
                         + "ZS5CeXRlQnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ByteByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteCharHashMapSerializationTest
                         + "ZS5CeXRlQ2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ByteCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteDoubleHashMapSerializationTest
                         + "ZS5CeXRlRG91YmxlSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new ByteDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteFloatHashMapSerializationTest
                         + "ZS5CeXRlRmxvYXRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new ByteFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteIntHashMapSerializationTest
                         + "ZS5CeXRlSW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new ByteIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteLongHashMapSerializationTest
                         + "ZS5CeXRlTG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ByteLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteObjectHashMapSerializationTest
                         + "ZS5CeXRlT2JqZWN0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new ByteObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ByteShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ByteShortHashMapSerializationTest
                         + "ZS5CeXRlU2hvcnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new ByteShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new ByteShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharBooleanHashMapSerializationTest
                         + "ZS5DaGFyQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new CharBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharByteHashMapSerializationTest
                         + "ZS5DaGFyQnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new CharByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharCharHashMapSerializationTest
                         + "ZS5DaGFyQ2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new CharCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharDoubleHashMapSerializationTest
                         + "ZS5DaGFyRG91YmxlSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new CharDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharFloatHashMapSerializationTest
                         + "ZS5DaGFyRmxvYXRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new CharFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharIntHashMapSerializationTest
                         + "ZS5DaGFySW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new CharIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharLongHashMapSerializationTest
                         + "ZS5DaGFyTG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new CharLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharObjectHashMapSerializationTest
                         + "ZS5DaGFyT2JqZWN0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new CharObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/CharShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class CharShortHashMapSerializationTest
                         + "ZS5DaGFyU2hvcnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new CharShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new CharShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleBooleanHashMapSerializationTest
                         + "ZS5Eb3VibGVCb29sZWFuSGFzaE1hcAAAAAAAAAABDAAAeHB3CAAAAAA/AAAAeA==",
                 new DoubleBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleByteHashMapSerializationTest
                         + "ZS5Eb3VibGVCeXRlSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new DoubleByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleCharHashMapSerializationTest
                         + "ZS5Eb3VibGVDaGFySGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new DoubleCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleDoubleHashMapSerializationTest
                         + "ZS5Eb3VibGVEb3VibGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new DoubleDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleFloatHashMapSerializationTest
                         + "ZS5Eb3VibGVGbG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new DoubleFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleIntHashMapSerializationTest
                         + "ZS5Eb3VibGVJbnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new DoubleIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleLongHashMapSerializationTest
                         + "ZS5Eb3VibGVMb25nSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new DoubleLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleObjectHashMapSerializationTest
                         + "ZS5Eb3VibGVPYmplY3RIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new DoubleObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/DoubleShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class DoubleShortHashMapSerializationTest
                         + "ZS5Eb3VibGVTaG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new DoubleShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new DoubleShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatBooleanHashMapSerializationTest
                         + "ZS5GbG9hdEJvb2xlYW5IYXNoTWFwAAAAAAAAAAEMAAB4cHcIAAAAAD8AAAB4",
                 new FloatBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatByteHashMapSerializationTest
                         + "ZS5GbG9hdEJ5dGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new FloatByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatCharHashMapSerializationTest
                         + "ZS5GbG9hdENoYXJIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new FloatCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatDoubleHashMapSerializationTest
                         + "ZS5GbG9hdERvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new FloatDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatFloatHashMapSerializationTest
                         + "ZS5GbG9hdEZsb2F0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new FloatFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatIntHashMapSerializationTest
                         + "ZS5GbG9hdEludEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new FloatIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatLongHashMapSerializationTest
                         + "ZS5GbG9hdExvbmdIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new FloatLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatObjectHashMapSerializationTest
                         + "ZS5GbG9hdE9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new FloatObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/FloatShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class FloatShortHashMapSerializationTest
                         + "ZS5GbG9hdFNob3J0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new FloatShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new FloatShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntBooleanHashMapSerializationTest
                         + "ZS5JbnRCb29sZWFuSGFzaE1hcAAAAAAAAAABDAAAeHB3CAAAAAA/AAAAeA==",
                 new IntBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntByteHashMapSerializationTest
                         + "ZS5JbnRCeXRlSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new IntByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntCharHashMapSerializationTest
                         + "ZS5JbnRDaGFySGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new IntCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntDoubleHashMapSerializationTest
                         + "ZS5JbnREb3VibGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new IntDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntFloatHashMapSerializationTest
                         + "ZS5JbnRGbG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new IntFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntIntHashMapSerializationTest
                         + "ZS5JbnRJbnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new IntIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntLongHashMapSerializationTest
                         + "ZS5JbnRMb25nSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new IntLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntObjectHashMapSerializationTest
                         + "ZS5JbnRPYmplY3RIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new IntObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/IntShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class IntShortHashMapSerializationTest
                         + "ZS5JbnRTaG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new IntShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new IntShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongBooleanHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongBooleanHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongBooleanHashMapSerializationTest
                         + "ZS5Mb25nQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new LongBooleanHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongBooleanHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongByteHashMapSerializationTest
                         + "ZS5Mb25nQnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new LongByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongCharHashMapSerializationTest
                         + "ZS5Mb25nQ2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new LongCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongDoubleHashMapSerializationTest
                         + "ZS5Mb25nRG91YmxlSGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new LongDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongFloatHashMapSerializationTest
                         + "ZS5Mb25nRmxvYXRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new LongFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongIntHashMapSerializationTest
                         + "ZS5Mb25nSW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new LongIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongLongHashMapSerializationTest
                         + "ZS5Mb25nTG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new LongLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongObjectHashMapSerializationTest
                         + "ZS5Mb25nT2JqZWN0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new LongObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/LongShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class LongShortHashMapSerializationTest
                         + "ZS5Mb25nU2hvcnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new LongShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new LongShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortByteHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortByteHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortByteHashMapSerializationTest
                         + "ZS5TaG9ydEJ5dGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new ShortByteHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortByteHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortCharHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortCharHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortCharHashMapSerializationTest
                         + "ZS5TaG9ydENoYXJIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new ShortCharHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortCharHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortDoubleHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortDoubleHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortDoubleHashMapSerializationTest
                         + "ZS5TaG9ydERvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ShortDoubleHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortDoubleHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortFloatHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortFloatHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortFloatHashMapSerializationTest
                         + "ZS5TaG9ydEZsb2F0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new ShortFloatHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortFloatHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortIntHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortIntHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortIntHashMapSerializationTest
                         + "ZS5TaG9ydEludEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ShortIntHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortIntHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortLongHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortLongHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortLongHashMapSerializationTest
                         + "ZS5TaG9ydExvbmdIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
                 new ShortLongHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortLongHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortObjectHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortObjectHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortObjectHashMapSerializationTest
                         + "ZS5TaG9ydE9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new ShortObjectHashMap<>());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortObjectHashMap<>().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortShortHashMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ShortShortHashMapSerializationTest.java
@@ -24,4 +24,14 @@ public class ShortShortHashMapSerializationTest
                         + "ZS5TaG9ydFNob3J0SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAAAAB4",
                 new ShortShortHashMap());
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new ShortShortHashMap().keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteBooleanMapSerializationTest
                         + "AQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedByteBooleanMap(new ByteBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAE1vcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlQm9vbGVhbk1hcAAAAAAAAAABAgAC\n"
+                        + "TAAEbG9ja3EAfgADTAADbWFwdABBTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJp\n"
+                        + "bWl0aXZlL011dGFibGVCeXRlQm9vbGVhbk1hcDt4cHEAfgAJc3IARW9yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkJ5dGVCb29sZWFuSGFzaE1hcAAAAAAA\n"
+                        + "AAABDAAAeHB3CAAAAAA/AAAAeA==",
+                new SynchronizedByteBooleanMap(new ByteBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteByteMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedByteByteMap(new ByteByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlQnl0ZU1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVCeXRlQnl0ZU1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkJ5dGVCeXRlSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedByteByteMap(new ByteByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteCharMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedByteCharMap(new ByteCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlQ2hhck1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVCeXRlQ2hhck1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkJ5dGVDaGFySGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedByteCharMap(new ByteCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteDoubleMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedByteDoubleMap(new ByteDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlRG91YmxlTWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUJ5dGVEb3VibGVNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5CeXRlRG91YmxlSGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedByteDoubleMap(new ByteDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteFloatMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedByteFloatMap(new ByteFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlRmxvYXRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlQnl0ZUZsb2F0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQnl0ZUZsb2F0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedByteFloatMap(new ByteFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteIntMapSerializationTest
                         + "eA==",
                 new SynchronizedByteIntMap(new ByteIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAElvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlSW50TWFwAAAAAAAAAAECAAJMAARs\n"
+                        + "b2NrcQB+AANMAANtYXB0AD1Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmltaXRp\n"
+                        + "dmUvTXV0YWJsZUJ5dGVJbnRNYXA7eHBxAH4ACXNyAEFvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5p\n"
+                        + "bXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5CeXRlSW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAA\n"
+                        + "AAB4",
+                new SynchronizedByteIntMap(new ByteIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteLongMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedByteLongMap(new ByteLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlTG9uZ01hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVCeXRlTG9uZ01hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkJ5dGVMb25nSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedByteLongMap(new ByteLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteObjectMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedByteObjectMap<>(new ByteObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlT2JqZWN0TWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUJ5dGVPYmplY3RNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5CeXRlT2JqZWN0SGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedByteObjectMap<>(new ByteObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedByteShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedByteShortMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedByteShortMap(new ByteShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQnl0ZUtleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRCeXRlU2hvcnRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlQnl0ZVNob3J0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQnl0ZVNob3J0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedByteShortMap(new ByteShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharBooleanMapSerializationTest
                         + "AQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedCharBooleanMap(new CharBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAE1vcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyQm9vbGVhbk1hcAAAAAAAAAABAgAC\n"
+                        + "TAAEbG9ja3EAfgADTAADbWFwdABBTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJp\n"
+                        + "bWl0aXZlL011dGFibGVDaGFyQm9vbGVhbk1hcDt4cHEAfgAJc3IARW9yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkNoYXJCb29sZWFuSGFzaE1hcAAAAAAA\n"
+                        + "AAABDAAAeHB3CAAAAAA/AAAAeA==",
+                new SynchronizedCharBooleanMap(new CharBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharByteMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedCharByteMap(new CharByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyQnl0ZU1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVDaGFyQnl0ZU1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkNoYXJCeXRlSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedCharByteMap(new CharByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharCharMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedCharCharMap(new CharCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyQ2hhck1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVDaGFyQ2hhck1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkNoYXJDaGFySGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedCharCharMap(new CharCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharDoubleMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedCharDoubleMap(new CharDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyRG91YmxlTWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUNoYXJEb3VibGVNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5DaGFyRG91YmxlSGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedCharDoubleMap(new CharDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharFloatMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedCharFloatMap(new CharFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyRmxvYXRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlQ2hhckZsb2F0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQ2hhckZsb2F0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedCharFloatMap(new CharFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharIntMapSerializationTest
                         + "eA==",
                 new SynchronizedCharIntMap(new CharIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAElvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFySW50TWFwAAAAAAAAAAECAAJMAARs\n"
+                        + "b2NrcQB+AANMAANtYXB0AD1Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmltaXRp\n"
+                        + "dmUvTXV0YWJsZUNoYXJJbnRNYXA7eHBxAH4ACXNyAEFvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5p\n"
+                        + "bXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5DaGFySW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAA\n"
+                        + "AAB4",
+                new SynchronizedCharIntMap(new CharIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharLongMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedCharLongMap(new CharLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyTG9uZ01hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVDaGFyTG9uZ01hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkNoYXJMb25nSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedCharLongMap(new CharLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharObjectMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedCharObjectMap<>(new CharObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyT2JqZWN0TWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUNoYXJPYmplY3RNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5DaGFyT2JqZWN0SGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedCharObjectMap<>(new CharObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedCharShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedCharShortMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedCharShortMap(new CharShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlQ2hhcktleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRDaGFyU2hvcnRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlQ2hhclNob3J0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQ2hhclNob3J0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedCharShortMap(new CharShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleBooleanMapSerializationTest
                         + "AAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedDoubleBooleanMap(new DoubleBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IAT29yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUJvb2xlYW5NYXAA\n"
+                        + "AAAAAAAAAQIAAkwABGxvY2txAH4AA0wAA21hcHQAQ0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9h\n"
+                        + "cGkvbWFwL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQm9vbGVhbk1hcDt4cHEAfgAJc3IAR29yZy5l\n"
+                        + "Y2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkRvdWJsZUJvb2xl\n"
+                        + "YW5IYXNoTWFwAAAAAAAAAAEMAAB4cHcIAAAAAD8AAAB4",
+                new SynchronizedDoubleBooleanMap(new DoubleBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleByteMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedDoubleByteMap(new DoubleByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUJ5dGVNYXAAAAAA\n"
+                        + "AAAAAQIAAkwABGxvY2txAH4AA0wAA21hcHQAQExvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkv\n"
+                        + "bWFwL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQnl0ZU1hcDt4cHEAfgAJc3IARG9yZy5lY2xpcHNl\n"
+                        + "LmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkRvdWJsZUJ5dGVIYXNoTWFw\n"
+                        + "AAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleByteMap(new DoubleByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleCharMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedDoubleCharMap(new DoubleCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUNoYXJNYXAAAAAA\n"
+                        + "AAAAAQIAAkwABGxvY2txAH4AA0wAA21hcHQAQExvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkv\n"
+                        + "bWFwL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ2hhck1hcDt4cHEAfgAJc3IARG9yZy5lY2xpcHNl\n"
+                        + "LmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkRvdWJsZUNoYXJIYXNoTWFw\n"
+                        + "AAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleCharMap(new DoubleCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleDoubleMapSerializationTest
                         + "AAAAAQwAAHhwdwQAAAAAeA==",
                 new SynchronizedDoubleDoubleMap(new DoubleDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZURvdWJsZU1hcAAA\n"
+                        + "AAAAAAABAgACTAAEbG9ja3EAfgADTAADbWFwdABCTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2Fw\n"
+                        + "aS9tYXAvcHJpbWl0aXZlL011dGFibGVEb3VibGVEb3VibGVNYXA7eHBxAH4ACXNyAEZvcmcuZWNs\n"
+                        + "aXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Eb3VibGVEb3VibGVI\n"
+                        + "YXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleDoubleMap(new DoubleDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleFloatMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedDoubleFloatMap(new DoubleFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUZsb2F0TWFwAAAA\n"
+                        + "AAAAAAECAAJMAARsb2NrcQB+AANMAANtYXB0AEFMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBp\n"
+                        + "L21hcC9wcmltaXRpdmUvTXV0YWJsZURvdWJsZUZsb2F0TWFwO3hwcQB+AAlzcgBFb3JnLmVjbGlw\n"
+                        + "c2UuY29sbGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuRG91YmxlRmxvYXRIYXNo\n"
+                        + "TWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleFloatMap(new DoubleFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleIntMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedDoubleIntMap(new DoubleIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IAS29yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUludE1hcAAAAAAA\n"
+                        + "AAABAgACTAAEbG9ja3EAfgADTAADbWFwdAA/TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9t\n"
+                        + "YXAvcHJpbWl0aXZlL011dGFibGVEb3VibGVJbnRNYXA7eHBxAH4ACXNyAENvcmcuZWNsaXBzZS5j\n"
+                        + "b2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Eb3VibGVJbnRIYXNoTWFwAAAA\n"
+                        + "AAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleIntMap(new DoubleIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleLongMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedDoubleLongMap(new DoubleLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZUxvbmdNYXAAAAAA\n"
+                        + "AAAAAQIAAkwABGxvY2txAH4AA0wAA21hcHQAQExvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkv\n"
+                        + "bWFwL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlTG9uZ01hcDt4cHEAfgAJc3IARG9yZy5lY2xpcHNl\n"
+                        + "LmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkRvdWJsZUxvbmdIYXNoTWFw\n"
+                        + "AAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleLongMap(new DoubleLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleObjectMapSerializationTest
                         + "AAAAAQwAAHhwdwQAAAAAeA==",
                 new SynchronizedDoubleObjectMap<>(new DoubleObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZU9iamVjdE1hcAAA\n"
+                        + "AAAAAAABAgACTAAEbG9ja3EAfgADTAADbWFwdABCTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2Fw\n"
+                        + "aS9tYXAvcHJpbWl0aXZlL011dGFibGVEb3VibGVPYmplY3RNYXA7eHBxAH4ACXNyAEZvcmcuZWNs\n"
+                        + "aXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Eb3VibGVPYmplY3RI\n"
+                        + "YXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleObjectMap<>(new DoubleObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedDoubleShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedDoubleShortMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedDoubleShortMap(new DoubleShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWREb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6\n"
+                        + "ZWREb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBVb3JnLmVjbGlwc2UuY29sbGVj\n"
+                        + "dGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRG91YmxlS2V5\n"
+                        + "U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4c3IATW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZERvdWJsZVNob3J0TWFwAAAA\n"
+                        + "AAAAAAECAAJMAARsb2NrcQB+AANMAANtYXB0AEFMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBp\n"
+                        + "L21hcC9wcmltaXRpdmUvTXV0YWJsZURvdWJsZVNob3J0TWFwO3hwcQB+AAlzcgBFb3JnLmVjbGlw\n"
+                        + "c2UuY29sbGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuRG91YmxlU2hvcnRIYXNo\n"
+                        + "TWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedDoubleShortMap(new DoubleShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatBooleanMapSerializationTest
                         + "AAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedFloatBooleanMap(new FloatBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBOb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRCb29sZWFuTWFwAAAAAAAA\n"
+                        + "AAECAAJMAARsb2NrcQB+AANMAANtYXB0AEJMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21h\n"
+                        + "cC9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Qm9vbGVhbk1hcDt4cHEAfgAJc3IARm9yZy5lY2xpcHNl\n"
+                        + "LmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkZsb2F0Qm9vbGVhbkhhc2hN\n"
+                        + "YXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
+                new SynchronizedFloatBooleanMap(new FloatBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatByteMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedFloatByteMap(new FloatByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRCeXRlTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZUZsb2F0Qnl0ZU1hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkZsb2F0Qnl0ZUhhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatByteMap(new FloatByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatCharMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedFloatCharMap(new FloatCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRDaGFyTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZUZsb2F0Q2hhck1hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkZsb2F0Q2hhckhhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatCharMap(new FloatCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatDoubleMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedFloatDoubleMap(new FloatDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBNb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXREb3VibGVNYXAAAAAAAAAA\n"
+                        + "AQIAAkwABGxvY2txAH4AA0wAA21hcHQAQUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFw\n"
+                        + "L3ByaW1pdGl2ZS9NdXRhYmxlRmxvYXREb3VibGVNYXA7eHBxAH4ACXNyAEVvcmcuZWNsaXBzZS5j\n"
+                        + "b2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5GbG9hdERvdWJsZUhhc2hNYXAA\n"
+                        + "AAAAAAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatDoubleMap(new FloatDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatFloatMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedFloatFloatMap(new FloatFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBMb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRGbG9hdE1hcAAAAAAAAAAB\n"
+                        + "AgACTAAEbG9ja3EAfgADTAADbWFwdABATG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAv\n"
+                        + "cHJpbWl0aXZlL011dGFibGVGbG9hdEZsb2F0TWFwO3hwcQB+AAlzcgBEb3JnLmVjbGlwc2UuY29s\n"
+                        + "bGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuRmxvYXRGbG9hdEhhc2hNYXAAAAAA\n"
+                        + "AAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatFloatMap(new FloatFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatIntMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedFloatIntMap(new FloatIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBKb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRJbnRNYXAAAAAAAAAAAQIA\n"
+                        + "AkwABGxvY2txAH4AA0wAA21hcHQAPkxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3By\n"
+                        + "aW1pdGl2ZS9NdXRhYmxlRmxvYXRJbnRNYXA7eHBxAH4ACXNyAEJvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5GbG9hdEludEhhc2hNYXAAAAAAAAAAAQwA\n"
+                        + "AHhwdwQAAAAAeA==",
+                new SynchronizedFloatIntMap(new FloatIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatLongMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedFloatLongMap(new FloatLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRMb25nTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZUZsb2F0TG9uZ01hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkZsb2F0TG9uZ0hhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatLongMap(new FloatLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatObjectMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedFloatObjectMap<>(new FloatObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBNb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRPYmplY3RNYXAAAAAAAAAA\n"
+                        + "AQIAAkwABGxvY2txAH4AA0wAA21hcHQAQUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFw\n"
+                        + "L3ByaW1pdGl2ZS9NdXRhYmxlRmxvYXRPYmplY3RNYXA7eHBxAH4ACXNyAEVvcmcuZWNsaXBzZS5j\n"
+                        + "b2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5GbG9hdE9iamVjdEhhc2hNYXAA\n"
+                        + "AAAAAAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatObjectMap<>(new FloatObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedFloatShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedFloatShortMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedFloatShortMap(new FloatShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZEZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlRmxvYXRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBMb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkRmxvYXRTaG9ydE1hcAAAAAAAAAAB\n"
+                        + "AgACTAAEbG9ja3EAfgADTAADbWFwdABATG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAv\n"
+                        + "cHJpbWl0aXZlL011dGFibGVGbG9hdFNob3J0TWFwO3hwcQB+AAlzcgBEb3JnLmVjbGlwc2UuY29s\n"
+                        + "bGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuRmxvYXRTaG9ydEhhc2hNYXAAAAAA\n"
+                        + "AAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedFloatShortMap(new FloatShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedIntBooleanMapSerializationTest
                         + "AHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedIntBooleanMap(new IntBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IATG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludEJvb2xlYW5NYXAAAAAAAAAAAQIAAkwABGxv\n"
+                        + "Y2txAH4AA0wAA21hcHQAQExvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1pdGl2\n"
+                        + "ZS9NdXRhYmxlSW50Qm9vbGVhbk1hcDt4cHEAfgAJc3IARG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkludEJvb2xlYW5IYXNoTWFwAAAAAAAAAAEMAAB4\n"
+                        + "cHcIAAAAAD8AAAB4",
+                new SynchronizedIntBooleanMap(new IntBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntByteMapSerializationTest.java
@@ -28,4 +28,24 @@ public class SynchronizedIntByteMapSerializationTest
                         + "eA==",
                 new SynchronizedIntByteMap(new IntByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludEJ5dGVNYXAAAAAAAAAAAQIAAkwABGxvY2tx\n"
+                        + "AH4AA0wAA21hcHQAPUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1pdGl2ZS9N\n"
+                        + "dXRhYmxlSW50Qnl0ZU1hcDt4cHEAfgAJc3IAQW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwu\n"
+                        + "bWFwLm11dGFibGUucHJpbWl0aXZlLkludEJ5dGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new SynchronizedIntByteMap(new IntByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntCharMapSerializationTest.java
@@ -28,4 +28,24 @@ public class SynchronizedIntCharMapSerializationTest
                         + "eA==",
                 new SynchronizedIntCharMap(new IntCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludENoYXJNYXAAAAAAAAAAAQIAAkwABGxvY2tx\n"
+                        + "AH4AA0wAA21hcHQAPUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1pdGl2ZS9N\n"
+                        + "dXRhYmxlSW50Q2hhck1hcDt4cHEAfgAJc3IAQW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwu\n"
+                        + "bWFwLm11dGFibGUucHJpbWl0aXZlLkludENoYXJIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new SynchronizedIntCharMap(new IntCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedIntDoubleMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedIntDoubleMap(new IntDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IAS29yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludERvdWJsZU1hcAAAAAAAAAABAgACTAAEbG9j\n"
+                        + "a3EAfgADTAADbWFwdAA/TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0aXZl\n"
+                        + "L011dGFibGVJbnREb3VibGVNYXA7eHBxAH4ACXNyAENvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5p\n"
+                        + "bXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5JbnREb3VibGVIYXNoTWFwAAAAAAAAAAEMAAB4cHcE\n"
+                        + "AAAAAHg=",
+                new SynchronizedIntDoubleMap(new IntDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedIntFloatMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedIntFloatMap(new IntFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludEZsb2F0TWFwAAAAAAAAAAECAAJMAARsb2Nr\n"
+                        + "cQB+AANMAANtYXB0AD5Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmltaXRpdmUv\n"
+                        + "TXV0YWJsZUludEZsb2F0TWFwO3hwcQB+AAlzcgBCb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuSW50RmxvYXRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new SynchronizedIntFloatMap(new IntFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntIntMapSerializationTest.java
@@ -27,4 +27,24 @@ public class SynchronizedIntIntMapSerializationTest
                         + "bWFwLm11dGFibGUucHJpbWl0aXZlLkludEludEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
                 new SynchronizedIntIntMap(new IntIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASG9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludEludE1hcAAAAAAAAAABAgACTAAEbG9ja3EA\n"
+                        + "fgADTAADbWFwdAA8TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0aXZlL011\n"
+                        + "dGFibGVJbnRJbnRNYXA7eHBxAH4ACXNyAEBvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5JbnRJbnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new SynchronizedIntIntMap(new IntIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntLongMapSerializationTest.java
@@ -28,4 +28,24 @@ public class SynchronizedIntLongMapSerializationTest
                         + "eA==",
                 new SynchronizedIntLongMap(new IntLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludExvbmdNYXAAAAAAAAAAAQIAAkwABGxvY2tx\n"
+                        + "AH4AA0wAA21hcHQAPUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1pdGl2ZS9N\n"
+                        + "dXRhYmxlSW50TG9uZ01hcDt4cHEAfgAJc3IAQW9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwu\n"
+                        + "bWFwLm11dGFibGUucHJpbWl0aXZlLkludExvbmdIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAAAHg=\n",
+                new SynchronizedIntLongMap(new IntLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedIntObjectMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedIntObjectMap<>(new IntObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IAS29yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludE9iamVjdE1hcAAAAAAAAAABAgACTAAEbG9j\n"
+                        + "a3EAfgADTAADbWFwdAA/TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0aXZl\n"
+                        + "L011dGFibGVJbnRPYmplY3RNYXA7eHBxAH4ACXNyAENvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5p\n"
+                        + "bXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5JbnRPYmplY3RIYXNoTWFwAAAAAAAAAAEMAAB4cHcE\n"
+                        + "AAAAAHg=",
+                new SynchronizedIntObjectMap<>(new IntObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedIntShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedIntShortMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedIntShortMap(new IntShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RTeW5jaHJvbml6ZWRJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAJMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjtMAARs\n"
+                        + "b2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBSb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlSW50S2V5U2V0JFNlclJlcAAA\n"
+                        + "AAAAAAABDAAAeHB3BAAAAAB4c3IASm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25zLmltcGwubWFwLm11\n"
+                        + "dGFibGUucHJpbWl0aXZlLlN5bmNocm9uaXplZEludFNob3J0TWFwAAAAAAAAAAECAAJMAARsb2Nr\n"
+                        + "cQB+AANMAANtYXB0AD5Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmltaXRpdmUv\n"
+                        + "TXV0YWJsZUludFNob3J0TWFwO3hwcQB+AAlzcgBCb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuSW50U2hvcnRIYXNoTWFwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new SynchronizedIntShortMap(new IntShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongBooleanMapSerializationTest
                         + "AQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedLongBooleanMap(new LongBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAE1vcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nQm9vbGVhbk1hcAAAAAAAAAABAgAC\n"
+                        + "TAAEbG9ja3EAfgADTAADbWFwdABBTG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJp\n"
+                        + "bWl0aXZlL011dGFibGVMb25nQm9vbGVhbk1hcDt4cHEAfgAJc3IARW9yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkxvbmdCb29sZWFuSGFzaE1hcAAAAAAA\n"
+                        + "AAABDAAAeHB3CAAAAAA/AAAAeA==",
+                new SynchronizedLongBooleanMap(new LongBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongByteMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedLongByteMap(new LongByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nQnl0ZU1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVMb25nQnl0ZU1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkxvbmdCeXRlSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedLongByteMap(new LongByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongCharMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedLongCharMap(new LongCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nQ2hhck1hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVMb25nQ2hhck1hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkxvbmdDaGFySGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedLongCharMap(new LongCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongDoubleMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedLongDoubleMap(new LongDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nRG91YmxlTWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUxvbmdEb3VibGVNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Mb25nRG91YmxlSGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedLongDoubleMap(new LongDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongFloatMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedLongFloatMap(new LongFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nRmxvYXRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlTG9uZ0Zsb2F0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuTG9uZ0Zsb2F0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedLongFloatMap(new LongFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongIntMapSerializationTest
                         + "eA==",
                 new SynchronizedLongIntMap(new LongIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAElvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nSW50TWFwAAAAAAAAAAECAAJMAARs\n"
+                        + "b2NrcQB+AANMAANtYXB0AD1Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmltaXRp\n"
+                        + "dmUvTXV0YWJsZUxvbmdJbnRNYXA7eHBxAH4ACXNyAEFvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5p\n"
+                        + "bXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Mb25nSW50SGFzaE1hcAAAAAAAAAABDAAAeHB3BAAA\n"
+                        + "AAB4",
+                new SynchronizedLongIntMap(new LongIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongLongMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedLongLongMap(new LongLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nTG9uZ01hcAAAAAAAAAABAgACTAAE\n"
+                        + "bG9ja3EAfgADTAADbWFwdAA+TG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAvcHJpbWl0\n"
+                        + "aXZlL011dGFibGVMb25nTG9uZ01hcDt4cHEAfgAJc3IAQm9yZy5lY2xpcHNlLmNvbGxlY3Rpb25z\n"
+                        + "LmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLkxvbmdMb25nSGFzaE1hcAAAAAAAAAABDAAAeHB3\n"
+                        + "BAAAAAB4",
+                new SynchronizedLongLongMap(new LongLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongObjectMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedLongObjectMap<>(new LongObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAExvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nT2JqZWN0TWFwAAAAAAAAAAECAAJM\n"
+                        + "AARsb2NrcQB+AANMAANtYXB0AEBMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9wcmlt\n"
+                        + "aXRpdmUvTXV0YWJsZUxvbmdPYmplY3RNYXA7eHBxAH4ACXNyAERvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5Mb25nT2JqZWN0SGFzaE1hcAAAAAAAAAAB\n"
+                        + "DAAAeHB3BAAAAAB4",
+                new SynchronizedLongObjectMap<>(new LongObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedLongShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedLongShortMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedLongShortMap(new LongShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0U3luY2hyb25pemVk\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAkwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjtM\n"
+                        + "AARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBTb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMu\n"
+                        + "aW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlTG9uZ0tleVNldCRTZXJS\n"
+                        + "ZXAAAAAAAAAAAQwAAHhwdwQAAAAAeHNyAEtvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1h\n"
+                        + "cC5tdXRhYmxlLnByaW1pdGl2ZS5TeW5jaHJvbml6ZWRMb25nU2hvcnRNYXAAAAAAAAAAAQIAAkwA\n"
+                        + "BGxvY2txAH4AA0wAA21hcHQAP0xvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3ByaW1p\n"
+                        + "dGl2ZS9NdXRhYmxlTG9uZ1Nob3J0TWFwO3hwcQB+AAlzcgBDb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuTG9uZ1Nob3J0SGFzaE1hcAAAAAAAAAABDAAA\n"
+                        + "eHB3BAAAAAB4",
+                new SynchronizedLongShortMap(new LongShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortBooleanMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortBooleanMapSerializationTest
                         + "AAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new SynchronizedShortBooleanMap(new ShortBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBOb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRCb29sZWFuTWFwAAAAAAAA\n"
+                        + "AAECAAJMAARsb2NrcQB+AANMAANtYXB0AEJMb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21h\n"
+                        + "cC9wcmltaXRpdmUvTXV0YWJsZVNob3J0Qm9vbGVhbk1hcDt4cHEAfgAJc3IARm9yZy5lY2xpcHNl\n"
+                        + "LmNvbGxlY3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlNob3J0Qm9vbGVhbkhhc2hN\n"
+                        + "YXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
+                new SynchronizedShortBooleanMap(new ShortBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortByteMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortByteMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedShortByteMap(new ShortByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRCeXRlTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZVNob3J0Qnl0ZU1hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlNob3J0Qnl0ZUhhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortByteMap(new ShortByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortCharMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortCharMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedShortCharMap(new ShortCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRDaGFyTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZVNob3J0Q2hhck1hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlNob3J0Q2hhckhhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortCharMap(new ShortCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortDoubleMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortDoubleMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedShortDoubleMap(new ShortDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBNb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnREb3VibGVNYXAAAAAAAAAA\n"
+                        + "AQIAAkwABGxvY2txAH4AA0wAA21hcHQAQUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFw\n"
+                        + "L3ByaW1pdGl2ZS9NdXRhYmxlU2hvcnREb3VibGVNYXA7eHBxAH4ACXNyAEVvcmcuZWNsaXBzZS5j\n"
+                        + "b2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5TaG9ydERvdWJsZUhhc2hNYXAA\n"
+                        + "AAAAAAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortDoubleMap(new ShortDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortFloatMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortFloatMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedShortFloatMap(new ShortFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBMb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRGbG9hdE1hcAAAAAAAAAAB\n"
+                        + "AgACTAAEbG9ja3EAfgADTAADbWFwdABATG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAv\n"
+                        + "cHJpbWl0aXZlL011dGFibGVTaG9ydEZsb2F0TWFwO3hwcQB+AAlzcgBEb3JnLmVjbGlwc2UuY29s\n"
+                        + "bGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU2hvcnRGbG9hdEhhc2hNYXAAAAAA\n"
+                        + "AAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortFloatMap(new ShortFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortIntMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortIntMapSerializationTest
                         + "AAAAeA==",
                 new SynchronizedShortIntMap(new ShortIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBKb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRJbnRNYXAAAAAAAAAAAQIA\n"
+                        + "AkwABGxvY2txAH4AA0wAA21hcHQAPkxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFwL3By\n"
+                        + "aW1pdGl2ZS9NdXRhYmxlU2hvcnRJbnRNYXA7eHBxAH4ACXNyAEJvcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5TaG9ydEludEhhc2hNYXAAAAAAAAAAAQwA\n"
+                        + "AHhwdwQAAAAAeA==",
+                new SynchronizedShortIntMap(new ShortIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortLongMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortLongMapSerializationTest
                         + "dwQAAAAAeA==",
                 new SynchronizedShortLongMap(new ShortLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBLb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRMb25nTWFwAAAAAAAAAAEC\n"
+                        + "AAJMAARsb2NrcQB+AANMAANtYXB0AD9Mb3JnL2VjbGlwc2UvY29sbGVjdGlvbnMvYXBpL21hcC9w\n"
+                        + "cmltaXRpdmUvTXV0YWJsZVNob3J0TG9uZ01hcDt4cHEAfgAJc3IAQ29yZy5lY2xpcHNlLmNvbGxl\n"
+                        + "Y3Rpb25zLmltcGwubWFwLm11dGFibGUucHJpbWl0aXZlLlNob3J0TG9uZ0hhc2hNYXAAAAAAAAAA\n"
+                        + "AQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortLongMap(new ShortLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortObjectMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortObjectMapSerializationTest
                         + "AQwAAHhwdwQAAAAAeA==",
                 new SynchronizedShortObjectMap<>(new ShortObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBNb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRPYmplY3RNYXAAAAAAAAAA\n"
+                        + "AQIAAkwABGxvY2txAH4AA0wAA21hcHQAQUxvcmcvZWNsaXBzZS9jb2xsZWN0aW9ucy9hcGkvbWFw\n"
+                        + "L3ByaW1pdGl2ZS9NdXRhYmxlU2hvcnRPYmplY3RNYXA7eHBxAH4ACXNyAEVvcmcuZWNsaXBzZS5j\n"
+                        + "b2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5TaG9ydE9iamVjdEhhc2hNYXAA\n"
+                        + "AAAAAAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortObjectMap<>(new ShortObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedShortShortMapSerializationTest.java
@@ -28,4 +28,25 @@ public class SynchronizedShortShortMapSerializationTest
                         + "AHhwdwQAAAAAeA==",
                 new SynchronizedShortShortMap(new ShortShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5TeW5jaHJvbml6ZWRTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFN5bmNocm9uaXpl\n"
+                        + "ZFNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgACTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjtMAARsb2NrdAASTGphdmEvbGFuZy9PYmplY3Q7eHBzcgBUb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RNdXRhYmxlU2hvcnRLZXlTZXQk\n"
+                        + "U2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHhzcgBMb3JnLmVjbGlwc2UuY29sbGVjdGlvbnMuaW1w\n"
+                        + "bC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU3luY2hyb25pemVkU2hvcnRTaG9ydE1hcAAAAAAAAAAB\n"
+                        + "AgACTAAEbG9ja3EAfgADTAADbWFwdABATG9yZy9lY2xpcHNlL2NvbGxlY3Rpb25zL2FwaS9tYXAv\n"
+                        + "cHJpbWl0aXZlL011dGFibGVTaG9ydFNob3J0TWFwO3hwcQB+AAlzcgBEb3JnLmVjbGlwc2UuY29s\n"
+                        + "bGVjdGlvbnMuaW1wbC5tYXAubXV0YWJsZS5wcmltaXRpdmUuU2hvcnRTaG9ydEhhc2hNYXAAAAAA\n"
+                        + "AAAAAQwAAHhwdwQAAAAAeA==",
+                new SynchronizedShortShortMap(new ShortShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteBooleanMapSerializationTest
                         + "eXRlQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableByteBooleanMap(new ByteBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteBooleanMap(new ByteBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteByteMapSerializationTest
                         + "ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteByteMap(new ByteByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteByteMap(new ByteByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteCharMapSerializationTest
                         + "ckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteCharMap(new ByteCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteCharMap(new ByteCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteDoubleMapSerializationTest
                         + "ZURvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteDoubleMap(new ByteDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteDoubleMap(new ByteDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteFloatMapSerializationTest
                         + "bG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteFloatMap(new ByteFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteFloatMap(new ByteFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteIntMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteIntMap(new ByteIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteIntMap(new ByteIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteLongMapSerializationTest
                         + "Z0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteLongMap(new ByteLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteLongMap(new ByteLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteObjectMapSerializationTest
                         + "ZU9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteObjectMap<>(new ByteObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteObjectMap<>(new ByteObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableByteShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableByteShortMapSerializationTest
                         + "aG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableByteShortMap(new ByteShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVCeXRlU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Qnl0ZUNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVCeXRlQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVCeXRlS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableByteShortMap(new ByteShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharBooleanMapSerializationTest
                         + "aGFyQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableCharBooleanMap(new CharBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharBooleanMap(new CharBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharByteMapSerializationTest
                         + "ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharByteMap(new CharByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharByteMap(new CharByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharCharMapSerializationTest
                         + "ckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharCharMap(new CharCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharCharMap(new CharCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharDoubleMapSerializationTest
                         + "ckRvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharDoubleMap(new CharDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharDoubleMap(new CharDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharFloatMapSerializationTest
                         + "bG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharFloatMap(new CharFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharFloatMap(new CharFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharIntMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharIntMap(new CharIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharIntMap(new CharIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharLongMapSerializationTest
                         + "Z0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharLongMap(new CharLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharLongMap(new CharLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharObjectMapSerializationTest
                         + "ck9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharObjectMap<>(new CharObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharObjectMap<>(new CharObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableCharShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableCharShortMapSerializationTest
                         + "aG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableCharShortMap(new CharShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVDaGFyU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "Q2hhckNvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVDaGFyQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVDaGFyS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableCharShortMap(new CharShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleBooleanMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleBooleanMapSerializationTest
                         + "dmUuRG91YmxlQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableDoubleBooleanMap(new DoubleBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleBooleanMap(new DoubleBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleByteMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleByteMapSerializationTest
                         + "YmxlQnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleByteMap(new DoubleByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleByteMap(new DoubleByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleCharMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleCharMapSerializationTest
                         + "YmxlQ2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleCharMap(new DoubleCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleCharMap(new DoubleCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleDoubleMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleDoubleMapSerializationTest
                         + "LkRvdWJsZURvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleDoubleMap(new DoubleDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleDoubleMap(new DoubleDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleFloatMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleFloatMapSerializationTest
                         + "b3VibGVGbG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleFloatMap(new DoubleFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleFloatMap(new DoubleFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleIntMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleIntMapSerializationTest
                         + "ZUludEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleIntMap(new DoubleIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleIntMap(new DoubleIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleLongMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleLongMapSerializationTest
                         + "YmxlTG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleLongMap(new DoubleLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleLongMap(new DoubleLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleObjectMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleObjectMapSerializationTest
                         + "LkRvdWJsZU9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleObjectMap<>(new DoubleObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleObjectMap<>(new DoubleObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableDoubleShortMapSerializationTest.java
@@ -27,4 +27,20 @@ public class UnmodifiableDoubleShortMapSerializationTest
                         + "b3VibGVTaG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableDoubleShortMap(new DoubleShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEhvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVEb3VibGVTZXQAAAAAAAAAAQIAAHhyAF5vcmcuZWNsaXBzZS5jb2xsZWN0\n"
+                        + "aW9ucy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFi\n"
+                        + "bGVEb3VibGVDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABKTG9yZy9lY2xpcHNl\n"
+                        + "L2NvbGxlY3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlRG91YmxlQ29sbGVj\n"
+                        + "dGlvbjt4cHNyAFVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1p\n"
+                        + "dGl2ZS5BYnN0cmFjdE11dGFibGVEb3VibGVLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAA\n"
+                        + "AHg=",
+                new UnmodifiableDoubleShortMap(new DoubleShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatBooleanMapSerializationTest
                         + "LkZsb2F0Qm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableFloatBooleanMap(new FloatBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatBooleanMap(new FloatBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatByteMapSerializationTest
                         + "Qnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatByteMap(new FloatByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatByteMap(new FloatByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatCharMapSerializationTest
                         + "Q2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatCharMap(new FloatCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatCharMap(new FloatCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatDoubleMapSerializationTest
                         + "bG9hdERvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatDoubleMap(new FloatDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatDoubleMap(new FloatDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatFloatMapSerializationTest
                         + "YXRGbG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatFloatMap(new FloatFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatFloatMap(new FloatFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatIntMapSerializationTest
                         + "dEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatIntMap(new FloatIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatIntMap(new FloatIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatLongMapSerializationTest
                         + "TG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatLongMap(new FloatLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatLongMap(new FloatLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatObjectMapSerializationTest
                         + "bG9hdE9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatObjectMap<>(new FloatObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatObjectMap<>(new FloatObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableFloatShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableFloatShortMapSerializationTest
                         + "YXRTaG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableFloatShortMap(new FloatShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVGbG9hdFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZUZsb2F0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZUZsb2F0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVGbG9hdEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableFloatShortMap(new FloatShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntBooleanMapSerializationTest
                         + "Qm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableIntBooleanMap(new IntBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntBooleanMap(new IntBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntByteMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntByteMap(new IntByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntByteMap(new IntByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntCharMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntCharMap(new IntCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntCharMap(new IntCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntDoubleMapSerializationTest
                         + "dWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntDoubleMap(new IntDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntDoubleMap(new IntDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntFloatMapSerializationTest
                         + "dEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntFloatMap(new IntFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntFloatMap(new IntFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntIntMapSerializationTest
                         + "YXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntIntMap(new IntIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntIntMap(new IntIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntLongMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntLongMap(new IntLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntLongMap(new IntLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntObjectMapSerializationTest
                         + "amVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntObjectMap<>(new IntObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntObjectMap<>(new IntObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableIntShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableIntShortMapSerializationTest
                         + "dEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableIntShortMap(new IntShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEVvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVJbnRTZXQAAAAAAAAAAQIAAHhyAFtvcmcuZWNsaXBzZS5jb2xsZWN0aW9u\n"
+                        + "cy5pbXBsLmNvbGxlY3Rpb24ubXV0YWJsZS5wcmltaXRpdmUuQWJzdHJhY3RVbm1vZGlmaWFibGVJ\n"
+                        + "bnRDb2xsZWN0aW9uAAAAAAAAAAECAAFMAApjb2xsZWN0aW9udABHTG9yZy9lY2xpcHNlL2NvbGxl\n"
+                        + "Y3Rpb25zL2FwaS9jb2xsZWN0aW9uL3ByaW1pdGl2ZS9NdXRhYmxlSW50Q29sbGVjdGlvbjt4cHNy\n"
+                        + "AFJvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0\n"
+                        + "cmFjdE11dGFibGVJbnRLZXlTZXQkU2VyUmVwAAAAAAAAAAEMAAB4cHcEAAAAAHg=",
+                new UnmodifiableIntShortMap(new IntShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongBooleanMapSerializationTest
                         + "b25nQm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableLongBooleanMap(new LongBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongBooleanMap(new LongBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongByteMapSerializationTest
                         + "ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongByteMap(new LongByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongByteMap(new LongByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongCharMapSerializationTest
                         + "ckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongCharMap(new LongCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongCharMap(new LongCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongDoubleMapSerializationTest
                         + "Z0RvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongDoubleMap(new LongDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongDoubleMap(new LongDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongFloatMapSerializationTest
                         + "bG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongFloatMap(new LongFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongFloatMap(new LongFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongIntMapSerializationTest
                         + "c2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongIntMap(new LongIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongIntMap(new LongIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongLongMapSerializationTest
                         + "Z0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongLongMap(new LongLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongLongMap(new LongLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongObjectMapSerializationTest
                         + "Z09iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongObjectMap<>(new LongObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongObjectMap<>(new LongObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableLongShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableLongShortMapSerializationTest
                         + "aG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableLongShortMap(new LongShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEZvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVMb25nU2V0AAAAAAAAAAECAAB4cgBcb3JnLmVjbGlwc2UuY29sbGVjdGlv\n"
+                        + "bnMuaW1wbC5jb2xsZWN0aW9uLm11dGFibGUucHJpbWl0aXZlLkFic3RyYWN0VW5tb2RpZmlhYmxl\n"
+                        + "TG9uZ0NvbGxlY3Rpb24AAAAAAAAAAQIAAUwACmNvbGxlY3Rpb250AEhMb3JnL2VjbGlwc2UvY29s\n"
+                        + "bGVjdGlvbnMvYXBpL2NvbGxlY3Rpb24vcHJpbWl0aXZlL011dGFibGVMb25nQ29sbGVjdGlvbjt4\n"
+                        + "cHNyAFNvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2ZS5B\n"
+                        + "YnN0cmFjdE11dGFibGVMb25nS2V5U2V0JFNlclJlcAAAAAAAAAABDAAAeHB3BAAAAAB4",
+                new UnmodifiableLongShortMap(new LongShortHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortBooleanMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortBooleanMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortBooleanMapSerializationTest
                         + "LlNob3J0Qm9vbGVhbkhhc2hNYXAAAAAAAAAAAQwAAHhwdwgAAAAAPwAAAHg=",
                 new UnmodifiableShortBooleanMap(new ShortBooleanHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortBooleanMap(new ShortBooleanHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortByteMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortByteMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortByteMapSerializationTest
                         + "Qnl0ZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortByteMap(new ShortByteHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortByteMap(new ShortByteHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortCharMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortCharMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortCharMapSerializationTest
                         + "Q2hhckhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortCharMap(new ShortCharHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortCharMap(new ShortCharHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortDoubleMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortDoubleMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortDoubleMapSerializationTest
                         + "aG9ydERvdWJsZUhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortDoubleMap(new ShortDoubleHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortDoubleMap(new ShortDoubleHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortFloatMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortFloatMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortFloatMapSerializationTest
                         + "cnRGbG9hdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortFloatMap(new ShortFloatHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortFloatMap(new ShortFloatHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortIntMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortIntMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortIntMapSerializationTest
                         + "dEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortIntMap(new ShortIntHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortIntMap(new ShortIntHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortLongMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortLongMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortLongMapSerializationTest
                         + "TG9uZ0hhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortLongMap(new ShortLongHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortLongMap(new ShortLongHashMap()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortObjectMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortObjectMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortObjectMapSerializationTest
                         + "aG9ydE9iamVjdEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortObjectMap<>(new ShortObjectHashMap<>()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortObjectMap<>(new ShortObjectHashMap<>()).keySet());
+    }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortShortMapSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableShortShortMapSerializationTest.java
@@ -27,4 +27,19 @@ public class UnmodifiableShortShortMapSerializationTest
                         + "cnRTaG9ydEhhc2hNYXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==",
                 new UnmodifiableShortShortMap(new ShortShortHashMap()));
     }
+
+    @Test
+    public void keySetSerializedForm()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAEdvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLnNldC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5Vbm1vZGlmaWFibGVTaG9ydFNldAAAAAAAAAABAgAAeHIAXW9yZy5lY2xpcHNlLmNvbGxlY3Rp\n"
+                        + "b25zLmltcGwuY29sbGVjdGlvbi5tdXRhYmxlLnByaW1pdGl2ZS5BYnN0cmFjdFVubW9kaWZpYWJs\n"
+                        + "ZVNob3J0Q29sbGVjdGlvbgAAAAAAAAABAgABTAAKY29sbGVjdGlvbnQASUxvcmcvZWNsaXBzZS9j\n"
+                        + "b2xsZWN0aW9ucy9hcGkvY29sbGVjdGlvbi9wcmltaXRpdmUvTXV0YWJsZVNob3J0Q29sbGVjdGlv\n"
+                        + "bjt4cHNyAFRvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLm1hcC5tdXRhYmxlLnByaW1pdGl2\n"
+                        + "ZS5BYnN0cmFjdE11dGFibGVTaG9ydEtleVNldCRTZXJSZXAAAAAAAAAAAQwAAHhwdwQAAAAAeA==\n",
+                new UnmodifiableShortShortMap(new ShortShortHashMap()).keySet());
+    }
 }


### PR DESCRIPTION
I believe this is strictly better than not having the keySet be serializable. I reasoned about it like this:

1) 80% use case: I have a PrimitiveSet in my hand. I need to serialize it.
Status before PR: always make a defensive copy, because if that happens to be a `keySet()`, it won't serialize and this might not even show up until production runtime!
Status after PR: no need to make a copy.

2) 19% use case: I have a Primitive*Map.keySet in my hand. I need to serialize it. Why doesn't it work??
Status before PR: because... reasons. Make a copy.
Status after PR: works now!

3) 1% use case: I have a complex serial blob that somewhere inside it has a Primitive*Map and somewhere else inside it has the keySet from that map. I want the keySet to be able to modify the original map after deserialization.
Status before PR: can't be done because the keySet is not serializable.
Status after PR: can't be done because the keySet is detached from the original map after deserialization.

