### PR TITLE
Remove sonar-maven-plugin - fixes #1466

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -92,11 +92,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -78,11 +78,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -87,11 +87,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -57,11 +57,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -76,11 +76,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -76,11 +76,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -97,11 +97,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/jcstress-tests/pom.xml
+++ b/jcstress-tests/pom.xml
@@ -79,11 +79,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -185,11 +185,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -102,11 +102,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -475,12 +475,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>sonar-maven-plugin</artifactId>
-                    <version>2.7.1</version>
-                </plugin>
-
-                <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${checkstyle.plugin.version}</version>
                     <configuration>
@@ -556,11 +550,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>

--- a/scala-unit-tests/pom.xml
+++ b/scala-unit-tests/pom.xml
@@ -91,11 +91,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/serialization-tests/pom.xml
+++ b/serialization-tests/pom.xml
@@ -73,11 +73,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -98,11 +98,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 

--- a/unit-tests/pom.xml
+++ b/unit-tests/pom.xml
@@ -102,11 +102,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 


### PR DESCRIPTION
There is no configuration of a server anywhere in the POMs, so this has no functionality unless some external invocation provides a server url via settings.xml or system properties.