### PR TITLE
Optimize containsAll on primitive iterables.

### DIFF
--- a/acceptance-tests/src/test/java/org/eclipse/collections/api/IntIterableAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/org/eclipse/collections/api/IntIterableAcceptanceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api;
+
+import org.eclipse.collections.api.list.primitive.MutableIntList;
+import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * JUnit test for {@link IntIterable}.
+ */
+public class IntIterableAcceptanceTest
+{
+    @Test
+    public void testContainsAllWithMillionElementIterables()
+    {
+        MutableIntList list1 = IntLists.mutable.withInitialCapacity(1_000_000);
+        MutableIntList list2 = IntLists.mutable.withInitialCapacity(1_000_000);
+
+        for (int i = 0; i < 1_000_000 - 1; i++)
+        {
+            list1.add(i);
+            list2.add(i);
+        }
+
+        list1.add(1_000_000);
+        Assert.assertTrue(list1.containsAll(list2));
+    }
+}

--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -42,6 +42,7 @@ import org.eclipse.collections.api.collection.primitive.MutableLongCollection;
 import org.eclipse.collections.api.collection.primitive.MutableShortCollection;
 import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
+import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 
 /**
@@ -79,16 +80,52 @@ public interface <name>Iterable extends PrimitiveIterable
     boolean contains(<type> value);
 
     /**
-     * Returns true if the all of the values specified in the source array are contained
+     * Returns true if all of the values specified in the source array are contained
      * in the <name>Iterable, and false if they are not.
      */
-    boolean containsAll(<type>... source);
+    default boolean containsAll(<type>... source)
+    {
+        if (this.size() \<= 32 || source.length \< 4)
+        {
+            for (<type> item : source)
+            {
+                if (!this.contains(item))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        else
+        {
+            <name>Set set = this instanceof <name>Set ? (<name>Set) this : this.toSet();
+            for (<type> item : source)
+            {
+                if (!set.contains(item))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
 
     /**
-     * Returns true if the all of the values specified in the source <name>Iterable are contained
+     * Returns true if all of the values specified in the source <name>Iterable are contained
      * in the <name>Iterable, and false if they are not.
      */
-    boolean containsAll(<name>Iterable source);
+    default boolean containsAll(<name>Iterable source)
+    {
+        if (this.size() \<= 32 || source.size() \< 4)
+        {
+            return source.allSatisfy(this::contains);
+        }
+        else
+        {
+            <name>Set set = this instanceof <name>Set ? (<name>Set) this : this.toSet();
+            return source.allSatisfy(set::contains);
+        }
+    }
 
     /**
      * Applies the <name>Procedure to each element in the <name>Iterable.

--- a/eclipse-collections-code-generator/src/main/resources/impl/abstractPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/abstractPrimitiveIterable.stg
@@ -60,25 +60,6 @@ public abstract class Abstract<name>Iterable implements <name>Iterable
     {
         return <name>HashBag.newBag(this);
     }
-
-    @Override
-    public boolean containsAll(<type>... source)
-    {
-        for (<type> item : source)
-        {
-            if (!this.contains(item))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean containsAll(<name>Iterable source)
-    {
-        return source.allSatisfy(this::contains);
-    }
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -199,6 +199,25 @@ public abstract class Abstract<name>IterableTestCase
         Assert.assertTrue(iterable2.containsAll(<["0", "1", "2"]:(literal.(type))(); separator=", ">));
         Assert.assertFalse(iterable2.containsAll(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Assert.assertFalse(iterable2.containsAll(<["3", "4"]:(literal.(type))(); separator=", ">));
+
+        int size = 33;
+        <type>[] array = new <type>[size];
+        for (int i = 0; i \< size; i++)
+        {
+            array[i] = <(castIntToNarrowTypeWithParens.(type))("i + 1")>;
+        }
+
+        <name>Iterable iterable3 = this.newWith(array);
+        Assert.assertTrue(iterable3.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        Assert.assertTrue(iterable3.containsAll());
+        Assert.assertFalse(iterable3.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
+        Assert.assertTrue(iterable3.containsAll(array));
+
+        <name>Iterable iterable4 = <name>Sets.mutable.with(array);
+        Assert.assertTrue(iterable4.containsAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        Assert.assertTrue(iterable4.containsAll());
+        Assert.assertFalse(iterable4.containsAll(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">));
+        Assert.assertTrue(iterable4.containsAll(array));
     }
 
     @Test
@@ -234,6 +253,25 @@ public abstract class Abstract<name>IterableTestCase
         Assert.assertTrue(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">)));
         Assert.assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">)));
         Assert.assertFalse(iterable2.containsAll(<name>ArrayList.newListWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
+
+        int size = 33;
+        <type>[] array = new <type>[size];
+        for (int i = 0; i \< size; i++)
+        {
+            array[i] = <(castIntToNarrowTypeWithParens.(type))("i + 1")>;
+        }
+
+        <name>Iterable iterable3 = this.newWith(array);
+        Assert.assertTrue(iterable3.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        Assert.assertTrue(iterable3.containsAll(<name>Lists.mutable.empty()));
+        Assert.assertFalse(iterable3.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
+        Assert.assertTrue(iterable3.containsAll(<name>Lists.immutable.with(array)));
+
+        <name>Iterable iterable4 = <name>Sets.mutable.with(array);
+        Assert.assertTrue(iterable4.containsAll(<name>Lists.immutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        Assert.assertTrue(iterable4.containsAll(<name>Lists.mutable.empty()));
+        Assert.assertFalse(iterable4.containsAll(<name>Lists.mutable.with(<["3", "4", "5", "33", "34"]:(literal.(type))(); separator=", ">)));
+        Assert.assertTrue(iterable4.containsAll(<name>Lists.immutable.with(array)));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin@bnymellon.com>

I moved up containsAll as a default method on primitive iterables. I was going to add containsAny and containsNone as default methods there so this way they are all in the same place.  The build and tests work fine with this change. If there is some reason to not do this, please let me know and I'll move it back to the abstract primitive iterable where it was before.