### PR TITLE
fix : rename parameter

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/factory/Sets.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/factory/Sets.java
@@ -97,9 +97,9 @@ public final class Sets
     /**
      * @since 9.0.
      */
-    public static <T> MutableSet<T> adapt(Set<T> list)
+    public static <T> MutableSet<T> adapt(Set<T> set)
     {
-        return SetAdapter.adapt(list);
+        return SetAdapter.adapt(set);
     }
 
     public static <E> MutableSet<E> union(


### PR DESCRIPTION
rename the 'list' parameter in org.eclipse.collections.impl.factory.Sets.adapt to 'set'