### PR TITLE
Add allSatisfyKeyValue method to Object/Primitive Maps to optimize HashBag equals method.

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/objectPrimitiveMap.stg
@@ -95,6 +95,21 @@ public interface Object<name>Map\<K> extends <name>Iterable
     <if(!primitive.booleanPrimitive)><(flipUniqueValues.(name))(name)><endif>
 
     /**
+     * @since 12.0
+     */
+    default boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        for (Object<name>Pair\<K> pair : this.keyValuesView())
+        {
+            if (!predicate.accept(pair.getOne(), pair.getTwo()))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Implements the injectInto pattern with each key/value pair of the map.
      * @param value to be injected into the map
      * @param function to apply to the injected value and key/value pairs

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveHashMap.stg
@@ -298,6 +298,15 @@ final class ImmutableObject<name>HashMap\<K> extends AbstractImmutableObject<nam
         this.delegate.forEachKeyValue(object<name>Procedure);
     }
 
+    /**
+     * @since 12.0
+     */
+    @Override
+    public boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        return this.delegate.allSatisfyKeyValue(predicate);
+    }
+
     @Override
     public ImmutableObject<name>Map\<K> select(Object<name>Predicate\<? super K> object<name>Predicate)
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutableObjectPrimitiveSingletonMap.stg
@@ -1,4 +1,4 @@
-import "copyright.stg"
+import "copyrightAndOthers.stg"
 import "primitiveEquals.stg"
 import "primitiveHashCode.stg"
 import "primitiveLiteral.stg"
@@ -12,7 +12,7 @@ class(primitive) ::= <<
 >>
 
 body(type, name) ::= <<
-<copyright()>
+<copyrightAndOthers()>
 
 package org.eclipse.collections.impl.map.immutable.primitive;
 
@@ -326,6 +326,19 @@ final class ImmutableObject<name>SingletonMap\<K> extends AbstractImmutableObjec
     public void forEachKeyValue(Object<name>Procedure\<? super K> object<name>Procedure)
     {
         object<name>Procedure.value(this.key1, this.value1);
+    }
+
+    /**
+     * @since 12.0
+     */
+    @Override
+    public boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        if (!predicate.accept(this.key1, this.value1))
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMap.stg
@@ -216,9 +216,14 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
 
         for (int i = 0; i \< this.keys.length; i++)
         {
-            if (isNonSentinel(this.keys[i]) && (!other.containsKey(this.toNonSentinel(this.keys[i])) || <(notEquals.(type))("this.values[i]", "other.getOrThrow(this.toNonSentinel(this.keys[i]))")>))
+            Object key = this.keys[i];
+            if (isNonSentinel(key))
             {
-                return false;
+                K nonSentinel = this.toNonSentinel(key);
+                if (!other.containsKey(nonSentinel) || <(notEquals.(type))("this.values[i]", "other.getOrThrow(nonSentinel)")>)
+                {
+                    return false;
+                }
             }
         }
         return true;
@@ -863,6 +868,26 @@ public class Object<name>HashMap\<K> implements MutableObject<name>Map\<K>, Exte
             }
         }
         return count;
+    }
+
+    /**
+     * @since 12.0
+     */
+    @Override
+    public boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        for (int i = 0; i \< this.keys.length; i++)
+        {
+            Object key = this.keys[i];
+            if (isNonSentinel(key))
+            {
+                if (!predicate.accept(this.toNonSentinel(key), this.values[i]))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/objectPrimitiveHashMapWithHashingStrategy.stg
@@ -788,6 +788,26 @@ public class Object<name>HashMapWithHashingStrategy\<K> implements MutableObject
         }
     }
 
+    /**
+     * @since 12.0
+     */
+    @Override
+    public boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        for (int i = 0; i \< this.keys.length; i++)
+        {
+            Object key = this.keys[i];
+            if (isNonSentinel(key))
+            {
+                if (!predicate.accept(this.toNonSentinel(key), this.values[i]))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     @Override
     public Object<name>HashMapWithHashingStrategy\<K> select(Object<name>Predicate\<? super K> predicate)
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedObjectPrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedObjectPrimitiveMap.stg
@@ -285,6 +285,18 @@ public class SynchronizedObject<name>Map\<K>
         }
     }
 
+    /**
+     * @since 12.0
+     */
+    @Override
+    public boolean allSatisfyKeyValue(Object<name>Predicate\<K> predicate)
+    {
+        synchronized (this.lock)
+        {
+            return this.allSatisfyKeyValue(predicate);
+        }
+    }
+
     @Override
     public MutableObject<name>Map\<K> select(Object<name>Predicate\<? super K> predicate)
     {

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractHashBag.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bag/mutable/AbstractHashBag.java
@@ -67,8 +67,7 @@ public abstract class AbstractHashBag<T> extends AbstractMutableBag<T>
         {
             return false;
         }
-
-        return this.items.keyValuesView().allSatisfy(each -> bag.occurrencesOf(each.getOne()) == each.getTwo());
+        return this.items.allSatisfyKeyValue((key, count) -> bag.occurrencesOf(key) == count);
     }
 
     @Override

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/BagEqualsTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/BagEqualsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.jmh;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.tuple.Triplet;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.factory.Bags;
+import org.eclipse.collections.impl.list.Interval;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 2)
+@Measurement(iterations = 10, time = 2)
+public class BagEqualsTest
+{
+    private final MutableBag<String> bag = Bags.mutable.withOccurrences("1", 1, "2", 2, "3", 3, "4", 4);
+    private final MutableBag<String> equalBag = Bags.mutable.withOccurrences("1", 1, "2", 2, "3", 3, "4", 4);
+    private final MutableBag<String> unequalBag1 = Bags.mutable.withOccurrences("1", 4, "2", 3, "3", 2, "4", 1);
+    private final MutableBag<String> unequalBag2 = Bags.mutable.withOccurrences("1", 1, "2", 2, "3", 3, "4", 1);
+    private final Multiset<String> multiset = HashMultiset.create(this.bag);
+    private final Multiset<String> equalMultiset = HashMultiset.create(this.bag);
+    private final Multiset<String> unequalMultiset1 = HashMultiset.create(this.unequalBag1);
+    private final Multiset<String> unequalMultiset2 = HashMultiset.create(this.unequalBag2);
+    private final Map<String, Long> map =
+            this.bag.stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<String, Long> equalMap =
+            this.bag.stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<String, Long> unequalMap1 =
+            this.unequalBag1.stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<String, Long> unequalMap2 =
+            this.unequalBag2.stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+
+    @Benchmark
+    public boolean[] multisetEquals()
+    {
+        boolean equals = this.multiset.equals(this.equalMultiset);
+        boolean unequals1 = this.multiset.equals(this.unequalMultiset1);
+        boolean unequals2 = this.multiset.equals(this.unequalMultiset2);
+        return new boolean[]{equals, unequals1, unequals2};
+    }
+
+    @Benchmark
+    public boolean[] bagEquals()
+    {
+        boolean equals = this.bag.equals(this.equalBag);
+        boolean unequals1 = this.bag.equals(this.unequalBag1);
+        boolean unequals2 = this.bag.equals(this.unequalBag2);
+        return new boolean[]{equals, unequals1, unequals2};
+    }
+
+    @Benchmark
+    public boolean[] mapEquals()
+    {
+        boolean equals = this.map.equals(this.equalMap);
+        boolean unequals1 = this.map.equals(this.unequalMap1);
+        boolean unequals2 = this.map.equals(this.unequalMap2);
+        return new boolean[]{equals, unequals1, unequals2};
+    }
+}


### PR DESCRIPTION
I wrote a JMH Benchmark to compare the performance of the equals methods in HashBag, HashMultiset (Guava) and HashMap (Java). I was surprised to find that HashBag equals was slower than HashMap. I added a new method named shortCircuitKeyValue to Object/Primitive Maps and based the equals method in AbstractHashBag on using this method as a manual way of implementing allSatisfyKeyValue. I had originally added any/all/noneSatisfyKeyValue as well, but backed out those additions as a potential later change.

The following are the results of the JMH tests before and after changes.

Original Code

```
Benchmark                      Mode  Cnt      Score      Error   Units
BagEqualsTest.bagEquals       thrpt   20  19770.401 ±  139.757  ops/ms
BagEqualsTest.mapEquals       thrpt   20  23120.905 ±  246.497  ops/ms
BagEqualsTest.multisetEquals  thrpt   20  12867.562 ± 1087.486  ops/ms
```

Using `AbstractHashBag` `instanceof` and direct items map `equals`

```
Benchmark                      Mode  Cnt      Score     Error   Units
BagEqualsTest.bagEquals       thrpt   20  19328.068 ± 158.372  ops/ms
BagEqualsTest.mapEquals       thrpt   20  22618.070 ± 362.793  ops/ms
BagEqualsTest.multisetEquals  thrpt   20  13990.621 ±  29.081  ops/ms
```

Using `allSatisfyKeyValue`

```
Benchmark                      Mode  Cnt      Score     Error   Units
BagEqualsTest.bagEquals       thrpt   20  24719.542 ±  17.943  ops/ms
BagEqualsTest.mapEquals       thrpt   20  23109.328 ± 235.381  ops/ms
BagEqualsTest.multisetEquals  thrpt   20  14542.701 ±  66.522  ops/ms
```
Additionally, I refactored the value based any/all/noneSatisfy methods on the Object/Primitive Maps to use shortCircuitKeyValue. I tried using Object/Primitive Map equals to implement the HashBag equals, but found that was even slower. I updated the equals method slightly to remove some extra index lookups and multiple conversions. This sped the code up by around 10% when I measured it, but it was still slower than the shortCircuitKeyValue solution. 

Update: I rolled back the `shortCircuitKeyValue` implementation and renamed to `allSatisfyKeyValue`.
