### PR TITLE
Add toStack to Ordered primitive Iterable

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/ordered/orderedPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/ordered/orderedPrimitiveIterable.stg
@@ -26,6 +26,7 @@ import org.eclipse.collections.api.block.function.primitive.Object<name>IntToObj
 import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.ordered.OrderedIterable;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 
 /**
  * This file was automatically generated from template file orderedPrimitiveIterable.stg.
@@ -65,6 +66,14 @@ public interface Ordered<name>Iterable extends <name>Iterable
     {
         int[] index = {0};
         return this.collect(each -> function.value(each, index[0]++), target);
+    }
+
+    /**
+     * Converts the collection to a <name>Stack.
+     */
+    default Mutable<name>Stack toStack();
+    {
+        throw new UnsupportedOperationException("Implement in concrete classes.");
     }
 
     \<T> T injectIntoWithIndex(T injectedValue, Object<name>IntToObjectFunction\<? super T, ? extends T> function);

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
@@ -41,11 +41,13 @@ import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -785,6 +787,12 @@ final class Immutable<name>ArrayList
             target.add(PrimitiveTuples.pair(this.items[i], iterator.next()));
         }
         return target.toImmutable();
+    }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
     }
 
     private class Internal<name>Iterator implements <name>Iterator

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveEmptyList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveEmptyList.stg
@@ -34,11 +34,13 @@ import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.iterator.ImmutableEmpty<name>Iterator;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
@@ -399,6 +401,13 @@ final class Immutable<name>EmptyList implements Immutable<name>List, Serializabl
     {
         return Lists.immutable.empty();
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
+
 <if(primitive.specializedStream)>
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveSingletonList.stg
@@ -35,12 +35,15 @@ import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.iterator.Singleton<name>Iterator;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
+import org.eclipse.collections.impl.iterator.Unmodifiable<name>Iterator;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
@@ -456,6 +459,13 @@ final class Immutable<name>SingletonList implements Immutable<name>List, Seriali
         }
         return Lists.immutable.with(PrimitiveTuples.pair(this.element1, Iterate.getFirst(iterable)));
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
+
     <if(primitive.specializedStream)>
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -44,10 +44,12 @@ import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.<name>Set;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.primitive.Abstract<name>Iterable;
@@ -1097,6 +1099,12 @@ public class <name>ArrayList extends Abstract<name>Iterable
             target.add(PrimitiveTuples.pair(this.items[i], iterator.next()));
         }
         return target;
+    }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
     }
 
     private class Internal<name>Iterator implements Mutable<name>Iterator

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/synchronizedPrimitiveList.stg
@@ -34,10 +34,12 @@ import org.eclipse.collections.api.list.MutableList;
 <if(!primitive.booleanPrimitive)>import org.eclipse.collections.api.list.primitive.<name>List;<endif>
 import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractSynchronized<name>Collection;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
 <if(primitive.specializedStream)>
@@ -415,6 +417,16 @@ public class Synchronized<name>List
             return this.getMutable<name>List().collectWithIndex(function, target);
         }
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        synchronized (this.getLock())
+        {
+            return <name>Stacks.mutable.withAll(this);
+        }
+    }
+
 <if(primitive.specializedStream)>
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/unmodifiablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/unmodifiablePrimitiveList.stg
@@ -28,11 +28,13 @@ import org.eclipse.collections.api.block.procedure.primitive.<name>IntProcedure;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.primitive.<name><name>Pair;
 import org.eclipse.collections.api.tuple.primitive.<name>ObjectPair;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 <if(!primitive.booleanPrimitive)>import org.eclipse.collections.api.list.primitive.<name>List;<endif>
 import org.eclipse.collections.api.list.primitive.Immutable<name>List;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractUnmodifiable<name>Collection;
 import org.eclipse.collections.impl.factory.primitive.<name>Lists;
+import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.lazy.primitive.Reverse<name>Iterable;
 <if(primitive.specializedStream)>
 import java.util.Spliterator;<endif>
@@ -292,6 +294,13 @@ public class Unmodifiable<name>List
     {
         return this.getMutable<name>List().collectWithIndex(function, target);
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
+
 <if(primitive.specializedStream)>
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveArrayStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveArrayStack.stg
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.block.predicate.primitive.<name>Predicate;
 import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.stack.primitive.<name>Stack;
 import org.eclipse.collections.api.stack.primitive.Immutable<name>Stack;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.block.procedure.checked.primitive.Checked<name>Procedure;
 import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
@@ -178,6 +179,12 @@ final class Immutable<name>ArrayStack extends Abstract<name>Stack
     private Object writeReplace()
     {
         return new Immutable<name>StackSerializationProxy(this);
+    }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
     }
 
     private static class Immutable<name>StackSerializationProxy implements Externalizable

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveEmptyStack.stg
@@ -35,6 +35,7 @@ import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.stack.primitive.Immutable<name>Stack;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.api.stack.primitive.<name>Stack;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Stacks;
@@ -363,6 +364,12 @@ final class Immutable<name>EmptyStack implements Immutable<name>Stack, Serializa
     public void forEachWithIndex(<name>IntProcedure procedure)
     {
         throw new UnsupportedOperationException(this.getClass().getSimpleName() + ".forEachWithIndex() not implemented yet");
+    }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/immutable/immutablePrimitiveSingletonStack.stg
@@ -36,6 +36,7 @@ import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.stack.primitive.<name>Stack;
 import org.eclipse.collections.api.stack.primitive.Immutable<name>Stack;
+import org.eclipse.collections.api.stack.primitive.Mutable<name>Stack;
 import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Stacks;
@@ -415,6 +416,12 @@ final class Immutable<name>SingletonStack implements Immutable<name>Stack, Seria
         {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/primitiveArrayStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/primitiveArrayStack.stg
@@ -242,6 +242,12 @@ public class <name>ArrayStack extends Abstract<name>Stack
         }
         this.delegate = <name>ArrayList.newListWith(array);
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/synchronizedPrimitiveStack.stg
@@ -543,6 +543,12 @@ public class Synchronized<name>Stack
             return this.stack.collectWithIndex(function, target);
         }
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/stack/mutable/unmodifiablePrimitiveStack.stg
@@ -383,6 +383,12 @@ public class Unmodifiable<name>Stack
     {
         return this.stack.collectWithIndex(function, target);
     }
+
+    @Override
+    public Mutable<name>Stack toStack()
+    {
+        return <name>Stacks.mutable.withAll(this);
+    }
 }
 
 >>

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
@@ -36,8 +36,10 @@ import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
+import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
+import org.eclipse.collections.impl.factory.primitive.BooleanStacks;
 import org.eclipse.collections.impl.lazy.primitive.LazyBooleanIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseBooleanIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -646,6 +648,12 @@ final class ImmutableBooleanArrayList
     private Object writeReplace()
     {
         return new ImmutableBooleanListSerializationProxy(this);
+    }
+
+    @Override
+    public MutableBooleanStack toStack()
+    {
+        return BooleanStacks.mutable.withAll(this);
     }
 
     private static class ImmutableBooleanListSerializationProxy implements Externalizable

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
@@ -36,8 +36,10 @@ import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.api.set.primitive.BooleanSet;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
+import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
+import org.eclipse.collections.impl.factory.primitive.BooleanStacks;
 import org.eclipse.collections.impl.lazy.primitive.LazyBooleanIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseBooleanIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -969,6 +971,12 @@ public final class BooleanArrayList
                 this.items.set(i, in.readBoolean());
             }
         }
+    }
+
+    @Override
+    public MutableBooleanStack toStack()
+    {
+        return BooleanStacks.mutable.withAll(this);
     }
 
     private class InternalBooleanIterator implements MutableBooleanIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -38,11 +38,13 @@ import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.api.stack.primitive.MutableIntStack;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.IntStacks;
 import org.eclipse.collections.impl.lazy.primitive.CollectIntToObjectIterable;
 import org.eclipse.collections.impl.lazy.primitive.LazyIntIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseIntIterable;
@@ -949,6 +951,12 @@ public final class IntInterval
     public Spliterator.OfInt spliterator()
     {
         return new IntIntervalSpliterator(this.from, this.to, this.step);
+    }
+
+    @Override
+    public MutableIntStack toStack()
+    {
+        return IntStacks.mutable.withAll(this);
     }
 
     private class IntIntervalIterator implements IntIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
@@ -38,11 +38,13 @@ import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.LongList;
 import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
+import org.eclipse.collections.api.stack.primitive.MutableLongStack;
 import org.eclipse.collections.api.tuple.primitive.LongLongPair;
 import org.eclipse.collections.api.tuple.primitive.LongObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
 import org.eclipse.collections.impl.block.factory.primitive.LongPredicates;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
+import org.eclipse.collections.impl.factory.primitive.LongStacks;
 import org.eclipse.collections.impl.lazy.primitive.CollectLongToObjectIterable;
 import org.eclipse.collections.impl.lazy.primitive.LazyLongIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseLongIterable;
@@ -996,6 +998,12 @@ public final class LongInterval
     public Spliterator.OfLong spliterator()
     {
         return new LongIntervalSpliterator(this.from, this.to, this.step);
+    }
+
+    @Override
+    public MutableLongStack toStack()
+    {
+        return LongStacks.mutable.withAll(this);
     }
 
     private class LongIntervalIterator implements LongIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
@@ -34,10 +34,14 @@ import org.eclipse.collections.api.list.primitive.CharList;
 import org.eclipse.collections.api.list.primitive.ImmutableCharList;
 import org.eclipse.collections.api.list.primitive.MutableCharList;
 import org.eclipse.collections.api.set.primitive.MutableCharSet;
+import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
+import org.eclipse.collections.api.stack.primitive.MutableCharStack;
 import org.eclipse.collections.api.tuple.primitive.CharCharPair;
 import org.eclipse.collections.api.tuple.primitive.CharObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.CharHashBag;
+import org.eclipse.collections.impl.factory.primitive.BooleanStacks;
 import org.eclipse.collections.impl.factory.primitive.CharLists;
+import org.eclipse.collections.impl.factory.primitive.CharStacks;
 import org.eclipse.collections.impl.lazy.primitive.ReverseCharIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
@@ -621,6 +625,12 @@ public class CharAdapter
             target.add(PrimitiveTuples.pair(this.get(i), iterator.next()));
         }
         return target.toImmutable();
+    }
+
+    @Override
+    public MutableCharStack toStack()
+    {
+        return CharStacks.mutable.withAll(this);
     }
 
     private class InternalCharIterator implements CharIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
@@ -35,10 +35,14 @@ import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.api.stack.primitive.MutableCharStack;
+import org.eclipse.collections.api.stack.primitive.MutableIntStack;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
 import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
+import org.eclipse.collections.impl.factory.primitive.CharStacks;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.IntStacks;
 import org.eclipse.collections.impl.lazy.primitive.ReverseIntIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
@@ -798,6 +802,12 @@ public class CodePointAdapter
     public Spliterator.OfInt spliterator()
     {
         return this.adapted.codePoints().spliterator();
+    }
+
+    @Override
+    public MutableIntStack toStack()
+    {
+        return IntStacks.mutable.withAll(this);
     }
 
     private class InternalIntIterator implements IntIterator

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
@@ -34,9 +34,11 @@ import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.api.stack.primitive.MutableIntStack;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
+import org.eclipse.collections.impl.factory.primitive.IntStacks;
 import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.primitive.AbstractIntIterable;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
@@ -510,5 +512,11 @@ public class CodePointList extends AbstractIntIterable implements CharSequence, 
     public Spliterator.OfInt spliterator()
     {
         return this.codePoints.spliterator();
+    }
+
+    @Override
+    public MutableIntStack toStack()
+    {
+        return IntStacks.mutable.withAll(this);
     }
 }


### PR DESCRIPTION
Signed-off-by: Dinesh Purushothamacharya <p.dinesh87@gmail.com>

Fixes [1045](https://github.com/eclipse/eclipse-collections/issues/1045)