### PR TITLE
Closes #1044: Adds toSortedList(Comparator) and toSortedListBy(Function) to primitive Iterables

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/block/function/primitiveComparator.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/block/function/primitiveComparator.stg
@@ -25,7 +25,7 @@ import java.io.Serializable;
  *
  */
 @FunctionalInterface
-public interface <name>Comparator\<T>
+public interface <name>Comparator
         extends Serializable
 {
     int compare(<type> value1, <type> value2);

--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.NoSuchElementException;
 <(wideStatisticsImport.(type))>
 
+<(comparatorImports.(type))(type)>
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
 import org.eclipse.collections.api.block.function.primitive.<(wideName.(type))><name>To<(wideName.(type))>Function;
 import org.eclipse.collections.api.block.function.primitive.<name>ToBooleanFunction;
@@ -613,6 +614,32 @@ default double medianIfEmpty(double defaultValue)
 <type>[] toSortedArray();
 
 Mutable<name>List toSortedList();
+
+/**
+ * Converts the collection to a Mutable<name>List implementation sorted using the provided comparator.
+ */
+default Mutable<name>List toSortedList(<name>Comparator comparator)
+{
+    return this.toList().sortThis(comparator);
+}
+
+/**
+ * Converts the collection to a Mutable<name>ListImplementation sorted based on the natural order of the key returned
+ * by {@code function}.
+ */
+default \<T> Mutable<name>List toSortedListBy(<name>ToObjectFunction\<T> function)
+{
+    return this.toList().sortThisBy(function);
+}
+
+/**
+ * Converts the collection to a Mutable<name>List implementation, which is sorted based on the key returned by
+ * {@code function} using the provided {@code comparator}.
+ */
+default \<T> Mutable<name>List toSortedListBy(<name>ToObjectFunction\<T> function, Comparator\<? super T> comparator)
+{
+    return this.toList().sortThisBy(function, comparator);
+}
 >>
 
 noMethods() ::= ""
@@ -639,3 +666,22 @@ wideStatisticsImport ::= [
     "double": "import java.util.DoubleSummaryStatistics;",
     default: "no matching wide type"
 ]
+
+comparatorImports ::= [
+    "byte": "allComparatorImports",
+    "short": "allComparatorImports",
+    "char": "allComparatorImports",
+    "int": "allComparatorImports",
+    "long": "allComparatorImports",
+    "float": "allComparatorImports",
+    "double": "allComparatorImports",
+    "boolean": "noComparatorImports"
+]
+
+allComparatorImports(type) ::= <<
+import java.util.Comparator;
+import org.eclipse.collections.api.block.comparator.primitive.<name>Comparator;
+
+>>
+
+noComparatorImports(type) ::= ""

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -29,8 +29,10 @@ import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.primitive.<name>ToObjectFunction;
 import org.eclipse.collections.api.iterator.<name>Iterator;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
+import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.factory.Bags;
 import org.eclipse.collections.impl.factory.Lists;
@@ -1178,6 +1180,44 @@ public void sumConsistentRounding()
         Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWith(<(literal.(type))("1")>).toSortedList());
         Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "1"]:(literal.(type))(); separator=", ">).toSortedList());
         Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "32", "1"]:(literal.(type))(); separator=", ">).toSortedList());
+    }
+
+    @Test
+    public void toSortedListByComparator()
+    {
+        <name>Iterable iterable = this.newWith(<["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:(literal.(type))(); separator=", ">);
+
+        Mutable<name>List result = iterable.toSortedList((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1))); // odd/even comparator
+
+        Assert.assertNotSame(iterable, result);
+
+        result
+                .collectBoolean(e -> e % 2 == 0, BooleanLists.mutable.of())
+                .forEachWithIndex((e, i) -> Assert.assertEquals("index " + i, i \< 5, e));
+    }
+
+    @Test
+    public void toSortedListByFunctionNaturalOrder()
+    {
+        MutableList\<String> list = Lists.mutable.of("Foo", "Bar", "Baz", "Waldo", "Qux");
+        <name>Iterable index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
+
+        Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i));
+
+        Assert.assertNotSame(index, result);
+        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), result);
+    }
+
+    @Test
+    public void toSortedListByFunctionWithComparator()
+    {
+        MutableList\<String> list = Lists.mutable.of("Foo", "Bar", "Baz", "Waldo", "Qux");
+        <name>Iterable index = this.newMutableCollectionWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
+
+        Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i), Comparators.naturalOrder().reversed());
+
+        Assert.assertNotSame(index, result);
+        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test


### PR DESCRIPTION
Supports `toSortedListBy` implementations on primitive Itrerables that accept one of the following:
- a primitive comparator
- a primitive to object function that takes the elements of the iterable
- a primitive to object function that takes iterable elements and a comparator applied to the results of the function
These methods convert the collection to a corresponding primitive Mutable List implementation, which is sorted based on the primitive comparator , the natural order of the values returned by the function, or the comparator applied to the results returned by the function respectively.