### PR TITLE
@Test(expected=X) → assertThrows(X) in bag tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/immutable/immutablePrimitiveEmptyBagTest.stg
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Immutable<name>Set;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Immutable<name>EmptyBag}.
  * This file was automatically generated from template file immutablePrimitiveEmptyBagTest.stg.
@@ -41,10 +43,10 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average()
     {
-        this.classUnderTest().average();
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
@@ -55,10 +57,10 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median()
     {
-        this.classUnderTest().median();
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
@@ -69,17 +71,17 @@ public class Immutable<name>EmptyBagTest extends AbstractImmutable<name>BagTestC
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max()
     {
-        this.classUnderTest().max();
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min()
     {
-        this.classUnderTest().min();
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/abstractMutablePrimitiveBagTestCase.stg
@@ -38,6 +38,8 @@ import org.junit.Test;
 import org.eclipse.collections.impl.factory.primitive.<name>Sets;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Mutable<name>Bag}.
  * This file was automatically generated from template file abstractMutablePrimitiveBagTestCase.stg.
@@ -177,10 +179,10 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Assert.assertEquals(<name>HashBag.newBagWith(<["100", "100", "100", "100", "100"]:(literal.(type))(); separator=", ">), bag);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addOccurrences_throws()
     {
-        this.newWith().addOccurrences(<(literal.(type))("100")>, -1);
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().addOccurrences(<(literal.(type))("100")>, -1));
     }
 
     @Test
@@ -199,10 +201,11 @@ public abstract class AbstractMutable<name>BagTestCase extends AbstractMutable<n
         Assert.assertEquals(new <name>HashBag(), bag);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void removeOccurrences_throws()
     {
-        this.newWith().removeOccurrences(<(literal.(type))("100")>, -1);
+        assertThrows(IllegalArgumentException.class, () ->
+                this.newWith().removeOccurrences(<(literal.(type))("100")>, -1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
@@ -28,6 +28,8 @@ import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Unmodifiable<name>Bag}.
  * This file was automatically generated from template file unmodifiablePrimitiveBagTest.stg.
@@ -61,10 +63,10 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addOccurrences()
     {
-        this.bag.addOccurrences(<(literal.(type))("1")>, 3);
+        assertThrows(UnsupportedOperationException.class, () -> this.bag.addOccurrences(<(literal.(type))("1")>, 3));
     }
 
     @Override
@@ -75,115 +77,125 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeOccurrences()
     {
-        this.bag.removeOccurrences(<(literal.(type))("1")>, 1);
+        assertThrows(UnsupportedOperationException.class, () -> this.bag.removeOccurrences(<(literal.(type))("1")>, 1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeOccurrences_throws()
     {
-        this.newWith().removeOccurrences(<(literal.(type))("1")>, -1);
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().removeOccurrences(<(literal.(type))("1")>, -1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.bag.clear();
+        assertThrows(UnsupportedOperationException.class, () -> this.bag.clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newWith().add(<(literal.(type))("1")>);
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll();
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(this.newMutableCollectionWith());
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type))("1")>);
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(this.newMutableCollectionWith());
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(this.newMutableCollectionWith());
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().retainAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.newWith().with(<["1"]:(literal.(type))(); separator=", ">);
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>);
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)
+                .withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
     }
 
     @Override
@@ -212,7 +224,7 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws_non_empty_collection()
     {
         Unmodifiable<name>Bag collection = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
@@ -221,7 +233,7 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
         {
             iterator.next();
         }
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.