### PR TITLE
Deprecate ImmutableArrayStack. Closes #976

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStack.java
@@ -112,7 +112,11 @@ import org.eclipse.collections.impl.utility.LazyIterate;
 
 /**
  * The immutable equivalent of ArrayStack. Wraps a FastList.
+ *
+ * @deprecated Replaced by {@link ImmutableNotEmptyStack}.
+ * Use {@link org.eclipse.collections.api.factory.Stacks#immutable}.{@link ImmutableStackFactoryImpl#with(Object[]) with()}
  */
+@Deprecated
 final class ImmutableArrayStack<T> implements ImmutableStack<T>, Serializable
 {
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Deprecate ImmutableArrayStack. Closes #976
Signed-off-by: John Jabamani <john.jabamani@bnymellon.com>