### PR TITLE
remove duplicate maven-dependency-plugin version

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -101,7 +101,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>analyze</id>

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -158,7 +158,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>analyze</id>


### PR DESCRIPTION
This is already specified (with the same version) in eclipse-collections/pom.xml, section pluginManagement. m2e even warns about the duplication.