### PR TITLE
[12.0] Expose trimToSize in HashBag implementations

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/HashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/HashBag.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.predicate.primitive.IntPredicate;
-import org.eclipse.collections.api.factory.primitive.ObjectIntMaps;
 import org.eclipse.collections.api.map.primitive.MutableObjectIntMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
 
@@ -36,17 +36,19 @@ public class HashBag<T>
 {
     private static final long serialVersionUID = 1L;
 
+    private ObjectIntHashMap<T> items;
+
     public HashBag()
     {
-        this.items = ObjectIntMaps.mutable.empty();
+        this.items = new ObjectIntHashMap<>();
     }
 
     public HashBag(int size)
     {
-        this.items = ObjectIntMaps.mutable.withInitialCapacity(size);
+        this.items = new ObjectIntHashMap<>(size);
     }
 
-    private HashBag(MutableObjectIntMap<T> map)
+    private HashBag(ObjectIntHashMap<T> map)
     {
         this.items = map;
         this.size = (int) map.sum();
@@ -87,6 +89,20 @@ public class HashBag<T>
     }
 
     @Override
+    protected MutableObjectIntMap<T> items()
+    {
+        return this.items;
+    }
+
+    /**
+     * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     */
+    public void trimToSize()
+    {
+        this.items.compact();
+    }
+
+    @Override
     protected int computeHashCode(T item)
     {
         return item.hashCode();
@@ -95,7 +111,7 @@ public class HashBag<T>
     @Override
     public MutableBag<T> selectByOccurrences(IntPredicate predicate)
     {
-        MutableObjectIntMap<T> map = this.items.select((each, occurrences) -> predicate.accept(occurrences));
+        ObjectIntHashMap<T> map = this.items.select((each, occurrences) -> predicate.accept(occurrences));
         return new HashBag<>(map);
     }
 
@@ -108,7 +124,7 @@ public class HashBag<T>
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
     {
-        this.items = ObjectIntMaps.mutable.empty();
+        this.items = new ObjectIntHashMap<>();
         ((Externalizable) this.items).readExternal(in);
         this.size = (int) this.items.sum();
     }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBag.java
@@ -78,7 +78,7 @@ public final class MultiReaderHashBag<T>
 {
     private static final long serialVersionUID = 1L;
 
-    private MutableBag<T> delegate;
+    private HashBag<T> delegate;
 
     /**
      * @deprecated Empty default constructor used for serialization.
@@ -90,12 +90,12 @@ public final class MultiReaderHashBag<T>
         // For Externalizable use only
     }
 
-    private MultiReaderHashBag(MutableBag<T> newDelegate)
+    private MultiReaderHashBag(HashBag<T> newDelegate)
     {
         this(newDelegate, new ReentrantReadWriteLock());
     }
 
-    private MultiReaderHashBag(MutableBag<T> newDelegate, ReadWriteLock newLock)
+    private MultiReaderHashBag(HashBag<T> newDelegate, ReadWriteLock newLock)
     {
         this.lock = newLock;
         this.lockWrapper = new ReadWriteLockWrapper(newLock);
@@ -120,6 +120,14 @@ public final class MultiReaderHashBag<T>
     public static <T> MultiReaderHashBag<T> newBagWith(T... elements)
     {
         return new MultiReaderHashBag<>(HashBag.newBagWith(elements));
+    }
+
+    /**
+     * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     */
+    public void trimToSize()
+    {
+        this.delegate.trimToSize();
     }
 
     @Override
@@ -648,7 +656,7 @@ public final class MultiReaderHashBag<T>
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
     {
-        this.delegate = (MutableBag<T>) in.readObject();
+        this.delegate = (HashBag<T>) in.readObject();
         this.lock = new ReentrantReadWriteLock();
         this.lockWrapper = new ReadWriteLockWrapper(this.lock);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.bag.ImmutableBagFactory;
 import org.eclipse.collections.api.factory.bag.MultiReaderBagFactory;
 import org.eclipse.collections.api.factory.bag.MutableBagFactory;
-import org.eclipse.collections.impl.bag.mutable.AbstractHashBag;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.MultiReaderHashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
@@ -182,7 +181,7 @@ public class BagsTest
     {
         try
         {
-            Field itemsField = AbstractHashBag.class.getDeclaredField("items");
+            Field itemsField = HashBag.class.getDeclaredField("items");
             itemsField.setAccessible(true);
             ObjectIntHashMap<Object> items = (ObjectIntHashMap<Object>) itemsField.get(bag);
 


### PR DESCRIPTION
This is for https://github.com/eclipse/eclipse-collections/issues/1393 to be merged in 12.0

TODO
- [ ] have https://github.com/eclipse/eclipse-collections/pull/1403 merged
- [ ] replace calls to `compact()` by calls to `trimToSize()`