### PR TITLE
Fix CheckStyle whitespace settings.

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [8]
+        java-version: [11]
 
     runs-on: ${{ matrix.os }}
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -34,6 +34,8 @@
           <package name="" withSubpackages="true" static="true" />
         </value>
       </option>
+      <option name="RECORD_COMPONENTS_WRAP" value="5" />
+      <option name="NEW_LINE_AFTER_LPAREN_IN_RECORD_HEADER" value="true" />
       <option name="JD_P_AT_EMPTY_LINES" value="false" />
       <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
       <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
@@ -77,6 +79,8 @@
     <codeStyleSettings language="JAVA">
       <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
       <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
@@ -96,10 +100,12 @@
       <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
       <option name="RESOURCE_LIST_WRAP" value="5" />
       <option name="RESOURCE_LIST_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="5" />
       <option name="EXTENDS_KEYWORD_WRAP" value="1" />
       <option name="THROWS_KEYWORD_WRAP" value="1" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+      <option name="PARENTHESES_EXPRESSION_LPAREN_WRAP" value="true" />
       <option name="BINARY_OPERATION_WRAP" value="5" />
       <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
       <option name="TERNARY_OPERATION_WRAP" value="5" />
@@ -116,6 +122,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="ENUM_CONSTANTS_WRAP" value="5" />
     </codeStyleSettings>
     <codeStyleSettings language="JSON">
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -86,54 +86,110 @@
 
         <!-- Checks for whitespace                               -->
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForInitializerPad" />
         <module name="EmptyForIteratorPad">
             <property name="option" value="space" />
         </module>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true" />
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false" />
+        </module>
+        <module name="GenericWhitespace" />
         <module name="MethodParamPad" />
+        <module name="NoLineWrap" />
         <module name="NoWhitespaceAfter">
-            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS" />
+            <property name="tokens" value="ARRAY_INIT" />
+            <property name="tokens" value="AT" />
+            <property name="tokens" value="BNOT" />
+            <property name="tokens" value="DEC" />
+            <property name="tokens" value="DOT" />
+            <property name="tokens" value="INC" />
+            <property name="tokens" value="LNOT" />
+            <property name="tokens" value="UNARY_MINUS" />
+            <property name="tokens" value="UNARY_PLUS" />
+            <property name="tokens" value="ARRAY_DECLARATOR" />
+            <property name="tokens" value="INDEX_OP" />
+            <property name="tokens" value="METHOD_REF" />
         </module>
 
         <module name="NoWhitespaceBefore" />
-
-        <module name="OperatorWrap">
-            <property name="tokens" value="ASSIGN, DIV_ASSIGN, PLUS_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN, SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN" />
-            <property name="option" value="eol" />
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="DOT" />
+            <property name="tokens" value="METHOD_REF" />
+            <property name="allowLineBreaks" value="true" />
         </module>
 
         <module name="OperatorWrap">
-            <property name="tokens" value="QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD, SR, BSR, GE, GT, SL, LE, LT, BXOR, BOR, LOR, BAND, LAND, LITERAL_INSTANCEOF, TYPE_EXTENSION_AND, METHOD_REF" />
+            <property name="tokens" value="QUESTION" />
+            <property name="tokens" value="COLON" />
+            <property name="tokens" value="EQUAL" />
+            <property name="tokens" value="NOT_EQUAL" />
+            <property name="tokens" value="DIV" />
+            <property name="tokens" value="PLUS" />
+            <property name="tokens" value="MINUS" />
+            <property name="tokens" value="STAR" />
+            <property name="tokens" value="MOD" />
+            <property name="tokens" value="SR" />
+            <property name="tokens" value="BSR" />
+            <property name="tokens" value="GE" />
+            <property name="tokens" value="GT" />
+            <property name="tokens" value="SL" />
+            <property name="tokens" value="LE" />
+            <property name="tokens" value="LT" />
+            <property name="tokens" value="BXOR" />
+            <property name="tokens" value="BOR" />
+            <property name="tokens" value="LOR" />
+            <property name="tokens" value="BAND" />
+            <property name="tokens" value="LAND" />
+            <property name="tokens" value="TYPE_EXTENSION_AND" />
+            <property name="tokens" value="LITERAL_INSTANCEOF" />
+            <property name="tokens" value="METHOD_REF" />
             <property name="option" value="nl" />
         </module>
 
-        <module name="ParenPad" />
+        <module name="OperatorWrap">
+            <property name="tokens" value="ASSIGN" />
+            <property name="tokens" value="DIV_ASSIGN" />
+            <property name="tokens" value="PLUS_ASSIGN" />
+            <property name="tokens" value="MINUS_ASSIGN" />
+            <property name="tokens" value="STAR_ASSIGN" />
+            <property name="tokens" value="MOD_ASSIGN" />
+            <property name="tokens" value="SR_ASSIGN" />
+            <property name="tokens" value="BSR_ASSIGN" />
+            <property name="tokens" value="SL_ASSIGN" />
+            <property name="tokens" value="BXOR_ASSIGN" />
+            <property name="tokens" value="BOR_ASSIGN" />
+            <property name="tokens" value="BAND_ASSIGN" />
+            <property name="option" value="eol" />
+        </module>
 
+        <module name="ParenPad" />
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapNl" />
+            <property name="tokens" value="DOT" />
+            <property name="tokens" value="AT" />
+            <property name="tokens" value="METHOD_REF" />
+            <property name="option" value="nl" />
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapEol" />
+            <property name="tokens" value="COMMA" />
+            <property name="tokens" value="RPAREN" />
+            <property name="tokens" value="RBRACK" />
+            <property name="tokens" value="ARRAY_DECLARATOR" />
+            <property name="tokens" value="ELLIPSIS" />
+            <property name="tokens" value="SEMI" />
+            <property name="option" value="EOL" />
+        </module>
         <module name="TypecastParenPad" />
 
         <module name="WhitespaceAfter" />
 
         <module name="WhitespaceAround">
-            <property
-                name="tokens"
-                value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND" />
             <property name="allowEmptyConstructors" value="true" />
             <property name="allowEmptyMethods" value="true" />
             <property name="allowEmptyTypes" value="true" />
             <property name="allowEmptyLoops" value="true" />
-        </module>
-
-        <module name="EmptyLineSeparator">
-            <property name="allowNoEmptyLineBetweenFields" value="true" />
-        </module>
-
-        <module name="SeparatorWrap">
-            <property name="tokens" value="DOT" />
-            <property name="option" value="nl" />
-        </module>
-
-        <module name="SeparatorWrap">
-            <property name="tokens" value="COMMA, RPAREN" />
-            <property name="option" value="EOL" />
         </module>
 
         <module name="Indentation">
@@ -239,7 +295,6 @@
         <!-- Effective Java Item 6 - Avoid finalizers -->
         <module name="NoFinalizer" />
 
-        <module name="GenericWhitespace" />
         <module name="AnnotationLocation">
             <property name="id" value="AnnotationLocationMostCases" />
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF" />
@@ -299,8 +354,6 @@
         </module>
 
         <module name="OneTopLevelClass" />
-
-        <module name="NoLineWrap" />
 
         <module name="UnusedImports">
             <property name="processJavadoc" value="true" />

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -292,6 +292,30 @@
                 value="System.err.println." />
         </module>
 
+        <module name="RegexpSinglelineJava">
+            <property name="ignoreComments" value="true" />
+
+            <property
+                name="format"
+                value=", \w+,\n" />
+
+            <property
+                name="message"
+                value="Comma separated list should have one item per line, or be all on a single line." />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="ignoreComments" value="true" />
+
+            <property
+                name="format"
+                value="\(\w+,\n" />
+
+            <property
+                name="message"
+                value="Comma separated list should have one item per line, or be all on a single line." />
+        </module>
+
         <!-- Effective Java Item 6 - Avoid finalizers -->
         <module name="NoFinalizer" />
 

--- a/eclipse-collections-code-generator/src/main/resources/api/list/immutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/immutablePrimitiveList.stg
@@ -55,7 +55,7 @@ public interface Immutable<name>List extends Immutable<name>Collection, <name>Li
     @Override
     default \<V> ImmutableList\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
@@ -74,7 +74,7 @@ public interface Mutable<name>List extends Mutable<name>Collection, <name>List
     @Override
     default \<V> MutableList\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/list/primitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/primitiveList.stg
@@ -69,7 +69,7 @@ public interface <name>List extends Reversible<name>Iterable
     @Override
     default \<V> ListIterable\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/ordered/orderedPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/ordered/orderedPrimitiveIterable.stg
@@ -51,7 +51,7 @@ public interface Ordered<name>Iterable extends <name>Iterable
      */
     default \<V> OrderedIterable\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 
@@ -63,7 +63,7 @@ public interface Ordered<name>Iterable extends <name>Iterable
      */
     default \<V, R extends Collection\<V\>> R collectWithIndex(<name>IntToObjectFunction\<? extends V> function, R target)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++), target);
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/ordered/reversiblePrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/ordered/reversiblePrimitiveIterable.stg
@@ -49,7 +49,7 @@ public interface Reversible<name>Iterable extends Ordered<name>Iterable
     @Override
     default \<V> ReversibleIterable\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/stack/immutablePrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/stack/immutablePrimitiveStack.stg
@@ -57,7 +57,7 @@ public interface Immutable<name>Stack extends <name>Stack
     @Override
     default \<V> ImmutableStack\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/api/stack/mutablePrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/stack/mutablePrimitiveStack.stg
@@ -72,7 +72,7 @@ public interface Mutable<name>Stack extends <name>Stack
     @Override
     default \<V> MutableStack\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/api/stack/primitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/stack/primitiveStack.stg
@@ -72,7 +72,7 @@ public interface <name>Stack extends Ordered<name>Iterable
     @Override
     default \<V> StackIterable\<V> collectWithIndex(<name>IntToObjectFunction\<? extends V> function)
     {
-        int[] index = { 0 };
+        int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++));
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
@@ -41,8 +41,14 @@ import org.junit.Test;
  */
 public class <name>BooleanHashMapKeysViewTest
 {
-    private final Lazy<name>Iterable iterable = <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false, <(literal.(type))("31")>, true,
-            generateCollisions1().getFirst(), false).withKeyValue(generateCollisions1().get(1), true).keysView();
+    private final Lazy<name>Iterable iterable = <name>BooleanHashMap
+            .newWithKeysValues(
+                    <(literal.(type))("0")>, true,
+                    <(literal.(type))("1")>, false,
+                    <(literal.(type))("31")>, true,
+                    generateCollisions1().getFirst(), false)
+            .withKeyValue(generateCollisions1().get(1), true)
+            .keysView();
 
     private static <name>ArrayList generateCollisions1()
     {

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
@@ -167,7 +167,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void removeAll_iterable()
     {
         this.newWith().removeAll(new <name>ArrayList());
@@ -181,14 +181,14 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void retainAll_iterable()
     {
         this.newWith().retainAll(new <name>ArrayList());
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void clear()
     {
         Mutable<name>Collection emptyCollection = this.newWith();

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
@@ -197,35 +197,35 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void removeAll()
     {
         this.newWith().removeAll();
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void removeAll_iterable()
     {
         this.newWith().removeAll(BooleanArrayList.newListWith(false, true));
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void retainAll()
     {
         this.newWith().retainAll();
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void retainAll_iterable()
     {
         this.newWith().retainAll(BooleanArrayList.newListWith(false, true));
     }
 
     @Override
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void clear()
     {
         MutableBooleanCollection emptyCollection = this.newWith();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategy.java
@@ -230,7 +230,9 @@ public class ImmutableUnifiedMapWithHashingStrategy<K, V>
     @Override
     public <R> ImmutableMap<K, R> collectValues(Function2<? super K, ? super V, ? extends R> function)
     {
-        MutableMap<K, R> result = MapIterate.collectValues(this, function,
+        MutableMap<K, R> result = MapIterate.collectValues(
+                this,
+                function,
                 UnifiedMapWithHashingStrategy.newMap(this.delegate.hashingStrategy(), this.delegate.size()));
         return result.toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ArrayProcedureFJTaskRunner.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ArrayProcedureFJTaskRunner.java
@@ -54,8 +54,13 @@ public final class ArrayProcedureFJTaskRunner<T, BT extends Procedure<? super T>
         int sectionSize = array.length / this.taskCount;
         for (int index = 0; index < this.taskCount; index++)
         {
-            ArrayProcedureFJTask<T, BT> procedureFJTask = new ArrayProcedureFJTask<>(this, procedureFactory, array, index,
-                    sectionSize, index == this.taskCount - 1);
+            ArrayProcedureFJTask<T, BT> procedureFJTask = new ArrayProcedureFJTask<>(
+                    this,
+                    procedureFactory,
+                    array,
+                    index,
+                    sectionSize,
+                    index == this.taskCount - 1);
             this.procedures[index] = procedureFJTask;
             executor.execute(procedureFJTask);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunner.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunner.java
@@ -32,7 +32,9 @@ public final class ObjectIntProcedureFJTaskRunner<T, BT extends ObjectIntProcedu
 
     public ObjectIntProcedureFJTaskRunner(Combiner<BT> newCombiner, int taskCount)
     {
-        this(newCombiner, taskCount,
+        this(
+                newCombiner,
+                taskCount,
                 ObjectIntProcedureFJTaskRunner.buildQueue(newCombiner, taskCount),
                 ObjectIntProcedureFJTaskRunner.buildCountDownLatch(newCombiner, taskCount));
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ProcedureFJTaskRunner.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ProcedureFJTaskRunner.java
@@ -52,7 +52,12 @@ public final class ProcedureFJTaskRunner<T, BT extends Procedure<? super T>>
         int sectionSize = list.size() / this.taskCount;
         for (int index = 0; index < this.taskCount; index++)
         {
-            ProcedureFJTask<T, BT> procedureFJTask = new ProcedureFJTask<>(this, procedureFactory, list, index, sectionSize,
+            ProcedureFJTask<T, BT> procedureFJTask = new ProcedureFJTask<>(
+                    this,
+                    procedureFactory,
+                    list,
+                    index,
+                    sectionSize,
                     index == this.taskCount - 1);
             this.procedures[index] = procedureFJTask;
             executor.execute(procedureFJTask);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
@@ -1035,14 +1035,16 @@ public final class Iterate
      * Example using anonymous inner class:
      * <pre>
      * MutableList&lt;Person&gt; rejected =
-     *      Iterate.<b>reject</b>(people,
+     *      Iterate.<b>reject</b>(
+     *          people,
      *          new Predicate&lt;Person&gt;()
      *          {
      *              public boolean accept(Person person)
      *              {
      *                  return person.person.getLastName().equals("Smith");
      *              }
-     *          }, FastList.newList());
+     *          },
+     *          FastList.newList());
      * </pre>
      * <p>
      * Example using Predicates factory:
@@ -1173,7 +1175,8 @@ public final class Iterate
      * Example using an anonymous inner class:
      * <pre>
      * Collection&lt;String&gt; names =
-     *      Iterate.<b>collect</b>(people,
+     *      Iterate.<b>collect</b>(
+     *          people,
      *          new Function&lt;Person, String&gt;()
      *          {
      *              public String valueOf(Person person)
@@ -1228,14 +1231,16 @@ public final class Iterate
      * Example using an anonymous inner class:
      * <pre>
      * MutableList&lt;String&gt; names =
-     *      Iterate.<b>collect</b>(people,
+     *      Iterate.<b>collect</b>(
+     *          people,
      *          new Function&lt;Person, String&gt;()
      *          {
      *              public String valueOf(Person person)
      *              {
      *                  return person.getFirstName() + " " + person.getLastName();
      *              }
-     *          }, FastList.newList());
+     *          },
+     *          FastList.newList());
      * </pre>
      */
     public static <T, A, R extends Collection<A>> R collect(
@@ -1274,7 +1279,8 @@ public final class Iterate
      * Example using anonymous inner class:
      * <pre>
      * MutableBooleanCollection voters =
-     *      Iterate.<b>collectBoolean</b>(people,
+     *      Iterate.<b>collectBoolean</b>(
+     *          people,
      *          new BooleanFunction&lt;Person&gt;()
      *          {
      *              public boolean booleanValueOf(Person person)
@@ -1320,14 +1326,16 @@ public final class Iterate
      * Example using an anonymous inner class:
      * <pre>
      * BooleanArrayList voters =
-     *      Iterate.<b>collectBoolean</b>(people,
+     *      Iterate.<b>collectBoolean</b>(
+     *          people,
      *          new BooleanFunction&lt;Person&gt;()
      *          {
      *              public boolean booleanValueOf(Person person)
      *              {
      *                  return person.canVote();
      *              }
-     *          }, new BooleanArrayList());
+     *          },
+     *          new BooleanArrayList());
      * </pre>
      */
     public static <T, R extends MutableBooleanCollection> R collectBoolean(
@@ -1366,7 +1374,8 @@ public final class Iterate
      * Example using anonymous inner class:
      * <pre>
      * MutableByteCollection bytes =
-     *      Iterate.<b>collectByte</b>(people,
+     *      Iterate.<b>collectByte</b>(
+     *          people,
      *          new ByteFunction&lt;Person&gt;()
      *          {
      *              public byte byteValueOf(Person person)
@@ -1412,14 +1421,16 @@ public final class Iterate
      * Example using an anonymous inner class:
      * <pre>
      * ByteArrayList bytes =
-     *      Iterate.<b>collectByte</b>(people,
+     *      Iterate.<b>collectByte</b>(
+     *          people,
      *          new ByteFunction&lt;Person&gt;()
      *          {
      *              public byte byteValueOf(Person person)
      *              {
      *                  return person.getCode();
      *              }
-     *          }, new ByteArrayList());
+     *          },
+     *          new ByteArrayList());
      * </pre>
      */
     public static <T, R extends MutableByteCollection> R collectByte(
@@ -1458,7 +1469,8 @@ public final class Iterate
      * Example using anonymous inner class:
      * <pre>
      * MutableCharCollection chars =
-     *      Iterate.<b>collectChar</b>(people,
+     *      Iterate.<b>collectChar</b>(
+     *          people,
      *          new CharFunction&lt;Person&gt;()
      *          {
      *              public char charValueOf(Person person)
@@ -1503,14 +1515,16 @@ public final class Iterate
      * Example using anonymous inner class:
      * <pre>
      * CharArrayList chars =
-     *      Iterate.<b>collectChar</b>(people,
+     *      Iterate.<b>collectChar</b>(
+     *          people,
      *          new CharFunction&lt;Person&gt;()
      *          {
      *              public char charValueOf(Person person)
      *              {
      *                  return person.getMiddleInitial();
      *              }
-     *          }, new CharArrayList());
+     *          },
+     *          new CharArrayList());
      * </pre>
      */
     public static <T, R extends MutableCharCollection> R collectChar(

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IterableIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IterableIterate.java
@@ -334,8 +334,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectByte(Iterable, ByteFunction,
-     * MutableByteCollection)
+     * @see Iterate#collectByte(Iterable, ByteFunction, MutableByteCollection)
      */
     public static <T, R extends MutableByteCollection> R collectByte(Iterable<T> iterable, ByteFunction<? super T> byteFunction, R target)
     {
@@ -353,8 +352,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectChar(Iterable, CharFunction,
-     * MutableCharCollection)
+     * @see Iterate#collectChar(Iterable, CharFunction, MutableCharCollection)
      */
     public static <T, R extends MutableCharCollection> R collectChar(Iterable<T> iterable, CharFunction<? super T> charFunction, R target)
     {
@@ -372,8 +370,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectDouble(Iterable, DoubleFunction,
-     * MutableDoubleCollection)
+     * @see Iterate#collectDouble(Iterable, DoubleFunction, MutableDoubleCollection)
      */
     public static <T, R extends MutableDoubleCollection> R collectDouble(Iterable<T> iterable, DoubleFunction<? super T> doubleFunction, R target)
     {
@@ -391,8 +388,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectFloat(Iterable, FloatFunction,
-     * MutableFloatCollection)
+     * @see Iterate#collectFloat(Iterable, FloatFunction, MutableFloatCollection)
      */
     public static <T, R extends MutableFloatCollection> R collectFloat(Iterable<T> iterable, FloatFunction<? super T> floatFunction, R target)
     {
@@ -410,8 +406,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectInt(Iterable, IntFunction,
-     * MutableIntCollection)
+     * @see Iterate#collectInt(Iterable, IntFunction, MutableIntCollection)
      */
     public static <T, R extends MutableIntCollection> R collectInt(Iterable<T> iterable, IntFunction<? super T> intFunction, R target)
     {
@@ -429,8 +424,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectLong(Iterable, LongFunction,
-     * MutableLongCollection)
+     * @see Iterate#collectLong(Iterable, LongFunction, MutableLongCollection)
      */
     public static <T, R extends MutableLongCollection> R collectLong(Iterable<T> iterable, LongFunction<? super T> longFunction, R target)
     {
@@ -448,8 +442,7 @@ public final class IterableIterate
     }
 
     /**
-     * @see Iterate#collectShort(Iterable, ShortFunction,
-     * MutableShortCollection)
+     * @see Iterate#collectShort(Iterable, ShortFunction, MutableShortCollection)
      */
     public static <T, R extends MutableShortCollection> R collectShort(Iterable<T> iterable, ShortFunction<? super T> shortFunction, R target)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/internal/IteratorIterate.java
@@ -424,8 +424,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectByte(Iterable, ByteFunction,
-     * MutableByteCollection)
+     * @see Iterate#collectByte(Iterable, ByteFunction, MutableByteCollection)
      */
     public static <T, R extends MutableByteCollection> R collectByte(
             Iterator<T> iterator,
@@ -455,8 +454,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectChar(Iterable, CharFunction,
-     * MutableCharCollection)
+     * @see Iterate#collectChar(Iterable, CharFunction, MutableCharCollection)
      */
     public static <T, R extends MutableCharCollection> R collectChar(
             Iterator<T> iterator,
@@ -486,8 +484,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectDouble(Iterable, DoubleFunction,
-     * MutableDoubleCollection)
+     * @see Iterate#collectDouble(Iterable, DoubleFunction, MutableDoubleCollection)
      */
     public static <T, R extends MutableDoubleCollection> R collectDouble(
             Iterator<T> iterator,
@@ -517,8 +514,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectFloat(Iterable, FloatFunction,
-     * MutableFloatCollection)
+     * @see Iterate#collectFloat(Iterable, FloatFunction, MutableFloatCollection)
      */
     public static <T, R extends MutableFloatCollection> R collectFloat(
             Iterator<T> iterator,
@@ -548,8 +544,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectInt(Iterable, IntFunction,
-     * MutableIntCollection)
+     * @see Iterate#collectInt(Iterable, IntFunction, MutableIntCollection)
      */
     public static <T, R extends MutableIntCollection> R collectInt(
             Iterator<T> iterator,
@@ -579,8 +574,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectLong(Iterable, LongFunction,
-     * MutableLongCollection)
+     * @see Iterate#collectLong(Iterable, LongFunction, MutableLongCollection)
      */
     public static <T, R extends MutableLongCollection> R collectLong(
             Iterator<T> iterator,
@@ -610,8 +604,7 @@ public final class IteratorIterate
     }
 
     /**
-     * @see Iterate#collectShort(Iterable, ShortFunction,
-     * MutableShortCollection)
+     * @see Iterate#collectShort(Iterable, ShortFunction, MutableShortCollection)
      */
     public static <T, R extends MutableShortCollection> R collectShort(
             Iterator<T> iterator,

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <scala.version>2.12.6</scala.version>
         <guava.version>28.2-jre</guava.version>
         <trove4j.version>3.0.3</trove4j.version>
-        <checkstyle.version>8.29</checkstyle.version>
+        <checkstyle.version>8.34</checkstyle.version>
         <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
         <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
         <jacoco.plugin.version>0.8.5</jacoco.plugin.version>

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/CollisionsTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/CollisionsTestCase.java
@@ -27,7 +27,13 @@ public interface CollisionsTestCase
     Integer COLLISION_10 = 152;
 
     ImmutableList<Integer> COLLISIONS = Lists.immutable.with(
-            COLLISION_1, COLLISION_2, COLLISION_3,
-            COLLISION_4, COLLISION_5, COLLISION_6,
-            COLLISION_7, COLLISION_8, COLLISION_9);
+            COLLISION_1,
+            COLLISION_2,
+            COLLISION_3,
+            COLLISION_4,
+            COLLISION_5,
+            COLLISION_6,
+            COLLISION_7,
+            COLLISION_8,
+            COLLISION_9);
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListIterableTestCase.java
@@ -66,7 +66,8 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
         MutableList<Pair<Integer, String>> result = Lists.mutable.empty();
         ListIterable<Integer> integers = this.newWith(1, 2, 3);
         ImmutableList<String> strings = this.newWith("1", "2", "3").toImmutable();
-        integers.forEachInBoth(strings,
+        integers.forEachInBoth(
+                strings,
                 (integer, string) -> result.add(Tuples.pair(integer, string)));
         assertEquals(
                 Lists.immutable.with(Tuples.pair(1, "1"), Tuples.pair(2, "2"), Tuples.pair(3, "3")),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
@@ -770,8 +770,12 @@ public abstract class AbstractListTestCase
         Assert.assertEquals("19282736353443424140", builder5.toString());
 
         MutableList<Integer> result = Lists.mutable.empty();
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
+        Verify.assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
+        Verify.assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
     }
 
     @Test
@@ -1144,20 +1148,20 @@ public abstract class AbstractListTestCase
         MutableList<Pair<Integer, String>> result = Lists.mutable.empty();
         ListIterable<Integer> integers = this.newWith(1, 2, 3);
         ImmutableList<String> strings = this.newWith("1", "2", "3").toImmutable();
-        integers.forEachInBoth(strings,
-                (integer, string) -> result.add(Tuples.pair(integer, string)));
+        integers.forEachInBoth(strings, (integer, string) -> result.add(Tuples.pair(integer, string)));
         Assert.assertEquals(
                 Lists.immutable.with(Tuples.pair(1, "1"), Tuples.pair(2, "2"), Tuples.pair(3, "3")),
                 result);
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEachInBothThrowsOnDifferentListSizes()
     {
         MutableList<Pair<Integer, String>> result = Lists.mutable.empty();
         ListIterable<Integer> integers = this.newWith(1, 2, 3);
         ImmutableList<String> strings = this.newWith("1", "2").toImmutable();
-        integers.forEachInBoth(strings,
+        integers.forEachInBoth(
+                strings,
                 (integer, string) -> result.add(Tuples.pair(integer, string)));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
@@ -172,9 +172,11 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Pair<String, String>> list = MultiReaderFastList.newList();
         MutableList<String> list1 = Lists.multiReader.with("1", "2");
         MutableList<String> list2 = Lists.multiReader.with("a", "b");
-        list1.forEachInBoth(list2,
+        list1.forEachInBoth(
+                list2,
                 (argument1, argument2) -> list.add(Tuples.pair(argument1, argument2)));
-        Assert.assertEquals(Lists.mutable.with(Tuples.pair("1", "a"), Tuples.pair("2", "b")),
+        Assert.assertEquals(
+                Lists.mutable.with(Tuples.pair("1", "a"), Tuples.pair("2", "b")),
                 list);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -892,15 +892,11 @@ public class IntIntervalTest
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
         Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected,
-                interval.injectInto(
-                        new MutableLong(),
-                        MutableLong::add)
-                        .longValue());
-        Assert.assertEquals(expected + 1L,
-                interval.injectIntoWithIndex(
-                        new MutableLong(),
-                        (value, each, index) -> value.add(each + index))
+        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        Assert.assertEquals(
+                expected + 1L,
+                interval
+                        .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
                         .longValue());
     }
 
@@ -921,15 +917,11 @@ public class IntIntervalTest
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
         Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected,
-                interval.injectInto(
-                        new MutableLong(),
-                        MutableLong::add)
-                        .longValue());
-        Assert.assertEquals(expected + 1L,
-                interval.injectIntoWithIndex(
-                        new MutableLong(),
-                        (value, each, index) -> value.add(each + index))
+        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        Assert.assertEquals(
+                expected + 1L,
+                interval
+                        .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
                         .longValue());
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
@@ -908,15 +908,11 @@ public class LongIntervalTest
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
         Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected,
-                interval.injectInto(
-                        new MutableLong(),
-                        MutableLong::add)
-                        .longValue());
-        Assert.assertEquals(expected + 1L,
-                interval.injectIntoWithIndex(
-                        new MutableLong(),
-                        (value, each, index) -> value.add(each + index))
+        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        Assert.assertEquals(
+                expected + 1L,
+                interval
+                        .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
                         .longValue());
     }
 
@@ -937,15 +933,11 @@ public class LongIntervalTest
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
         Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected,
-                interval.injectInto(
-                        new MutableLong(),
-                        MutableLong::add)
-                        .longValue());
-        Assert.assertEquals(expected + 1L,
-                interval.injectIntoWithIndex(
-                        new MutableLong(),
-                        (value, each, index) -> value.add(each + index))
+        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        Assert.assertEquals(
+                expected + 1L,
+                interval
+                        .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
                         .longValue());
     }
 


### PR DESCRIPTION
Our original CheckStyle settings file was derived from CheckStyle's [own configuration](https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml). That file has evolved separately from ours over the years. Also, I've seen rule violations creep in that I thought were already banned. Rather than dig into what happened, I just synced up some rule settings from "upstream" and fixed the violations that I noticed.