### PR TITLE
#1109: Improve Pit Coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
                             <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                         </avoidCallsTo>
                         <maxMutationsPerClass>1</maxMutationsPerClass>
+                        <additionalClasspathElements>target/generated-sources/java/*</additionalClasspathElements>
                         <excludedClasses>
                             <param>org.eclipse.collections.impl.lazy.parallel*</param>
                             <param>org.eclipse.collections.impl.parallel*</param>


### PR DESCRIPTION
Add generated code directories to pit maven target to display source code in pit coverage reports for generated code (primitive types for example).
![Before Change](https://user-images.githubusercontent.com/62764301/153674284-5d096fca-1346-4522-8af3-2ad6c936db52.jpeg)
![After Change](https://user-images.githubusercontent.com/62764301/153674321-ebddef2c-38cc-40a5-a078-e9674b5a31ff.jpeg)

