### PR TITLE
Disable coverage job from running on every fork

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   applications:
     name: Coverage Report ${{ matrix.java-version }}
+    if: github.repository == 'eclipse/eclipse-collections'
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Similar to what we did with Mutation tests in this [PR](https://github.com/eclipse/eclipse-collections/pull/993).

Signed-off-by: Sirisha Pratha <sirisha.pratha@bnymellon.com>

