### PR TITLE
Make sun.misc an optional Import-Package in OSGi metadata

### DIFF
--- a/eclipse-collections/bnd.bnd
+++ b/eclipse-collections/bnd.bnd
@@ -5,3 +5,7 @@ Bundle-SymbolicName: org.eclipse.collections.impl
 
 Export-Package: \
 	org.eclipse.collections.impl.*;version="${package-version}"
+
+Import-Package: \
+ sun.misc.*;resolution:=optional, \
+ *


### PR DESCRIPTION
Signed-off-by: Dirk Fauth <dirk.fauth@googlemail.com>