### PR TITLE
Upgrade eclipse-jarsigner-plugin version to 1.3.2

### DIFF
--- a/p2-feature/org.eclipse.collections.feature/pom.xml
+++ b/p2-feature/org.eclipse.collections.feature/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.eclipse.cbi.maven.plugins</groupId>
                 <artifactId>eclipse-jarsigner-plugin</artifactId>
-                <version>1.1.3</version>
+                <version>1.3.2</version>
                 <executions>
                   <execution>
                       <id>sign</id>

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.maven.plugins</groupId>
                     <artifactId>eclipse-jarsigner-plugin</artifactId>
-                    <version>1.1.7</version>
+                    <version>1.3.2</version>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e
                     settings only. It has no influence on the Maven build itself. -->
@@ -830,7 +830,7 @@
                     <plugin>
                         <groupId>org.eclipse.cbi.maven.plugins</groupId>
                         <artifactId>eclipse-jarsigner-plugin</artifactId>
-                        <version>1.1.7</version>
+                        <version>1.3.2</version>
                         <executions>
                             <execution>
                                 <id>jarsign</id>


### PR DESCRIPTION
Signed-off-by: Sirisha Pratha <sirisha.pratha@bnymellon.com>

Context: Error signing jars in deploy (sonatype) builds. Found the same exact issue reported on Bugzilla on a different eclipse project and the recommendation was to upgrade to the latest version 1.3.2. Details [here.](https://bugs.eclipse.org/bugs/show_bug.cgi?id=576028). 