### PR TITLE
Add missing overrides in multi-reader interfaces.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MultiReaderBag.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/bag/MultiReaderBag.java
@@ -23,4 +23,42 @@ public interface MultiReaderBag<T>
     void withReadLockAndDelegate(Procedure<? super MutableBag<T>> procedure);
 
     void withWriteLockAndDelegate(Procedure<? super MutableBag<T>> procedure);
+
+    @Override
+    MultiReaderBag<T> newEmpty();
+
+    @Override
+    default MultiReaderBag<T> with(T element)
+    {
+        this.add(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderBag<T> without(T element)
+    {
+        this.remove(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderBag<T> withAll(Iterable<? extends T> elements)
+    {
+        this.addAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderBag<T> withoutAll(Iterable<? extends T> elements)
+    {
+        this.removeAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderBag<T> tap(Procedure<? super T> procedure)
+    {
+        this.forEach(procedure);
+        return this;
+    }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MultiReaderList.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/list/MultiReaderList.java
@@ -37,6 +37,49 @@ public interface MultiReaderList<T>
     void withWriteLockAndDelegate(Procedure<? super MutableList<T>> procedure);
 
     @Override
+    MultiReaderList<T> newEmpty();
+
+    MultiReaderList<T> clone();
+
+    @Override
+    MultiReaderList<T> subList(int fromIndex, int toIndex);
+
+    @Override
+    default MultiReaderList<T> with(T element)
+    {
+        this.add(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderList<T> without(T element)
+    {
+        this.remove(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderList<T> withAll(Iterable<? extends T> elements)
+    {
+        this.addAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderList<T> withoutAll(Iterable<? extends T> elements)
+    {
+        this.removeAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderList<T> tap(Procedure<? super T> procedure)
+    {
+        this.forEach(procedure);
+        return this;
+    }
+
+    @Override
     default MultiReaderList<T> sortThis(Comparator<? super T> comparator)
     {
         this.sort(comparator);

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/MultiReaderSet.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/set/MultiReaderSet.java
@@ -23,4 +23,45 @@ public interface MultiReaderSet<T>
     void withReadLockAndDelegate(Procedure<? super MutableSet<T>> procedure);
 
     void withWriteLockAndDelegate(Procedure<? super MutableSet<T>> procedure);
+
+    @Override
+    MultiReaderSet<T> newEmpty();
+
+    @Override
+    MultiReaderSet<T> clone();
+
+    @Override
+    default MultiReaderSet<T> with(T element)
+    {
+        this.add(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderSet<T> without(T element)
+    {
+        this.remove(element);
+        return this;
+    }
+
+    @Override
+    default MultiReaderSet<T> withAll(Iterable<? extends T> elements)
+    {
+        this.addAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderSet<T> withoutAll(Iterable<? extends T> elements)
+    {
+        this.removeAllIterable(elements);
+        return this;
+    }
+
+    @Override
+    default MultiReaderSet<T> tap(Procedure<? super T> procedure)
+    {
+        this.forEach(procedure);
+        return this;
+    }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
@@ -385,7 +385,7 @@ public final class MultiReaderHashBag<T>
     }
 
     @Override
-    public MutableBag<T> newEmpty()
+    public MultiReaderBag<T> newEmpty()
     {
         return MultiReaderHashBag.newBag();
     }
@@ -411,7 +411,7 @@ public final class MultiReaderHashBag<T>
     }
 
     @Override
-    public MutableBag<T> tap(Procedure<? super T> procedure)
+    public MultiReaderBag<T> tap(Procedure<? super T> procedure)
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastList.java
@@ -200,7 +200,7 @@ public final class MultiReaderFastList<T>
     }
 
     @Override
-    public MutableList<T> clone()
+    public MultiReaderList<T> clone()
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {
@@ -322,58 +322,18 @@ public final class MultiReaderFastList<T>
     }
 
     @Override
-    public MutableList<T> newEmpty()
+    public MultiReaderList<T> newEmpty()
     {
         return MultiReaderFastList.newList();
     }
 
     @Override
-    public MutableList<T> reject(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.reject(predicate);
-        }
-    }
-
-    @Override
-    public <P> MutableList<T> rejectWith(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.rejectWith(predicate, parameter);
-        }
-    }
-
-    @Override
-    public MutableList<T> tap(Procedure<? super T> procedure)
+    public MultiReaderList<T> tap(Procedure<? super T> procedure)
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {
             this.forEach(procedure);
             return this;
-        }
-    }
-
-    @Override
-    public MutableList<T> select(Predicate<? super T> predicate)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.select(predicate);
-        }
-    }
-
-    @Override
-    public <P> MutableList<T> selectWith(
-            Predicate2<? super T, ? super P> predicate,
-            P parameter)
-    {
-        try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
-        {
-            return this.delegate.selectWith(predicate, parameter);
         }
     }
 
@@ -546,7 +506,7 @@ public final class MultiReaderFastList<T>
     }
 
     @Override
-    public MutableList<T> subList(int fromIndex, int toIndex)
+    public MultiReaderList<T> subList(int fromIndex, int toIndex)
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSet.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSet.java
@@ -192,7 +192,7 @@ public final class MultiReaderUnifiedSet<T>
     }
 
     @Override
-    public MutableSet<T> clone()
+    public MultiReaderSet<T> clone()
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {
@@ -313,7 +313,7 @@ public final class MultiReaderUnifiedSet<T>
     }
 
     @Override
-    public MutableSet<T> newEmpty()
+    public MultiReaderSet<T> newEmpty()
     {
         return MultiReaderUnifiedSet.newSet();
     }
@@ -339,7 +339,7 @@ public final class MultiReaderUnifiedSet<T>
     }
 
     @Override
-    public MutableSet<T> tap(Procedure<? super T> procedure)
+    public MultiReaderSet<T> tap(Procedure<? super T> procedure)
     {
         try (LockWrapper wrapper = this.lockWrapper.acquireReadLock())
         {
@@ -393,34 +393,6 @@ public final class MultiReaderUnifiedSet<T>
         {
             return this.delegate.selectInstancesOf(clazz);
         }
-    }
-
-    @Override
-    public MutableSet<T> with(T element)
-    {
-        this.add(element);
-        return this;
-    }
-
-    @Override
-    public MutableSet<T> without(T element)
-    {
-        this.remove(element);
-        return this;
-    }
-
-    @Override
-    public MutableSet<T> withAll(Iterable<? extends T> elements)
-    {
-        this.addAllIterable(elements);
-        return this;
-    }
-
-    @Override
-    public MutableSet<T> withoutAll(Iterable<? extends T> elements)
-    {
-        this.removeAllIterable(elements);
-        return this;
     }
 
     @Override


### PR DESCRIPTION
I was code reviewing changes related to multi-reader collections and I noticed that they're missing a bunch of overrides.

These changes are not technically backwards compatible. I don't know if we're planning on a minor release next. Anyway, I wanted to show the changes even if they can't be merged for a while.