### PR TITLE
Fix issue mentioned in #1196

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -2897,6 +2897,12 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         {
             return UnifiedMap.this.hashCode();
         }
+
+        @Override
+        public String toString()
+        {
+            return Iterate.makeString(this, "[", ", ", "]");
+        }
     }
 
     protected class EntrySetIterator extends PositionalIterator<Entry<K, V>>


### PR DESCRIPTION
Adding missing toString() method in UnifiedMap.EntrySet. This should solve the bug mentioned in issue #1196. However, there are currently no tests covering this case in the EC code. Apart from that, the code should be good to go.

The way I see it, there are two options with regard to tests:

1. Add `guava-testlib` dependency and the test code similar to the code provided in the issue, or
2. Write a separate test that covers this case.

Would love to hear your thoughts on this. 

Signed-off-by: Rustam Mehmandarov <mehmandarov@gmail.com>