### PR TITLE
Remove unsupported Javadoc option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,6 @@
                     <excludePackageNames>
                         org.openjdk,org.eclipse.collections.impl.jmh,org.eclipse.collections.codegenerator,org.eclipse.collections.codegenerator.maven
                     </excludePackageNames>
-                    <additionalOptions>-html5</additionalOptions>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The reason to remove this is because we need to run deploy builds with JDK 8.
