### PR TITLE
implement subList() on primitive immutable lists

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
@@ -638,9 +638,9 @@ final class ImmutableBooleanArrayList
     }
 
     @Override
-    public ImmutableBooleanList subList(int fromIndex, int toIndex)
+    public ImmutableBooleanArrayList subList(int fromIndex, int toIndex)
     {
-        throw new UnsupportedOperationException("subList not yet implemented!");
+        return new ImmutableBooleanArrayList(this.BitSet.get(fromIndex, toIndex), toIndex - fromIndex)
     }
 
     private Object writeReplace()

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
@@ -530,9 +530,9 @@ public final class LongInterval
     }
 
     @Override
-    public ImmutableLongList subList(int fromIndex, int toIndex)
+    public LongInterval subList(int fromIndex, int toIndex)
     {
-        throw new UnsupportedOperationException("subList not yet implemented!");
+        return new LongInterval(fromIndex, toIndex, this.step);
     }
 
     /**


### PR DESCRIPTION
implement subList() on primitive immutable lists

part of #1053

AbstractImmutableList defines  subList() as returning an object of an inner class
but here it is implemented as returning an object of the class itself