### PR TITLE
Expose trimToSize in primitive maps and sets

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
@@ -1211,9 +1211,23 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
     }
     <endif>
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
@@ -1238,9 +1238,23 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
     }
     <endif>
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveBooleanHashMap.stg
@@ -289,9 +289,23 @@ public class <name>BooleanHashMap extends AbstractMutableBooleanValuesMap implem
         this.values = new BitSet(sizeToAllocate);
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitiveObjectHashMap.stg
@@ -2867,9 +2867,23 @@ public class <name>ObjectHashMap\<V> implements Mutable<name>ObjectMap\<V>, Exte
         return new KeySet();
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -954,9 +954,23 @@ public class <name1><name2>HashMap extends AbstractMutable<name2>ValuesMap imple
         }
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.<keyArray>.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/set/mutable/primitiveHashSet.stg
@@ -942,9 +942,23 @@ public class <name>HashSet extends Abstract<name>Set implements Mutable<name>Set
         return new <name>HashSet();
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.table.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Rehashes every element in the set into a new backing table of the smallest possible size and eliminating removed sentinels.
+     *
+     * @deprecated since 12.0.0 - use trimToSize instead
      */
+    @Deprecated
     public void compact()
     {
         this.rehash(this.smallestPowerOfTwoGreaterThan(this.size()));

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMap.java
@@ -1109,6 +1109,17 @@ public class ObjectBooleanHashMap<K> implements MutableObjectBooleanMap<K>, Exte
         return Math.min(capacity - 1, capacity / OCCUPIED_DATA_RATIO);
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     private void rehashAndGrow()
     {
         this.rehash(this.keys.length << 1);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategy.java
@@ -1132,6 +1132,17 @@ public class ObjectBooleanHashMapWithHashingStrategy<K> implements MutableObject
         return Math.min(capacity - 1, capacity / OCCUPIED_DATA_RATIO);
     }
 
+    public boolean trimToSize()
+    {
+        int newCapacity = this.smallestPowerOfTwoGreaterThan(this.size());
+        if (this.keys.length > newCapacity)
+        {
+            this.rehash(newCapacity);
+            return true;
+        }
+        return false;
+    }
+
     private void rehashAndGrow()
     {
         this.rehash(this.keys.length << 1);


### PR DESCRIPTION
This is for #1396 and #1402.

It introduces trimToSize for primitive boolean map
It conditionally trim the underlying array if required.
It also deprecates compact (which is not conditional and could be costly).