### PR TITLE
Use correct minimum Maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
                                         <version>1.8.0</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
-                                        <version>3.1.1</version>
+                                        <version>3.3.9</version>
                                     </requireMavenVersion>
                                     <requirePluginVersions>
                                         <unCheckedPluginList>


### PR DESCRIPTION
The Maven plugin versions specified require a higher Maven core version. This can be checked via `mvn versions:display-plugin-updates`.