### PR TITLE
Remove references to deleted classes in findbugs-exclude file.

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -385,18 +385,12 @@
     <Match>
         <Bug pattern="REC_CATCH_EXCEPTION" />
         <Or>
-            <Class name="org.eclipse.collections.impl.collector.SerializableDoubleSummaryStatistics" />
-            <Class name="org.eclipse.collections.impl.collector.SerializableIntSummaryStatistics" />
-            <Class name="org.eclipse.collections.impl.collector.SerializableLongSummaryStatistics" />
             <Class name="org.eclipse.collections.impl.utility.ArrayListIterate" />
         </Or>
     </Match>
     <Match>
         <Bug pattern="DE_MIGHT_IGNORE" />
         <Or>
-            <Class name="org.eclipse.collections.impl.collector.SerializableDoubleSummaryStatistics" />
-            <Class name="org.eclipse.collections.impl.collector.SerializableIntSummaryStatistics" />
-            <Class name="org.eclipse.collections.impl.collector.SerializableLongSummaryStatistics" />
             <Class name="org.eclipse.collections.impl.utility.ArrayListIterate" />
         </Or>
     </Match>


### PR DESCRIPTION
Signed-off-by: Sirisha Pratha <sirisha.pratha@bnymellon.com>

Classes themselves were removed as part of this PR https://github.com/eclipse/eclipse-collections/pull/599.
Deleting references to those classes in findbugs-exclude.xml file in this PR. 
