### PR TITLE
refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
@@ -160,7 +160,7 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
             return new ImmutableUnifiedMap<>(map);
         }
 
-        Map.Entry<K, V>[] entries = map.entrySet().toArray(new Map.Entry[map.entrySet().size()]);
+        Map.Entry<K, V>[] entries = map.entrySet().toArray(new Map.Entry[0]);
         switch (entries.length)
         {
             case 1:


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:Qodana-eclipse-collections-ToArrayCallWithZeroLengthArrayArgument-00c126bc12344fa1588f6ef500eb31c437943571-sl:163-el:0-sc:52-ec:0-co:4653-cl:7 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
