### PR TITLE
Remove direct dependencies on primitive containers in String adapters…

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/abstractPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/abstractPrimitiveIterable.stg
@@ -1,4 +1,4 @@
-import "copyright.stg"
+import "copyrightAndOthers.stg"
 import "primitiveEquals.stg"
 import "primitiveHashCode.stg"
 import "primitiveLiteral.stg"
@@ -12,7 +12,7 @@ class(primitive) ::= <<
 >>
 
 body(type, name) ::= <<
-<copyright()>
+<copyrightAndOthers()>
 
 package org.eclipse.collections.impl.primitive;
 
@@ -22,12 +22,12 @@ package org.eclipse.collections.impl.primitive;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.Lazy<name>Iterable;
 import org.eclipse.collections.api.bag.primitive.Mutable<name>Bag;
+import org.eclipse.collections.api.factory.primitive.<name>Bags;
+import org.eclipse.collections.api.factory.primitive.<name>Lists;
+import org.eclipse.collections.api.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.list.primitive.Mutable<name>List;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
-import org.eclipse.collections.impl.bag.mutable.primitive.<name>HashBag;
 import org.eclipse.collections.impl.lazy.primitive.Lazy<name>IterableAdapter;
-import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
-import org.eclipse.collections.impl.set.mutable.primitive.<name>HashSet;
 
 /**
  * This file was automatically generated from template file abstractPrimitiveIterable.stg.
@@ -46,19 +46,19 @@ public abstract class Abstract<name>Iterable implements <name>Iterable
     @Override
     public Mutable<name>List toList()
     {
-        return <name>ArrayList.newList(this);
+        return <name>Lists.mutable.withAll(this);
     }
 
     @Override
     public Mutable<name>Set toSet()
     {
-        return <name>HashSet.newSet(this);
+        return <name>Sets.mutable.withAll(this);
     }
 
     @Override
     public Mutable<name>Bag toBag()
     {
-        return <name>HashBag.newBag(this);
+        return <name>Bags.mutable.withAll(this);
     }
 }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -31,6 +31,9 @@ import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.IntIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.IntProcedure;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.IntBags;
+import org.eclipse.collections.api.factory.primitive.IntLists;
+import org.eclipse.collections.api.factory.primitive.IntSets;
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -40,16 +43,12 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
-import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
-import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.lazy.primitive.CollectIntToObjectIterable;
 import org.eclipse.collections.impl.lazy.primitive.LazyIntIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseIntIterable;
 import org.eclipse.collections.impl.lazy.primitive.SelectIntIterable;
 import org.eclipse.collections.impl.list.IntervalUtils;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
-import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 
@@ -763,13 +762,13 @@ public final class IntInterval
     @Override
     public ImmutableIntList select(IntPredicate predicate)
     {
-        return IntArrayList.newList(new SelectIntIterable(this, predicate)).toImmutable();
+        return IntLists.mutable.withAll(new SelectIntIterable(this, predicate)).toImmutable();
     }
 
     @Override
     public ImmutableIntList reject(IntPredicate predicate)
     {
-        return IntArrayList.newList(new SelectIntIterable(this, IntPredicates.not(predicate))).toImmutable();
+        return IntLists.mutable.withAll(new SelectIntIterable(this, IntPredicates.not(predicate))).toImmutable();
     }
 
     @Override
@@ -858,25 +857,25 @@ public final class IntInterval
     @Override
     public MutableIntList toList()
     {
-        return IntArrayList.newList(this);
+        return IntLists.mutable.withAll(this);
     }
 
     @Override
     public MutableIntList toSortedList()
     {
-        return IntArrayList.newList(this).sortThis();
+        return IntLists.mutable.withAll(this).sortThis();
     }
 
     @Override
     public MutableIntSet toSet()
     {
-        return IntHashSet.newSet(this);
+        return IntSets.mutable.withAll(this);
     }
 
     @Override
     public MutableIntBag toBag()
     {
-        return IntHashBag.newBag(this);
+        return IntBags.mutable.withAll(this);
     }
 
     @Override
@@ -894,25 +893,25 @@ public final class IntInterval
     @Override
     public ImmutableIntList newWith(int element)
     {
-        return IntArrayList.newList(this).with(element).toImmutable();
+        return IntLists.mutable.withAll(this).with(element).toImmutable();
     }
 
     @Override
     public ImmutableIntList newWithout(int element)
     {
-        return IntArrayList.newList(this).without(element).toImmutable();
+        return IntLists.mutable.withAll(this).without(element).toImmutable();
     }
 
     @Override
     public ImmutableIntList newWithAll(IntIterable elements)
     {
-        return IntArrayList.newList(this).withAll(elements).toImmutable();
+        return IntLists.mutable.withAll(this).withAll(elements).toImmutable();
     }
 
     @Override
     public ImmutableIntList newWithoutAll(IntIterable elements)
     {
-        return IntArrayList.newList(this).withoutAll(elements).toImmutable();
+        return IntLists.mutable.withAll(this).withoutAll(elements).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -31,6 +31,9 @@ import org.eclipse.collections.api.block.procedure.primitive.LongIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.LongLongProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.LongProcedure;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.LongBags;
+import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.factory.primitive.LongSets;
 import org.eclipse.collections.api.iterator.LongIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -40,16 +43,12 @@ import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
 import org.eclipse.collections.api.tuple.primitive.LongLongPair;
 import org.eclipse.collections.api.tuple.primitive.LongObjectPair;
-import org.eclipse.collections.impl.bag.mutable.primitive.LongHashBag;
 import org.eclipse.collections.impl.block.factory.primitive.LongPredicates;
-import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.lazy.primitive.CollectLongToObjectIterable;
 import org.eclipse.collections.impl.lazy.primitive.LazyLongIterableAdapter;
 import org.eclipse.collections.impl.lazy.primitive.ReverseLongIterable;
 import org.eclipse.collections.impl.lazy.primitive.SelectLongIterable;
 import org.eclipse.collections.impl.list.IntervalUtils;
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
-import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 
@@ -794,13 +793,13 @@ public final class LongInterval
     @Override
     public ImmutableLongList select(LongPredicate predicate)
     {
-        return LongArrayList.newList(new SelectLongIterable(this, predicate)).toImmutable();
+        return LongLists.mutable.withAll(new SelectLongIterable(this, predicate)).toImmutable();
     }
 
     @Override
     public ImmutableLongList reject(LongPredicate predicate)
     {
-        return LongArrayList.newList(new SelectLongIterable(this, LongPredicates.not(predicate))).toImmutable();
+        return LongLists.mutable.withAll(new SelectLongIterable(this, LongPredicates.not(predicate))).toImmutable();
     }
 
     @Override
@@ -905,25 +904,25 @@ public final class LongInterval
     @Override
     public MutableLongList toList()
     {
-        return LongArrayList.newList(this);
+        return LongLists.mutable.withAll(this);
     }
 
     @Override
     public MutableLongList toSortedList()
     {
-        return LongArrayList.newList(this).sortThis();
+        return LongLists.mutable.withAll(this).sortThis();
     }
 
     @Override
     public MutableLongSet toSet()
     {
-        return LongHashSet.newSet(this);
+        return LongSets.mutable.withAll(this);
     }
 
     @Override
     public MutableLongBag toBag()
     {
-        return LongHashBag.newBag(this);
+        return LongBags.mutable.withAll(this);
     }
 
     @Override
@@ -941,25 +940,25 @@ public final class LongInterval
     @Override
     public ImmutableLongList newWith(long element)
     {
-        return LongArrayList.newList(this).with(element).toImmutable();
+        return LongLists.mutable.withAll(this).with(element).toImmutable();
     }
 
     @Override
     public ImmutableLongList newWithout(long element)
     {
-        return LongArrayList.newList(this).without(element).toImmutable();
+        return LongLists.mutable.withAll(this).without(element).toImmutable();
     }
 
     @Override
     public ImmutableLongList newWithAll(LongIterable elements)
     {
-        return LongArrayList.newList(this).withAll(elements).toImmutable();
+        return LongLists.mutable.withAll(this).withAll(elements).toImmutable();
     }
 
     @Override
     public ImmutableLongList newWithoutAll(LongIterable elements)
     {
-        return LongArrayList.newList(this).withoutAll(elements).toImmutable();
+        return LongLists.mutable.withAll(this).withoutAll(elements).toImmutable();
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CharAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -27,6 +27,9 @@ import org.eclipse.collections.api.block.predicate.primitive.CharPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.CharIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.CharProcedure;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.CharBags;
+import org.eclipse.collections.api.factory.primitive.CharLists;
+import org.eclipse.collections.api.factory.primitive.CharSets;
 import org.eclipse.collections.api.iterator.CharIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -36,13 +39,9 @@ import org.eclipse.collections.api.list.primitive.MutableCharList;
 import org.eclipse.collections.api.set.primitive.MutableCharSet;
 import org.eclipse.collections.api.tuple.primitive.CharCharPair;
 import org.eclipse.collections.api.tuple.primitive.CharObjectPair;
-import org.eclipse.collections.impl.bag.mutable.primitive.CharHashBag;
-import org.eclipse.collections.impl.factory.primitive.CharLists;
 import org.eclipse.collections.impl.lazy.primitive.ReverseCharIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.CharArrayList;
 import org.eclipse.collections.impl.primitive.AbstractCharIterable;
-import org.eclipse.collections.impl.set.mutable.primitive.CharHashSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.StringIterate;
@@ -174,7 +173,7 @@ public class CharAdapter
     public CharAdapter distinct()
     {
         StringBuilder builder = new StringBuilder();
-        CharHashSet seenSoFar = new CharHashSet();
+        MutableCharSet seenSoFar = CharSets.mutable.empty();
 
         int size = this.size();
         for (int i = 0; i < size; i++)
@@ -401,7 +400,7 @@ public class CharAdapter
     public MutableCharList toList()
     {
         int size = this.size();
-        CharArrayList list = new CharArrayList(size);
+        MutableCharList list = CharLists.mutable.withInitialCapacity(size);
         for (int i = 0; i < size; i++)
         {
             list.add(this.get(i));
@@ -413,7 +412,7 @@ public class CharAdapter
     public MutableCharSet toSet()
     {
         int size = this.size();
-        CharHashSet set = new CharHashSet(size);
+        MutableCharSet set = CharSets.mutable.empty();
         for (int i = 0; i < size; i++)
         {
             set.add(this.get(i));
@@ -425,7 +424,7 @@ public class CharAdapter
     public MutableCharBag toBag()
     {
         int size = this.size();
-        CharHashBag bag = new CharHashBag(size);
+        MutableCharBag bag = CharBags.mutable.empty();
         for (int i = 0; i < size; i++)
         {
             bag.add(this.get(i));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -28,6 +28,7 @@ import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.IntIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.IntProcedure;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.IntSets;
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -37,13 +38,11 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
-import org.eclipse.collections.impl.bag.mutable.primitive.IntHashBag;
+import org.eclipse.collections.impl.factory.primitive.IntBags;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.lazy.primitive.ReverseIntIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.primitive.AbstractIntIterable;
-import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 
@@ -182,7 +181,7 @@ public class CodePointAdapter
     public CodePointAdapter distinct()
     {
         StringBuilder builder = new StringBuilder();
-        IntHashSet seenSoFar = new IntHashSet();
+        MutableIntSet seenSoFar = IntSets.mutable.empty();
 
         int length = this.adapted.length();
         for (int i = 0; i < length; )
@@ -505,7 +504,7 @@ public class CodePointAdapter
     @Override
     public MutableIntList toList()
     {
-        IntArrayList list = new IntArrayList(this.adapted.length());
+        MutableIntList list = IntLists.mutable.withInitialCapacity(this.adapted.length());
         for (int i = 0; i < this.adapted.length(); )
         {
             int codePoint = this.adapted.codePointAt(i);
@@ -518,7 +517,7 @@ public class CodePointAdapter
     @Override
     public MutableIntSet toSet()
     {
-        IntHashSet set = new IntHashSet(this.adapted.length());
+        MutableIntSet set = IntSets.mutable.empty();
         for (int i = 0; i < this.adapted.length(); )
         {
             int codePoint = this.adapted.codePointAt(i);
@@ -531,7 +530,7 @@ public class CodePointAdapter
     @Override
     public MutableIntBag toBag()
     {
-        IntHashBag bag = new IntHashBag(this.adapted.length());
+        MutableIntBag bag = IntBags.mutable.empty();
         for (int i = 0; i < this.adapted.length(); )
         {
             int codePoint = this.adapted.codePointAt(i);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/string/immutable/CodePointList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -27,6 +27,7 @@ import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.IntIntProcedure;
 import org.eclipse.collections.api.block.procedure.primitive.IntProcedure;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.IntLists;
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -36,8 +37,6 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.api.tuple.primitive.IntIntPair;
 import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
-import org.eclipse.collections.impl.factory.primitive.IntLists;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.primitive.AbstractIntIterable;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -57,7 +56,7 @@ public class CodePointList extends AbstractIntIterable implements CharSequence, 
     public CodePointList(String value)
     {
         int stringSize = value.length();
-        IntArrayList list = new IntArrayList(stringSize);
+        MutableIntList list = IntLists.mutable.withInitialCapacity(stringSize);
         for (int i = 0; i < stringSize; )
         {
             int codePoint = value.codePointAt(i);
@@ -328,7 +327,7 @@ public class CodePointList extends AbstractIntIterable implements CharSequence, 
 
     public CodePointList collectInt(IntToIntFunction function)
     {
-        IntArrayList collected = new IntArrayList(this.size());
+        MutableIntList collected = IntLists.mutable.withInitialCapacity(this.size());
         for (int i = 0; i < this.size(); i++)
         {
             int codePoint = this.get(i);


### PR DESCRIPTION
… and primitive intervals.

Signed-off-by: Donald Raab <Donald.Raab@bnymellon.com>