### PR TITLE
@Test(expected=X) → assertThrows(X) in set tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/immutable/immutablePrimitiveEmptySetTest.stg
@@ -46,10 +46,10 @@ public class Immutable<name>EmptySetTest extends AbstractImmutable<name>HashSetT
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average()
     {
-        this.classUnderTest().average();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
@@ -60,10 +60,10 @@ public class Immutable<name>EmptySetTest extends AbstractImmutable<name>HashSetT
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median()
     {
-        this.classUnderTest().median();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
@@ -74,17 +74,17 @@ public class Immutable<name>EmptySetTest extends AbstractImmutable<name>HashSetT
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max()
     {
-        this.classUnderTest().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min()
     {
-        this.classUnderTest().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractImmutablePrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractImmutablePrimitiveSetTestCase.stg
@@ -137,7 +137,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws()
     {
         Immutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, AbstractImmutable<name>HashSetTestCase.generateCollisions().getFirst(), AbstractImmutable<name>HashSetTestCase.generateCollisions().get(1));
@@ -147,7 +147,7 @@ public abstract class AbstractImmutable<name>HashSetTestCase extends AbstractImm
             iterator.next();
         }
 
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/abstractPrimitiveSetTestCase.stg
@@ -298,7 +298,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws()
     {
         Mutable<name>Set set = this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">, Abstract<name>SetTestCase.generateCollisions1().getFirst(), Abstract<name>SetTestCase.generateCollisions1().get(1));
@@ -308,7 +308,7 @@ public abstract class Abstract<name>SetTestCase extends AbstractMutable<name>Col
             iterator.next();
         }
 
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/boxedMutableHashSetTest.stg
@@ -37,10 +37,10 @@ public class BoxedMutable<name>SetTest
         return new BoxedMutable<name>Set(new <name>HashSet(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void setCreationValidation()
     {
-        new BoxedMutable<name>Set(null);
+        Assert.assertThrows(NullPointerException.class, () -> new BoxedMutable<name>Set(null));
     }
 
     @Test
@@ -52,16 +52,16 @@ public class BoxedMutable<name>SetTest
         Verify.assertEmpty(set);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getFirst()
     {
-        this.classUnderTest().getFirst();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getFirst());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getLast()
     {
-        this.classUnderTest().getLast();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getLast());
     }
 
     @Test
@@ -111,10 +111,10 @@ public class BoxedMutable<name>SetTest
         Verify.assertEmpty(set);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void asParallel()
     {
-        this.classUnderTest().asParallel(null, 1);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().asParallel(null, 1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/primitiveHashSetTest.stg
@@ -65,10 +65,10 @@ public class <name>HashSetTest extends Abstract<name>SetTestCase
         Assert.assertEquals(32L, ((<type>[]) table.get(hashSet2)).length);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        new <name>HashSet(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>HashSet(-1));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/set/mutable/unmodifiablePrimitiveSetTest.stg
@@ -44,102 +44,110 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newWith().add(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().removeAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().retainAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.newWith().with(<["1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)
+                        .withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
     }
 
     @Override
@@ -168,7 +176,7 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws_non_empty_collection()
     {
         Unmodifiable<name>Set set = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
@@ -177,7 +185,7 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
         {
             iterator.next();
         }
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -218,30 +226,32 @@ public class Unmodifiable<name>SetTest extends Abstract<name>SetTestCase
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void boxed()
 {
-    this.classUnderTest().boxed().add(<(literal.(type))("4")>);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("4")>));
 }
 
 >>


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.