### PR TITLE
Disable mutation tests from running on every fork

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   applications:
     name: Mutation Test ${{ matrix.java-version }}
+    if: github.repository == 'eclipse/eclipse-collections'
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Signed-off-by: Sirisha Pratha <sirisha.pratha@bnymellon.com>

Found a couple of helpful resources such as [this](https://github.community/t/do-not-run-cron-workflows-in-forks/17636) outlining the solution. 