### PR TITLE
Removed a typo in ImmutableSet

### DIFF
--- a/docs/2-Collection_Containers.adoc
+++ b/docs/2-Collection_Containers.adoc
@@ -1275,7 +1275,6 @@ PartitionMutableList<Person> partitionedFolks =
 ImmutableList<Person> list0 = Lists.immutable.empty();
 ImmutableList<Person> list1 = list0.newWith(new Person(...)); // add a single element to the new immutable list
 ImmutableList<Person> adults = list1.newWithAll(partitionedFolks.getSelected()); // add none, one or more objects to the new immutable list
-I
 
 ImmutableSet<String> set0 = Sets.immutable.empty();
 ImmutableSet<String> set1 = set0.newWith("1"); // add a single element to the new immutable set


### PR DESCRIPTION
In line 1278 there is an extra 'I', removed it.

Hi @donraab, 
updated a typo in the doc, please verify and approve for merge.
Thank you!