### PR TITLE
@Test(expected=X) → assertThrows(X) in map tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapKeyValuesViewTestCase.stg
@@ -313,16 +313,16 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Assert.assertNull(this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_empty_throws()
     {
-        this.newWith().min(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_empty_throws()
     {
-        this.newWith().max(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
@@ -525,7 +525,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
         Assert.assertEquals(objects.toBag(), actual);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_throws()
     {
         RichIterable\<Object<name>Pair\<Integer>\> objects = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
@@ -536,7 +536,7 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
             iterator.next();
         }
         Assert.assertFalse(iterator.hasNext());
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -877,11 +877,11 @@ public abstract class AbstractObject<name>MapKeyValuesViewTestCase
                 collection.chunk(1).toBag());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_zero_throws()
     {
         RichIterable\<Object<name>Pair\<Integer>\> collection = this.newWith(1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3, <(literal.(type))("4")>);
-        collection.chunk(0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractObjectPrimitiveMapTestCase.stg
@@ -525,10 +525,10 @@ public abstract class AbstractObject<name>MapTestCase
         Assert.assertEquals(<(literal.(type))("3")>, this.newWithKeysValues(null, <(literal.(type))("3")>, 0, <(literal.(type))("0")>, 2, <(literal.(type))("2")>).max()<delta.(type)>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_emptyList()
     {
-        this.\<Integer>getEmptyMap().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().max());
     }
 
     @Test
@@ -538,10 +538,10 @@ public abstract class AbstractObject<name>MapTestCase
         Assert.assertEquals(<(literal.(type))("0")>, this.newWithKeysValues(null, <(literal.(type))("0")>, 5, <(literal.(type))("5")>, 1, <(literal.(type))("1")>).min()<delta.(type)>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_emptyList()
     {
-        this.\<Integer>getEmptyMap().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.\<Integer>getEmptyMap().min());
     }
 
     @Test
@@ -566,10 +566,10 @@ public abstract class AbstractObject<name>MapTestCase
         Assert.assertEquals(1.0, this.map.average(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        this.getEmptyMap().average();
+        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
     }
 
     @Test
@@ -579,10 +579,10 @@ public abstract class AbstractObject<name>MapTestCase
         Assert.assertEquals(1.5, this.newWithKeysValues("0", <(literal.(type))("0")>, "1", <(literal.(type))("1")>, "2", <(literal.(type))("2")>, "3", <(literal.(type))("3")>).median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        this.getEmptyMap().median();
+        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveBooleanMapKeyValuesViewTest.stg
@@ -326,16 +326,16 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Assert.assertNull(this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false).detect(PrimitiveTuples.pair(2, 4L)::equals));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_empty_throws()
     {
-        this.newWith().min(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_empty_throws()
     {
-        this.newWith().max(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
@@ -542,7 +542,7 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
         Assert.assertEquals(objects.toBag(), actual);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_next_throws()
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
@@ -553,15 +553,15 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
             iterator.next();
         }
         Assert.assertFalse(iterator.hasNext());
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void iterator_remove_throws()
     {
         RichIterable\<<name>BooleanPair> objects = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
         Iterator\<<name>BooleanPair> iterator = objects.iterator();
-        iterator.remove();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -921,11 +921,11 @@ public abstract class Abstract<name>BooleanMapKeyValuesViewTestCase
                 collection.chunk(1).toBag());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_zero_throws()
     {
         RichIterable\<<name>BooleanPair> collection = this.newWith(<(literal.(type))("1")>, false, <(literal.(type))("2")>, true, <(literal.(type))("3")>, false);
-        collection.chunk(0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapKeyValuesViewTestCase.stg
@@ -354,16 +354,16 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Assert.assertNull(this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4).detect(Predicates.equal(PrimitiveTuples.pair(<(literal.(type))("2")>, Integer.valueOf(4)))));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_empty_throws()
     {
-        this.newWith().min(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_empty_throws()
     {
-        this.newWith().max(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
@@ -585,7 +585,7 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
         Assert.assertEquals(objects.toBag(), actual);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_next_throws()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
@@ -596,15 +596,15 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
             iterator.next();
         }
         Assert.assertFalse(iterator.hasNext());
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void iterator_remove_throws()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> objects = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
         Iterator\<<name>ObjectPair\<Integer>\> iterator = objects.iterator();
-        iterator.remove();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -953,11 +953,11 @@ public abstract class Abstract<name>ObjectMapKeyValuesViewTestCase
                 collection.chunk(1).toBag());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_zero_throws()
     {
         RichIterable\<<name>ObjectPair\<Integer>\> collection = this.newWith(<(literal.(type))("1")>, 2, <(literal.(type))("2")>, 3, <(literal.(type))("3")>, 4);
-        collection.chunk(0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitiveObjectMapTestCase.stg
@@ -913,10 +913,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         Assert.assertEquals("abcd", map3.min(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_empty()
     {
-        <name>ObjectHashMap.newMap().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().min());
     }
 
     @Test
@@ -947,10 +947,10 @@ public abstract class Abstract<name>ObjectMapTestCase
         Assert.assertEquals("zyx", map3.max(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_empty()
     {
-        <name>ObjectHashMap.newMap().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> <name>ObjectHashMap.newMap().max());
     }
 
     @Test
@@ -1346,16 +1346,17 @@ public abstract class Abstract<name>ObjectMapTestCase
         Assert.assertEquals("two", this.newWithKeysValues(<(literal.(type))("2")>, "two").getOnly());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getOnly_empty_throws()
     {
-        this.getEmptyMap().getOnly();
+        Assert.assertThrows(IllegalStateException.class, () -> this.getEmptyMap().getOnly());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getOnly_not_only_one_throws()
     {
-        this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").getOnly();
+        Assert.assertThrows(IllegalStateException.class, () ->
+                this.newWithKeysValues(<(literal.(type))("1")>, "one", <(literal.(type))("5")>, "five").getOnly());
     }
 
     @Test
@@ -1552,18 +1553,18 @@ public abstract class Abstract<name>ObjectMapTestCase
                 || FastList.newListWith(FastList.newListWith("five"), FastList.newListWith("one")).equals(chunk2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_throws_negative_size()
     {
-        this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
-                .chunk(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
+                .chunk(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_throws_zero_size()
     {
-        this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
-                .chunk(0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("5")>, "five")
+                .chunk(0));
     }
 
     @Test
@@ -1670,12 +1671,12 @@ public abstract class Abstract<name>ObjectMapTestCase
         Assert.assertEquals(UnifiedMap.newWithKeysValues('t', "two"), map2.groupByUniqueKey(firstChar));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void groupByUniqueKey_throws()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Function\<String, Character> firstChar = (String object) -> 'a';
-        map1.groupByUniqueKey(firstChar);
+        Assert.assertThrows(IllegalStateException.class, () -> map1.groupByUniqueKey(firstChar));
     }
 
     @Test
@@ -1688,28 +1689,31 @@ public abstract class Abstract<name>ObjectMapTestCase
         Assert.assertEquals(UnifiedMap.newWithKeysValues('z', "zero", 't', "two"), map2.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void groupByUniqueKey_target_throws_1()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero", <(literal.(type))("1")>, "one");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero"));
+        Assert.assertThrows(IllegalStateException.class, () ->
+                map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero")));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void groupByUniqueKey_target_throws_2()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("0")>, "zero");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero"));
+        Assert.assertThrows(IllegalStateException.class, () ->
+                map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('z', "zero")));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void groupByUniqueKey_target_throws_3()
     {
         <name>ObjectMap\<String> map1 = this.newWithKeysValues(<(literal.(type))("2")>, "two");
         Function\<String, Character> firstChar = (String object) -> object.charAt(0);
-        map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two"));
+        Assert.assertThrows(IllegalStateException.class, () ->
+                map1.groupByUniqueKey(firstChar, UnifiedMap.newWithKeysValues('t', "two")));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapKeyValuesViewTestCase.stg
@@ -348,16 +348,16 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Assert.assertNull(this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>).detect(PrimitiveTuples.pair(<(literal.(type1))("2")>, <(literal.(type2))("4")>)::equals));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_empty_throws()
     {
-        this.newWith().min(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.naturalOrder()));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_empty_throws()
     {
-        this.newWith().max(Comparators.naturalOrder());
+        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.naturalOrder()));
     }
 
     @Test
@@ -577,7 +577,7 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
         Assert.assertEquals(objects.toBag(), actual);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_next_throws()
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
@@ -588,15 +588,15 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
             iterator.next();
         }
         Assert.assertFalse(iterator.hasNext());
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void iterator_remove_throws()
     {
         RichIterable\<<name1><name2>Pair> objects = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
         Iterator\<<name1><name2>Pair> iterator = objects.iterator();
-        iterator.remove();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
     }
 
     @Test
@@ -937,11 +937,11 @@ public abstract class Abstract<name1><name2>MapKeyValuesViewTestCase
                 collection.chunk(1).toBag());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void chunk_zero_throws()
     {
         RichIterable\<<name1><name2>Pair> collection = this.newWith(<(literal.(type1))("1")>, <(literal.(type2))("2")>, <(literal.(type1))("2")>, <(literal.(type2))("3")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
-        collection.chunk(0);
+        Assert.assertThrows(IllegalArgumentException.class, () -> collection.chunk(0));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -457,11 +457,11 @@ public abstract class Abstract<name1><name2>MapTestCase
     {
         <name1><name2>Map map0 = this.newWithKeysValues(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type1))("3")>, <(literal.(type2))("4")>);
 
-        Long sum0 = map0.injectIntoKeyValue(new Long(0), (Long sum, <type1> eachKey, <type2> eachValue) ->
+        Long sum0 = map0.injectIntoKeyValue(Long.valueOf(0), (Long sum, <type1> eachKey, <type2> eachValue) ->
         {
-            return new Long((long) (sum + eachKey + eachValue));
+            return Long.valueOf((long) (sum + eachKey + eachValue));
         });
-        Assert.assertEquals(new Long(8), sum0);
+        Assert.assertEquals(Long.valueOf(8), sum0);
 
         <name1><name2>Map copy = map0.injectIntoKeyValue(<name1><name2>Maps.mutable.empty(), Mutable<name1><name2>Map::withKeyValue);
         Assert.assertEquals(map0, copy);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -700,16 +700,16 @@ public abstract class Abstract<name1><name2>MapTestCase
         Assert.assertEquals(<(literal.(type2))("3")>, this.newWithKeysValues(<["3"]:keyValue(); separator=", ">).min()<(wideDelta.(type2))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_empty_throws()
     {
-        this.getEmptyMap().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().max());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_empty_throws()
     {
-        this.getEmptyMap().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.getEmptyMap().min());
     }
 
     @Test
@@ -752,10 +752,10 @@ public abstract class Abstract<name1><name2>MapTestCase
         Assert.assertEquals(1.0, map1.average(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        this.getEmptyMap().average();
+        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().average());
     }
 
     @Test
@@ -769,10 +769,10 @@ public abstract class Abstract<name1><name2>MapTestCase
         Assert.assertEquals(1.0, map3.median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        this.getEmptyMap().median();
+        Assert.assertThrows(ArithmeticException.class, () -> this.getEmptyMap().median());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutableObjectPrimitiveEmptyMapTest.stg
@@ -127,10 +127,10 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median()
     {
-        this.classUnderTest().median();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
@@ -181,10 +181,10 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average()
     {
-        this.classUnderTest().average();
+        Assert.assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
@@ -215,17 +215,17 @@ public class ImmutableObject<name>EmptyMapTest extends AbstractImmutableObject<n
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max()
     {
-        this.classUnderTest().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min()
     {
-        this.classUnderTest().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/immutable/immutablePrimitiveObjectEmptyMapTest.stg
@@ -250,10 +250,10 @@ public class Immutable<name>ObjectEmptyMapTest extends AbstractImmutable<name>Ob
     }
 
     @Override
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getOnly()
     {
-        this.classUnderTest().getOnly();
+        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapKeySetTestCase.stg
@@ -44,16 +44,18 @@ public abstract class Object<name>HashMapKeySetTestCase
 
     public abstract MutableObject<name>Map\<String> newEmptyMap();
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().addAll(FastList.newListWith("Four"));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().addAll(FastList.newListWith("Four")));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapTestCase.stg
@@ -72,10 +72,11 @@ public abstract class Object<name>HashMapTestCase extends AbstractMutableObject<
         Assert.assertEquals(32L, ((<type>[]) values.get(hashMap2)).length);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        this.newMapWithInitialCapacity(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                this.newMapWithInitialCapacity(-1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTestCase.stg
@@ -118,53 +118,57 @@ public abstract class Object<name>HashMapValuesTestCase extends AbstractMutable<
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                 this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
@@ -57,59 +57,60 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void freeze()
     {
-        this.classUnderTest().freeze();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
@@ -195,24 +196,26 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeysViewTest.stg
@@ -151,7 +151,7 @@ public class <name>BooleanHashMapKeysViewTest
         Assert.assertThrows(NoSuchElementException.class, iterator::next);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterator_throws()
     {
         <name>Iterator iterator = this.iterable.<type>Iterator();
@@ -160,7 +160,7 @@ public class <name>BooleanHashMapKeysViewTest
             iterator.next();
         }
 
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -243,10 +243,10 @@ public class <name>BooleanHashMapKeysViewTest
         Assert.assertEquals(generateCollisions1().get(1), this.iterable.max()<delta.(type)>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_emptyList()
     {
-        new <name>BooleanHashMap().keysView().max();
+        Assert.assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().max());
     }
 
     @Test
@@ -272,10 +272,10 @@ public class <name>BooleanHashMapKeysViewTest
         Assert.assertEquals(generateCollisions1().get(1), this.iterable.maxIfEmpty(<(literal.(type))("5")>)<delta.(type)>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_emptyList()
     {
-        new <name>BooleanHashMap().keysView().min();
+        Assert.assertThrows(NoSuchElementException.class, () -> new <name>BooleanHashMap().keysView().min());
     }
 
     @Test
@@ -284,10 +284,10 @@ public class <name>BooleanHashMapKeysViewTest
         Assert.assertEquals(<(wideLiteral.(type))("94")>, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeysValues(<(literal.(type))("0")>, true, <(literal.(type))("1")>, false).keysView().sum()<wideDelta.(type)>);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average_throws_emptyList()
     {
-        new <name>BooleanHashMap().keysView().average();
+        Assert.assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().average());
     }
 
     @Test
@@ -303,10 +303,10 @@ public class <name>BooleanHashMapKeysViewTest
         Assert.assertEquals(30.5, <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("30")>, true, <(literal.(type))("31")>, false, <(literal.(type))("32")>, true).withKeyValue(<(literal.(type))("1")>, true).keysView().median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median_throws_emptyList()
     {
-        new <name>BooleanHashMap().keysView().median();
+        Assert.assertThrows(ArithmeticException.class, () -> new <name>BooleanHashMap().keysView().median());
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapTest.stg
@@ -104,10 +104,10 @@ public class <name>BooleanHashMapTest extends AbstractMutable<name>BooleanMapTes
         Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        new <name>BooleanHashMap(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>BooleanHashMap(-1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapValuesTest.stg
@@ -93,52 +93,55 @@ public class <name>BooleanHashMapValuesTest extends AbstractMutableBooleanCollec
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(true, false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new BooleanArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
@@ -57,53 +57,53 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
@@ -188,24 +188,26 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapTest.stg
@@ -103,10 +103,10 @@ public class <name>ObjectHashMapTest extends AbstractMutable<name>ObjectMapTestC
         Assert.assertEquals(32L, ((Object[]) values.get(hashMap2)).length);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        new <name>ObjectHashMap\<>(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> new <name>ObjectHashMap\<>(-1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapValuesTest.stg
@@ -55,16 +55,19 @@ public class <name>ObjectHashMapValuesTest
         return <name>ObjectHashMap.newWithKeysValues(key1, value1, key2, value2, key3, value3).withKeyValue(key4, value4);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
+                    .values().addAll(FastList.newListWith(4)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
@@ -55,53 +55,53 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
     }
 
     @Override
@@ -154,24 +154,26 @@ keyValue(value) ::= <<
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapTest.stg
@@ -124,10 +124,10 @@ public class <name1><name2>HashMapTest extends AbstractMutable<name1><name2>MapT
         <endif>
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newWithInitialCapacity_negative_throws()
     {
-        new <name1><name2>HashMap(-1);
+        Assert.assertThrows(IllegalArgumentException.class, () -> new <name1><name2>HashMap(-1));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
@@ -97,53 +97,53 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
     <if(primitive2.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name2>ArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapKeySetTest.stg
@@ -47,16 +47,19 @@ public class SynchronizedObject<name>MapKeySetTest
         return new SynchronizedObject<name>Map\<>(Object<name>HashMap.newWithKeysValues(key1, value1, key2, value2, key3, value3, key4, value4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().addAll(FastList.newListWith("Four"));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>)
+                    .keySet().addAll(FastList.newListWith("Four")));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
@@ -94,39 +94,39 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
@@ -57,39 +57,39 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -115,10 +115,10 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Assert.assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void freeze()
     {
-        this.classUnderTest().freeze();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
@@ -204,24 +204,26 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapValuesTest.stg
@@ -72,38 +72,40 @@ public class Synchronized<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(true, false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
@@ -53,39 +53,40 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -157,24 +158,26 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapValuesTest.stg
@@ -55,16 +55,19 @@ public class Synchronized<name>ObjectMapValuesTest
         return new Synchronized<name>ObjectMap\<>(<name>ObjectHashMap.newWithKeysValues(key1, value1, key2, value2, key3, value3).withKeyValue(key4, value4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
+                    .values().addAll(FastList.newListWith(4)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
@@ -55,39 +55,39 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
@@ -163,24 +163,26 @@ keyValue(value) ::= <<
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
@@ -97,39 +97,39 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
     <if(primitive2.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapKeySetTest.stg
@@ -47,16 +47,19 @@ public class UnmodifiableObject<name>MapKeySetTest
         return new UnmodifiableObject<name>Map\<>(Object<name>HashMap.newWithKeysValues(key1, value1, key2, value2, key3, value3, key4, value4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().add("Four"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>).keySet().addAll(FastList.newListWith("Four"));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues("One", <(literal.(type))("1")>, "Two", <(literal.(type))("2")>, "Three", <(literal.(type))("3")>)
+                    .keySet().addAll(FastList.newListWith("Four")));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapTest.stg
@@ -84,81 +84,83 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.map.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKey()
     {
-        this.map.removeKey("0");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey("0"));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.map.remove("0");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove("0"));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void put()
     {
-        this.map.put("0", <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put("0", <(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putPair()
     {
-        this.map.putPair(PrimitiveTuples.pair("0", <(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair("0", <(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValues()
     {
-        this.map.updateValues((k, v) -> v);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withKeysValues()
     {
-        this.map.withKeyValue("1", <(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue("1", <(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutKey()
     {
-        this.map.withoutKey("0");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey("0"));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAllKeys()
     {
-        this.map.withoutAllKeys(FastList.newListWith("0", "1"));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.withoutAllKeys(FastList.newListWith("0", "1")));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAllKeyValues()
     {
-        this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair("1", <(literal.(type))("1")>)));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair("1", <(literal.(type))("1")>))));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putDuplicateWithRemovedSlot()
     {
         String collision1 = AbstractMutableObject<name>MapTestCase.generateCollisions().getFirst();
-        this.getEmptyMap().put(collision1, <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, <(literal.(type))("1")>));
     }
 
     @Override
@@ -189,17 +191,17 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
         Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", <(literal.(type))("100")>)<delta.(type)>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_ValueThrowsException()
     {
-        this.map.getIfAbsentPut("10", <(literal.(type))("100")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", <(literal.(type))("100")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getAndPut()
     {
-        this.map.getAndPut("10", <(literal.(type))("200")>, <(literal.(type))("100")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut("10", <(literal.(type))("200")>, <(literal.(type))("100")>));
     }
 
     @Override
@@ -211,12 +213,12 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
         Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPut("0", factory)<delta.(type)>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_FunctionThrowsException()
     {
         <name>Function0 factory = () -> { throw new AssertionError(); };
 
-        this.map.getIfAbsentPut("10", factory);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut("10", factory));
     }
 
     @Override
@@ -228,12 +230,13 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
         Assert.assertEquals(<(wideLiteral.(type))("0")>, this.map.getIfAbsentPutWith("0", functionLength, "123456789")<delta.(type)>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithThrowsException()
     {
         <name>Function\<String> functionLength = (String string) -> { throw new AssertionError(); };
 
-        this.map.getIfAbsentPutWith("10", functionLength, "123456789");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.getIfAbsentPutWith("10", functionLength, "123456789"));
     }
 
     @Override
@@ -245,29 +248,30 @@ public class UnmodifiableObject<name>MapTest extends AbstractMutableObject<name>
         Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWithKeysValues(0, <(literal.(type))("0")>).getIfAbsentPutWithKey(0, function)<delta.(type)>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name>Function\<Integer> function = (Integer anObject) -> { throw new AssertionError(); };
 
-        this.\<Integer>getEmptyMap().getIfAbsentPutWithKey(10, function);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.\<Integer>getEmptyMap().getIfAbsentPutWithKey(10, function));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addToValue()
     {
-        this.\<Integer>getEmptyMap().addToValue(10, <(literal.(type))("2")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.\<Integer>getEmptyMap().addToValue(10, <(literal.(type))("2")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValue()
     {
         <name>To<name>Function incrementFunction = (<type> value) -> { throw new AssertionError(); };
 
         MutableObject<name>Map\<Integer> map1 = this.getEmptyMap();
-        map1.updateValue(0, <(literal.(type))("0")>, incrementFunction);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> map1.updateValue(0, <(literal.(type))("0")>, incrementFunction));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
@@ -95,104 +95,108 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()>
     <endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.newWith().remove(<(literal.(type))("3")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().remove(<(literal.(type))("3")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.newWith().removeIf(<name>Predicates.equal(<(literal.(type))("3")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.newWith().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.newWith().removeAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.newWith().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.newWith().retainAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
         Mutable<name>Collection emptyCollection = this.newWith();
-        emptyCollection.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
@@ -58,66 +58,69 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void freeze()
     {
-        this.classUnderTest().freeze();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -128,45 +131,45 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -278,24 +281,26 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapTest.stg
@@ -76,17 +76,17 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKey()
     {
-        this.classUnderTest().removeKey(<(literal.(type))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKey(<(literal.(type))("5")>));
     }
 
     @Override
@@ -96,62 +96,64 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         Assert.assertTrue(this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("10")>, true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKeyIfAbsentThrowsException()
     {
-        this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("0")>, true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeKeyIfAbsent(<(literal.(type))("0")>, true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void put()
     {
-        this.classUnderTest().put(<(literal.(type))("0")>, true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().put(<(literal.(type))("0")>, true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValues()
     {
-        this.classUnderTest().updateValues((k, v) -> v);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().updateValues((k, v) -> v));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withKeysValues()
     {
-        this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withKeyValue(<(literal.(type))("1")>, true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutKey()
     {
-        this.classUnderTest().withoutKey(<(literal.(type))("32")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutKey(<(literal.(type))("32")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAllKeys()
     {
-        this.classUnderTest().withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAllKeyValues()
     {
-        this.classUnderTest().withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, true)));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, true))));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putDuplicateWithRemovedSlot()
     {
         <type> collision1 = AbstractMutable<name>BooleanMapTestCase.generateCollisions().getFirst();
 
         Unmodifiable<name>BooleanMap hashMap = this.getEmptyMap();
-        hashMap.put(collision1, true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, true));
     }
 
     @Override
@@ -196,10 +198,10 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         Assert.assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, false));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutThrowsException()
     {
-        this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, true));
     }
 
     @Override
@@ -211,12 +213,13 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         Assert.assertTrue(this.classUnderTest().getIfAbsentPut(<(literal.(type))("0")>, factory));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_FunctionThrowsException()
     {
         BooleanFunction0 factory = () -> true;
 
-        this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, factory);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().getIfAbsentPut(<(literal.(type))("10")>, factory));
     }
 
     @Override
@@ -228,12 +231,13 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         Assert.assertTrue(this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("0")>, functionLengthEven, "12345678"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithThrowsException()
     {
         BooleanFunction\<String> functionLengthEven = (String string) -> (string.length() & 1) == <(literal.(type))("0")>;
 
-        this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("10")>, functionLengthEven, "unused");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().getIfAbsentPutWith(<(literal.(type))("10")>, functionLengthEven, "unused"));
     }
 
     @Override
@@ -245,21 +249,23 @@ public class Unmodifiable<name>BooleanMapTest extends AbstractMutable<name>Boole
         Assert.assertTrue(this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("0")>, keyIsEven));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name>ToBooleanFunction keyIsEven = (<type> parameter) -> (<(castRealTypeToInt.(type))("parameter")> & 1) == <(literal.(type))("0")>;
 
-        this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("10")>, keyIsEven);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().getIfAbsentPutWithKey(<(literal.(type))("10")>, keyIsEven));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValue()
     {
         BooleanToBooleanFunction flip = (boolean value) -> !value;
 
-        this.classUnderTest().updateValue(<(literal.(type))("0")>, false, flip);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().updateValue(<(literal.(type))("0")>, false, flip));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapValuesTest.stg
@@ -94,52 +94,55 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(new BooleanArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(true, false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(true, false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(true);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(true));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(false);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(false));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withAll(new BooleanArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new BooleanArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new BooleanArrayList()));
     }
 
     @Override
@@ -197,39 +200,41 @@ public class Unmodifiable<name>BooleanMapValuesTest extends AbstractMutableBoole
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.newWith().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.newWith().removeAll(BooleanArrayList.newListWith(false, true));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().removeAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.newWith().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.newWith().retainAll(BooleanArrayList.newListWith(false, true));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().retainAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        emptyCollection.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
@@ -54,60 +54,61 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -118,45 +119,48 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                 this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(new <name>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -228,24 +232,26 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapTest.stg
@@ -79,82 +79,84 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.map.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKey()
     {
-        this.map.removeKey(<(literal.(type))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type))("5")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.map.remove(<(literal.(type))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type))("5")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void put()
     {
-        this.map.put(<(literal.(type))("0")>, "one");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type))("0")>, "one"));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putPair()
     {
-        this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type))("0")>, "one")));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putAll()
     {
         <name>ObjectHashMap\<String> hashMap = <name>ObjectHashMap.newMap();
-        this.map.putAll(hashMap);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(hashMap));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withKeysValues()
     {
-        this.map.withKeyValue(<(literal.(type))("1")>, "one");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type))("1")>, "one"));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutKey()
     {
-        this.map.withoutKey(<(literal.(type))("32")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type))("32")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAllKeys()
     {
-        this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.withoutAllKeys(<name>ArrayList.newListWith(<(literal.(type))("0")>, <(literal.(type))("32")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAllKeyValues()
     {
-        this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, "one")));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type))("1")>, "one"))));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putDuplicateWithRemovedSlot()
     {
         <type> collision1 = AbstractMutable<name>ObjectMapTestCase.generateCollisions().getFirst();
-        this.getEmptyMap().put(collision1, "one");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().put(collision1, "one"));
     }
 
 <if(primitive.floatingPoint)>
@@ -196,10 +198,10 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, "zeroValue"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_Value_throws()
     {
-        this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type))("1")>, "oneValue"));
     }
 
     @Override
@@ -209,10 +211,11 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Assert.assertEquals("zero", this.map.getIfAbsentPut(<(literal.(type))("0")>, () -> "zeroValue"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_Function_throws()
     {
-        this.map.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.getIfAbsentPut(<(literal.(type))("1")>, () -> "oneValue"));
     }
 
     @Override
@@ -223,11 +226,12 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Assert.assertEquals("zero", this.map.getIfAbsentPutWith(<(literal.(type))("0")>, toUpperCase, "zeroValue"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithThrowsException()
     {
         Function\<String, String> toUpperCase = String::toUpperCase;
-        this.map.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "zeroValue");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.getIfAbsentPutWith(<(literal.(type))("1")>, toUpperCase, "zeroValue"));
     }
 
     @Override
@@ -238,18 +242,18 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
         Assert.assertEquals("zero", this.map.getIfAbsentPutWithKey(<(literal.(type))("0")>, toString));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name>ToObjectFunction\<String> toString = String::valueOf;
-        this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type))("1")>, toString));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        super.removeIf();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> super.removeIf());
     }
 
     @Override
@@ -263,23 +267,25 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValue()
     {
         Function\<Integer, Integer> incrementFunction = (Integer integer) -> integer + 1;
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
-        this.\<Integer>getEmptyMap().updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.\<Integer>getEmptyMap().updateValue(<(literal.(type))("0")>, zeroFactory, incrementFunction));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValueWith()
     {
         Function2\<Integer, Integer, Integer> incrementFunction = AddFunction.INTEGER;
         Function0\<Integer> zeroFactory = Functions0.value(0);
 
-        this.\<Integer>getEmptyMap().updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.\<Integer>getEmptyMap().updateValueWith(<(literal.(type))("0")>, zeroFactory, incrementFunction, 1));
     }
 
     @Override
@@ -380,22 +386,22 @@ public class Unmodifiable<name>ObjectMapTest extends AbstractMutable<name>Object
 
 NaNTests(key) ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void put_<key>()
 {
     Mutable<name>ObjectMap\<String> map = this.getEmptyMap();
-    map.put(<wrapperName>.<key>, "one");
+    Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(<wrapperName>.<key>, "one"));
 }
 
 >>
 
 ZeroTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void put_zero()
 {
     Mutable<name>ObjectMap\<String> map = this.getEmptyMap();
-    map.put(<(literal.(type))("0")>, "one");
+    Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(<(literal.(type))("0")>, "one"));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapValuesTest.stg
@@ -54,16 +54,18 @@ public class Unmodifiable<name>ObjectMapValuesTest
         return new Unmodifiable<name>ObjectMap\<>(<name>ObjectHashMap.newWithKeysValues(key1, value1, key2, value2, key3, value3).withKeyValue(key4, value4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().add(4);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)
+                    .values().add(4));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll()
     {
-        this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).values().addAll(FastList.newListWith(4)));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
@@ -57,102 +57,103 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type1))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type1))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type1))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name1>Predicates.equal(<(literal.(type1))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeIf(<name1>Predicates.equal(<(literal.(type1))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(new <name1>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name1>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -268,24 +269,26 @@ keyValue(value) ::= <<
 
 NaNTests() ::= <<
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NaN()
 {
-    this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN);
+    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_POSITIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
 @Override
-@Test(expected = UnsupportedOperationException.class)
+@Test
 public void add_NEGATIVE_INFINITY()
 {
-    this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY);
+    Assert.assertThrows(UnsupportedOperationException.class, () ->
+            this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapTest.stg
@@ -82,24 +82,24 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.map.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKey()
     {
-        this.map.removeKey(<(literal.(type1))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKey(<(literal.(type1))("5")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.map.remove(<(literal.(type1))("5")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.remove(<(literal.(type1))("5")>));
     }
 
     @Override
@@ -109,84 +109,85 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Assert.assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeKeyIfAbsentThrowsException()
     {
         Assert.assertEquals(<(literal.(type2))("100")>, this.map.removeKeyIfAbsent(<(literal.(type1))("10")>, <(literal.(type2))("100")>)<(wideDelta.(type2))>);
-        this.map.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.removeKeyIfAbsent(<(literal.(type1))("0")>, <(literal.(type2))("100")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void put()
     {
-        this.map.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.put(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getAndPut()
     {
-        this.map.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getAndPut(<(literal.(type1))("0")>, <(literal.(type2))("1")>, <(literal.(type2))("2")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putPair()
     {
-        this.map.putPair(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putPair(PrimitiveTuples.pair(<(literal.(type1))("0")>, <(literal.(type2))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValues()
     {
-        this.map.updateValues((k, v) -> v);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValues((k, v) -> v));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addToValue()
     {
-        this.map.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.addToValue(<(literal.(type1))("0")>, <(literal.(type2))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withKeysValues()
     {
-        this.map.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withKeyValue(<(literal.(type1))("1")>, <(literal.(type2))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutKey()
     {
-        this.map.withoutKey(<(literal.(type1))("32")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutKey(<(literal.(type1))("32")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAllKeys()
     {
-        this.map.withoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.withoutAllKeys(<name1>ArrayList.newListWith(<(literal.(type1))("0")>, <(literal.(type1))("32")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAllKeyValues()
     {
-        this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("1")>)));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.withAllKeyValues(Iterables.iList(PrimitiveTuples.pair(<(literal.(type1))("1")>, <(literal.(type2))("1")>))));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putDuplicateWithRemovedSlot()
     {
         <type1> collision1 = AbstractMutable<name1><name2>MapTestCase.generateCollisions().getFirst();
 
         Unmodifiable<name1><name2>Map hashMap = this.getEmptyMap();
-        hashMap.put(collision1, <(literal.(type2))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> hashMap.put(collision1, <(literal.(type2))("1")>));
     }
 
     @Override
@@ -229,10 +230,10 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, <(literal.(type2))("50")>)<(wideDelta.(type2))>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutThrowsException()
     {
-        this.map.getIfAbsentPut(<(literal.(type1))("10")>, <(literal.(type2))("100")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, <(literal.(type2))("100")>));
     }
 
     @Override
@@ -244,12 +245,12 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPut(<(literal.(type1))("0")>, factory)<(wideDelta.(type2))>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPut_FunctionThrowsException()
     {
         <name2>Function0 factory = () -> <(literal.(type2))("100")>;
 
-        this.map.getIfAbsentPut(<(literal.(type1))("10")>, factory);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPut(<(literal.(type1))("10")>, factory));
     }
 
     @Override
@@ -261,12 +262,13 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Assert.assertEquals(<(wideLiteral.(type2))("0")>, this.map.getIfAbsentPutWith(<(literal.(type1))("0")>, functionLength, "123456789")<(wideDelta.(type2))>);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithThrowsException()
     {
         <name2>Function\<String> functionLength = (String string) -> <(castFromInt.(type2))("string.length()")>;
 
-        this.map.getIfAbsentPutWith(<(literal.(type1))("10")>, functionLength, "unused");
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.map.getIfAbsentPutWith(<(literal.(type1))("10")>, functionLength, "unused"));
     }
 
     @Override
@@ -287,26 +289,26 @@ public class Unmodifiable<name1><name2>MapTest extends AbstractMutable<name1><na
         Assert.assertEquals(frozenSet, frozenSetCopy);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void getIfAbsentPutWithKeyThrowsException()
     {
         <name1>To<name2>Function function = (<type1> <type1>Parameter) -> <castExactly(type2, {<type1>Parameter}, sameTwoPrimitives)>;
-        this.map.getIfAbsentPutWithKey(<(literal.(type1))("10")>, function);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.getIfAbsentPutWithKey(<(literal.(type1))("10")>, function));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void putAllThrowsException()
     {
         Unmodifiable<name1><name2>Map copyMap = new Unmodifiable<name1><name2>Map(<name1><name2>HashMap.newWithKeysValues(<["0", "31", "32"]:keyValue(); separator=", ">));
-        this.map.putAll(copyMap);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.putAll(copyMap));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void updateValue()
     {
         <name2>To<name2>Function incrementFunction = (<type2> value) -> <(castIntToNarrowTypeWithParens.(type2))({value + <(literal.(type2))("1")>})>;
-        this.map.updateValue(<keyValue("0")>, incrementFunction);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.map.updateValue(<keyValue("0")>, incrementFunction));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
@@ -126,67 +126,76 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.classUnderTest().add(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
     <if(primitive2.floatingPoint)><NaNTests()><endif>
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.classUnderTest().with(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.classUnderTest().without(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().without(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.classUnderTest().withAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.classUnderTest().withoutAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().withoutAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type2))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().remove(<(literal.(type2))("0")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name2>Predicates.equal(<(literal.(type2))("0")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                    this.classUnderTest().removeIf(<name2>Predicates.equal(<(literal.(type2))("0")>)));
     }
 
     @Override
@@ -199,39 +208,39 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.newWith().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.newWith().removeAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.newWith().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.newWith().retainAll(new <name2>ArrayList());
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name2>ArrayList()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
         Mutable<name2>Collection emptyCollection = this.newWith();
-        emptyCollection.clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.

Also fix some compiler warnings by converting `new Long()` to `Long.valueOf()`