### PR TITLE
Adding default override for Map.computeIfPresent - closes #1400

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ConcurrentMutableMap.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/ConcurrentMutableMap.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.api.map;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 
@@ -42,5 +43,12 @@ public interface ConcurrentMutableMap<K, V>
     {
         this.putAllMapIterable(mapIterable);
         return this;
+    }
+
+    @Override
+    default V computeIfPresent(K key,
+            BiFunction<? super K,? super V,? extends V> remappingFunction)
+    {
+        return ConcurrentMap.super.computeIfPresent(key, remappingFunction);
     }
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.map;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.block.function.Function;
@@ -433,4 +434,8 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
                 valueFunction.valueOf(value)));
         return map;
     }
+
+    @Override
+    V computeIfPresent(K key,
+            BiFunction<? super K,? super V,? extends V> remappingFunction);
 }

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/map/MutableMapIterable.java
@@ -434,8 +434,4 @@ public interface MutableMapIterable<K, V> extends MapIterable<K, V>, Map<K, V>
                 valueFunction.valueOf(value)));
         return map;
     }
-
-    @Override
-    V computeIfPresent(K key,
-            BiFunction<? super K,? super V,? extends V> remappingFunction);
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
@@ -227,24 +227,4 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
     {
         return this.flatCollect(function, Bags.mutable.empty());
     }
-
-    @Override
-    public V computeIfPresent(K key,
-            BiFunction<? super K,? super V,? extends V> remappingFunction)
-    {
-        V oldValue = this.get(key);
-        if (oldValue != null)
-        {
-            V newValue = remappingFunction.apply(key, oldValue);
-            if (newValue == null)
-            {
-                return this.remove(key);
-            }
-            else
-            {
-                return this.put(key, newValue);
-            }
-        }
-        return null;
-    }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMapIterable.java
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.map.mutable;
 
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.MutableBag;
@@ -225,5 +226,25 @@ public abstract class AbstractMutableMapIterable<K, V> extends AbstractMapIterab
     public <V1> MutableBag<V1> countByEach(Function<? super V, ? extends Iterable<V1>> function)
     {
         return this.flatCollect(function, Bags.mutable.empty());
+    }
+
+    @Override
+    public V computeIfPresent(K key,
+            BiFunction<? super K,? super V,? extends V> remappingFunction)
+    {
+        V oldValue = this.get(key);
+        if (oldValue != null)
+        {
+            V newValue = remappingFunction.apply(key, oldValue);
+            if (newValue == null)
+            {
+                return this.remove(key);
+            }
+            else
+            {
+                return this.put(key, newValue);
+            }
+        }
+        return null;
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -2321,6 +2321,7 @@ public final class ConcurrentHashMap<K, V>
     public V computeIfPresent(K key,
             BiFunction<? super K,? super V,? extends V> remappingFunction)
     {
+        Objects.requireNonNull(remappingFunction);
         int hash = this.hash(key);
         AtomicReferenceArray currentArray = this.table;
         int length = currentArray.length();
@@ -2343,10 +2344,12 @@ public final class ConcurrentHashMap<K, V>
                 if (value == null)
                 {
                     this.slowRemove(key, hash, currentArray);
+                    return null;
                 }
                 else
                 {
-                    return this.slowPut(key, value, hash, currentArray);
+                    this.slowPut(key, value, hash, currentArray);
+                    return value;
                 }
             }
         }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
@@ -277,4 +277,28 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase
                 Collections.nCopies(1000, 2),
                 map4.values());
     }
+
+    @Test
+    default void Map_computeIfPresent()
+    {
+        MutableMapIterable<Integer, Integer> map = this.newWithKeysValues(1, 1, 2, 2, 3, 3);
+        Map<Integer, Integer> hashMap = new LinkedHashMap<>();
+        hashMap.put(1, 1);
+        hashMap.put(2, 2);
+        hashMap.put(3, 3);
+
+        assertEquals(
+                map.computeIfPresent(1, Integer::sum),
+                hashMap.computeIfPresent(1, Integer::sum));
+        MutableMapIterable<Integer, Integer> map2 =
+                this.newWithKeysValues(1, hashMap.get(1), 2, 2, 3, 3);
+        assertEquals(map, map2);
+        assertNull(map.computeIfPresent(4, Integer::sum));
+        assertNull(hashMap.computeIfPresent(4, Integer::sum));
+        assertNull(map.computeIfPresent(2, (x, y) -> null));
+        assertNull(hashMap.computeIfPresent(2, (x, y) -> null));
+        MutableMapIterable<Integer, Integer> map3 =
+                this.newWithKeysValues(1, 2, 3, 3);
+        assertEquals(map, map3);
+    }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
@@ -175,4 +175,11 @@ public class UnmodifiableMutableMapTest implements MutableMapTestCase, FixedSize
                     throw new AssertionError();
                 }, "test"));
     }
+
+    @Override
+    public void Map_computeIfPresent()
+    {
+        MutableMapIterable<Integer, Integer> map = this.newWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.computeIfPresent(1, Integer::sum));
+    }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
@@ -183,4 +183,11 @@ public class UnmodifiableMutableOrderedMapTest implements MutableOrderedMapTestC
                     throw new AssertionError();
                 }, "test"));
     }
+
+    @Override
+    public void Map_computeIfPresent()
+    {
+        MutableMapIterable<Integer, Integer> map = this.newWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.computeIfPresent(1, Integer::sum));
+    }
 }


### PR DESCRIPTION
For #500 and #1400. 

From my tests, the override has the same functionality as the default `Map#computeIfPresent` implementation. Let me know if there's any concerns with it!