### PR TITLE
Fix ref guide's broken links and sundry typos

### DIFF
--- a/docs/1-Iteration_Patterns.adoc
+++ b/docs/1-Iteration_Patterns.adoc
@@ -2093,7 +2093,7 @@ Use the *collectKeysAndValues* method to add all the entries derived from anothe
 ##`*collectKeysAndValues(_collection_, _keyFunction_, _valueFunction_): MutableMap*`##
 ****
 
-_(Mutable maps only)_ The key and value for each entry is determined by applying the _keyFunction_ and _valueFunction_ (in each case, a {*Function*}) to each item in _collection_.
+_(Mutable maps only)_ The key and value for each entry is determined by applying the _keyFunction_ and _valueFunction_ (in each case, a *{Function}*) to each item in _collection_.
 Each is converted into a key-value entry and inserted into the *Map*.
 If a new entry has the same key as an existing entry in the calling map, the new entry's value replaces that of the existing entry.
 

--- a/docs/2-Collection_Containers.adoc
+++ b/docs/2-Collection_Containers.adoc
@@ -18,6 +18,7 @@ All rights reserved.
 // Javadoc links
 :api-url:               https://www.eclipse.org/collections/javadoc/11.0.0/org/eclipse/collections
 //
+:ArrayStack            {api-url}/impl/stack/mutable/ArrayStack.html[ArrayStack]
 :Bag:                  {api-url}/api/bag/Bag.html[Bag]
 :Bags:                 {api-url}/impl/factory/Bags.html[Bags]
 :BiMap:                {api-url}/api/bimap/BiMap.html[BiMap]
@@ -40,6 +41,7 @@ All rights reserved.
 :IntArrayList:         {api-url}/impl/list/mutable/primitive/IntArrayList.html[IntArrayList]
 :IntHashSet:           {api-url}/impl/set/mutable/primitive/IntHashSet.html[IntHashSet]
 :IntLists:             {api-url}/impl/factory/primitive/IntLists.html[IntLists]
+:IntIntHashMap         {api-url}/impl/map/mutable/primitive/IntIntHashMap.html[IntIntHashMap]
 :IntObjectHashMap:     {api-url}/impl/map/mutable/primitive/IntObjectHashMap.html[IntObjectHashMap]
 :ListIterable:         {api-url}/api/list/ListIterable.html[ListIterable]
 :Lists:                {api-url}/impl/factory/Lists.html[Lists]
@@ -54,12 +56,14 @@ All rights reserved.
 :MutableSetMultimap:   {api-url}/api/multimap/set/MutableSetMultimap.html[MutableSetMultimap]
 :MutableSortedBag:     {api-url}/api/bag/sorted/MutableSortedBag.html[MutableSortedBag]
 :MutableSortedSet:     {api-url}/api/set/sorted/MutableSortedSet.html[MutableSortedSet]
+:MutableSortedMap:     {api-url}/api/map/sorted/MutableSortedSet.html[MutableSortedMap]
 :MutableStack:         {api-url}/api/stack/MutableStack.html[MutableStack]
 :ObjectIntHashMap:     {api-url}/impl/map/mutable/primitive/ObjectIntHashMap.html[ObjectIntHashMap]
 :RichIterable:         {api-url}/api/RichIterable.html[RichIterable]
 :Sets:                 {api-url}/impl/factory/Sets.html[Sets]
 :SortedBag:            {api-url}/api/bag/sorted/SortedBag.html[SortedBag]
 :SortedSetIterable:    {api-url}/api/set/sorted/SortedSetIterable.html[SortedSetIterable]
+:StackIterable:        {api-url}//api/stack/StackIterable.html[StackIterable]
 :Stacks:               {api-url}/impl/factory/Stacks.html[Stacks]
 :StringFunctions:      {api-url}/impl/block/factory/StringFunctions.html[StringFunctions]
 :TreeBag:              {api-url}/impl/bag/sorted/mutable/TreeBag.html[TreeBag]
@@ -1426,5 +1430,5 @@ There are similar methods for each primitive type, e.g., *MutableFloatCollection
 
 [cols="3,^1,>3",]
 |===
-|xref:1-Iteration_Patterns.adoc[previous: Iteration Patterns]|xref:0-RefGuide.adoc[top] |xref:3-Code_Blocks.adoc[next: Code Blocks]
+|xref:1-Iteration_Patterns.adoc[previous: Iteration patterns]|xref:0-RefGuide.adoc[top] |xref:3-Code_Blocks.adoc[next: Code blocks]
 |===

--- a/docs/3-Code_Blocks.adoc
+++ b/docs/3-Code_Blocks.adoc
@@ -260,5 +260,5 @@ A *{Procedure}* is a code block that performs an evaluation on its single argume
 
 [cols="3,^1,>3",]
 |===
-|xref:2-Collection_Containers.adoc[previous: Collections and containers]  |xref:0-RefGuide.adoc[top] |xref:4-Testing_Utilities.adoc[next: Testing Utilities]
+|xref:2-Collection_Containers.adoc[previous: Collections and containers]  |xref:0-RefGuide.adoc[top] |xref:4-Testing_Utilities.adoc[next: Unit testing]
 |===

--- a/docs/4-Testing_Utilities.adoc
+++ b/docs/4-Testing_Utilities.adoc
@@ -41,5 +41,5 @@ Verify.assertContains(1, Lists.mutable.with(1));
 
 [cols="3,^1,>3",]
 |===
-|xref:3-Code_Blocks.adoc[previous: Code Blocks]  |xref:0-RefGuide.adoc[top] |xref:2-Collection_Containers.adoc[next: 5-Quick_Reference.adoc]
+|xref:3-Code_Blocks.adoc[previous: Code blocks]  |xref:0-RefGuide.adoc[top] |xref:5-Quick_Reference.adoc[next: Quick Reference]
 |===

--- a/docs/5-Quick_Reference.adoc
+++ b/docs/5-Quick_Reference.adoc
@@ -168,3 +168,9 @@
 
 [link=EclipseCollectionsMindMap.png]
 image::EclipseCollectionsMindMap.png[Mindmap,800,945]
+
+[cols="3,^1",]
+[%autowidth]
+|===
+|xref:4-Testing_Utilities.adoc[previous: Unit testing]  |xref:0-RefGuide.adoc[top] 
+|===


### PR DESCRIPTION
- [x] Add missing javadoc URL
- [x] Fix typos
- [x] Normalize page-end navigators