### PR TITLE
Disambiguate and deprecate primitive injectInto methods on RichIterable.

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -1580,8 +1580,22 @@ public interface RichIterable<T>
      * item in the iterable is used as the second parameter.
      *
      * @since 1.0
+     * @deprecated since 11.1 - use injectIntoInt instead
      */
+    @Deprecated
     int injectInto(int injectedValue, IntObjectToIntFunction<? super T> function);
+
+    /**
+     * Returns the final int result of evaluating function using each element of the iterable and the previous evaluation
+     * result as the parameters. The injected value is used for the first parameter of the first evaluation, and the current
+     * item in the iterable is used as the second parameter.
+     *
+     * @since 11.1
+     */
+    default int injectIntoInt(int injectedValue, IntObjectToIntFunction<? super T> function)
+    {
+        return this.injectInto(injectedValue, function);
+    }
 
     /**
      * Returns the final long result of evaluating function using each element of the iterable and the previous evaluation
@@ -1589,8 +1603,22 @@ public interface RichIterable<T>
      * item in the iterable is used as the second parameter.
      *
      * @since 1.0
+     * @deprecated since 11.1 - use injectIntoLong instead
      */
+    @Deprecated
     long injectInto(long injectedValue, LongObjectToLongFunction<? super T> function);
+
+    /**
+     * Returns the final long result of evaluating function using each element of the iterable and the previous evaluation
+     * result as the parameters. The injected value is used for the first parameter of the first evaluation, and the current
+     * item in the iterable is used as the second parameter.
+     *
+     * @since 11.1
+     */
+    default long injectIntoLong(long injectedValue, LongObjectToLongFunction<? super T> function)
+    {
+        return this.injectInto(injectedValue, function);
+    }
 
     /**
      * Returns the final float result of evaluating function using each element of the iterable and the previous evaluation
@@ -1598,8 +1626,22 @@ public interface RichIterable<T>
      * item in the iterable is used as the second parameter.
      *
      * @since 2.0
+     * @deprecated since 11.1 - use injectIntoFloat instead
      */
+    @Deprecated
     float injectInto(float injectedValue, FloatObjectToFloatFunction<? super T> function);
+
+    /**
+     * Returns the final float result of evaluating function using each element of the iterable and the previous evaluation
+     * result as the parameters. The injected value is used for the first parameter of the first evaluation, and the current
+     * item in the iterable is used as the second parameter.
+     *
+     * @since 11.1
+     */
+    default float injectIntoFloat(float injectedValue, FloatObjectToFloatFunction<? super T> function)
+    {
+        return this.injectInto(injectedValue, function);
+    }
 
     /**
      * Returns the final double result of evaluating function using each element of the iterable and the previous evaluation
@@ -1607,8 +1649,22 @@ public interface RichIterable<T>
      * item in the iterable is used as the second parameter.
      *
      * @since 1.0
+     * @deprecated since 11.1 - use injectIntoDouble instead
      */
+    @Deprecated
     double injectInto(double injectedValue, DoubleObjectToDoubleFunction<? super T> function);
+
+    /**
+     * Returns the final double result of evaluating function using each element of the iterable and the previous evaluation
+     * result as the parameters. The injected value is used for the first parameter of the first evaluation, and the current
+     * item in the iterable is used as the second parameter.
+     *
+     * @since 11.1
+     */
+    default double injectIntoDouble(double injectedValue, DoubleObjectToDoubleFunction<? super T> function)
+    {
+        return this.injectInto(injectedValue, function);
+    }
 
     /**
      * Adds all the elements in this iterable to the specific target Collection.

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
@@ -1941,17 +1941,17 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        Assert.assertEquals(31, iterable.injectInto(1, AddFunction.INTEGER_TO_INT));
-        Assert.assertEquals(30, iterable.injectInto(0, AddFunction.INTEGER_TO_INT));
+        Assert.assertEquals(31, iterable.injectIntoInt(1, AddFunction.INTEGER_TO_INT));
+        Assert.assertEquals(30, iterable.injectIntoInt(0, AddFunction.INTEGER_TO_INT));
 
-        Assert.assertEquals(31L, iterable.injectInto(1, AddFunction.INTEGER_TO_LONG));
-        Assert.assertEquals(30L, iterable.injectInto(0, AddFunction.INTEGER_TO_LONG));
+        Assert.assertEquals(31L, iterable.injectIntoLong(1, AddFunction.INTEGER_TO_LONG));
+        Assert.assertEquals(30L, iterable.injectIntoLong(0, AddFunction.INTEGER_TO_LONG));
 
-        Assert.assertEquals(31.0d, iterable.injectInto(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
-        Assert.assertEquals(30.0d, iterable.injectInto(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        Assert.assertEquals(31.0d, iterable.injectIntoDouble(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        Assert.assertEquals(30.0d, iterable.injectIntoDouble(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
 
-        Assert.assertEquals(31.0f, iterable.injectInto(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
-        Assert.assertEquals(30.0f, iterable.injectInto(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        Assert.assertEquals(31.0f, iterable.injectIntoFloat(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        Assert.assertEquals(30.0f, iterable.injectIntoFloat(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -1204,9 +1204,9 @@ public abstract class AbstractRichIterableTestCase
     public void injectIntoInt()
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
-        int result = objects.injectInto(1, AddFunction.INTEGER_TO_INT);
+        int result = objects.injectIntoInt(1, AddFunction.INTEGER_TO_INT);
         Assert.assertEquals(7, result);
-        int sum = objects.injectInto(0, AddFunction.INTEGER_TO_INT);
+        int sum = objects.injectIntoInt(0, AddFunction.INTEGER_TO_INT);
         Assert.assertEquals(6, sum);
     }
 
@@ -1214,9 +1214,9 @@ public abstract class AbstractRichIterableTestCase
     public void injectIntoLong()
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
-        long result = objects.injectInto(1, AddFunction.INTEGER_TO_LONG);
+        long result = objects.injectIntoLong(1, AddFunction.INTEGER_TO_LONG);
         Assert.assertEquals(7, result);
-        long sum = objects.injectInto(0, AddFunction.INTEGER_TO_LONG);
+        long sum = objects.injectIntoLong(0, AddFunction.INTEGER_TO_LONG);
         Assert.assertEquals(6, sum);
     }
 
@@ -1224,9 +1224,9 @@ public abstract class AbstractRichIterableTestCase
     public void injectIntoDouble()
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
-        double result = objects.injectInto(1, AddFunction.INTEGER_TO_DOUBLE);
+        double result = objects.injectIntoDouble(1, AddFunction.INTEGER_TO_DOUBLE);
         Assert.assertEquals(7.0d, result, 0.001);
-        double sum = objects.injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
+        double sum = objects.injectIntoDouble(0, AddFunction.INTEGER_TO_DOUBLE);
         Assert.assertEquals(6.0d, sum, 0.001);
     }
 
@@ -1234,9 +1234,9 @@ public abstract class AbstractRichIterableTestCase
     public void injectIntoFloat()
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
-        float result = objects.injectInto(1, AddFunction.INTEGER_TO_FLOAT);
+        float result = objects.injectIntoFloat(1, AddFunction.INTEGER_TO_FLOAT);
         Assert.assertEquals(7.0f, result, 0.001f);
-        float sum = objects.injectInto(0, AddFunction.INTEGER_TO_FLOAT);
+        float sum = objects.injectIntoFloat(0, AddFunction.INTEGER_TO_FLOAT);
         Assert.assertEquals(6.0f, sum, 0.001f);
     }
 


### PR DESCRIPTION
Signed-off-by: Donald Raab <Donald.Raab@bnymellon.com>