### PR TITLE
Turn on additional IntelliJ inspections and fix violations. #1323

### DIFF
--- a/.idea/inspectionProfiles/2_Inconsistent_Constructs.xml
+++ b/.idea/inspectionProfiles/2_Inconsistent_Constructs.xml
@@ -986,7 +986,7 @@
     </inspection_tool>
     <inspection_tool class="IntentionDescriptionNotFoundInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="InterceptionAnnotationWithoutRuntimeRetention" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="InterfaceNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
       <option name="m_minLength" value="8" />
@@ -1745,7 +1745,7 @@
     <inspection_tool class="SingleImport" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Singleton" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SingletonInjectsScoped" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SizeReplaceableByIsEmpty" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SleepWhileHoldingLock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SocketResource" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="insideTryAllowed" value="false" />

--- a/.idea/inspectionProfiles/IDE.xml
+++ b/.idea/inspectionProfiles/IDE.xml
@@ -764,6 +764,7 @@
     <inspection_tool class="StaticCollection" enabled="true" level="INSPECTION" enabled_by_default="true">
       <option name="m_ignoreWeakCollections" value="false" />
     </inspection_tool>
+    <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StaticFieldReferenceOnSubclass" enabled="true" level="INSPECTION" enabled_by_default="true" />
     <inspection_tool class="StaticGuardedByInstance" enabled="true" level="INSPECTION" enabled_by_default="true" />
     <inspection_tool class="StaticImport" enabled="true" level="WARNING" enabled_by_default="true">

--- a/eclipse-collections-code-generator/src/main/java/org/eclipse/collections/codegenerator/ErrorListener.java
+++ b/eclipse-collections-code-generator/src/main/java/org/eclipse/collections/codegenerator/ErrorListener.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.codegenerator;
 
+@FunctionalInterface
 public interface ErrorListener
 {
     void error(String string);

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -281,19 +281,19 @@ public final class Verify extends Assert
             {
                 Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
             }
-            if (actualMutableMapIterable.size() != 0)
+            if (!actualMutableMapIterable.isEmpty())
             {
                 Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.size() + '>');
             }
-            if (actualMutableMapIterable.keySet().size() != 0)
+            if (!actualMutableMapIterable.keySet().isEmpty())
             {
                 Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.keySet().size() + '>');
             }
-            if (actualMutableMapIterable.values().size() != 0)
+            if (!actualMutableMapIterable.values().isEmpty())
             {
                 Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.values().size() + '>');
             }
-            if (actualMutableMapIterable.entrySet().size() != 0)
+            if (!actualMutableMapIterable.entrySet().isEmpty())
             {
                 Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.entrySet().size() + '>');
             }
@@ -322,6 +322,7 @@ public final class Verify extends Assert
     /**
      * Assert that the given {@link PrimitiveIterable} is empty.
      */
+    @SuppressWarnings("SizeReplaceableByIsEmpty")
     public static void assertEmpty(String iterableName, PrimitiveIterable primitiveIterable)
     {
         try
@@ -489,6 +490,7 @@ public final class Verify extends Assert
     /**
      * Assert that the given {@link Multimap} is empty.
      */
+    @SuppressWarnings("SizeReplaceableByIsEmpty")
     public static void assertEmpty(String multimapName, Multimap<?, ?> actualMultimap)
     {
         try
@@ -511,23 +513,23 @@ public final class Verify extends Assert
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
             }
-            if (actualMultimap.keyBag().size() != 0)
+            if (!actualMultimap.keyBag().isEmpty())
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyBag().size() + '>');
             }
-            if (actualMultimap.keysView().size() != 0)
+            if (!actualMultimap.keysView().isEmpty())
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keysView().size() + '>');
             }
-            if (actualMultimap.valuesView().size() != 0)
+            if (!actualMultimap.valuesView().isEmpty())
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.valuesView().size() + '>');
             }
-            if (actualMultimap.keyValuePairsView().size() != 0)
+            if (!actualMultimap.keyValuePairsView().isEmpty())
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyValuePairsView().size() + '>');
             }
-            if (actualMultimap.keyMultiValuePairsView().size() != 0)
+            if (!actualMultimap.keyMultiValuePairsView().isEmpty())
             {
                 Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyMultiValuePairsView().size() + '>');
             }
@@ -541,6 +543,7 @@ public final class Verify extends Assert
     /**
      * Assert that the given {@link Map} is empty.
      */
+    @SuppressWarnings("SizeReplaceableByIsEmpty")
     public static void assertEmpty(String mapName, Map<?, ?> actualMap)
     {
         try
@@ -555,15 +558,15 @@ public final class Verify extends Assert
             {
                 Assert.fail(mapName + " should be empty; actual size:<" + actualMap.size() + '>');
             }
-            if (actualMap.keySet().size() != 0)
+            if (!actualMap.keySet().isEmpty())
             {
                 Assert.fail(mapName + " should be empty; actual size:<" + actualMap.keySet().size() + '>');
             }
-            if (actualMap.values().size() != 0)
+            if (!actualMap.values().isEmpty())
             {
                 Assert.fail(mapName + " should be empty; actual size:<" + actualMap.values().size() + '>');
             }
-            if (actualMap.entrySet().size() != 0)
+            if (!actualMap.entrySet().isEmpty())
             {
                 Assert.fail(mapName + " should be empty; actual size:<" + actualMap.entrySet().size() + '>');
             }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/StringPredicates.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/StringPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -202,7 +202,7 @@ public final class StringPredicates
         @Override
         public boolean accept(String anObject)
         {
-            return anObject != null && anObject.length() == 0;
+            return anObject != null && anObject.isEmpty();
         }
 
         @Override
@@ -219,7 +219,7 @@ public final class StringPredicates
         @Override
         public boolean accept(String anObject)
         {
-            return anObject != null && anObject.length() > 0;
+            return anObject != null && !anObject.isEmpty();
         }
 
         @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingFunction<T, V> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction0.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingFunction0<R> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/checked/ThrowingFunction2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingFunction2<T1, T2, R> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/primitive/CharFunction.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/primitive/CharFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.block.function.primitive.CharToCharFunction;
  *
  * @deprecated since 3.0. Use {@link CharToCharFunction} instead.
  */
+@FunctionalInterface
 @Deprecated
 public interface CharFunction
         extends Serializable

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/primitive/CodePointFunction.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/function/primitive/CodePointFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A CharFunction can be used to convert one character to another.
  */
+@FunctionalInterface
 public interface CodePointFunction
         extends Serializable
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/CodePointPredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/CodePointPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A Predicate that accepts an int value
  */
+@FunctionalInterface
 public interface CodePointPredicate
         extends Serializable
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/checked/ThrowingPredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/checked/ThrowingPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingPredicate<T> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/checked/ThrowingPredicate2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/checked/ThrowingPredicate2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingPredicate2<T, P> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/primitive/CharPredicate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/predicate/primitive/CharPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -17,6 +17,7 @@ import java.io.Serializable;
  *
  * @deprecated since 3.0. Use {@link org.eclipse.collections.api.block.predicate.primitive.CharPredicate} instead.
  */
+@FunctionalInterface
 @Deprecated
 public interface CharPredicate
         extends Serializable

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/checked/ThrowingProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/checked/ThrowingProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingProcedure<T> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/checked/ThrowingProcedure2.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/checked/ThrowingProcedure2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import java.io.Serializable;
 /**
  * A functional interface that can be represented by a Lambda that can throw a CheckedException.
  */
+@FunctionalInterface
 public interface ThrowingProcedure2<T, P> extends Serializable
 {
     @SuppressWarnings("ProhibitedExceptionDeclared")

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/CharProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/CharProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.block.procedure.primitive;
 /**
  * @deprecated since 3.0 use {@link org.eclipse.collections.api.block.procedure.primitive.CharProcedure}
  */
+@FunctionalInterface
 @Deprecated
 public interface CharProcedure
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/CodePointProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/CodePointProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.impl.block.procedure.primitive;
 
+@FunctionalInterface
 public interface CodePointProcedure
 {
     void value(int codePoint);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntIntProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntIntProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -18,6 +18,7 @@ import java.io.Serializable;
  *
  * @deprecated since 3.0 use {@link org.eclipse.collections.api.block.procedure.primitive.IntIntProcedure}
  */
+@FunctionalInterface
 @Deprecated
 public interface IntIntProcedure extends Serializable
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntObjectProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntObjectProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.block.procedure.primitive;
 /**
  * @deprecated since 3.0 use {@link org.eclipse.collections.api.block.procedure.primitive.IntObjectProcedure}
  */
+@FunctionalInterface
 @Deprecated
 public interface IntObjectProcedure<T>
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntProcedure.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -13,6 +13,7 @@ package org.eclipse.collections.impl.block.procedure.primitive;
 /**
  * @deprecated since 3.0 use {@link org.eclipse.collections.api.block.procedure.primitive.IntProcedure}
  */
+@FunctionalInterface
 @Deprecated
 public interface IntProcedure
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntProcedureWithInt.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/procedure/primitive/IntProcedureWithInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -18,6 +18,7 @@ import java.io.Serializable;
  *
  * @deprecated since 1.2 use {@link IntIntProcedure}
  */
+@FunctionalInterface
 @Deprecated
 public interface IntProcedureWithInt extends Serializable
 {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFactory.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -15,6 +15,7 @@ import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 /**
  * ObjectIntProcedureFactory is used by parallel iterators as a factory for stateful ObjectIntProcedure instances.
  */
+@FunctionalInterface
 public interface ObjectIntProcedureFactory<T extends ObjectIntProcedure<?>>
 {
     T create();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ProcedureFactory.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/parallel/ProcedureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.parallel;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 
+@FunctionalInterface
 public interface ProcedureFactory<T extends Procedure<?>>
 {
     T create();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/StringIterate.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/utility/StringIterate.java
@@ -1061,7 +1061,7 @@ public final class StringIterate
 
     public static boolean isEmpty(String string)
     {
-        return string == null || string.length() == 0;
+        return string == null || string.isEmpty();
     }
 
     public static boolean isEmptyOrWhitespace(String string)

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapLargeStressTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapLargeStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -311,7 +311,7 @@ public class IntIntMapLargeStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.ecIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (newMap.notEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -328,7 +328,7 @@ public class IntIntMapLargeStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.jdkIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -345,7 +345,7 @@ public class IntIntMapLargeStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.kolobokeIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapSmallStressTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntIntMapSmallStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -319,7 +319,7 @@ public class IntIntMapSmallStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.ecIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (newMap.notEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -336,7 +336,7 @@ public class IntIntMapSmallStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.jdkIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -353,7 +353,7 @@ public class IntIntMapSmallStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.kolobokeIntKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/LongLongMapLargeStressTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/LongLongMapLargeStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -229,7 +229,7 @@ public class LongLongMapLargeStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.ecLongKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (newMap.notEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -246,7 +246,7 @@ public class LongLongMapLargeStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.kolobokeLongKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/LongLongMapSmallStressTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/LongLongMapSmallStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -235,7 +235,7 @@ public class LongLongMapSmallStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.ecLongKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (newMap.notEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }
@@ -252,7 +252,7 @@ public class LongLongMapSmallStressTest extends AbstractJMHTestRunner
             {
                 newMap.remove(this.kolobokeLongKeysForMap[i]);
             }
-            if (newMap.size() != 0)
+            if (!newMap.isEmpty())
             {
                 throw new AssertionError("size is " + newMap.size());
             }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/domain/A.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/domain/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -10,6 +10,7 @@
 
 package org.eclipse.collections.test.domain;
 
+@FunctionalInterface
 public interface A extends Comparable<A>
 {
     double getDoubleValue();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs and others.
+ * Copyright (c) 2022 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -578,7 +578,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> mutableList = Lists.mutable.ofAll(immutableList);
         Assert.assertEquals(mutableList.drop(1), immutableList.drop(1));
 
-        if (mutableList.size() > 0)
+        if (mutableList.notEmpty())
         {
             Assert.assertEquals(
                     mutableList.drop(mutableList.size() - 1),


### PR DESCRIPTION
In this PR I enabled two new inspections:

Interface may be annotated as ‘@FunctionalInterface’
‘size() == 0’ can be replaced with ‘isEmpty()’

I kept size() == 0 check in some methods in Verify class since it seemed like those calls were used to validate that size() method is working as expected.

Signed-off-by: Alexander Goldberg <alexander.goldberg@bnymellon.com>