### PR TITLE
Implement containsAny, containsNone, containsAnyIterable, containsNoneIterable on RichIterable.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -24,6 +24,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
@@ -204,6 +205,50 @@ public interface RichIterable<T>
     {
         Objects.requireNonNull(function);
         return this.anySatisfy(each -> Objects.equals(value, function.valueOf(each)));
+    }
+
+    /**
+     * Returns true if any of the elements in source is contained in this collection.
+     *
+     * @since 11.0
+     */
+    default boolean containsAny(Collection<?> source)
+    {
+        return source instanceof RichIterable ? ((RichIterable<?>) source).anySatisfy(this::contains)
+                : source.stream().anyMatch(this::contains);
+    }
+
+    /**
+     * Returns true if none of the elements in source are contained in this collection.
+     *
+     * @since 11.0
+     */
+    default boolean containsNone(Collection<?> source)
+    {
+        return source instanceof RichIterable ? ((RichIterable<?>) source).noneSatisfy(this::contains)
+                : source.stream().noneMatch(this::contains);
+    }
+
+    /**
+     * Returns true if any of the elements in source is contained in this collection.
+     *
+     * @since 11.0
+     */
+    default boolean containsAnyIterable(Iterable<?> source)
+    {
+        return source instanceof RichIterable ? ((RichIterable<?>) source).anySatisfy(this::contains)
+                : StreamSupport.stream(source.spliterator(), false).anyMatch(this::contains);
+    }
+
+    /**
+     * Returns true if none of the elements in source are contained in this collection.
+     *
+     * @since 11.0
+     */
+    default boolean containsNoneIterable(Iterable<?> source)
+    {
+        return source instanceof RichIterable ? ((RichIterable<?>) source).noneSatisfy(this::contains)
+                : StreamSupport.stream(source.spliterator(), false).noneMatch(this::contains);
     }
 
     /**

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -11,6 +11,7 @@
 package org.eclipse.collections.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.DoubleSummaryStatistics;
@@ -235,11 +236,51 @@ public abstract class AbstractRichIterableTestCase
     }
 
     @Test
+    public void containsAnyIterable()
+    {
+        RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
+        Assert.assertTrue(collection.containsAnyIterable(Lists.mutable.with(0, 1)));
+        Assert.assertTrue(collection.containsAnyIterable(Arrays.asList(0, 1)));
+        Assert.assertFalse(collection.containsAnyIterable(Lists.mutable.with(5, 6)));
+        Assert.assertFalse(collection.containsAnyIterable(Arrays.asList(5, 6)));
+    }
+
+    @Test
+    public void containsNoneIterable()
+    {
+        RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
+        Assert.assertTrue(collection.containsNoneIterable(Lists.mutable.with(0, 5, 6, 7)));
+        Assert.assertTrue(collection.containsNoneIterable(Arrays.asList(0, 5, 6, 7)));
+        Assert.assertFalse(collection.containsNoneIterable(Lists.mutable.with(0, 1, 5, 6)));
+        Assert.assertFalse(collection.containsNoneIterable(Arrays.asList(0, 1, 5, 6)));
+    }
+
+    @Test
     public void containsAllArray()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
         Assert.assertTrue(collection.containsAllArguments(1, 2));
         Assert.assertFalse(collection.containsAllArguments(1, 5));
+    }
+
+    @Test
+    public void containsAnyCollection()
+    {
+        RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
+        Assert.assertTrue(collection.containsAny(Lists.mutable.with(0, 1)));
+        Assert.assertTrue(collection.containsAny(Arrays.asList(0, 1)));
+        Assert.assertFalse(collection.containsAny(Lists.mutable.with(5, 6)));
+        Assert.assertFalse(collection.containsAny(Arrays.asList(5, 6)));
+    }
+
+    @Test
+    public void containsNoneCollection()
+    {
+        RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
+        Assert.assertTrue(collection.containsNone(Lists.mutable.with(0, 5, 6, 7)));
+        Assert.assertTrue(collection.containsNone(Arrays.asList(0, 5, 6, 7)));
+        Assert.assertFalse(collection.containsNone(Lists.mutable.with(0, 1, 5, 6)));
+        Assert.assertFalse(collection.containsNone(Arrays.asList(0, 1, 5, 6)));
     }
 
     @Test


### PR DESCRIPTION
Resolves #1006 

I read your suggestion @donraab, about "fusing `anySatisfy` and `nonSatisfy` with `contains`". But, I couldn't figure out as to how `anySatisfy` and `nonSatisfy` fit into this context. So, I didn't use those methods for implementing these.