### PR TITLE
Closes #871: Add links for Github interaction to the wiki page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Please add a description of your changes to the [draft release notes](RELEASE_NO
 
 Finally, submit a pull request.
 
+Details on [working with GitHub for Eclipse Collections](https://github.com/eclipse/eclipse-collections/wiki/Working-with-GitHub) is located at the Wiki.
+
 Contact us
 ----------
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ We welcome contributions! We accept contributions via pull requests here in GitH
 * StackOverflow: http://stackoverflow.com/questions/tagged/eclipse-collections
 * Mailing lists: https://dev.eclipse.org/mailman/listinfo/collections-dev
 * Forum: https://www.eclipse.org/forums/index.php?t=thread&frm_id=329
+* Working with GitHub: https://github.com/eclipse/eclipse-collections/wiki/Working-with-GitHub
 
 [actions acceptance-tests]:https://github.com/eclipse/eclipse-collections/actions?query=workflow%3A%22Acceptance+Tests%22
 [actions acceptance-tests img]:https://github.com/eclipse/eclipse-collections/workflows/Acceptance%20Tests/badge.svg?branch=master


### PR DESCRIPTION
Comments from #873 are fixed in this.