### PR TITLE
@Test(expected=X) → assertThrows(X) in stack tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/abstractImmutablePrimitiveStackTestCase.stg
@@ -117,16 +117,17 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
         Assert.assertEquals(this.classUnderTest(), stack);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void pop_with_negative_count_throws_exception()
     {
-        this.classUnderTest().pop(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().pop(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        this.classUnderTest().pop(this.classUnderTest().size() + 1);
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                this.classUnderTest().pop(this.classUnderTest().size() + 1));
     }
 
     @Override
@@ -172,10 +173,10 @@ public abstract class AbstractImmutable<name>StackTestCase extends Abstract<name
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        <name>Stacks.immutable.of().median();
+        Assert.assertThrows(ArithmeticException.class, () -> <name>Stacks.immutable.of().median());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveArrayStackTest.stg
@@ -40,10 +40,11 @@ public class Immutable<name>ArrayStackTest extends AbstractImmutable<name>StackT
         return Immutable<name>ArrayStack.newStackWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNewStack_throws()
     {
-        Immutable<name>ArrayStack.newStack(<name>Stacks.mutable.with(<["1"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                Immutable<name>ArrayStack.newStack(<name>Stacks.mutable.with(<["1"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/immutable/immutablePrimitiveEmptyStackTest.stg
@@ -45,17 +45,17 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     }
 
     @Override
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void pop()
     {
-        this.classUnderTest().pop();
+        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop());
     }
 
     @Override
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        this.classUnderTest().pop(1);
+        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().pop(1));
     }
 
     @Override
@@ -77,10 +77,10 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     }
 
     @Override
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void peek()
     {
-        this.classUnderTest().peek();
+        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peek());
     }
 
     @Test
@@ -91,24 +91,24 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     }
 
     @Override
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void peek_at_index_equal_to_size_throws_exception()
     {
-        this.classUnderTest().peekAt(0);
+        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(0));
     }
 
     @Override
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void peek_at_index_greater_than_size_throws_exception()
     {
-        this.classUnderTest().peekAt(1);
+        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peekAt(1));
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average()
     {
-        this.classUnderTest().average();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
@@ -119,10 +119,10 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median()
     {
-        this.classUnderTest().median();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
@@ -133,17 +133,17 @@ public class Immutable<name>EmptyStackTest extends AbstractImmutable<name>StackT
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max()
     {
-        this.classUnderTest().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min()
     {
-        this.classUnderTest().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractMutablePrimitiveStackTestCase.stg
@@ -85,10 +85,10 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         Assert.assertEquals(<name>ArrayList.newListWith(<(castIntToNarrowTypeWithParens.(type))("size - 2")>), stack.peek(1));
     }
 
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void peek_empty_stack_throws_exception()
     {
-        this.newWith().peek();
+        Assert.assertThrows(EmptyStackException.class, () -> this.newWith().peek());
     }
 
     @Test
@@ -170,22 +170,22 @@ public abstract class AbstractMutable<name>StackTestCase extends Abstract<name>S
         Verify.assertSize(0, stack1);
     }
 
-    @Test(expected = EmptyStackException.class)
+    @Test
     public void pop_empty_stack_throws_exception()
     {
-        this.newWith().pop();
+        Assert.assertThrows(EmptyStackException.class, () -> this.newWith().pop());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void pop_with_negative_count_throws_exception()
     {
-        this.newWith(<(literal.(type))("1")>).pop(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void pop_with_count_greater_than_stack_size_throws_exception()
     {
-        this.newWith(<(literal.(type))("1")>).pop(2);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<(literal.(type))("1")>).pop(2));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/abstractPrimitiveStackTestCase.stg
@@ -104,22 +104,24 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void peek_at_index_less_than_zero_throws_exception()
     {
-        this.classUnderTest().peekAt(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().peekAt(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void peek_at_index_greater_than_size_throws_exception()
     {
-        this.classUnderTest().peekAt(this.classUnderTest().size() + 1);
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                this.classUnderTest().peekAt(this.classUnderTest().size() + 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void peek_at_index_equal_to_size_throws_exception()
     {
-        this.classUnderTest().peekAt(this.classUnderTest().size());
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                this.classUnderTest().peekAt(this.classUnderTest().size()));
     }
 
     @Override
@@ -349,28 +351,30 @@ public abstract class Abstract<name>StackTestCase extends Abstract<name>Iterable
         Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(-1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getFirst()
     {
-        this.classUnderTest().getFirst();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void indexOf()
     {
-        this.classUnderTest().indexOf(<["0"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().indexOf(<["0"]:(literal.(type))(); separator=", ">));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void injectIntoWithIndex()
     {
-        this.classUnderTest().injectIntoWithIndex(null, null);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().injectIntoWithIndex(null, null));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void forEachWithIndex()
     {
-        this.classUnderTest().forEachWithIndex(null);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().forEachWithIndex(null));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/stack/mutable/unmodifiablePrimitiveStackTest.stg
@@ -54,28 +54,29 @@ public class Unmodifiable<name>StackTest extends Abstract<name>StackTestCase
         return new Unmodifiable<name>Stack(<name>ArrayStack.newStackFromTopToBottom(elements));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void push()
     {
-        this.classUnderTest().push(<(literal.(type))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().push(<(literal.(type))("5")>));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void pop()
     {
-        this.classUnderTest().pop();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void popWithCount()
     {
-        this.classUnderTest().pop(2);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().pop(2));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Test


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.