### PR TITLE
Fix types on Multimap.*MultiValues().

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ImmutableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ImmutableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -66,10 +67,10 @@ public interface ImmutableMultimap<K, V>
     ImmutableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/Multimap.java
@@ -121,7 +121,7 @@ public interface Multimap<K, V>
      *
      * @since 6.0
      */
-    void forEachKeyMultiValues(Procedure2<? super K, ? super Iterable<V>> procedure);
+    void forEachKeyMultiValues(Procedure2<? super K, ? super RichIterable<V>> procedure);
 
     /**
      * Returns the number of key-value entry pairs.
@@ -351,7 +351,7 @@ public interface Multimap<K, V>
      * @return {@code Multimap}, which contains elements as a result of the select criteria
      * @since 6.0
      */
-    Multimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    Multimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     /**
      * Same as the select method but uses the specified target multimap for the results.
@@ -372,7 +372,7 @@ public interface Multimap<K, V>
      * @return {@code target}, which contains appended elements as a result of the select criteria
      * @since 6.0
      */
-    <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target);
+    <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target);
 
     /**
      * Returns all elements of the source multimap that don't satisfy the predicate.
@@ -392,7 +392,7 @@ public interface Multimap<K, V>
      * @return {@code Multimap}, which contains elements that don't satisfy the {@code predicate}
      * @since 6.0
      */
-    Multimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    Multimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     /**
      * Same as the reject method but uses the specified target multimap for the results.
@@ -413,7 +413,7 @@ public interface Multimap<K, V>
      * @return {@code target}, which contains appended elements that don't satisfy the {@code predicate}
      * @since 6.0
      */
-    <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target);
+    <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target);
 
     /**
      * Returns a new multimap with the results of applying the specified function on each key and value of the source

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/MutableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/MutableMultimap.java
@@ -97,10 +97,10 @@ public interface MutableMultimap<K, V>
     MutableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/BagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/BagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -33,8 +34,8 @@ public interface BagMultimap<K, V>
     BagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    BagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    BagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    BagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    BagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/ImmutableBagIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/ImmutableBagIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -51,10 +52,10 @@ public interface ImmutableBagIterableMultimap<K, V>
     ImmutableBagIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableBagIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableBagIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableBagIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableBagIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagIterableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/ImmutableBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/ImmutableBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -50,10 +51,10 @@ public interface ImmutableBagMultimap<K, V>
     ImmutableBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/MutableBagIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/MutableBagIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -48,10 +49,10 @@ public interface MutableBagIterableMultimap<K, V>
     MutableBagIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableBagIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableBagIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableBagIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableBagIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagIterableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/MutableBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/MutableBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -49,10 +50,10 @@ public interface MutableBagMultimap<K, V>
     MutableBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/UnsortedBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/bag/UnsortedBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.bag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.UnsortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -37,10 +38,10 @@ public interface UnsortedBagMultimap<K, V> extends BagMultimap<K, V>
     UnsortedBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    UnsortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    UnsortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    UnsortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    UnsortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> UnsortedBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/ImmutableListMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/ImmutableListMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.list;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -52,10 +53,10 @@ public interface ImmutableListMultimap<K, V>
     ImmutableListMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/ListMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/ListMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.list;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -44,10 +45,10 @@ public interface ListMultimap<K, V>
     ListMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> BagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/MutableListMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/list/MutableListMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.list;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -49,10 +50,10 @@ public interface MutableListMultimap<K, V>
     MutableListMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/OrderedIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/OrderedIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.ordered;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -37,10 +38,10 @@ public interface OrderedIterableMultimap<K, V>
     OrderedIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    OrderedIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    OrderedIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    OrderedIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    OrderedIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> BagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/ReversibleIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/ReversibleIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.ordered;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.ordered.ReversibleIterable;
@@ -30,10 +31,10 @@ public interface ReversibleIterableMultimap<K, V>
     ReversibleIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ReversibleIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ReversibleIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ReversibleIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ReversibleIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <V2> ReversibleIterableMultimap<K, V2> collectValues(Function<? super V, ? extends V2> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/SortedIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/ordered/SortedIterableMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.api.multimap.ordered;
 
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
@@ -38,10 +39,10 @@ public interface SortedIterableMultimap<K, V>
     SortedIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    SortedIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    SortedIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <V2> ListMultimap<K, V2> collectValues(Function<? super V, ? extends V2> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/ImmutableSetIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/ImmutableSetIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -52,10 +53,10 @@ public interface ImmutableSetIterableMultimap<K, V>
     ImmutableSetIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableSetIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSetIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableSetIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSetIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagIterableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/ImmutableSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/ImmutableSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -51,10 +52,10 @@ public interface ImmutableSetMultimap<K, V>
     ImmutableSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/MutableSetIterableMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/MutableSetIterableMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -49,10 +50,10 @@ public interface MutableSetIterableMultimap<K, V>
     MutableSetIterableMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableSetIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSetIterableMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableSetIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSetIterableMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagIterableMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/MutableSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/MutableSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -48,10 +49,10 @@ public interface MutableSetMultimap<K, V>
     MutableSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/SetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/SetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.set.SetIterable;
@@ -33,8 +34,8 @@ public interface SetMultimap<K, V>
     SetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    SetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    SetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/UnsortedSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/set/UnsortedSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.set;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -38,10 +39,10 @@ public interface UnsortedSetMultimap<K, V> extends SetMultimap<K, V>
     UnsortedSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    UnsortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    UnsortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    UnsortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    UnsortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> UnsortedBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/ImmutableSortedBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/ImmutableSortedBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedbag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -53,10 +54,10 @@ public interface ImmutableSortedBagMultimap<K, V>
     ImmutableSortedBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/MutableSortedBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/MutableSortedBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedbag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -50,10 +51,10 @@ public interface MutableSortedBagMultimap<K, V>
     MutableSortedBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/SortedBagMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedbag/SortedBagMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedbag;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.SortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -45,10 +46,10 @@ public interface SortedBagMultimap<K, V>
     SortedBagMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    SortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    SortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> BagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/ImmutableSortedSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/ImmutableSortedSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedset;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -54,10 +55,10 @@ public interface ImmutableSortedSetMultimap<K, V>
     ImmutableSortedSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    ImmutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    ImmutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    ImmutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> ImmutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/MutableSortedSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/MutableSortedSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedset;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -51,10 +52,10 @@ public interface MutableSortedSetMultimap<K, V>
     MutableSortedSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    MutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    MutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    MutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> MutableBagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/SortedSetMultimap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/multimap/sortedset/SortedSetMultimap.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.api.multimap.sortedset;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -46,10 +47,10 @@ public interface SortedSetMultimap<K, V>
     SortedSetMultimap<K, V> rejectKeysValues(Predicate2<? super K, ? super V> predicate);
 
     @Override
-    SortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
-    SortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate);
+    SortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate);
 
     @Override
     <K2, V2> BagMultimap<K2, V2> collectKeysValues(Function2<? super K, ? super V, Pair<K2, V2>> function);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractMultimap.java
@@ -28,7 +28,6 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.UnmodifiableRichIterable;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.eclipse.collections.impl.utility.Iterate;
 
 public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
         implements Multimap<K, V>
@@ -184,7 +183,7 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
     }
 
     @Override
-    public void forEachKeyMultiValues(Procedure2<? super K, ? super Iterable<V>> procedure)
+    public void forEachKeyMultiValues(Procedure2<? super K, ? super RichIterable<V>> procedure)
     {
         this.getMap().forEachKeyValue(procedure);
     }
@@ -210,7 +209,7 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
     }
 
     @Override
-    public <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target)
+    public <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target)
     {
         this.forEachKeyMultiValues((key, collection) -> {
             if (predicate.accept(key, collection))
@@ -222,7 +221,7 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
     }
 
     @Override
-    public <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target)
+    public <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target)
     {
         this.forEachKeyMultiValues((key, collection) -> {
             if (!predicate.accept(key, collection))
@@ -264,14 +263,17 @@ public abstract class AbstractMultimap<K, V, C extends RichIterable<V>>
         this.forEachKeyMultiValues((key, values) ->
                 target.putAll(
                         keyFunction.valueOf(key),
-                        Iterate.collect(values, valueFunction)));
+                        values.collect(valueFunction)));
         return target;
     }
 
     @Override
     public <V2, R extends MutableMultimap<K, V2>> R collectValues(Function<? super V, ? extends V2> function, R target)
     {
-        this.getMap().forEachKeyValue((key, collection) -> target.putAll(key, collection.collect(function)));
+        this.forEachKeyMultiValues((key, values) ->
+                target.putAll(
+                        key,
+                        values.collect(function)));
         return target;
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractSynchronizedMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/AbstractSynchronizedMultimap.java
@@ -212,7 +212,7 @@ public abstract class AbstractSynchronizedMultimap<K, V> implements MutableMulti
     }
 
     @Override
-    public void forEachKeyMultiValues(Procedure2<? super K, ? super Iterable<V>> procedure)
+    public void forEachKeyMultiValues(Procedure2<? super K, ? super RichIterable<V>> procedure)
     {
         synchronized (this.lock)
         {
@@ -362,7 +362,7 @@ public abstract class AbstractSynchronizedMultimap<K, V> implements MutableMulti
     }
 
     @Override
-    public <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target)
+    public <R extends MutableMultimap<K, V>> R selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target)
     {
         synchronized (this.lock)
         {
@@ -371,7 +371,7 @@ public abstract class AbstractSynchronizedMultimap<K, V> implements MutableMulti
     }
 
     @Override
-    public <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate, R target)
+    public <R extends MutableMultimap<K, V>> R rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate, R target)
     {
         synchronized (this.lock)
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/HashBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/HashBagMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.bag;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -117,13 +118,13 @@ public final class HashBagMultimap<K, V>
     }
 
     @Override
-    public HashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public HashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapImpl.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -196,13 +197,13 @@ public final class ImmutableBagMultimapImpl<K, V>
     }
 
     @Override
-    public ImmutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, HashBagMultimap.newMultimap()).toImmutable();
     }
 
     @Override
-    public ImmutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, HashBagMultimap.newMultimap()).toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.bag;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -117,13 +118,13 @@ public final class MultiReaderHashBagMultimap<K, V>
     }
 
     @Override
-    public MultiReaderHashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MultiReaderHashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public MultiReaderHashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MultiReaderHashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/SynchronizedBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/SynchronizedBagMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.bag;
 
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -164,7 +165,7 @@ public class SynchronizedBagMultimap<K, V>
     }
 
     @Override
-    public MutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {
@@ -173,7 +174,7 @@ public class SynchronizedBagMultimap<K, V>
     }
 
     @Override
-    public MutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.bag;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -127,13 +128,13 @@ public final class SynchronizedPutHashBagMultimap<K, V>
     }
 
     @Override
-    public HashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, HashBagMultimap.newMultimap());
     }
 
     @Override
-    public HashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, HashBagMultimap.newMultimap());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -170,13 +171,13 @@ public final class TreeBagMultimap<K, V>
     }
 
     @Override
-    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -182,13 +183,13 @@ public final class TreeBagMultimap<K, V>
     }
 
     @Override
-    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImpl.java
@@ -17,6 +17,7 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -144,13 +145,13 @@ public class ImmutableSortedBagMultimapImpl<K, V>
     }
 
     @Override
-    public ImmutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, TreeBagMultimap.newMultimap(this.comparator)).toImmutable();
     }
 
     @Override
-    public ImmutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, TreeBagMultimap.newMultimap(this.comparator)).toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/SynchronizedSortedBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/SynchronizedSortedBagMultimap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.multimap.bag.sorted.mutable;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
@@ -167,7 +168,7 @@ public class SynchronizedSortedBagMultimap<K, V>
     }
 
     @Override
-    public MutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSortedBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {
@@ -176,7 +177,7 @@ public class SynchronizedSortedBagMultimap<K, V>
     }
 
     @Override
-    public MutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSortedBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.bag.sorted.MutableSortedBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -177,13 +178,13 @@ public final class TreeBagMultimap<K, V>
     }
 
     @Override
-    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeBagMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategy.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.function.Function;
@@ -175,13 +176,13 @@ public final class HashBagMultimapWithHashingStrategy<K, V>
     }
 
     @Override
-    public HashBagMultimapWithHashingStrategy<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimapWithHashingStrategy<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public HashBagMultimapWithHashingStrategy<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public HashBagMultimapWithHashingStrategy<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/FastListMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/FastListMultimap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.multimap.list;
 import java.io.Externalizable;
 import java.util.Collection;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
@@ -140,13 +141,13 @@ public final class FastListMultimap<K, V>
     }
 
     @Override
-    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.multimap.list;
 import java.io.Externalizable;
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -149,13 +150,13 @@ public final class ImmutableListMultimapImpl<K, V>
     }
 
     @Override
-    public ImmutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, FastListMultimap.newMultimap()).toImmutable();
     }
 
     @Override
-    public ImmutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, FastListMultimap.newMultimap()).toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.list;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
@@ -130,13 +131,13 @@ public final class MultiReaderFastListMultimap<K, V>
     }
 
     @Override
-    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, FastListMultimap.newMultimap());
     }
 
     @Override
-    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, FastListMultimap.newMultimap());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/SynchronizedListMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/SynchronizedListMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.list;
 
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -156,7 +157,7 @@ public class SynchronizedListMultimap<K, V>
     }
 
     @Override
-    public MutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {
@@ -165,7 +166,7 @@ public class SynchronizedListMultimap<K, V>
     }
 
     @Override
-    public MutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/SynchronizedPutFastListMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/list/SynchronizedPutFastListMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.list;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -138,13 +139,13 @@ public final class SynchronizedPutFastListMultimap<K, V>
     }
 
     @Override
-    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, FastListMultimap.newMultimap());
     }
 
     @Override
-    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public FastListMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, FastListMultimap.newMultimap());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.multimap.set;
 import java.io.Externalizable;
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -149,13 +150,13 @@ public final class ImmutableSetMultimapImpl<K, V>
     }
 
     @Override
-    public ImmutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap()).toImmutable();
     }
 
     @Override
-    public ImmutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap()).toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.set;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -110,13 +111,13 @@ public final class MultiReaderUnifiedSetMultimap<K, V>
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap());
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.set;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -131,13 +132,13 @@ public final class SynchronizedPutUnifiedSetMultimap<K, V>
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap());
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, UnifiedSetMultimap.newMultimap());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/SynchronizedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/SynchronizedSetMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.set;
 
 import java.io.Serializable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -156,7 +157,7 @@ public class SynchronizedSetMultimap<K, V>
     }
 
     @Override
-    public MutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {
@@ -165,7 +166,7 @@ public class SynchronizedSetMultimap<K, V>
     }
 
     @Override
-    public MutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.multimap.set;
 
 import java.io.Externalizable;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -110,13 +111,13 @@ public final class UnifiedSetMultimap<K, V>
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapImpl.java
@@ -17,6 +17,7 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -193,13 +194,13 @@ public final class ImmutableSortedSetMultimapImpl<K, V>
     }
 
     @Override
-    public ImmutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, TreeSortedSetMultimap.newMultimap(this.comparator())).toImmutable();
     }
 
     @Override
-    public ImmutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public ImmutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, TreeSortedSetMultimap.newMultimap(this.comparator())).toImmutable();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -160,13 +161,13 @@ public final class SynchronizedPutTreeSortedSetMultimap<K, V>
     }
 
     @Override
-    public TreeSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, TreeSortedSetMultimap.newMultimap(this.comparator));
     }
 
     @Override
-    public TreeSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, TreeSortedSetMultimap.newMultimap(this.comparator));
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedSortedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedSortedSetMultimap.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.multimap.set.sorted;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -168,7 +169,7 @@ public class SynchronizedSortedSetMultimap<K, V>
     }
 
     @Override
-    public MutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {
@@ -177,7 +178,7 @@ public class SynchronizedSortedSetMultimap<K, V>
     }
 
     @Override
-    public MutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public MutableSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         synchronized (this.getLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimap.java
@@ -16,6 +16,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Comparator;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.predicate.Predicate2;
@@ -176,13 +177,13 @@ public final class TreeSortedSetMultimap<K, V>
     }
 
     @Override
-    public TreeSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeSortedSetMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public TreeSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public TreeSortedSetMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/strategy/UnifiedSetWithHashingStrategyMultimap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/multimap/set/strategy/UnifiedSetWithHashingStrategyMultimap.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.map.MutableMap;
@@ -165,13 +166,13 @@ public final class UnifiedSetWithHashingStrategyMultimap<K, V>
     }
 
     @Override
-    public UnifiedSetWithHashingStrategyMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetWithHashingStrategyMultimap<K, V> selectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.selectKeysMultiValues(predicate, this.newEmpty());
     }
 
     @Override
-    public UnifiedSetWithHashingStrategyMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super Iterable<V>> predicate)
+    public UnifiedSetWithHashingStrategyMultimap<K, V> rejectKeysMultiValues(Predicate2<? super K, ? super RichIterable<V>> predicate)
     {
         return this.rejectKeysMultiValues(predicate, this.newEmpty());
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/Iterate.java
@@ -3817,7 +3817,7 @@ public final class Iterate
     public static <K, V> HashBagMultimap<V, K> flip(BagMultimap<K, V> bagMultimap)
     {
         HashBagMultimap<V, K> result = new HashBagMultimap<>();
-        bagMultimap.forEachKeyMultiValues((key, values) -> Iterate.forEach(values, value -> result.put(value, key)));
+        bagMultimap.forEachKeyMultiValues((key, values) -> values.forEach(value -> result.put(value, key)));
         return result;
     }
 
@@ -3827,7 +3827,7 @@ public final class Iterate
     public static <K, V> HashBagMultimap<V, K> flip(ListMultimap<K, V> listMultimap)
     {
         HashBagMultimap<V, K> result = new HashBagMultimap<>();
-        listMultimap.forEachKeyMultiValues((key, values) -> Iterate.forEach(values, value -> result.put(value, key)));
+        listMultimap.forEachKeyMultiValues((key, values) -> values.forEach(value -> result.put(value, key)));
         return result;
     }
 
@@ -3837,7 +3837,7 @@ public final class Iterate
     public static <K, V> UnifiedSetMultimap<V, K> flip(SetMultimap<K, V> setMultimap)
     {
         UnifiedSetMultimap<V, K> result = new UnifiedSetMultimap<>();
-        setMultimap.forEachKeyMultiValues((key, values) -> Iterate.forEach(values, value -> result.put(value, key)));
+        setMultimap.forEachKeyMultiValues((key, values) -> values.forEach(value -> result.put(value, key)));
         return result;
     }
 }


### PR DESCRIPTION
It occurred to me that the type `C` in `AbstractMultimap<K, V, C extends RichIterable<V>>` extends RichIterable rather than Iterable. Unless we want to leave room for future Multimaps where the value types aren't ours, we can be more specific with our types.