### PR TITLE
Avoid copying in immutable primitive set factory

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveSetFactoryImpl.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/immutable/immutablePrimitiveSetFactoryImpl.stg
@@ -77,7 +77,7 @@ public enum Immutable<name>SetFactoryImpl implements Immutable<name>SetFactory
         {
             return this.with(items[0]);
         }
-        return <name>HashSet.newSetWith(items).toImmutable();
+        return <name>HashSet.newSetWith(items).freeze();
     }
 
     @Override
@@ -111,7 +111,7 @@ public enum Immutable<name>SetFactoryImpl implements Immutable<name>SetFactory
     @Override
     public Immutable<name>Set withAll(Iterable\<<wrapperName>\> iterable)
     {
-        return <name>Sets.mutable.withAll(iterable).toImmutable();
+        return <name>Sets.mutable.withAll(iterable).freeze();
     }
     <(streamMethods.(type))()>
 }


### PR DESCRIPTION
Creating immutable primitive sets results in some unnecessary copying in `toImmutable`. The mutable set is temporary, so we can just call `freeze` instead.