### PR TITLE
Implement Comparators.fromPredicate(), to create a Comparator from a Predicate2 that can answer isBefore.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Comparators.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/block/factory/Comparators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -12,6 +12,7 @@ package org.eclipse.collections.impl.block.factory;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.function.BiPredicate;
 
 import org.eclipse.collections.api.block.SerializableComparator;
 import org.eclipse.collections.api.block.factory.SerializableComparators;
@@ -191,6 +192,15 @@ public final class Comparators
     public static <T> SerializableComparator<Pair<?, T>> bySecondOfPair(Comparator<? super T> comparator)
     {
         return new BySecondOfPairComparator<>(comparator);
+    }
+
+    /**
+     * @param isBeforePredicate a predicate that returns true if the first argument is less than, or should appear before, the second argument
+     * @since 12.0.0
+     */
+    public static <T> SerializableComparator<T> fromPredicate(BiPredicate<? super T, ? super T> isBeforePredicate)
+    {
+        return new FromPredicateSerializableComparator<>(isBeforePredicate);
     }
 
     private static final class NaturalOrderComparator<T extends Comparable<T>> implements SerializableComparator<T>
@@ -551,6 +561,32 @@ public final class Comparators
         public int compare(T one, T two)
         {
             return ((Comparable<T>) one).compareTo(two);
+        }
+    }
+
+    private static final class FromPredicateSerializableComparator<T> implements SerializableComparator<T>
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final BiPredicate<? super T, ? super T> isBeforePredicate;
+
+        private FromPredicateSerializableComparator(BiPredicate<? super T, ? super T> isBeforePredicate)
+        {
+            this.isBeforePredicate = isBeforePredicate;
+        }
+
+        @Override
+        public int compare(T o1, T o2)
+        {
+            if (this.isBeforePredicate.test(o1, o2))
+            {
+                return -1;
+            }
+            if (this.isBeforePredicate.test(o2, o1))
+            {
+                return 1;
+            }
+            return 0;
         }
     }
 }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -282,6 +282,17 @@ public class ComparatorsSerializationTest
                         + "YXRvcnMkQnlTZWNvbmRPZlBhaXJDb21wYXJhdG9yAAAAAAAAAAECAAFMAApjb21wYXJhdG9ydAAW\n"
                         + "TGphdmEvdXRpbC9Db21wYXJhdG9yO3hwcA==",
                 Comparators.bySecondOfPair(null));
+    }
+
+    @Test
+    public void fromPredicate()
+    {
+        Verify.assertSerializedForm(
+                1L,
+                "rO0ABXNyAFpvcmcuZWNsaXBzZS5jb2xsZWN0aW9ucy5pbXBsLmJsb2NrLmZhY3RvcnkuQ29tcGFy\n"
+                        + "YXRvcnMkRnJvbVByZWRpY2F0ZVNlcmlhbGl6YWJsZUNvbXBhcmF0b3IAAAAAAAAAAQIAAUwAEWlz\n"
+                        + "QmVmb3JlUHJlZGljYXRldAAgTGphdmEvdXRpbC9mdW5jdGlvbi9CaVByZWRpY2F0ZTt4cHA=",
+                Comparators.fromPredicate(null));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.block.function.primitive.IntFunction;
 import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.Interval;
@@ -365,6 +367,19 @@ public class ComparatorsTest
         MutableList<Pair<Integer, String>> list = Lists.mutable.with(Tuples.pair(3, "B"), Tuples.pair(1, "C"), Tuples.pair(2, "A"));
         MutableList<Pair<Integer, String>> sorted = Lists.mutable.with(Tuples.pair(2, "A"), Tuples.pair(3, "B"), Tuples.pair(1, "C"));
         Verify.assertListsEqual(sorted, list.sortThis(Comparators.bySecondOfPair(String::compareTo)));
+    }
+
+    @Test
+    public void fromPredicate()
+    {
+        ImmutableList<Instant> orderedInstants = Lists.immutable.with(
+                Instant.parse("2000-01-01T00:00:00Z"),
+                Instant.parse("2001-01-01T00:00:00Z"),
+                Instant.parse("2002-01-01T00:00:00Z"),
+                Instant.parse("2003-01-01T00:00:00Z"));
+        MutableList<Instant> shuffledInstants = orderedInstants.toList().shuffleThis();
+        shuffledInstants.sortThis(Comparators.fromPredicate(Instant::isBefore));
+        Verify.assertListsEqual(orderedInstants.castToList(), shuffledInstants);
     }
 
     @Test


### PR DESCRIPTION
I have a use-case for sorting where I can answer whether one object should come before another object, but I don't have a Comparator. I looked around for a function that convert a BiPredicate to a Comparator and couldn't find one, so here it is. I looked on Comparator, Comparators, and on BiPredicate.

The unit test sorts Instants using the isBefore() method. This is a good example of using a single-arg, non-static method.

```java
ImmutableList<Instant> orderedInstants = Lists.immutable.with(
        Instant.parse("2000-01-01T00:00:00Z"),
        Instant.parse("2001-01-01T00:00:00Z"),
        Instant.parse("2002-01-01T00:00:00Z"),
        Instant.parse("2003-01-01T00:00:00Z"));
MutableList<Instant> shuffledInstants = orderedInstants.toList().shuffleThis();
shuffledInstants.sortThis(Comparators.fromPredicate(Instant::isBefore));
```

In my real use-case, I have a multimap of dependencies. If a key/value appears in the multimap, then the key is a dependent of the value and should come before. This is a good example of using a two-arg method.

Anonymized, but realistic example:

```java
MutableSetMultimap<MyObject, MyObject> transitiveDependencies = getTransitiveDependencies(directDependencies);

Comparator<MyObject> dependencyComparator = fromPredicate(transitiveDependencies::containsKeyAndValue);

Comparator<MyContainingObject> comparator = Comparator
        .comparing(MyContainingObject::getDependencyKey, dependencyComparator)
        .thenComparing(MyContainingObject::getName);

MutableList<MyContainingObject> sortedObjects = SetAdapter
        .adapt(objects)
        .toSortedList(comparator);
```