### PR TITLE
Optimize primitive hash set newSet and withAll

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -92,6 +92,12 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
         this.addAll(elements);
     }
 
+    public <name>HashSet(<name>Iterable elements)
+    {
+        this();
+        this.addAll(elements);
+    }
+
     public <name>HashSet(<name>HashSet set)
     {
         this.occupiedWithData = set.occupiedWithData;
@@ -114,8 +120,7 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
         {
             return new <name>HashSet((<name>HashSet) source);
         }
-
-        return <name>HashSet.newSetWith(source.toArray());
+        return new <name>HashSet(source);
     }
 
     public static <name>HashSet newSetWith(<type>... source)
@@ -429,7 +434,7 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
     @Override
     public <name>HashSet withAll(<name>Iterable elements)
     {
-        this.addAll(elements.toArray());
+        this.addAll(elements);
         return this;
     }
 


### PR DESCRIPTION
Avoid some unnecessary `toArray` calls.

The new constructor taking a primitive iterable is similar to the existing constructor in primitive hash bag. 