### PR TITLE
remove prompt from documentation code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ The Eclipse Collections build requires below as dependencies.
 The Eclipse Collections build performs code generation to create primitive collections. Run the full build once before opening your IDE.
 
 ```bash
-$ mvn install -DskipTests=true
+mvn install -DskipTests=true
 ```
 
 Now you can open the project in your IDE and it won't complain about missing files. You'll be able to use the IDE to perform incremental builds and run tests. You should rarely need to run the maven build, except when:
@@ -68,7 +68,7 @@ Coding Style
 Eclipse Collections follows a coding style that is similar to [Google's Style Guide for Java][style-guide], but with curly braces on their own lines. Many aspects of the style guide are enforced by CheckStyle, but not all, so please take care.
 
 ```bash
-$ mvn clean install checkstyle:check --projects "!scala-unit-tests,!jmh-scala-tests,!jmh-tests" -DskipTests=true
+mvn clean install checkstyle:check --projects "!scala-unit-tests,!jmh-scala-tests,!jmh-tests" -DskipTests=true
 ```
 
 Avoid changing whitespace on lines that are unrelated to your pull request. This helps preserve the accuracy of the git blame view, and makes code reviews easier.


### PR DESCRIPTION
People are used to copying the complete block from the documentation, and then the prompt will lead to syntax errors.