### PR TITLE
@Test(expected=X) → assertThrows(X) in lazy tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
@@ -43,6 +43,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * Abstract JUnit test for {@link Lazy<name>Iterable}.
  * This file was automatically generated from template file abstractLazyPrimitiveIterableTestCase.stg.
@@ -66,7 +68,7 @@ public abstract class AbstractLazy<name>IterableTestCase
         Assert.assertEquals(<(wideLiteral.(type))("6")>, sum<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
@@ -75,7 +77,7 @@ public abstract class AbstractLazy<name>IterableTestCase
             iterator.next();
         }
 
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -236,10 +238,10 @@ public abstract class AbstractLazy<name>IterableTestCase
         this.getEmptyIterable().max();
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_emptyIterable()
     {
-        this.getEmptyIterable().min();
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyIterable().min());
     }
 
     @Test
@@ -286,10 +288,10 @@ public abstract class AbstractLazy<name>IterableTestCase
         new Lazy<name>IterableAdapter(new <name>ArrayList()).max();
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void minThrowsOnEmpty()
     {
-        new Lazy<name>IterableAdapter(new <name>ArrayList()).min();
+        assertThrows(NoSuchElementException.class, () -> new Lazy<name>IterableAdapter(new <name>ArrayList()).min());
     }
 
     @Test
@@ -298,10 +300,10 @@ public abstract class AbstractLazy<name>IterableTestCase
         Assert.assertEquals(2.0d, this.classUnderTest().average(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        this.getEmptyIterable().average();
+        assertThrows(ArithmeticException.class, () -> this.getEmptyIterable().average());
     }
 
     @Test
@@ -311,10 +313,10 @@ public abstract class AbstractLazy<name>IterableTestCase
         Assert.assertEquals(16.0d, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        this.getEmptyIterable().median();
+        assertThrows(ArithmeticException.class, () -> this.getEmptyIterable().median());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
@@ -37,6 +37,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * This file was automatically generated from template file collectPrimitiveIterableTest.stg.
  */
@@ -194,16 +196,18 @@ public void sumConsistentRounding()
         Assert.assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void maxThrowsOnEmpty()
     {
-        Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max();
+        assertThrows(NoSuchElementException.class, () ->
+                Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void minThrowsOnEmpty()
     {
-        Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min();
+        assertThrows(NoSuchElementException.class, () ->
+                Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min());
     }
 
     @Test
@@ -212,10 +216,11 @@ public void sumConsistentRounding()
         Assert.assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average(), 0.001);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average();
+        assertThrows(ArithmeticException.class, () ->
+                Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveToObjectIterableTest.stg
@@ -31,6 +31,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * This file was automatically generated from template file collectPrimitiveToObjectIterableTest.stg.
  */
@@ -102,10 +104,10 @@ public class Collect<name>ToObjectIterableTest
         Assert.assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeThrows()
     {
-        this.newPrimitiveWith().iterator().remove();
+        assertThrows(UnsupportedOperationException.class, () -> this.newPrimitiveWith().iterator().remove());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/flatCollectPrimitiveToObjectIterableTest.stg
@@ -33,6 +33,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * This file was automatically generated from template file flatCollectPrimitiveToObjectIterableTest.stg.
  */
@@ -104,10 +106,10 @@ public class FlatCollect<name>ToObjectIterableTest
         Assert.assertTrue(this.newPrimitiveWith(<["1", "2"]:(literal.(type))(); separator=", ">).notEmpty());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeThrows()
     {
-        this.newPrimitiveWith().iterator().remove();
+        assertThrows(UnsupportedOperationException.class, () -> this.newPrimitiveWith().iterator().remove());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
@@ -32,6 +32,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Select<name>Iterable}.
  * This file was automatically generated from template file primitiveSelectIterableTest.stg.
@@ -205,10 +207,11 @@ public void sumConsistentRounding()
                 this.iterable.select(<name>Predicates.lessThan(<(literal.(type))("0")>)).maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void maxThrowsOnEmpty()
     {
-        new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).max();
+        assertThrows(NoSuchElementException.class, () ->
+            new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).max());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -223,10 +226,11 @@ public void sumConsistentRounding()
         Assert.assertEquals(1.5d, this.iterable.average(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).average();
+        assertThrows(ArithmeticException.class, () ->
+            new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).average());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
@@ -33,6 +33,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Tap<name>Iterable}.
  * This file was automatically generated from template file primitiveTapIterableTest.stg.
@@ -223,16 +225,18 @@ public class Tap<name>IterableTest
         Assert.assertEquals(list.makeString(""), builder.toString());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void maxThrowsOnEmpty()
     {
-        new Tap<name>Iterable(new <name>ArrayList(), System.out::println).max();
+        assertThrows(NoSuchElementException.class, () ->
+            new Tap<name>Iterable(new <name>ArrayList(), System.out::println).max());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void minThrowsOnEmpty()
     {
-        new Tap<name>Iterable(new <name>ArrayList(), System.out::println).min();
+        assertThrows(NoSuchElementException.class, () ->
+            new Tap<name>Iterable(new <name>ArrayList(), System.out::println).min());
     }
 
     @Test
@@ -245,10 +249,11 @@ public class Tap<name>IterableTest
         Assert.assertEquals(list.makeString("") + list.makeString(""), builder.toString());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        new Tap<name>Iterable(new <name>ArrayList(), System.out::println).average();
+        assertThrows(ArithmeticException.class, () ->
+            new Tap<name>Iterable(new <name>ArrayList(), System.out::println).average());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
@@ -31,6 +31,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Reverse<name>Iterable}.
  * This file was automatically generated from template file reversePrimitiveIterableTest.stg.
@@ -85,7 +87,7 @@ public class Reverse<name>IterableTest
         Assert.assertFalse(iterator.hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_throws()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
@@ -95,7 +97,7 @@ public class Reverse<name>IterableTest
             iterator.next();
         }
 
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -200,10 +202,10 @@ public class Reverse<name>IterableTest
         Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().min()<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_emptyList()
     {
-        new <name>ArrayList().asReversed().min();
+        assertThrows(NoSuchElementException.class, () -> new <name>ArrayList().asReversed().min());
     }
 
     @Test


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.