### PR TITLE
Upgrade Maven wrapper

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/earlyaccess-javadoc.yml
+++ b/.github/workflows/earlyaccess-javadoc.yml
@@ -32,7 +32,7 @@ jobs:
           echo "steps.download-jdk.outputs.archive = ${{ steps.download-jdk.outputs.archive }}"
           echo "steps.download-jdk.outputs.version = ${{ steps.download-jdk.outputs.version }}"
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: 'JDK Version'
         run: java --version
       - name: Javadoc

--- a/.github/workflows/earlyaccess-unit.yml
+++ b/.github/workflows/earlyaccess-unit.yml
@@ -32,7 +32,7 @@ jobs:
           echo "steps.download-jdk.outputs.archive = ${{ steps.download-jdk.outputs.archive }}"
           echo "steps.download-jdk.outputs.version = ${{ steps.download-jdk.outputs.version }}"
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: 'JDK Version'
         run: java --version
       - name: Unit-Test

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,11 +37,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Maven Install
-        run: mvn clean install -DskipTests=true
+        run: mvn clean install -DskipTests=true --no-transfer-progress
         env:
           MAVEN_OPTS: "-Xmx1g"
       - name: Mutation Test
-        run: mvn eu.stamp-project:pitmp-maven-plugin:run -DwithHistory -DtimeoutConstant=8000
+        run: mvn eu.stamp-project:pitmp-maven-plugin:run -DwithHistory -DtimeoutConstant=8000 --no-transfer-progress
         env:
           MAVEN_OPTS: "-Xmx1g"
       - name: Archive pitest reports

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/unit-no-p2.yml
+++ b/.github/workflows/unit-no-p2.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set Maven Wrapper
-        run: mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn -N wrapper:wrapper -Dmaven=3.6.3 --no-transfer-progress
       - name: Set JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The maven wrapper is meanwhile an official Maven project and should be used with the maven groupid. Also silence the download transfer progress on all Maven invocations.