### PR TITLE
@Test(expected=X) → assertThrows(X) in mutable List tests

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/abstractPrimitiveListTestCase.stg
@@ -88,16 +88,16 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(expected, actual);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void get_throws_index_greater_than_size()
     {
-        this.classUnderTest().get(3);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void get_throws_index_negative()
     {
-        this.classUnderTest().get(-1);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(-1));
     }
 
     @Test
@@ -108,10 +108,10 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getFirst_emptyList_throws()
     {
-        this.newWith().getFirst();
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getFirst());
     }
 
     @Test
@@ -122,10 +122,10 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(<(wideLiteral.(type))("3")>, this.classUnderTest().getLast()<(wideDelta.(type))>);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLast_emptyList_throws()
     {
-        this.newWith().getLast();
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().getLast());
     }
 
     @Test
@@ -136,12 +136,12 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void dotProduct_throwsOnListsOfDifferentSizes()
     {
         Mutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>List list2 = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        list1.dotProduct(list2);
+        Assert.assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Test
@@ -175,16 +175,16 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "5", "3", "4"]:(literal.(type))(); separator=", ">), arrayList);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAtIndex_throws_index_greater_than_size()
     {
-        this.newWith().addAtIndex(1, <(literal.(type))("0")>);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().addAtIndex(1, <(literal.(type))("0")>));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAtIndex_throws_index_negative()
     {
-        this.classUnderTest().addAtIndex(-1, <(literal.(type))("4")>);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAtIndex(-1, <(literal.(type))("4")>));
     }
 
     @Override
@@ -214,28 +214,30 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6", "5", "6", "7", "8"]:(literal.(type))(); separator=", ">), list);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAll_throws_index_negative()
     {
-        this.classUnderTest().addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAll_throws_index_greater_than_size()
     {
-        this.classUnderTest().addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAllIterable_throws_index_negative()
     {
-        this.classUnderTest().addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+                this.classUnderTest().addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAllIterable_throws_index_greater_than_size()
     {
-        this.classUnderTest().addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+                this.classUnderTest().addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
@@ -246,16 +248,16 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void removeAtIndex_throws_index_greater_than_size()
     {
-        this.newWith().removeAtIndex(1);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith().removeAtIndex(1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void removeAtIndex_throws_index_negative()
     {
-        this.classUnderTest().removeAtIndex(-1);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().removeAtIndex(-1));
     }
 
     @Test
@@ -276,10 +278,10 @@ public abstract class Abstract<name>ListTestCase extends AbstractMutable<name>Co
         Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "2"]:(literal.(type))(); separator=", ">), list);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void subList()
     {
-        this.classUnderTest().subList(0, 1);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/boxedMutableArrayListTest.stg
@@ -70,10 +70,10 @@ public class BoxedMutable<name>ListTest
         Assert.assertEquals(<(literal.(type))("2")>, (<type>) this.classUnderTest().remove(1)<wideDelta.(type)>);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void removeIndexOutOfBounds()
     {
-        this.classUnderTest().remove(10);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().remove(10));
     }
 
     @Test
@@ -125,10 +125,10 @@ public class BoxedMutable<name>ListTest
         Verify.assertEmpty(list);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexOutOfBounds()
     {
-        this.classUnderTest().set(5, <(literal.(type))("5")>);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().set(5, <(literal.(type))("5")>));
     }
 
     @Test
@@ -139,10 +139,10 @@ public class BoxedMutable<name>ListTest
         Assert.assertEquals(<(literal.(type))("2")>, (<type>) list.get(1)<wideDelta.(type)>);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getIndexOutOfBounds()
     {
-        this.classUnderTest().get(5);
+        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(5));
     }
 
     @Test
@@ -153,16 +153,17 @@ public class BoxedMutable<name>ListTest
         Assert.assertEquals(Lists.mutable.of(<["1", "7", "9", "2", "3"]:(literal.(type))(); separator=", ">), list);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void addAllIndexOutOfBounds()
     {
-        this.classUnderTest().addAll(5, Lists.mutable.of(<(literal.(type))("7")>, <(literal.(type))("9")>));
+        Assert.assertThrows(IndexOutOfBoundsException.class, () ->
+                this.classUnderTest().addAll(5, Lists.mutable.of(<(literal.(type))("7")>, <(literal.(type))("9")>)));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void subList()
     {
-        this.classUnderTest().subList(1, 3);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(1, 3));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/primitiveArrayListTest.stg
@@ -69,10 +69,10 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
         Verify.assertSize(0, newList2);
     }
 
-    @Test(expected = NegativeArraySizeException.class)
+    @Test
     public void newWithNValues_throws_negative_size()
     {
-        <name>ArrayList.newWithNValues(-5, <(literal.(type))("42")>);
+        Assert.assertThrows(NegativeArraySizeException.class, () -> <name>ArrayList.newWithNValues(-5, <(literal.(type))("42")>));
     }
 
     @Test
@@ -126,12 +126,12 @@ public class <name>ArrayListTest extends Abstract<name>ListTestCase
     }
 
     @Override
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void dotProduct_throwsOnListsOfDifferentSizes()
     {
         <name>ArrayList list1 = <name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         <name>ArrayList list2 = <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        list1.dotProduct(list2);
+        Assert.assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/mutable/unmodifiablePrimitiveListTest.stg
@@ -49,268 +49,293 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAtIndex()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(0, <(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(0, <(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAtIndex_throws_index_greater_than_size()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(1, <(literal.(type))("0")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).addAtIndex(1, <(literal.(type))("0")>));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void unmodifiableBoxed()
     {
-        this.classUnderTest().boxed().add(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().boxed().add(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAtIndex_throws_index_negative()
     {
-        this.list.addAtIndex(-1, <(literal.(type))("4")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAtIndex(-1, <(literal.(type))("4")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll_throws_index_negative()
     {
-        this.list.addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(-1, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAll_throws_index_greater_than_size()
     {
-        this.list.addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.addAllAtIndex(5, <["5", "6"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable_throws_index_negative()
     {
-        this.list.addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.list.addAllAtIndex(-1, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable_throws_index_greater_than_size()
     {
-        this.list.addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.list.addAllAtIndex(5, <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAtIndex()
     {
-        this.list.removeAtIndex(1);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAtIndex_throws_index_greater_than_size()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).removeAtIndex(1);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).removeAtIndex(1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAtIndex_throws_index_negative()
     {
-        this.list.removeAtIndex(-1);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.removeAtIndex(-1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void set()
     {
-        this.list.set(1, <(literal.(type))("4")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.set(1, <(literal.(type))("4")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void swap()
     {
-        this.list.swap(0, 1);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.swap(0, 1));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void clear()
     {
-        this.classUnderTest().clear();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void add()
     {
-        this.newWith().add(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().add(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllArray()
     {
-        this.classUnderTest().addAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addAllIterable()
     {
-        this.classUnderTest().addAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().addAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void remove()
     {
-        this.classUnderTest().remove(<(literal.(type))("1")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeIf()
     {
-        this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll()
     {
-        this.classUnderTest().removeAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void removeAll_iterable()
     {
-        this.classUnderTest().removeAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().removeAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll()
     {
-        this.classUnderTest().retainAll();
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retainAll_iterable()
     {
-        this.classUnderTest().retainAll(this.newMutableCollectionWith());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.classUnderTest().retainAll(this.newMutableCollectionWith()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void with()
     {
-        this.newWith().with(<["1"]:(literal.(type))(); separator=", ">);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().with(<["1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withAll()
     {
-        this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith().withAll(this.newMutableCollectionWith(<(literal.(type))("1")>)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void without()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).without(<(literal.(type))("9")>));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void withoutAll()
     {
-        this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+                this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void reverseThis()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).reverseThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).reverseThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortThis()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortWithPrimitiveComparator()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis(<wrapperName>::compare);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis(<wrapperName>::compare));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortWithOddEvenComparator()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1)));
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList())
+                .sortThis((a, b) -> (int) ((int) ((int) a & 1) - ((int) b & 1))));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortWithKeyExtractorNaturalComparator()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString);
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortWithKeyExtractorUnnaturalComparator()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThisBy(<wrapperName>::toString, Comparators.naturalOrder().reversed());
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList())
+                .sortThisBy(<wrapperName>::toString, Comparators.naturalOrder().reversed()));
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortShuffledInputWithDupes()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortShuffledInput()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortSortedInput()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void sortReversedSortedInput()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).sortThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).sortThis());
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shuffleThis()
     {
-        new Unmodifiable<name>List(new <name>ArrayList()).shuffleThis();
+        Assert.assertThrows(UnsupportedOperationException.class, () ->
+            new Unmodifiable<name>List(new <name>ArrayList()).shuffleThis());
     }
 
     @Override
@@ -339,7 +364,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws_non_empty_collection()
     {
         Unmodifiable<name>List collection = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
@@ -348,7 +373,7 @@ public class Unmodifiable<name>ListTest extends Abstract<name>ListTestCase
         {
             iterator.next();
         }
-        iterator.next();
+        Assert.assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override


### PR DESCRIPTION
`@Test` does not have the "expected" field in junit-jupiter. This paves the way to moving to junit-jupiter.