### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
-  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ The Eclipse Public License is available at https://www.eclipse.org/legal/epl-v10.html
   ~ and the Eclipse Distribution License is available at
-  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  ~ https://www.eclipse.org/org/documents/edl-v10.php.
   -->
 [![][maven img]][maven]
 [![][release img]][release]
@@ -22,9 +22,9 @@
 [![][actions checkstyle img]][actions checkstyle]
 [![][actions javadoc img]][actions javadoc]
 
-<a href="https://www.eclipse.org/collections/"><img src="https://github.com/eclipse/eclipse-collections/blob/master/artwork/eclipse-collections-logo.png" height="50%" width="50%"></a>
+<a href="https://eclipse.dev/collections/"><img src="https://github.com/eclipse/eclipse-collections/blob/master/artwork/eclipse-collections-logo.png" height="50%" width="50%"></a>
 
-#### [English](https://www.eclipse.org/collections/) | [中文](https://www.eclipse.org/collections/cn/index.html) | [Deutsch](https://www.eclipse.org/collections/de/index.html) | [Español](https://www.eclipse.org/collections/es/index.html) | [Ελληνικά](https://www.eclipse.org/collections/el/index.html) | [Français](https://www.eclipse.org/collections/fr/index.html) | [日本語](https://www.eclipse.org/collections/ja/index.html) | [Norsk (bokmål)](https://www.eclipse.org/collections/no-nb/index.html) | [Português-Brasil](https://www.eclipse.org/collections/pt-br/index.html) | [Русский](https://www.eclipse.org/collections/ru/index.html) | [हिंदी](https://www.eclipse.org/collections/hi/index.html)
+#### [English](https://eclipse.dev/collections/) | [Deutsch](https://eclipse.dev/collections/de/index.html) | [Ελληνικά](https://eclipse.dev/collections/el/index.html) | [Español](https://eclipse.dev/collections/es/index.html) | [中文](https://eclipse.dev/collections/cn/index.html) | [Français](https://eclipse.dev/collections/fr/index.html) | [日本語](https://eclipse.dev/collections/ja/index.html) | [Norsk (bokmål)](https://eclipse.dev/collections/no-nb/index.html) | [Português-Brasil](https://eclipse.dev/collections/pt-br/index.html) | [Русский](https://eclipse.dev/collections/ru/index.html) | [हिंदी](https://eclipse.dev/collections/hi/index.html) | [Srpski (latinica)](https://eclipse.dev/collections/sr-rs-latn/index.html)
 Eclipse Collections is a comprehensive collections library for Java. The library enables productivity and performance by delivering an expressive and efficient set of APIs and types. The iteration protocol was inspired by the Smalltalk collection framework, and the collections are compatible with the Java Collection Framework types.
 
 Eclipse Collections is compatible with Java 8+. Eclipse Collections is a part of the OpenJDK [Quality Outreach](https://wiki.openjdk.java.net/display/quality/Quality+Outreach) program, and it is validated for different versions of the OpenJDK.
@@ -46,9 +46,9 @@ Eclipse Collections is compatible with Java 8+. Eclipse Collections is a part of
 
 * [Some Quick Code Examples](./README_EXAMPLES.md)
 * [Eclipse Collections Katas](https://github.com/eclipse/eclipse-collections-kata), a fun way to help you learn idiomatic Eclipse Collections usage.
-    * Start Here - [Pet Kata](http://eclipse.github.io/eclipse-collections-kata/pet-kata/#/)
-    * Continue Here - [Company Kata](http://eclipse.github.io/eclipse-collections-kata/company-kata/#/)
-* [Eclipse Collections Reference Guide](https://github.com/eclipse/eclipse-collections/blob/master/docs/0-RefGuide.adoc) and [Javadoc](https://www.eclipse.org/collections/javadoc/11.1.0/overview-summary.html)
+    * Start Here - [Pet Kata](https://eclipse.github.io/eclipse-collections-kata/pet-kata/#/)
+    * Continue Here - [Company Kata](https://eclipse.github.io/eclipse-collections-kata/company-kata/#/)
+* [Eclipse Collections Reference Guide](https://github.com/eclipse/eclipse-collections/blob/master/docs/0-RefGuide.adoc) and [Javadoc](https://eclipse.dev/collections/javadoc/11.1.0/index.html)
 * [Serializing Eclipse Collections with Jackson](./docs/jackson.md)
 * [Articles](https://github.com/eclipse/eclipse-collections/wiki/Articles) and [Blogs](https://medium.com/tag/eclipse-collections/latest)
 * Some OSS projects that use Eclipse Collections
@@ -89,7 +89,7 @@ implementation 'org.eclipse.collections:eclipse-collections:11.1.0'
 ```
 
 ### OSGi Bundle
-Eclipse software repository location: http://download.eclipse.org/collections/11.1.0/repository
+Eclipse software repository location: https://download.eclipse.org/collections/11.1.0/repository
 
 
 ## How to Contribute
@@ -99,9 +99,9 @@ We welcome contributions! We accept contributions via pull requests here in GitH
 
 ## Additional information
 
-* Project Website: http://www.eclipse.org/collections
+* Project Website: https://eclipse.dev/collections
 * Eclipse PMI: https://projects.eclipse.org/projects/technology.collections
-* StackOverflow: http://stackoverflow.com/questions/tagged/eclipse-collections
+* StackOverflow: https://stackoverflow.com/questions/tagged/eclipse-collections
 * Mailing lists: https://dev.eclipse.org/mailman/listinfo/collections-dev
 * Forum: https://www.eclipse.org/forums/index.php?t=thread&frm_id=329
 * Working with GitHub: https://github.com/eclipse/eclipse-collections/wiki/Working-with-GitHub
@@ -121,7 +121,7 @@ We welcome contributions! We accept contributions via pull requests here in GitH
 [actions javadoc]:https://github.com/eclipse/eclipse-collections/actions?query=workflow%3A%22JavaDoc%22
 [actions javadoc img]:https://github.com/eclipse/eclipse-collections/workflows/JavaDoc/badge.svg?branch=master
 
-[maven]:http://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
+[maven]:https://search.maven.org/#search|gav|1|g:"org.eclipse.collections"%20AND%20a:"eclipse-collections"
 [maven img]:https://maven-badges.herokuapp.com/maven-central/org.eclipse.collections/eclipse-collections/badge.svg
 
 [release]:https://github.com/eclipse/eclipse-collections/releases
@@ -142,24 +142,24 @@ We welcome contributions! We accept contributions via pull requests here in GitH
 [snyk-badge]:https://snyk.io/vuln/maven:org.eclipse.collections:eclipse-collections@11.1.0?utm_medium=referral&utm_source=badge&utm_campaign=snyk-widget
 [snyk-badge img]:https://snyk-widget.herokuapp.com/badge/mvn/org.eclipse.collections/eclipse-collections/11.1.0/badge.svg
 
-[RichIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/RichIterable.html
-[ListIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/list/ListIterable.html
-[SetIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/set/SetIterable.html
-[Bag]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/bag/Bag.html
-[StackIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/stack/StackIterable.html
-[MapIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/map/MapIterable.html
-[Multimap]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/multimap/Multimap.html
-[BiMap]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/bimap/BiMap.html
-[Interval]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/impl/list/Interval.html
-[MutableCollection]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/collection/MutableCollection.html
-[ImmutableCollection]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/collection/ImmutableCollection.html
-[LazyIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/LazyIterable.html
-[ParallelIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/ParallelIterable.html
-[PrimitiveIterable]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/api/PrimitiveIterable.html
-[Utilities]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/impl/utility/package-summary.html
-[Adapters]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.html
+[RichIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/RichIterable.html
+[ListIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/list/ListIterable.html
+[SetIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/set/SetIterable.html
+[Bag]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/bag/Bag.html
+[StackIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/stack/StackIterable.html
+[MapIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/map/MapIterable.html
+[Multimap]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/multimap/Multimap.html
+[BiMap]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/bimap/BiMap.html
+[Interval]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/impl/list/Interval.html
+[MutableCollection]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/collection/MutableCollection.html
+[ImmutableCollection]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/collection/ImmutableCollection.html
+[LazyIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/LazyIterable.html
+[ParallelIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/ParallelIterable.html
+[PrimitiveIterable]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/api/PrimitiveIterable.html
+[Utilities]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/impl/utility/package-summary.html
+[Adapters]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/impl/collection/mutable/AbstractCollectionAdapter.html
 
-[Factories]: https://www.eclipse.org/collections/javadoc/11.1.0/org/eclipse/collections/impl/factory/package-summary.html
+[Factories]: https://eclipse.dev/collections/javadoc/11.1.0/org/eclipse/collections/impl/factory/package-summary.html
 [10-0-Release]: https://github.com/eclipse/eclipse-collections/releases/tag/10.0.0
 [10-1-Release]: https://github.com/eclipse/eclipse-collections/releases/tag/10.1.0
 [10-2-Release]: https://github.com/eclipse/eclipse-collections/releases/tag/10.2.0


### PR DESCRIPTION
This PR fixes links for all languages that point to Collections website. It also reorders them so that the order is the same as in the website's Language drop-down menu. Additionally, it rewrites old www.eclipse.org/collections URLs with new eclipse.dev ones.

@donraab @motlin @Desislav-Petrov @nikhilnanivadekar when you have a bit of time please review :)