### PR TITLE
Replace @Test(expected=X) with assertThrows(X) in unit-tests-java8

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -234,10 +234,10 @@ public interface IterableTestCase
         IterableTestCase.assertEquals(Sets.immutable.with(3, 2, 1), set);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     default void Iterable_next_throws_on_empty()
     {
-        this.newWith().iterator().next();
+        assertThrows(NoSuchElementException.class, () -> this.newWith().iterator().next());
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/OrderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/OrderedIterableTestCase.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public interface OrderedIterableTestCase extends RichIterableTestCase
 {
@@ -92,10 +93,10 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
         assertEquals(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getFirstOptional());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     default void OrderedIterable_getFirstOptional_null_element()
     {
-        ((OrderedIterable<?>) this.newWith(new Object[]{null})).getFirstOptional();
+        assertThrows(NullPointerException.class, () -> ((OrderedIterable<?>) this.newWith(new Object[]{null})).getFirstOptional());
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrderedIterableTestCase, MutableBagIterableTestCase
@@ -39,11 +40,11 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
     }
 
     @Override
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     default void MutableBagIterable_addOccurrences_throws()
     {
         MutableSortedBag<Integer> mutableSortedBag = this.newWith(3, 3, 3, 2, 2, 1);
-        mutableSortedBag.addOccurrences(4, -1);
+        assertThrows(IllegalArgumentException.class, () -> mutableSortedBag.addOccurrences(4, -1));
     }
 
     @Override
@@ -66,10 +67,12 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
     }
 
     @Override
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     default void MutableBagIterable_removeOccurrences_throws()
     {
-        MutableSortedBag<Integer> mutableBag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertFalse(mutableBag.removeOccurrences(4, -1));
+        assertThrows(IllegalArgumentException.class, () -> {
+            MutableSortedBag<Integer> mutableBag = this.newWith(3, 3, 3, 2, 2, 1);
+            assertFalse(mutableBag.removeOccurrences(4, -1));
+        });
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
@@ -13,15 +13,17 @@ package org.eclipse.collections.test.collection.mutable;
 import org.eclipse.collections.impl.collection.mutable.AbstractMultiReaderMutableCollection;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public interface MultiReaderMutableCollectionTestCase extends MutableCollectionTestCase
 {
     @Override
     <T> AbstractMultiReaderMutableCollection<T> newWith(T... elements);
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void Iterable_iterator_throws()
     {
-        this.newWith(3, 2, 1).iterator();
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith(3, 2, 1).iterator());
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
@@ -58,16 +58,16 @@ public interface ListTestCase extends CollectionTestCase
         assertEquals(Integer.valueOf(3), list.get(2));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     default void List_get_negative()
     {
-        this.newWith(1, 2, 3).get(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(1, 2, 3).get(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     default void List_get_out_of_bounds()
     {
-        this.newWith(1, 2, 3).get(4);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(1, 2, 3).get(4));
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/UnmodifiableMutableListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/UnmodifiableMutableListTestCase.java
@@ -15,24 +15,25 @@ import java.util.Random;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.test.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.test.list.UnmodifiableListTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public interface UnmodifiableMutableListTestCase extends UnmodifiableMutableCollectionTestCase, UnmodifiableListTestCase, MutableListTestCase
 {
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void MutableList_sortThis()
     {
-        this.newWith(5, 1, 4, 2, 3).sortThis();
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith(5, 1, 4, 2, 3).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void MutableList_shuffleThis()
     {
-        this.newWith(5, 1, 4, 2, 3).shuffleThis();
-        this.newWith(5, 1, 4, 2, 3).shuffleThis(new Random(8));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith(5, 1, 4, 2, 3).shuffleThis());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith(5, 1, 4, 2, 3).shuffleThis(new Random(8)));
     }
 
     @Override
@@ -43,16 +44,17 @@ public interface UnmodifiableMutableListTestCase extends UnmodifiableMutableColl
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void MutableList_sortThis_comparator()
     {
-        this.newWith(5, 1, 4, 2, 3).sortThis(Comparators.reverseNaturalOrder());
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(5, 1, 4, 2, 3).sortThis(Comparators.reverseNaturalOrder()));
     }
 
     @Override
     @Test
     default void MutableList_subList_subList_remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().subList(0, 0).remove(new Object()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().subList(0, 0).remove(new Object()));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/HashBiMapKeySetTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/HashBiMapKeySetTest.java
@@ -19,6 +19,8 @@ import org.eclipse.collections.test.set.SetTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertThrows;
+
 @RunWith(Java8Runner.class)
 public class HashBiMapKeySetTest implements SetTestCase
 {
@@ -39,10 +41,10 @@ public class HashBiMapKeySetTest implements SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void Collection_add()
     {
         // TODO Move up to a keySet view abstraction
-        SetTestCase.super.Collection_add();
+        assertThrows(UnsupportedOperationException.class, () -> SetTestCase.super.Collection_add());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/UnifiedMapKeySetTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/UnifiedMapKeySetTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 // TODO MapIterable.keySet() should return SetIterable, and use SetIterableTestCase here
 @RunWith(Java8Runner.class)
@@ -43,10 +44,10 @@ public class UnifiedMapKeySetTest implements SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void Collection_add()
     {
         // TODO Move up to a keySet view abstraction
-        SetTestCase.super.Collection_add();
+        assertThrows(UnsupportedOperationException.class, () -> SetTestCase.super.Collection_add());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
@@ -66,17 +66,17 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     default void RichIterable_getFirst_empty_null()
     {
-        this.newWith().getFirst();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().getFirst());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     default void RichIterable_getLast_empty_null()
     {
-        this.newWith().getLast();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().getLast());
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
@@ -117,17 +117,19 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void OrderedIterable_getLastOptional()
     {
-        ((OrderedIterable<?>) this.newWith(3, 2, 1)).getLastOptional();
+        assertThrows(UnsupportedOperationException.class, () ->
+                ((OrderedIterable<?>) this.newWith(3, 2, 1)).getLastOptional());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void OrderedIterable_getLastOptional_null_element()
     {
-        ((OrderedIterable<?>) this.newWith(new Object[]{null})).getLastOptional();
+        assertThrows(UnsupportedOperationException.class, () ->
+                ((OrderedIterable<?>) this.newWith(new Object[]{null})).getLastOptional());
     }
 
     @Test
@@ -136,10 +138,10 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
         assertEquals(Integer.valueOf(5), this.newWith(5, 1, 4, 2, 3).peek());
     }
 
-    @Test(expected = EmptyStackException.class)
+    @Test
     default void StackIterable_peek_throws()
     {
-        this.newWith().peek();
+        assertThrows(EmptyStackException.class, () -> this.newWith().peek());
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/mutable/UnmodifiableMutableStackTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/mutable/UnmodifiableMutableStackTestCase.java
@@ -14,6 +14,8 @@ import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public interface UnmodifiableMutableStackTestCase extends MutableStackTestCase, FixedSizeIterableTestCase
 {
     @Override
@@ -24,18 +26,18 @@ public interface UnmodifiableMutableStackTestCase extends MutableStackTestCase, 
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void MutableStack_pop()
     {
         MutableStack<Integer> mutableStack = this.newWith(5, 1, 4, 2, 3);
-        mutableStack.pop();
+        assertThrows(UnsupportedOperationException.class, () -> mutableStack.pop());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     default void MutableStack_pop_throws()
     {
         MutableStack<Integer> mutableStack = this.newWith();
-        mutableStack.pop();
+        assertThrows(UnsupportedOperationException.class, () -> mutableStack.pop());
     }
 }


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter.  This is a small first step in moving to junit-jupiter.