### PR TITLE
Combine tests in unit-tests-java8 that cover the same method contract.

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -232,34 +232,26 @@ public interface IterableTestCase
         assertTrue(set.add(iterator.next()));
         assertTrue(set.add(iterator.next()));
         IterableTestCase.assertEquals(Sets.immutable.with(3, 2, 1), set);
-    }
 
-    @Test
-    default void Iterable_next_throws_on_empty()
-    {
         assertThrows(NoSuchElementException.class, () -> this.newWith().iterator().next());
-    }
 
-    @Test
-    default void Iterable_next_throws_at_end()
-    {
-        Iterable<Integer> iterable = this.newWith(3, 2, 1);
-        Iterator<Integer> iterator = iterable.iterator();
-        assertTrue(iterator.hasNext());
-        iterator.next();
-        assertTrue(iterator.hasNext());
-        iterator.next();
-        assertTrue(iterator.hasNext());
-        iterator.next();
-        assertFalse(iterator.hasNext());
-        assertThrows(NoSuchElementException.class, iterator::next);
+        Iterable<Integer> iterable2 = this.newWith(3, 2, 1);
+        Iterator<Integer> iterator2 = iterable2.iterator();
+        assertTrue(iterator2.hasNext());
+        iterator2.next();
+        assertTrue(iterator2.hasNext());
+        iterator2.next();
+        assertTrue(iterator2.hasNext());
+        iterator2.next();
+        assertFalse(iterator2.hasNext());
+        assertThrows(NoSuchElementException.class, iterator2::next);
 
-        Iterator<Integer> iterator2 = iterable.iterator();
-        iterator2.next();
-        iterator2.next();
-        iterator2.next();
-        assertThrows(NoSuchElementException.class, iterator2::next);
-        assertThrows(NoSuchElementException.class, iterator2::next);
+        Iterator<Integer> iterator3 = iterable2.iterator();
+        iterator3.next();
+        iterator3.next();
+        iterator3.next();
+        assertThrows(NoSuchElementException.class, iterator3::next);
+        assertThrows(NoSuchElementException.class, iterator3::next);
     }
 
     void Iterable_remove();

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoIteratorTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/NoIteratorTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -59,20 +59,6 @@ public interface NoIteratorTestCase extends RichIterableTestCase
     @Override
     @Test
     default void Iterable_next()
-    {
-        // Not applicable
-    }
-
-    @Override
-    @Test
-    default void Iterable_next_throws_on_empty()
-    {
-        // Not applicable
-    }
-
-    @Override
-    @Test
-    default void Iterable_next_throws_at_end()
     {
         // Not applicable
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -106,22 +106,9 @@ public class MultiReaderHashBagTest implements MutableBagTestCase, MultiReaderMu
             assertEquals(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
             assertFalse(iterator.hasNext());
         });
-    }
 
-    @Test
-    public void MultiReaderHashBag_hasNext()
-    {
-        MultiReaderHashBag<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
-        iterable.withReadLockAndDelegate(delegate -> assertTrue(delegate.iterator().hasNext()));
-        MultiReaderHashBag<?> emptyIterable = this.newWith();
-        emptyIterable.withReadLockAndDelegate(delegate -> assertFalse(delegate.iterator().hasNext()));
-    }
-
-    @Test
-    public void MultiReaderHashBag_next_throws_at_end()
-    {
-        MultiReaderHashBag<Integer> iterable = this.newWith(3, 2, 1);
-        iterable.withReadLockAndDelegate(delegate -> {
+        MultiReaderHashBag<Integer> iterable2 = this.newWith(3, 2, 1);
+        iterable2.withReadLockAndDelegate(delegate -> {
             Iterator<Integer> iterator = delegate.iterator();
             assertTrue(iterator.hasNext());
             iterator.next();
@@ -132,14 +119,18 @@ public class MultiReaderHashBagTest implements MutableBagTestCase, MultiReaderMu
             assertFalse(iterator.hasNext());
             assertThrows(NoSuchElementException.class, iterator::next);
         });
+
+        assertThrows(
+                NoSuchElementException.class,
+                () -> this.newWith().withReadLockAndDelegate(delegate -> delegate.iterator().next()));
     }
 
     @Test
-    public void MultiReaderHashBag_next_throws_on_empty()
+    public void MultiReaderHashBag_hasNext()
     {
-        MultiReaderHashBag<Object> iterable = this.newWith();
-        assertThrows(
-                NoSuchElementException.class,
-                () -> iterable.withReadLockAndDelegate(delegate -> delegate.iterator().next()));
+        MultiReaderHashBag<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
+        iterable.withReadLockAndDelegate(delegate -> assertTrue(delegate.iterator().hasNext()));
+        MultiReaderHashBag<?> emptyIterable = this.newWith();
+        emptyIterable.withReadLockAndDelegate(delegate -> assertFalse(delegate.iterator().hasNext()));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/UnmodifiableBagIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/UnmodifiableBagIterableTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -20,29 +20,15 @@ public interface UnmodifiableBagIterableTestCase extends UnmodifiableMutableColl
 {
     @Override
     @Test
-    default void MutableBagIterable_addOccurrences_throws()
-    {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> this.newWith(1, 2, 2, 3, 3, 3).addOccurrences(4, -1));
-    }
-
-    @Override
-    @Test
-    default void MutableBagIterable_removeOccurrences_throws()
-    {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> this.newWith(1, 2, 2, 3, 3, 3).removeOccurrences(4, -1));
-    }
-
-    @Override
-    @Test
     default void MutableBagIterable_addOccurrences()
     {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.newWith(1, 2, 2, 3, 3, 3).addOccurrences(4, 4));
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> this.newWith(1, 2, 2, 3, 3, 3).addOccurrences(4, -1));
     }
 
     @Override
@@ -52,5 +38,9 @@ public interface UnmodifiableBagIterableTestCase extends UnmodifiableMutableColl
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.newWith(1, 2, 2, 3, 3, 3).removeOccurrences(4, 4));
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> this.newWith(1, 2, 2, 3, 3, 3).removeOccurrences(4, -1));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -26,22 +26,6 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
     <T> MutableBagIterable<T> newWith(T... elements);
 
     @Test
-    default void MutableBagIterable_addOccurrences_throws()
-    {
-        Assert.assertThrows(
-                IllegalArgumentException.class,
-                () -> this.newWith(1, 2, 2, 3, 3, 3).addOccurrences(4, -1));
-    }
-
-    @Test
-    default void MutableBagIterable_removeOccurrences_throws()
-    {
-        Assert.assertThrows(
-                IllegalArgumentException.class,
-                () -> this.newWith(1, 2, 2, 3, 3, 3).removeOccurrences(4, -1));
-    }
-
-    @Test
     default void MutableBagIterable_addOccurrences()
     {
         MutableBagIterable<Integer> mutableBag = this.newWith(1, 2, 2, 3, 3, 3);
@@ -49,6 +33,10 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
         assertEquals(Bags.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
         assertEquals(3, mutableBag.addOccurrences(1, 2));
         assertEquals(Bags.immutable.with(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
+
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> mutableBag.addOccurrences(4, -1));
     }
 
     @Test
@@ -63,5 +51,9 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
         assertEquals(Bags.immutable.with(2, 2, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 1));
         assertEquals(Bags.immutable.with(2, 3), mutableBag);
+
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> mutableBag.removeOccurrences(4, -1));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -37,13 +37,7 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
         assertEquals(3, mutableSortedBag.addOccurrences(1, 0));
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
-    }
 
-    @Override
-    @Test
-    default void MutableBagIterable_addOccurrences_throws()
-    {
-        MutableSortedBag<Integer> mutableSortedBag = this.newWith(3, 3, 3, 2, 2, 1);
         assertThrows(IllegalArgumentException.class, () -> mutableSortedBag.addOccurrences(4, -1));
     }
 
@@ -64,15 +58,7 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 2), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 2));
         assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3), mutableBag);
-    }
 
-    @Override
-    @Test
-    default void MutableBagIterable_removeOccurrences_throws()
-    {
-        assertThrows(IllegalArgumentException.class, () -> {
-            MutableSortedBag<Integer> mutableBag = this.newWith(3, 3, 3, 2, 2, 1);
-            assertFalse(mutableBag.removeOccurrences(4, -1));
-        });
+        assertThrows(IllegalArgumentException.class, () -> mutableBag.removeOccurrences(4, -1));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/UnmodifiableSortedBagTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/UnmodifiableSortedBagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -17,7 +17,6 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.bag.mutable.UnmodifiableBagIterableTestCase;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Java8Runner.class)
@@ -36,20 +35,6 @@ public class UnmodifiableSortedBagTest implements MutableSortedBagTestCase, Unmo
         MutableSortedBag<T> result = new TreeBag<>(Comparators.reverseNaturalOrder());
         IterableTestCase.addAllTo(elements, result);
         return UnmodifiableSortedBag.of(result);
-    }
-
-    @Override
-    @Test
-    public void MutableBagIterable_addOccurrences_throws()
-    {
-        UnmodifiableBagIterableTestCase.super.MutableBagIterable_addOccurrences_throws();
-    }
-
-    @Override
-    @Test
-    public void MutableBagIterable_removeOccurrences_throws()
-    {
-        UnmodifiableBagIterableTestCase.super.MutableBagIterable_removeOccurrences_throws();
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MultiReaderMutableCollectionTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Goldman Sachs.
+ * Copyright (c) 2024 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -43,20 +43,6 @@ public interface MultiReaderMutableCollectionTestCase extends MutableCollectionT
     @Test
     @Override
     default void Iterable_hasNext()
-    {
-        // Multi-reader collections don't support iterator()
-    }
-
-    @Test
-    @Override
-    default void Iterable_next_throws_at_end()
-    {
-        // Multi-reader collections don't support iterator()
-    }
-
-    @Test
-    @Override
-    default void Iterable_next_throws_on_empty()
     {
         // Multi-reader collections don't support iterator()
     }


### PR DESCRIPTION
The intention is to keep all the same assertions, but reduce lines of code and reduce number of tests. Our tests are so fast that more time is taken by the junit framework to create test and record results than to execute assertions, so reducing the number of tests can speed up our build a bit.