### PR TITLE
reverse interval ranges

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/Interval.java
@@ -100,7 +100,8 @@ public final class Interval
      */
     public Interval to(int newTo)
     {
-        return Interval.fromToBy(this.from, newTo, this.step);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(this.from, newTo, this.step);
+        return Interval.fromToBy(this.from, newTo, adjustedStep);
     }
 
     /**
@@ -137,7 +138,8 @@ public final class Interval
      */
     public static Interval oneTo(int count)
     {
-        return Interval.oneToBy(count, 1);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(1, count, 1);
+        return Interval.oneToBy(count, adjustedStep);
     }
 
     /**
@@ -145,10 +147,6 @@ public final class Interval
      */
     public static Interval oneToBy(int count, int step)
     {
-        if (count < 1)
-        {
-            throw new IllegalArgumentException("Only positive ranges allowed using oneToBy");
-        }
         return Interval.fromToBy(1, count, step);
     }
 
@@ -157,7 +155,8 @@ public final class Interval
      */
     public static Interval zeroTo(int count)
     {
-        return Interval.zeroToBy(count, 1);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(0, count, 1);
+        return Interval.zeroToBy(count, adjustedStep);
     }
 
     /**
@@ -181,7 +180,7 @@ public final class Interval
     }
 
     /**
-     * Returns an Interval starting from the value from until the specified value to (exclusive) with a step value of 1
+     * Returns an Interval starting from the value from until the specified value to (exclusive) with a step value of 1.
      */
     public static Interval fromToExclusive(int from, int to)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/IntervalUtils.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/IntervalUtils.java
@@ -113,5 +113,11 @@ public final class IntervalUtils
         int index = (int) (diff / step);
         return diff % step == 0L ? index : (index + 2) * -1;
     }
+
+    public static int calculateAdjustedStep(int from, int to, int stepBy)
+    {
+        int direction = Integer.signum(to - from);
+        return direction == 0 ? stepBy : direction * stepBy;
+    }
 }
 

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/IntInterval.java
@@ -101,7 +101,8 @@ public final class IntInterval
      */
     public IntInterval to(int newTo)
     {
-        return IntInterval.fromToBy(this.from, newTo, this.step);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(this.from, newTo, this.step);
+        return IntInterval.fromToBy(this.from, newTo, adjustedStep);
     }
 
     /**
@@ -138,7 +139,8 @@ public final class IntInterval
      */
     public static IntInterval oneTo(int count)
     {
-        return IntInterval.oneToBy(count, 1);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(1, count, 1);
+        return IntInterval.oneToBy(count, adjustedStep);
     }
 
     /**
@@ -146,10 +148,6 @@ public final class IntInterval
      */
     public static IntInterval oneToBy(int count, int step)
     {
-        if (count < 1)
-        {
-            throw new IllegalArgumentException("Only positive ranges allowed using oneToBy");
-        }
         return IntInterval.fromToBy(1, count, step);
     }
 
@@ -158,7 +156,8 @@ public final class IntInterval
      */
     public static IntInterval zeroTo(int count)
     {
-        return IntInterval.zeroToBy(count, 1);
+        int adjustedStep = IntervalUtils.calculateAdjustedStep(0, count, 1);
+        return IntInterval.zeroToBy(count, adjustedStep);
     }
 
     /**

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/primitive/LongInterval.java
@@ -104,7 +104,8 @@ public final class LongInterval
      */
     public LongInterval to(long newTo)
     {
-        return LongInterval.fromToBy(this.from, newTo, this.step);
+        long adjustedStep = LongInterval.calculateAdjustedStep(this.from, newTo, this.step);
+        return LongInterval.fromToBy(this.from, newTo, adjustedStep);
     }
 
     /**
@@ -141,7 +142,8 @@ public final class LongInterval
      */
     public static LongInterval oneTo(long count)
     {
-        return LongInterval.oneToBy(count, 1);
+        long adjustedStep = LongInterval.calculateAdjustedStep(1L, count, 1L);
+        return LongInterval.oneToBy(count, adjustedStep);
     }
 
     /**
@@ -149,10 +151,6 @@ public final class LongInterval
      */
     public static LongInterval oneToBy(long count, long step)
     {
-        if (count < 1)
-        {
-            throw new IllegalArgumentException("Only positive ranges allowed using oneToBy");
-        }
         return LongInterval.fromToBy(1, count, step);
     }
 
@@ -161,7 +159,8 @@ public final class LongInterval
      */
     public static LongInterval zeroTo(long count)
     {
-        return LongInterval.zeroToBy(count, 1);
+        long adjustedStep = LongInterval.calculateAdjustedStep(0L, count, 1L);
+        return LongInterval.zeroToBy(count, adjustedStep);
     }
 
     /**
@@ -1087,5 +1086,11 @@ public final class LongInterval
             }
             return this.current >= this.to;
         }
+    }
+
+    private static long calculateAdjustedStep(long from, long to, long stepBy)
+    {
+        int direction = Long.signum(to - from);
+        return direction == 0 ? stepBy : (long) direction * stepBy;
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -106,6 +106,7 @@ public class IntervalTest
         Verify.assertEqualsAndHashCode(interval3, Interval.fromToBy(1, 10, 2));
         Verify.assertSize(Integer.MAX_VALUE, Interval.fromTo(Integer.MIN_VALUE + 1, -1));
         Verify.assertSize(Integer.MAX_VALUE, Interval.fromTo(1, Integer.MAX_VALUE));
+        Verify.assertSize(21, Interval.from(10).to(-10).by(-1));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
         Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(-1, Integer.MAX_VALUE));
@@ -124,6 +125,13 @@ public class IntervalTest
     public void fromToBy_throws_step_size_zero()
     {
         Interval.fromToBy(0, 0, 0);
+    }
+
+    @Test
+    public void fromAndToAndBy_throws_step_is_incorrect()
+    {
+        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.from(10).to(-10).by(1));
+        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.from(-10).to(10).by(-1));
     }
 
     @Test
@@ -537,6 +545,8 @@ public class IntervalTest
         Verify.assertSize(500_000_000, Interval.oneTo(2_000_000_000).by(4));
         Verify.assertSize(222_222_223, Interval.oneTo(2_000_000_000).by(9));
         // Negative Ranges
+        Verify.assertSize(10, Interval.zeroTo(-9));
+        Verify.assertSize(11, Interval.oneTo(-9));
         Verify.assertSize(10, Interval.fromTo(0, -9));
         Verify.assertSize(2_000_000_000, Interval.fromTo(-1, -2_000_000_000));
         Verify.assertSize(200_000_000, Interval.fromTo(-1, -2_000_000_000).by(-10));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -62,6 +62,7 @@ public class IntIntervalTest
         Verify.assertEqualsAndHashCode(interval3, IntInterval.fromToBy(1, 10, 2));
         Verify.assertSize(Integer.MAX_VALUE, IntInterval.fromTo(Integer.MIN_VALUE + 1, -1));
         Verify.assertSize(Integer.MAX_VALUE, IntInterval.fromTo(1, Integer.MAX_VALUE));
+        Verify.assertSize(21, IntInterval.from(10).to(-10).by(-1));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
         Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(-1, Integer.MAX_VALUE));
@@ -86,6 +87,13 @@ public class IntIntervalTest
     public void fromToBy_throws_on_illegal_step()
     {
         IntInterval.fromToBy(5, 0, 1);
+    }
+
+    @Test
+    public void fromAndToAndBy_throws_step_is_incorrect()
+    {
+        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.from(10).to(-10).by(1));
+        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.from(-10).to(10).by(-1));
     }
 
     @Test
@@ -337,6 +345,8 @@ public class IntIntervalTest
         Verify.assertSize(2, IntInterval.fromToBy(Integer.MAX_VALUE - 10, Integer.MAX_VALUE, 8));
 
         // Negative Ranges
+        Verify.assertSize(10, IntInterval.zeroTo(-9));
+        Verify.assertSize(11, IntInterval.oneTo(-9));
         Verify.assertSize(10, IntInterval.fromTo(0, -9));
         Verify.assertSize(2_000_000_000, IntInterval.fromTo(-1, -2_000_000_000));
         Verify.assertSize(200_000_000, IntInterval.fromTo(-1, -2_000_000_000).by(-10));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
@@ -60,6 +60,7 @@ public class LongIntervalTest
         Verify.assertEqualsAndHashCode(interval3, LongInterval.fromToBy(1, 10, 2));
         Verify.assertSize(Integer.MAX_VALUE, LongInterval.fromTo(Integer.MIN_VALUE + 1, -1));
         Verify.assertSize(Integer.MAX_VALUE, LongInterval.fromTo(1, Integer.MAX_VALUE));
+        Verify.assertSize(21, LongInterval.from(10L).to(-10L).by(-1L));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
         Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(-1, Integer.MAX_VALUE));
@@ -102,6 +103,13 @@ public class LongIntervalTest
     public void fromToBy_throws_on_illegal_step()
     {
         LongInterval.fromToBy(5, 0, 1);
+    }
+
+    @Test
+    public void fromAndToAndBy_throws_step_is_incorrect()
+    {
+        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.from(10L).to(-10L).by(1L));
+        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.from(-10L).to(10L).by(-1L));
     }
 
     @Test
@@ -353,6 +361,8 @@ public class LongIntervalTest
         Verify.assertSize(2, LongInterval.fromToBy(Integer.MAX_VALUE - 10, Integer.MAX_VALUE, 8));
 
         // Negative Ranges
+        Verify.assertSize(10, LongInterval.zeroTo(-9));
+        Verify.assertSize(11, LongInterval.oneTo(-9));
         Verify.assertSize(10, LongInterval.fromTo(0, -9));
         Verify.assertSize(2_000_000_000, LongInterval.fromTo(-1, -2_000_000_000));
         Verify.assertSize(200_000_000, LongInterval.fromTo(-1, -2_000_000_000).by(-10));


### PR DESCRIPTION
Closes: #1564 

Hi @donraab,

In this PR, I tried to keep the changes as much consistent as possible.

Upon consideration, I think there might be a different way to approach this.

In my opinion we might consider allowing the direction of the interval to be determined by difference of `from - to`.

1. We allow `step` to have different values and sign
1.a. Pro: Not invasive
1.b. Con: The API doesn't look nice. i.e. fromToBy(0, 10, -1)

2. We allow `step` to only be positive
2.a. Pro: This would reflect more a "real life" situation, where having negative steps is not allowed. i.e. a car is moving in some direction with this many km/h. if the car reverses, the direction changes but the speed is still positive.
2.b. Con: Somehow invasive.