### PR TITLE
Turn on CheckStyle rule SingleSpaceSeparator and fix violations.

### DIFF
--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
-    "https://checkstyle.org/dtds/configuration_1_2.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
   ~ Copyright (c) 2021 Goldman Sachs.

--- a/checkstyle-configuration.xml
+++ b/checkstyle-configuration.xml
@@ -4,7 +4,7 @@
     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
-  ~ Copyright (c) 2021 Goldman Sachs.
+  ~ Copyright (c) 2022 Goldman Sachs and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -196,6 +196,10 @@
             <property name="lineWrappingIndentation" value="8"/>
         </module>
         <module name="CommentsIndentation" />
+
+        <module name="SingleSpaceSeparator">
+            <property name="validateComments" value="false" />
+        </module>
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->

--- a/eclipse-collections-code-generator/src/main/resources/api/factory/map/mutableObjectPrimitiveMapFactory.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/factory/map/mutableObjectPrimitiveMapFactory.stg
@@ -123,9 +123,9 @@ public interface MutableObject<name>MapFactory
     /**
      * Same as {@link #withAll(Object<name>Map)}.
      */
-    \<K> MutableObject<name>Map\<K> ofAll(Object<name>Map\<? extends K>  map);
+    \<K> MutableObject<name>Map\<K> ofAll(Object<name>Map\<? extends K> map);
 
-    \<K> MutableObject<name>Map\<K> withAll(Object<name>Map\<? extends K>  map);
+    \<K> MutableObject<name>Map\<K> withAll(Object<name>Map\<? extends K> map);
 
     /**
      * Creates an {@code MutableObject<name>Map} from an {@code Iterable\<T>} by applying {@code keyFunction} and {@code valueFunction}.

--- a/eclipse-collections-code-generator/src/main/resources/api/factory/map/mutablePrimitiveObjectMapFactory.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/factory/map/mutablePrimitiveObjectMapFactory.stg
@@ -117,9 +117,9 @@ public interface Mutable<name>ObjectMapFactory
     /**
      * Same as {@link #withAll(<name>ObjectMap)}.
      */
-    \<V> Mutable<name>ObjectMap\<V> ofAll(<name>ObjectMap\<? extends V>  map);
+    \<V> Mutable<name>ObjectMap\<V> ofAll(<name>ObjectMap\<? extends V> map);
 
-    \<V> Mutable<name>ObjectMap\<V> withAll(<name>ObjectMap\<? extends V>  map);
+    \<V> Mutable<name>ObjectMap\<V> withAll(<name>ObjectMap\<? extends V> map);
 
     /**
      * Creates an {@code Mutable<name>ObjectMap} from an {@code Iterable\<T>} by applying {@code keyFunction} and {@code valueFunction}.

--- a/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/list/mutablePrimitiveList.stg
@@ -230,7 +230,7 @@ default Mutable<name>List shuffleThis(Random rnd)
     for (int j = this.size() - 1; j > 0; j--)
     {
         int k = rnd.nextInt(j + 1);
-        <type> selected  = this.get(j);
+        <type> selected = this.get(j);
         this.set(j, this.get(k));
         this.set(k, selected);
     }

--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -657,7 +657,7 @@ collectPrimitive(toName) ::= <<
  */
 default \<R extends Mutable<toName>Collection> R collect<toName>(<name>To<toName>Function function, R target)
 {
-    this.each(each ->  target.add(function.valueOf(each)));
+    this.each(each -> target.add(function.valueOf(each)));
     return target;
 }
 >>

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -1546,7 +1546,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         {
             if (this.sentinelValues.containsZeroKey)
             {
-                Iterable\<VV> iterable  = function.valueOf(this.sentinelValues.zeroValue);
+                Iterable\<VV> iterable = function.valueOf(this.sentinelValues.zeroValue);
                 for (VV key : iterable)
                 {
                     target.put(key, this.sentinelValues.zeroValue);
@@ -1554,7 +1554,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             }
             if (this.sentinelValues.containsOneKey)
             {
-                Iterable\<VV> iterable  = function.valueOf(this.sentinelValues.oneValue);
+                Iterable\<VV> iterable = function.valueOf(this.sentinelValues.oneValue);
                 for (VV key : iterable)
                 {
                     target.put(key, this.sentinelValues.oneValue);
@@ -1565,7 +1565,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         {
             if (isNonSentinel(this.keys[i]))
             {
-                Iterable\<VV> iterable  = function.valueOf(this.values[i]);
+                Iterable\<VV> iterable = function.valueOf(this.values[i]);
                 for (VV key : iterable)
                 {
                     target.put(key, this.values[i]);
@@ -2546,7 +2546,7 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
             this.values[index] = function.value(this.values[index], parameter);
             return this.values[index];
         }
-        V value =  function.value(factory.value(), parameter);
+        V value = function.value(factory.value(), parameter);
         this.addKeyValueAtIndex(key, value, index);
         return value;
     }

--- a/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/factory/primitiveObjectMutableMapFactoryTest.stg
@@ -42,8 +42,8 @@ public class Mutable<name>ObjectMapFactoryTest
         Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
                 <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three",  <(literal.(type))("4")>, "four"),
-                <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three",  <(literal.(type))("4")>, "four"));
+        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
+                <name>ObjectMaps.mutable.with(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"));
     }
 
     @Test
@@ -58,8 +58,8 @@ public class Mutable<name>ObjectMapFactoryTest
         Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"),
                 <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three"));
 
-        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three",  <(literal.(type))("4")>, "four"),
-                <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three",  <(literal.(type))("4")>, "four"));
+        Assert.assertEquals(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"),
+                <name>ObjectMaps.mutable.of(<(literal.(type))("1")>, "one", <(literal.(type))("2")>, "two", <(literal.(type))("3")>, "three", <(literal.(type))("4")>, "four"));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
@@ -373,7 +373,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
     public void maxBy()
     {
         Assert.assertEquals(PrimitiveTuples.pair(<(literal.(type))("1")>, false),
-                this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("4")>, false).maxBy((<name>BooleanPair object) ->  (int) object.getOne() & 1));
+                this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("4")>, false).maxBy((<name>BooleanPair object) -> (int) object.getOne() & 1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
@@ -176,7 +176,7 @@ public abstract class Object<name>HashMapKeySetTestCase
         Assert.assertFalse(map.keySet().remove("Four"));
 
         Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
@@ -203,7 +203,7 @@ public abstract class Object<name>HashMapKeySetTestCase
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
@@ -215,7 +215,7 @@ public abstract class Object<name>HashMapKeySetTestCase
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
@@ -166,7 +166,7 @@ public class SynchronizedObject<name>MapKeySetTest
         Assert.assertFalse(map.keySet().remove("Four"));
 
         Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
@@ -193,7 +193,7 @@ public class SynchronizedObject<name>MapKeySetTest
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
@@ -205,7 +205,7 @@ public class SynchronizedObject<name>MapKeySetTest
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>,  "Three", <(literal.(type))("3")>), map);
+        Assert.assertEquals(Object<name>HashMap.newWithKeysValues("One", <(literal.(type))("1")>, "Three", <(literal.(type))("3")>), map);
         Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveKeySetTest.stg
@@ -52,7 +52,7 @@ public class Immutable<primitive.name>MapKeySetTest extends AbstractImmutable<na
         super.contains();
         <type> collision1 = AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst();
         <type> collision2 = AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1);
-        <name>ByteHashMap <type>ByteHashMap = <name>ByteHashMap.newWithKeysValues(collision1, (byte) 0, collision2,  (byte) 0);
+        <name>ByteHashMap <type>ByteHashMap = <name>ByteHashMap.newWithKeysValues(collision1, (byte) 0, collision2, (byte) 0);
         <type>ByteHashMap.removeKey(collision2);
         <name>Set <type>Set = <type>ByteHashMap.keySet().freeze();
         Assert.assertTrue(<type>Set.contains(collision1));

--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitivePrimitiveMapKeySetTest.stg
@@ -52,7 +52,7 @@ public class Immutable<primitive.name><primitive.name>MapKeySetTest extends Abst
         super.contains();
         <type> collision1 = AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst();
         <type> collision2 = AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1);
-        <name><name>HashMap <type><name>HashMap = <name><name>HashMap.newWithKeysValues(collision1, collision1, collision2,  collision2);
+        <name><name>HashMap <type><name>HashMap = <name><name>HashMap.newWithKeysValues(collision1, collision1, collision2, collision2);
         <type><name>HashMap.removeKey(collision2);
         <name>Set <type>Set = <type><name>HashMap.keySet().freeze();
         Assert.assertTrue(<type>Set.contains(collision1));

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/ClassComparer.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/ClassComparer.java
@@ -144,7 +144,7 @@ public class ClassComparer
     public MutableSortedSet<String> printClass(Class<?> clazz)
     {
         MutableSortedSet<String> methodNames = this.getMethodNames(clazz);
-        this.outputTitle("Class: "  + (this.includePackageNames ? clazz.getName() : clazz.getSimpleName()));
+        this.outputTitle("Class: " + (this.includePackageNames ? clazz.getName() : clazz.getSimpleName()));
         this.outputGroupByToString(methodNames);
         return methodNames;
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/collector/Collectors2.java
@@ -1601,13 +1601,13 @@ public final class Collectors2
      * commonly called filter. The new collection is created as the result of evaluating the provided Supplier.</p>
      * <p>Examples:</p>
      * {@code MutableList<Integer> evens1 =
-     * Interval.oneTo(10).stream().collect(Collectors2.select(e ->  e % 2 == 0, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).stream().collect(Collectors2.select(e -> e % 2 == 0, Lists.mutable::empty));}<br>
      * {@code MutableList<Integer> evens2 =
-     * Interval.oneTo(10).reduceInPlace(Collectors2.select(e ->  e % 2 == 0, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).reduceInPlace(Collectors2.select(e -> e % 2 == 0, Lists.mutable::empty));}<br>
      * <p>
      * Equivalent to using @{@link RichIterable#select(Predicate, Collection)}
      * </p>
-     * {@code MutableList<Integer> evens = Interval.oneTo(10).select(e ->  e % 2 == 0, Lists.mutable.empty());}
+     * {@code MutableList<Integer> evens = Interval.oneTo(10).select(e -> e % 2 == 0, Lists.mutable.empty());}
      */
     public static <T, R extends Collection<T>> Collector<T, ?, R> select(Predicate<? super T> predicate, Supplier<R> supplier)
     {
@@ -1629,13 +1629,13 @@ public final class Collectors2
      * The new collection is created as the result of evaluating the provided Supplier.</p>
      * <p>Examples:</p>
      * {@code MutableList<Integer> evens1 =
-     * Interval.oneTo(10).stream().collect(Collectors2.selectWith((e, p) ->  e % p == 0, 2, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).stream().collect(Collectors2.selectWith((e, p) -> e % p == 0, 2, Lists.mutable::empty));}<br>
      * {@code MutableList<Integer> evens2 =
-     * Interval.oneTo(10).reduceInPlace(Collectors2.selectWith((e, p) ->  e % p == 0, 2, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).reduceInPlace(Collectors2.selectWith((e, p) -> e % p == 0, 2, Lists.mutable::empty));}<br>
      * <p>
      * Equivalent to using @{@link RichIterable#selectWith(Predicate2, Object, Collection)}
      * </p>
-     * {@code MutableList<Integer> evens = Interval.oneTo(10).selectWith((e, p) ->  e % p == 0, 2, Lists.mutable.empty());}
+     * {@code MutableList<Integer> evens = Interval.oneTo(10).selectWith((e, p) -> e % p == 0, 2, Lists.mutable.empty());}
      */
     public static <T, P, R extends Collection<T>> Collector<T, ?, R> selectWith(
             Predicate2<? super T, ? super P> predicate,
@@ -1660,13 +1660,13 @@ public final class Collectors2
      * commonly called filterNot. The new collection is created as the result of evaluating the provided Supplier.</p>
      * <p>Examples:</p>
      * {@code MutableList<Integer> odds1 =
-     * Interval.oneTo(10).stream().collect(Collectors2.reject(e ->  e % 2 == 0, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).stream().collect(Collectors2.reject(e -> e % 2 == 0, Lists.mutable::empty));}<br>
      * {@code MutableList<Integer> odds2 =
-     * Interval.oneTo(10).reduceInPlace(Collectors2.reject(e ->  e % 2 == 0, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).reduceInPlace(Collectors2.reject(e -> e % 2 == 0, Lists.mutable::empty));}<br>
      * <p>
      * Equivalent to using @{@link RichIterable#reject(Predicate, Collection)}
      * </p>
-     * {@code MutableList<Integer> odds = Interval.oneTo(10).reject(e ->  e % 2 == 0, Lists.mutable.empty());}
+     * {@code MutableList<Integer> odds = Interval.oneTo(10).reject(e -> e % 2 == 0, Lists.mutable.empty());}
      */
     public static <T, R extends Collection<T>> Collector<T, ?, R> reject(Predicate<? super T> predicate, Supplier<R> supplier)
     {
@@ -1688,13 +1688,13 @@ public final class Collectors2
      * The new collection is created as the result of evaluating the provided Supplier.</p>
      * <p>Examples:</p>
      * {@code MutableList<Integer> odds1 =
-     * Interval.oneTo(10).stream().collect(Collectors2.rejectWith((e, p) ->  e % p == 0, 2, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).stream().collect(Collectors2.rejectWith((e, p) -> e % p == 0, 2, Lists.mutable::empty));}<br>
      * {@code MutableList<Integer> odds2 =
-     * Interval.oneTo(10).reduceInPlace(Collectors2.rejectWith((e, p) ->  e % p == 0, 2, Lists.mutable::empty));}<br>
+     * Interval.oneTo(10).reduceInPlace(Collectors2.rejectWith((e, p) -> e % p == 0, 2, Lists.mutable::empty));}<br>
      * <p>
      * Equivalent to using @{@link RichIterable#rejectWith(Predicate2, Object, Collection)}
      * </p>
-     * {@code MutableList<Integer> odds = Interval.oneTo(10).rejectWith((e, p) ->  e % p == 0, 2, Lists.mutable.empty());}
+     * {@code MutableList<Integer> odds = Interval.oneTo(10).rejectWith((e, p) -> e % p == 0, 2, Lists.mutable.empty());}
      */
     public static <T, P, R extends Collection<T>> Collector<T, ?, R> rejectWith(
             Predicate2<? super T, ? super P> predicate,
@@ -2142,4 +2142,3 @@ public final class Collectors2
         };
     }
 }
-

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -1981,7 +1981,7 @@ public final class ConcurrentHashMap<K, V>
     }
 
     @Override
-    public ConcurrentHashMap<K, V> withMap(Map<? extends  K, ? extends V> map)
+    public ConcurrentHashMap<K, V> withMap(Map<? extends K, ? extends V> map)
     {
         return (ConcurrentHashMap<K, V>) super.withMap(map);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <scala.version>2.12.15</scala.version>
         <guava.version>31.0.1-jre</guava.version>
         <trove4j.version>3.0.3</trove4j.version>
-        <checkstyle.version>9.1</checkstyle.version>
+        <checkstyle.version>10.1</checkstyle.version>
         <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
         <jacoco.plugin.version>0.8.7</jacoco.plugin.version>
         <junit.version>4.13.2</junit.version>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
@@ -74,14 +74,14 @@ public class SpreadFunctionsTest
     @Test
     public void shortSpreadOne()
     {
-        Assert.assertEquals(-1526665035L,  SpreadFunctions.shortSpreadOne((short) 123));
-        Assert.assertEquals(-1120388305L,  SpreadFunctions.shortSpreadOne((short) 234));
+        Assert.assertEquals(-1526665035L, SpreadFunctions.shortSpreadOne((short) 123));
+        Assert.assertEquals(-1120388305L, SpreadFunctions.shortSpreadOne((short) 234));
     }
 
     @Test
     public void shortSpreadTwo()
     {
-        Assert.assertEquals(-474242978L,  SpreadFunctions.shortSpreadTwo((short) 123));
-        Assert.assertEquals(-1572485272L,  SpreadFunctions.shortSpreadTwo((short) 234));
+        Assert.assertEquals(-474242978L, SpreadFunctions.shortSpreadTwo((short) 123));
+        Assert.assertEquals(-1572485272L, SpreadFunctions.shortSpreadTwo((short) 234));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AtomicCountProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AtomicCountProcedureTest.java
@@ -26,7 +26,7 @@ public class AtomicCountProcedureTest
         AtomicCountProcedure<String> atomicCountProcedure = new AtomicCountProcedure<>(each -> STRING_LENGTH < each.length());
 
         atomicCountProcedure.value("word");
-        assertEquals(0,  atomicCountProcedure.getCount());
+        assertEquals(0, atomicCountProcedure.getCount());
 
         atomicCountProcedure.value("america");
         assertEquals(1, atomicCountProcedure.getCount());

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
@@ -27,7 +27,7 @@ public class CollectionRemoveProcedureTest
         Verify.assertContainsAll(procedure.getResult(), 1, 2);
         procedure.value(1);
         Verify.assertSize(1, procedure.getResult());
-        Verify.assertContainsAll(procedure.getResult(),  2);
+        Verify.assertContainsAll(procedure.getResult(), 2);
     }
 
     public void toStringTest()

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -153,7 +153,7 @@ public class TuplesTest
         Pair<String, String> pair1 = Tuples.pair("1", "1");
         Assert.assertEquals("1:1", pair1.toString());
 
-        Triple<String, String, String> triple = Tuples.triple("1", "2",  "3");
+        Triple<String, String, String> triple = Tuples.triple("1", "2", "3");
         Assert.assertEquals("1:2:3", triple.toString());
 
         Twin<String> identicalTwin = Tuples.identicalTwin("1");
@@ -200,7 +200,7 @@ public class TuplesTest
     @Test
     public void reverse()
     {
-        Triple<String, Integer, Boolean> triple = Tuples.triple("One",  2,  true);
+        Triple<String, Integer, Boolean> triple = Tuples.triple("One", 2, true);
         Triple<Boolean, Integer, String> reversedTriple = triple.reverse();
         Triple<Boolean, Integer, String> expectedTriple = Tuples.triple(true, 2, "One");
         Assert.assertEquals(true, reversedTriple.getOne());

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -1467,8 +1467,8 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(7, 3),  ArrayIterate.minBy(integerTwins, Functions.firstOfPair()));
-        Assert.assertEquals(Tuples.twin(9, 1),  ArrayIterate.minBy(integerTwins, Functions.secondOfPair()));
+        Assert.assertEquals(Tuples.twin(7, 3), ArrayIterate.minBy(integerTwins, Functions.firstOfPair()));
+        Assert.assertEquals(Tuples.twin(9, 1), ArrayIterate.minBy(integerTwins, Functions.secondOfPair()));
     }
 
     @Test
@@ -1502,8 +1502,8 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(9, 1),  ArrayIterate.maxBy(integerTwins, Functions.firstOfPair()));
-        Assert.assertEquals(Tuples.twin(7, 3),  ArrayIterate.maxBy(integerTwins, Functions.secondOfPair()));
+        Assert.assertEquals(Tuples.twin(9, 1), ArrayIterate.maxBy(integerTwins, Functions.firstOfPair()));
+        Assert.assertEquals(Tuples.twin(7, 3), ArrayIterate.maxBy(integerTwins, Functions.secondOfPair()));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -794,7 +794,7 @@ public class IterateTest
     public void toMapTarget()
     {
         MutableSet<Integer> set = UnifiedSet.newSet(this.getIntegerSet());
-        Map<String, Integer> map =  Iterate.toMap(set, String::valueOf, object -> 10 * object, new HashMap<>());
+        Map<String, Integer> map = Iterate.toMap(set, String::valueOf, object -> 10 * object, new HashMap<>());
         Verify.assertSize(5, map);
         Object expectedValue = 10;
         Object expectedKey = "1";


### PR DESCRIPTION
I was comparing our rule set to [CheckStyle's rules](https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml) that it applies to its own source code. I made three changes.

1.  Upgrade checkstyle-configuration.xml from 1.2 schema to 1.3 schema.
2.  Upgrade CheckStyle from 9.1 to 10.1.
3.  Turn on CheckStyle rule SingleSpaceSeparator and fix violations.

(1) and (2) were to get in sync.
(3) Is the first of several rules I want to turn on.