### PR TITLE
Junit5 Migration Part 1 - #1576

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/bag/mutable/unmodifiablePrimitiveBagTest.stg
@@ -28,6 +28,7 @@ import org.eclipse.collections.impl.factory.primitive.<name>Bags;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -70,10 +71,10 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void addOccurrences_throws()
     {
-        this.newWith().addOccurrences(<(literal.(type))("1")>, -1);
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().addOccurrences(<(literal.(type))("1")>, -1));
     }
 
     @Override
@@ -242,7 +243,7 @@ public class Unmodifiable<name>BagTest extends AbstractMutable<name>BagTestCase
     {
         super.asUnmodifiable();
         Assert.assertSame(this.bag, this.bag.asUnmodifiable());
-        Assert.assertEquals(this.bag, this.bag.asUnmodifiable());
+        assertEquals(this.bag, this.bag.asUnmodifiable());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractMutablePrimitiveCollectionTestCase.stg
@@ -30,6 +30,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * Abstract JUnit test for {@link Mutable<name>Collection}s
  * This file was automatically generated from template file abstractMutablePrimitiveCollectionTestCase.stg.
@@ -73,7 +76,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         collection2.clear();
         Verify.assertSize(0, collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection2);
+        assertEquals(this.newMutableCollectionWith(), collection2);
     }
 
     @Override
@@ -111,10 +114,10 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection emptyCollection = this.newWith();
         Assert.assertTrue(emptyCollection.add(<(literal.(type))("1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyCollection);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), emptyCollection);
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertTrue(collection.add(<(literal.(type))("4")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
@@ -123,7 +126,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.addAll());
         Assert.assertTrue(collection.addAll(<["4", "5", "6"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
@@ -132,7 +135,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.addAll(this.newMutableCollectionWith()));
         Assert.assertTrue(collection.addAll(this.newMutableCollectionWith(<["4", "5", "6"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5", "6"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
@@ -140,9 +143,9 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.remove(<(literal.(type))("-1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.remove(<(literal.(type))("3")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
@@ -150,13 +153,13 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.removeIf(<name>Predicates.equal(<(literal.(type))("-1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.removeIf(<name>Predicates.equal(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
         Assert.assertFalse(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
         Assert.assertTrue(collection.removeIf(<name>Predicates.alwaysTrue()));
         Assert.assertTrue(collection.isEmpty());
         Assert.assertFalse(collection.removeIf(<name>Predicates.alwaysTrue()));
@@ -168,35 +171,35 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
 
         collection = this.classUnderTest();
         Assert.assertFalse(collection.removeIf(<name>Predicates.alwaysFalse()));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         Assert.assertTrue(collection.removeIf(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         Assert.assertTrue(collection.removeIf(<name>Predicates.lessThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         Mutable<name>Collection remove = this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.classUnderTest();
         remove = this.newMutableCollectionWith(<["2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "3"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.newMutableCollectionWith(<["1", "3", "2", "5", "6", "4"]:(literal.(type))(); separator=", ">);
         remove = this.newMutableCollectionWith(<["2", "4", "6"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">), collection);
 
         collection = this.newMutableCollectionWith(<["1", "3", "2", "5", "6", "4"]:(literal.(type))(); separator=", ">);
         remove = this.newMutableCollectionWith(<["1", "3", "5"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection.removeIf(remove::contains));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "6", "4"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["2", "6", "4"]:(literal.(type))(); separator=", ">), collection);
     }
 
     @Test
@@ -208,16 +211,16 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.removeAll());
         Assert.assertFalse(collection.removeAll(<(literal.(type))("-1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.removeAll(<["1", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.removeAll(<["3", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertFalse(collection1.removeAll());
         Assert.assertTrue(collection1.removeAll(<["0", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1);
     }
 
     @Test
@@ -226,24 +229,24 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.removeAll(this.newMutableCollectionWith()));
         Assert.assertFalse(collection.removeAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.removeAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">), collection);
         Mutable<name>Collection collection1 = this.classUnderTest();
         Assert.assertTrue(collection1.removeAll(this.newMutableCollectionWith(<["3", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3"]:(literal.(type))(); separator=", ">);
         Assert.assertFalse(collection2.removeAll(new <name>ArrayList()));
         Assert.assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2", "3"]:(literal.(type))(); separator=", ">), collection2);
         Assert.assertFalse(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("0")>)));
         Assert.assertTrue(collection2.removeAll(<name>ArrayList.newListWith(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection3.removeAll(<name>HashBag.newBagWith(<["0", "1", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
@@ -251,27 +254,27 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.retainAll(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.retainAll(<["1", "2", "5"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
 
         Mutable<name>Collection collection1 = this.classUnderTest();
         Assert.assertTrue(collection1.retainAll(<["-3", "1"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
         Assert.assertTrue(collection1.retainAll(<(literal.(type))("-1")>));
         Verify.assertEmpty(collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Assert.assertFalse(collection2.retainAll(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">));
         Assert.assertTrue(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
         Assert.assertFalse(collection2.retainAll(<["0", "1", "3"]:(literal.(type))(); separator=", ">));
         Assert.assertTrue(collection2.retainAll(<["5", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection3.retainAll(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
 
         Mutable<name>Collection collection4 = this.classUnderTest();
         Assert.assertTrue(collection4.retainAll());
@@ -283,27 +286,27 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.classUnderTest();
         Assert.assertFalse(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection);
         Assert.assertTrue(collection.retainAll(this.newMutableCollectionWith(<["1", "2", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection);
 
         Mutable<name>Collection collection1 = this.classUnderTest();
         Assert.assertTrue(collection1.retainAll(this.newMutableCollectionWith(<["-3", "1"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">), collection1);
         Assert.assertTrue(collection1.retainAll(this.newMutableCollectionWith(<(literal.(type))("-1")>)));
         Verify.assertEmpty(collection1);
 
         Mutable<name>Collection collection2 = this.newWith(<["0", "1", "1", "2", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Assert.assertFalse(collection2.retainAll(this.newMutableCollectionWith(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">)));
         Assert.assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "1", "3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
         Assert.assertFalse(collection2.retainAll(<name>ArrayList.newListWith(<["0", "1", "3"]:(literal.(type))(); separator=", ">)));
         Assert.assertTrue(collection2.retainAll(<name>ArrayList.newListWith(<["5", "3"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["3", "3", "3"]:(literal.(type))(); separator=", ">), collection2);
 
         Mutable<name>Collection collection3 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(collection3.retainAll(<name>HashBag.newBagWith(<["2", "8", "8", "2"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection3);
 
         Mutable<name>Collection collection4 = this.classUnderTest();
         Assert.assertTrue(collection4.retainAll(new <name>ArrayList()));
@@ -320,11 +323,11 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection2 = this.newWith().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>);
         Mutable<name>Collection collection3 = this.newWith().with(<(literal.(type))("1")>).with(<(literal.(type))("2")>).with(<(literal.(type))("3")>).with(<(literal.(type))("4")>).with(<(literal.(type))("5")>);
         Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
@@ -337,11 +340,11 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection collection2 = this.newWith().withAll(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">));
         Mutable<name>Collection collection3 = this.newWith().withAll(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">));
         Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
-        Assert.assertEquals(this.classUnderTest(), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("1")>), collection);
+        assertEquals(this.newMutableCollectionWith(<["1", "2"]:(literal.(type))(); separator=", ">), collection0);
+        assertEquals(this.classUnderTest(), collection1);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">), collection2);
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection3);
     }
 
     @Test
@@ -349,13 +352,13 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
         Assert.assertSame(collection, collection.without(<(literal.(type))("9")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("9")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("1")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("2")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("3")>));
-        Assert.assertEquals(this.newMutableCollectionWith(<(literal.(type))("5")>), collection.without(<(literal.(type))("4")>));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("5")>));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("6")>));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("9")>));
+        assertEquals(this.newMutableCollectionWith(<["2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("1")>));
+        assertEquals(this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("2")>));
+        assertEquals(this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">), collection.without(<(literal.(type))("3")>));
+        assertEquals(this.newMutableCollectionWith(<(literal.(type))("5")>), collection.without(<(literal.(type))("4")>));
+        assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("5")>));
+        assertEquals(this.newMutableCollectionWith(), collection.without(<(literal.(type))("6")>));
     }
 
     @Test
@@ -363,43 +366,43 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
     {
         Mutable<name>Collection collection = this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
         Assert.assertSame(collection, collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["2", "20"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<(literal.(type))("9")>)));
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["8", "9"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["1", "5"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">), collection.withoutAll(this.newMutableCollectionWith(<["2", "20"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<["3", "4"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(this.newMutableCollectionWith(<(literal.(type))("9")>)));
 
         Mutable<name>Collection collection1 = this.newWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1.withoutAll(<name>HashBag.newBagWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "2"]:(literal.(type))(); separator=", ">), collection1.withoutAll(<name>HashBag.newBagWith(<["0", "1"]:(literal.(type))(); separator=", ">)));
     }
 
     @Test
     public void asSynchronized()
     {
         Mutable<name>Collection collection = this.classUnderTest();
-        Assert.assertEquals(collection, collection.asSynchronized());
+        assertEquals(collection, collection.asSynchronized());
         Verify.assertInstanceOf(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asSynchronized().getClass(), this.classUnderTest().asSynchronized());
 
         Mutable<name>Collection collection1 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>Collection synchronizedCollection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).asSynchronized();
         Verify.assertInstanceOf(synchronizedCollection.getClass(), collection1.asSynchronized());
-        Assert.assertEquals(synchronizedCollection, collection1.asSynchronized());
+        assertEquals(synchronizedCollection, collection1.asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable().getClass(), this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
 
         Mutable<name>Collection collection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
         Mutable<name>Collection unmodifiableCollection = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).asUnmodifiable();
         Verify.assertInstanceOf(unmodifiableCollection.getClass(), collection.asUnmodifiable());
-        Assert.assertEquals(unmodifiableCollection, collection.asUnmodifiable());
+        assertEquals(unmodifiableCollection, collection.asUnmodifiable());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws_non_empty_collection()
     {
         super.<type>Iterator_throws_non_empty_collection();
@@ -412,7 +415,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         {
             iterator.next();
         }
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -426,7 +429,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
             iterator.remove();
         }
         Verify.assertEmpty(<type>Iterable);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -435,7 +438,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Mutable<name>Collection <type>Iterable = this.classUnderTest();
         Mutable<name>Iterator iterator = <type>Iterable.<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
@@ -446,7 +449,7 @@ public abstract class AbstractMutable<name>CollectionTestCase extends Abstract<n
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
         iterator.remove();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -60,6 +60,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * Abstract JUnit test for {@link <name>Iterable}s
  * This file was automatically generated from template file abstractPrimitiveIterableTestCase.stg.
@@ -94,9 +97,9 @@ public abstract class Abstract<name>IterableTestCase
     @Test
     public void newCollection()
     {
-        Assert.assertEquals(this.newMutableCollectionWith(), this.newWith());
-        Assert.assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(), this.newWith());
+        assertEquals(this.newMutableCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">));
+        assertEquals(this.newMutableCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">));
     }
 
     @Test
@@ -129,7 +132,7 @@ public abstract class Abstract<name>IterableTestCase
         Mutable<name>List tapResult = <name>Lists.mutable.empty();
         <name>Iterable collection = this.newWith(<["14", "2", "30", "31", "32", "35", "0", "1"]:(literal.(type))(); separator=", ">);
         Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Test
@@ -447,7 +450,7 @@ public abstract class Abstract<name>IterableTestCase
     @Test
     public abstract void <type>Iterator();
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws()
     {
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
@@ -455,10 +458,10 @@ public abstract class Abstract<name>IterableTestCase
         {
             iterator.next();
         }
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void <type>Iterator_throws_non_empty_collection()
     {
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
@@ -467,7 +470,7 @@ public abstract class Abstract<name>IterableTestCase
         {
             iterator.next();
         }
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -478,7 +481,7 @@ public abstract class Abstract<name>IterableTestCase
 
         int size = this.classUnderTest().size();
         long sum1 = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum1, sum[0]<wideDelta.(type)>);
+        assertEquals(sum1, sum[0]<wideDelta.(type)>);
     }
 
     @Test
@@ -494,11 +497,11 @@ public abstract class Abstract<name>IterableTestCase
     {
         <name>Iterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 3 ? 3 : size, iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertEquals(2L, this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).count(<name>Predicates.greaterThan(<zero.(type)>)));
+        assertEquals(size >= 3 ? 3 : size, iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertEquals(2L, this.newWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).count(<name>Predicates.greaterThan(<zero.(type)>)));
 
-        Assert.assertEquals(1, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysTrue()));
-        Assert.assertEquals(0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysFalse()));
+        assertEquals(1, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysTrue()));
+        assertEquals(0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.alwaysFalse()));
     }
 
     @Test
@@ -516,8 +519,8 @@ public abstract class Abstract<name>IterableTestCase
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size > 3, iterable1.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size != 0, iterable1.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size > 3, iterable1.anySatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size != 0, iterable1.anySatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
@@ -536,8 +539,8 @@ public abstract class Abstract<name>IterableTestCase
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size == 0, iterable1.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size \< 3, iterable1.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size == 0, iterable1.allSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size \< 3, iterable1.allSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
@@ -556,80 +559,80 @@ public abstract class Abstract<name>IterableTestCase
 
         <name>Iterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size \<= 3, iterable1.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
-        Assert.assertEquals(size == 0, iterable1.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
+        assertEquals(size \<= 3, iterable1.noneSatisfy(<name>Predicates.greaterThan(<(literal.(type))("3")>)));
+        assertEquals(size == 0, iterable1.noneSatisfy(<name>Predicates.lessThan(<(literal.(type))("3")>)));
     }
 
     @Test
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = parameter -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "1", "2", "2", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function));
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Test
     public void collectWithTarget()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = parameter -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().collect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.collect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().collect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void flatCollectWithTarget()
     {
         <name>ToObjectFunction\<List\<<wrapperName>\>> function = parameter -> Lists.mutable.with(<(castIntToNarrowTypeWithParens.(type))("parameter - 1")>);
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void flatCollectIterableWithTarget()
     {
         <name>ToObjectFunction\<Iterable\<<wrapperName>\>> function = parameter -> Lists.mutable.with(<(castIntToNarrowTypeWithParens.(type))("parameter - 1")>).asLazy();
-        Assert.assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
+        assertEquals(Bags.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).flatCollect(function, Bags.mutable.empty()));
         <name>Iterable iterable = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Sets.mutable.with(<["0", "1", "2"]:(literal.(type))(); separator=", ">), iterable.flatCollect(function, Sets.mutable.empty()));
+        assertEquals(Lists.mutable.empty(), this.newWith().flatCollect(function, Lists.mutable.empty()));
+        assertEquals(Lists.mutable.with(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).flatCollect(function, Lists.mutable.empty()));
     }
 
     @Test
     public void collectPrimitivesToLists()
     {
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 BooleanLists.mutable.with(true, true),
                 iterable.collectBoolean(each -> true, BooleanLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ByteLists.mutable.with((byte) 1, (byte) 1),
                 iterable.collectByte(each -> (byte) 1, ByteLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 CharLists.mutable.with('a', 'a'),
                 iterable.collectChar(each -> 'a', CharLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ShortLists.mutable.with((short) 1, (short) 1),
                 iterable.collectShort(each -> (short) 1, ShortLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(1, 1),
                 iterable.collectInt(each -> 1, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 FloatLists.mutable.with(1.0f, 1.0f),
                 iterable.collectFloat(each -> 1.0f, FloatLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 LongLists.mutable.with(1L, 1L),
                 iterable.collectLong(each -> 1L, LongLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 DoubleLists.mutable.with(1.0d, 1.0d),
                 iterable.collectDouble(each -> 1.0d, DoubleLists.mutable.empty()));
     }
@@ -638,28 +641,28 @@ public abstract class Abstract<name>IterableTestCase
     public void collectPrimitivesToSets()
     {
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 BooleanSets.mutable.with(false),
                 iterable.collectBoolean(each -> false, BooleanSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ByteSets.mutable.with((byte) 2),
                 iterable.collectByte(each -> (byte) 2, ByteSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 CharSets.mutable.with('b'),
                 iterable.collectChar(each -> 'b', CharSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 ShortSets.mutable.with((short) 2),
                 iterable.collectShort(each -> (short) 2, ShortSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(2),
                 iterable.collectInt(each -> 2, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 FloatSets.mutable.with(2.0f),
                 iterable.collectFloat(each -> 2.0f, FloatSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 LongSets.mutable.with(2L),
                 iterable.collectLong(each -> 2L, LongSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 DoubleSets.mutable.with(2.0d),
                 iterable.collectDouble(each -> 2.0d, DoubleSets.mutable.empty()));
     }
@@ -672,8 +675,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size >= 3 ? 3 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         Verify.assertSize(size >= 2 ? 2 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
 
         <name>Iterable iterable2 = this.newWith(<["0"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(iterable2.size() == 1 ? 1 : 0, iterable2.select(<name>Predicates.alwaysTrue()));
@@ -688,8 +691,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size >= 3 ? 3 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>), <name>Sets.mutable.empty()));
         Verify.assertSize(size >= 2 ? 2 : size, iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>), <name>Sets.mutable.empty()));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
-        Assert.assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.select(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
     }
 
     @Test
@@ -700,8 +703,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size \<= 3 ? 0 : size - 3, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)));
         Verify.assertSize(size \<= 2 ? 0 : size - 2, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(this.newMutableCollectionWith(<["2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
 
         <name>Iterable iterable2 = this.newWith(<["0"]:(literal.(type))(); separator=", ">);
         Verify.assertSize(iterable2.size() == 1 ? 1 : 0, iterable2.reject(<name>Predicates.alwaysFalse()));
@@ -716,8 +719,8 @@ public abstract class Abstract<name>IterableTestCase
         Verify.assertSize(size \<= 3 ? 0 : size - 3, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>), <name>Sets.mutable.empty()));
         Verify.assertSize(size \<= 2 ? 0 : size - 2, iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>), <name>Sets.mutable.empty()));
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
-        Assert.assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["2", "3"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.lessThan(<(literal.(type))("2")>), <name>Sets.mutable.empty()));
+        assertEquals(<name>Sets.mutable.with(<["0", "1"]:(literal.(type))(); separator=", ">), iterable1.reject(<name>Predicates.greaterThan(<(literal.(type))("1")>), <name>Sets.mutable.empty()));
     }
 
     @Test
@@ -725,15 +728,15 @@ public abstract class Abstract<name>IterableTestCase
     {
         <name>Iterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size > 0 ? <(wideLiteral.(type))("1")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size >= 4 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size >= 2 ? <(wideLiteral.(type))("2")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.equal(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size > 0 ? <(wideLiteral.(type))("1")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(size > 3 ? <(wideLiteral.(type))("4")> : <(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
 
         <name>Iterable iterable1 = this.newWith(<["0", "1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<(delta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<(delta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable1.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("1")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("2")>), <(literal.(type))("4")>)<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("4")>, iterable1.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("4")>), <(literal.(type))("4")>)<(delta.(type))>);
     }
 
     @Test
@@ -742,10 +745,10 @@ public abstract class Abstract<name>IterableTestCase
         <(maxTests.(type))(type, name)>
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_emptyCollection()
     {
-        this.newWith().max();
+        assertThrows(NoSuchElementException.class, () -> this.newWith().max());
     }
 
     @Test
@@ -754,30 +757,30 @@ public abstract class Abstract<name>IterableTestCase
         <(minTests.(type))(type, name)>
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min_throws_emptyCollection()
     {
-        this.newWith().min();
+        assertThrows(NoSuchElementException.class, () -> this.newWith().min());
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, this.newWith().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, this.newWith().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
         int size = this.classUnderTest().size();
-        Assert.assertEquals(size == 0 ? <(literal.(type))("5")> : <(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(size == 0 ? <(literal.(type))("5")> : <(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, this.newWith().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, this.newWith().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
         int size = this.classUnderTest().size();
-        Assert.assertEquals(size == 0 ? <(literal.(type))("5")> : size, this.classUnderTest().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(size == 0 ? <(literal.(type))("5")> : size, this.classUnderTest().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -785,9 +788,9 @@ public abstract class Abstract<name>IterableTestCase
     {
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum, this.classUnderTest().sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(sum, this.classUnderTest().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Test
@@ -795,9 +798,9 @@ public abstract class Abstract<name>IterableTestCase
     {
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
-        Assert.assertEquals(sum, this.classUnderTest().summaryStatistics().getSum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<wideDelta.(type)>);
+        assertEquals(sum, this.classUnderTest().summaryStatistics().getSum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, this.newWith(<["0", "1", "2", "3", "4"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("93")>, this.newWith(<["30", "31", "32"]:(literal.(type))(); separator=", ">).summaryStatistics().getSum()<wideDelta.(type)>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -811,7 +814,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -826,7 +829,7 @@ public void sumConsistentRounding()
             .collect<name>(i -> <["1.0"]:(decimalLiteral.(type))()> / (i.<type>Value() * i.<type>Value() * i.<type>Value() * i.<type>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -839,16 +842,16 @@ public void sumConsistentRounding()
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
         double average = sum / size;
-        Assert.assertEquals(average, this.classUnderTest().average(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(average, this.classUnderTest().average(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).average(), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).average(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void averageThrowsOnEmpty()
     {
-        this.newWith().average();
+        assertThrows(ArithmeticException.class, () -> this.newWith().average());
     }
 
     /**
@@ -857,30 +860,30 @@ public void sumConsistentRounding()
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(2.5, this.newWith().averageIfEmpty(2.5), 0.0);
+        assertEquals(2.5, this.newWith().averageIfEmpty(2.5), 0.0);
         int size = this.classUnderTest().size();
         long sum = (long) ((size * (size + 1)) / 2);
         double average = sum / size;
-        Assert.assertEquals(average, this.classUnderTest().averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(average, this.classUnderTest().averageIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32", "32"]:(literal.(type))(); separator=", ">).averageIfEmpty(0.0), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
-        Assert.assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        this.newWith().median();
+        assertThrows(ArithmeticException.class, () -> this.newWith().median());
     }
 
     /**
@@ -889,18 +892,18 @@ public void sumConsistentRounding()
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(2.5, this.newWith().medianIfEmpty(2.5), 0.0);
-        Assert.assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
-        Assert.assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith().medianIfEmpty(2.5), 0.0);
+        assertEquals(1.0, this.newWith(<["1"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(2.5, this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(3.0, this.newWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(31.0, this.newWith(<["30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
+        assertEquals(30.5, this.newWith(<["1", "30", "30", "31", "31", "32"]:(literal.(type))(); separator=", ">).medianIfEmpty(0.0), 0.0);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().toArray().length);
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().toArray().length);
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}, iterable.toArray())
                 || Arrays.equals(new <type>[]{<["2", "1"]:(literal.(type))(); separator=", ">}, iterable.toArray()));
@@ -940,7 +943,7 @@ public void sumConsistentRounding()
         Arrays.sort(targetTooBig);
         for (int i = 0; i \< originalAsSortedArray.length; i++)
         {
-            Assert.assertEquals(originalAsSortedArray[i], bigResult[i + 1]<(delta.(type))>);
+            assertEquals(originalAsSortedArray[i], bigResult[i + 1]<(delta.(type))>);
         }
     }
 
@@ -994,22 +997,22 @@ public void sumConsistentRounding()
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(this.newObjectCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32"]:(literal.(type))(); separator=", ">).hashCode());
         Assert.assertNotEquals(this.newObjectCollectionWith(<["32"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["0"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
+        assertEquals(this.newObjectCollectionWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["31", "32", "50"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode(), this.newWith(<["32", "50", "60"]:(literal.(type))(); separator=", ">).hashCode());
+        assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[]", this.newWith().toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("1")>]", this.newWith(<(literal.(type))("1")>).toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("31")>]", this.newWith(<(literal.(type))("31")>).toString());
-        Assert.assertEquals("[<(toStringLiteral.(type))("32")>]", this.newWith(<(literal.(type))("32")>).toString());
+        assertEquals("[]", this.newWith().toString());
+        assertEquals("[<(toStringLiteral.(type))("1")>]", this.newWith(<(literal.(type))("1")>).toString());
+        assertEquals("[<(toStringLiteral.(type))("31")>]", this.newWith(<(literal.(type))("31")>).toString());
+        assertEquals("[<(toStringLiteral.(type))("32")>]", this.newWith(<(literal.(type))("32")>).toString());
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue("[<["1", "2"]:(toStringLiteral.(type))(); separator=", ">]".equals(iterable.toString())
@@ -1044,13 +1047,13 @@ public void sumConsistentRounding()
     public void makeString()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(
@@ -1098,14 +1101,14 @@ public void sumConsistentRounding()
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
@@ -1118,15 +1121,15 @@ public void sumConsistentRounding()
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
@@ -1167,19 +1170,19 @@ public void sumConsistentRounding()
         <name>Iterable iterable = this.newWith(<["31", "32"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(<name>ArrayList.newListWith(<["31", "32"]:(literal.(type))(); separator=", ">).equals(iterable.toList())
                 || <name>ArrayList.newListWith(<["32", "31"]:(literal.(type))(); separator=", ">).equals(iterable.toList()));
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.newWith(<(literal.(type))("0")>).toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), this.newWith(<(literal.(type))("31")>).toList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("32")>), this.newWith(<(literal.(type))("32")>).toList());
-        Assert.assertEquals(new <name>ArrayList(), this.newWith().toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("0")>), this.newWith(<(literal.(type))("0")>).toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("31")>), this.newWith(<(literal.(type))("31")>).toList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("32")>), this.newWith(<(literal.(type))("32")>).toList());
+        assertEquals(new <name>ArrayList(), this.newWith().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(), this.newWith().toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWith(<(literal.(type))("1")>).toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "1"]:(literal.(type))(); separator=", ">).toSortedList());
-        Assert.assertEquals(<name>ArrayList.newListWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "32", "1"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(), this.newWith().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("1")>), this.newWith(<(literal.(type))("1")>).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "1"]:(literal.(type))(); separator=", ">).toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "31", "32", "1"]:(literal.(type))(); separator=", ">).toSortedList());
     }
 
     @Test
@@ -1193,7 +1196,7 @@ public void sumConsistentRounding()
 
         result
                 .collectBoolean(e -> e % 2 == 0, BooleanLists.mutable.of())
-                .forEachWithIndex((e, i) -> Assert.assertEquals("index " + i, i \< 5, e));
+                .forEachWithIndex((e, i) -> assertEquals("index " + i, i \< 5, e));
     }
 
     @Test
@@ -1205,7 +1208,7 @@ public void sumConsistentRounding()
         Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i));
 
         Assert.assertNotSame(index, result);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "0", "4", "3"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
@@ -1217,51 +1220,51 @@ public void sumConsistentRounding()
         Mutable<name>List result = index.toSortedListBy(i -> list.get((int) i), Comparators.naturalOrder().reversed());
 
         Assert.assertNotSame(index, result);
-        Assert.assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), result);
+        assertEquals(<name>ArrayList.newListWith(<["3", "4", "0", "2", "1"]:(literal.(type))(); separator=", ">), result);
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(), this.newWith().toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toSet());
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(), this.newWith().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(new <name>HashBag(), this.newWith().toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toBag());
-        Assert.assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(new <name>HashBag(), this.newWith().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1"]:(literal.(type))(); separator=", ">), this.newWith(<(literal.(type))("1")>).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">), this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">).toBag());
+        assertEquals(<name>HashBag.newBagWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">), this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).toBag());
     }
 
     @Test
     public void asLazy()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(iterable.toBag(), iterable.asLazy().toBag());
+        assertEquals(iterable.toBag(), iterable.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
 
         <name>Iterable iterable1 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable1.toBag(), iterable1.asLazy().toBag());
+        assertEquals(iterable1.toBag(), iterable1.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable1.asLazy());
 
         <name>Iterable iterable2 = this.newWith(<["1", "2", "2", "3", "3", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable2.toBag(), iterable2.asLazy().toBag());
+        assertEquals(iterable2.toBag(), iterable2.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable2.asLazy());
 
         <name>Iterable iterable3 = this.newWith();
-        Assert.assertEquals(iterable3.toBag(), iterable3.asLazy().toBag());
+        assertEquals(iterable3.toBag(), iterable3.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable3.asLazy());
 
         <name>Iterable iterable4 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(iterable4.toBag(), iterable4.asLazy().toBag());
+        assertEquals(iterable4.toBag(), iterable4.asLazy().toBag());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable4.asLazy());
     }
 
@@ -1270,15 +1273,15 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum1 = iterable1.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("36")>), sum1);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("36")>), sum1);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum2 = iterable2.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("37")>), sum2);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("37")>), sum2);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <wrapperName> sum3 = iterable3.injectInto(<wrapperName>.valueOf(<(literal.(type))("0")>), (<wrapperName> result, <type> value) -> <wrapperName>.valueOf((<type>) (result + value + 1)));
-        Assert.assertEquals(<wrapperName>.valueOf(<(literal.(type))("38")>), sum3);
+        assertEquals(<wrapperName>.valueOf(<(literal.(type))("38")>), sum3);
     }
 
     @Test
@@ -1286,11 +1289,11 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         boolean sum1 = iterable1.injectIntoBoolean(false, (boolean result, <type> value) -> (boolean) (result || value == <(literal.(type))("0")>));
-        Assert.assertEquals(true, sum1);
+        assertEquals(true, sum1);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         boolean sum2 = iterable2.injectIntoBoolean(false, (boolean result, <type> value) -> (boolean) (result || value == <(literal.(type))("0")>));
-        Assert.assertEquals(false, sum2);
+        assertEquals(false, sum2);
     }
 
     <injectIntoPrimitiveTest("Byte", "byte", false)>
@@ -1307,10 +1310,11 @@ public void sumConsistentRounding()
 
     <injectIntoPrimitiveTest("Double", "double", true)>
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void reduceOnEmptyThrows()
     {
-        this.newWith().reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
+        assertThrows(NoSuchElementException.class,
+                () -> this.newWith().reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>));
     }
 
     @Test
@@ -1318,43 +1322,43 @@ public void sumConsistentRounding()
     {
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum1 = iterable1.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum2 = iterable2.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum3 = iterable3.reduce((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
     }
 
     @Test
     public void reduceIfEmpty()
     {
         <(wideType.(type))> empty1 = this.newWith().reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("1")>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, empty1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("1")>, empty1<if(primitive.floatingPoint)>, 0.001<endif>);
         <(wideType.(type))> empty2 = this.newWith().reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, empty2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("0")>, empty2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum1 = iterable1.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("35")>, sum1<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum2 = iterable2.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("36")>, sum2<if(primitive.floatingPoint)>, 0.001<endif>);
 
         <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
         <(wideType.(type))> sum3 = iterable3.reduceIfEmpty((<(wideType.(type))> result, <type> value) -> <(castWideType.(type))>result + <(castWideType.(type))>value + <(wideLiteral.(type))("1")>, <(wideLiteral.(type))("0")>);
-        Assert.assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
+        assertEquals(<(wideLiteral.(type))("37")>, sum3<if(primitive.floatingPoint)>, 0.001<endif>);
     }
 
     @Test
     public void chunk()
     {
         <name>Iterable iterable = this.newWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["1"]:(literal.(type))(); separator=", ">),
@@ -1363,35 +1367,35 @@ public void sumConsistentRounding()
                         this.newMutableCollectionWith(<["4"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(1).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["2", "3"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(2).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         this.newMutableCollectionWith(<["0", "1", "2", "3"]:(literal.(type))(); separator=", ">),
                         this.newMutableCollectionWith(<["4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(6).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(this.newMutableCollectionWith(<["0", "1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(7).toSet());
-        Assert.assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
-        Assert.assertEquals(Lists.mutable.with(this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">)), this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(1));
-        Assert.assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
+        assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
+        assertEquals(Lists.mutable.with(this.newMutableCollectionWith(<["0"]:(literal.(type))(); separator=", ">)), this.newWith(<["0"]:(literal.(type))(); separator=", ">).chunk(1));
+        assertEquals(Lists.mutable.with(), this.newWith().chunk(1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newMutableCollectionWith().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newMutableCollectionWith().chunk(-1));
     }
 }
 
@@ -1423,31 +1427,31 @@ maxTests ::= [
 ]
 
 intMaxTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "-2", "-9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(delta.(type))>);
+assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "-2", "-9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(delta.(type))>);
 >>
 
 charMaxTest(type, name) ::= <<
-Assert.assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<(literal.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("32")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("31")>, this.newWith(<["31", "0", "30"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<(literal.(type))("39")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(this.classUnderTest().size(), this.classUnderTest().max()<(wideDelta.(type))>);
 >>
 
 floatMaxTest(type, name) ::= <<
 <intMaxTest(type, name)>
-Assert.assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(-1.5, this.newWith(<["-1.5", "-31.8", "-32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.POSITIVE_INFINITY, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).max()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.NaN, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN, 31.5f).max()<(wideDelta.(type))>);
-Assert.assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).max()<(wideDelta.(type))>);
+assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(-1.5, this.newWith(<["-1.5", "-31.8", "-32.5"]:(decimalLiteral.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+assertEquals(<name>.POSITIVE_INFINITY, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).max()<(wideDelta.(type))>);
+assertEquals(<name>.NaN, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN, 31.5f).max()<(wideDelta.(type))>);
+assertEquals(32.5, this.newWith(<["-1.5", "31.8", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).max()<(wideDelta.(type))>);
 >>
 
 minTests ::= [
@@ -1461,29 +1465,29 @@ minTests ::= [
 ]
 
 intMinTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("-2")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-2")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("-1")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
 >>
 
 charMinTest(type, name) ::= <<
-Assert.assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("9")>, this.newWith(<["-1", "-2", "9"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["-1", "0", "9", "30", "31", "32"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("31")>, this.newWith(<["31", "32", "33"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["32", "39", "35"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
 >>
 
 floatMinTest(type, name) ::= <<
 <intMinTest(type, name)>
-Assert.assertEquals(-1.5, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-Assert.assertEquals(1.5, this.newWith(<["1.5", "31.0", "30.0"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).min()<(wideDelta.(type))>);
-Assert.assertEquals(31.5, this.newWith(<["31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN).min()<(wideDelta.(type))>);
-Assert.assertEquals(<name>.NEGATIVE_INFINITY, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).min()<(wideDelta.(type))>);
+assertEquals(-1.5, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+assertEquals(1.5, this.newWith(<["1.5", "31.0", "30.0"]:(decimalLiteral.(type))(); separator=", ">, <name>.POSITIVE_INFINITY).min()<(wideDelta.(type))>);
+assertEquals(31.5, this.newWith(<["31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NaN).min()<(wideDelta.(type))>);
+assertEquals(<name>.NEGATIVE_INFINITY, this.newWith(<["-1.5", "31.5", "32.5"]:(decimalLiteral.(type))(); separator=", ">, <name>.NEGATIVE_INFINITY, 31.5f).min()<(wideDelta.(type))>);
 >>
 
 NaNTests(key) ::= <<
@@ -1522,12 +1526,12 @@ public void testEquals_NaN()
     Set\<<wrapperName>\> hashSet6 = new HashSet\<>();
     hashSet6.add(<wrapperName>.NEGATIVE_INFINITY);
 
-    Assert.assertEquals(hashSet1, hashSet2);
-    Assert.assertEquals(iterable1, iterable2);
-    Assert.assertEquals(hashSet3, hashSet4);
-    Assert.assertEquals(iterable3, iterable4);
-    Assert.assertEquals(hashSet5, hashSet6);
-    Assert.assertEquals(iterable5, iterable6);
+    assertEquals(hashSet1, hashSet2);
+    assertEquals(iterable1, iterable2);
+    assertEquals(hashSet3, hashSet4);
+    assertEquals(iterable3, iterable4);
+    assertEquals(hashSet5, hashSet6);
+    assertEquals(iterable5, iterable6);
 
     Assert.assertNotEquals(hashSet1, hashSet3);
     Assert.assertNotEquals(iterable1, iterable3);
@@ -1548,7 +1552,7 @@ public void contains_different_NaNs()
     Set\<<wrapperName>\> hashSet = new HashSet\<>();
     hashSet.add(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan1));
     <bitsType.(type)> nan2 = <NaNBits2.(type)>;
-    Assert.assertEquals(hashSet.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)), primitiveIterable.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
+    assertEquals(hashSet.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)), primitiveIterable.contains(<wrapperName>.<bitsType.(type)>BitsTo<name>(nan2)));
 }
 
 >>
@@ -1587,14 +1591,14 @@ public void injectInto<toName>()
 {
     <name>Iterable iterable1 = this.newWith(<["0", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum1 = iterable1.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("36")>, sum1<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("36")>, sum1<if(toFloatingPoint)>, 0.001<endif>);
 
     <name>Iterable iterable2 = this.newWith(<[ "1", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum2 = iterable2.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("37")>, sum2<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("37")>, sum2<if(toFloatingPoint)>, 0.001<endif>);
 
     <name>Iterable iterable3 = this.newWith(<["0", "1", "2", "31"]:(literal.(type))(); separator=", ">);
     <toType> sum3 = iterable3.injectInto<toName>(<(literal.(toType))("0")>, (<toType> result, <type> value) -> (<toType>) (result + value + 1));
-    Assert.assertEquals(<(literal.(toType))("38")>, sum3<if(toFloatingPoint)>, 0.001<endif>);
+    assertEquals(<(literal.(toType))("38")>, sum3<if(toFloatingPoint)>, 0.001<endif>);
 }
 >>

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/synchronizedPrimitiveIterableTest.stg
@@ -32,6 +32,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Synchronized<name>Iterable}s
  * This file was automatically generated from template file synchronizedPrimitiveIterableTest.stg.
@@ -62,10 +64,10 @@ public class Synchronized<name>IterableTest extends Abstract<name>IterableTestCa
         return FastList.newListWith(elements);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void null_iterable_throws()
     {
-        Synchronized<name>Iterable.of(null);
+        assertThrows(IllegalArgumentException.class, () -> Synchronized<name>Iterable.of(null));
     }
 
     @Override
@@ -83,7 +85,7 @@ public class Synchronized<name>IterableTest extends Abstract<name>IterableTestCa
         Verify.assertEmpty(list);
         Assert.assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/abstractLazyPrimitiveIterableTestCase.stg
@@ -43,6 +43,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -65,7 +66,7 @@ public abstract class AbstractLazy<name>IterableTestCase
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum<(wideDelta.(type))>);
     }
 
     @Test
@@ -85,7 +86,7 @@ public abstract class AbstractLazy<name>IterableTestCase
     {
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEach(each -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -111,11 +112,11 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
-        Assert.assertEquals(2L, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(2L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("34")>)));
-        Assert.assertEquals(0L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(1L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, this.classUnderTest().count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(2L, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(2L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("34")>)));
+        assertEquals(0L, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
     }
 
     @Test
@@ -180,12 +181,12 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["34", "35"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.classUnderTest().detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.lessThan(<(literal.(type))("2")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["32", "33"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("1")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("32")>, this.newWith(<["34", "35"]:(literal.(type))(); separator=", ">).detectIfNone(<name>Predicates.equal(<(literal.(type))("33")>), <(literal.(type))("32")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -200,9 +201,9 @@ public abstract class AbstractLazy<name>IterableTestCase
         StringBuilder tapStringBuilder = new StringBuilder();
         StringBuilder eachStringBuilder = new StringBuilder();
         Lazy<name>Iterable lazy = this.classUnderTest().tap(tapStringBuilder::append);
-        Assert.assertEquals(lazy.makeString(""), tapStringBuilder.toString());
+        assertEquals(lazy.makeString(""), tapStringBuilder.toString());
         lazy.tap(eachStringBuilder::append).forEach(eachStringBuilder::append);
-        Assert.assertEquals(CharAdapter.adapt(eachStringBuilder.toString()).toBag(), CharAdapter.adapt(tapStringBuilder.toString()).toBag());
+        assertEquals(CharAdapter.adapt(eachStringBuilder.toString()).toBag(), CharAdapter.adapt(tapStringBuilder.toString()).toBag());
     }
 
     @Test
@@ -214,28 +215,28 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void lazyCollectPrimitives()
     {
-        Assert.assertEquals(BooleanLists.immutable.of(false, true, false), this.classUnderTest().collectBoolean(e -> e % 2 == 0).toList());
-        Assert.assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), this.classUnderTest().asLazy().collectChar(e -> (char) (e + 1)).toList());
-        Assert.assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), this.classUnderTest().asLazy().collectByte(e -> (byte) (e + 1)).toList());
-        Assert.assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), this.classUnderTest().asLazy().collectShort(e -> (short) (e + 1)).toList());
-        Assert.assertEquals(IntLists.immutable.of(2, 3, 4), this.classUnderTest().asLazy().collectInt(e -> (int) (e + 1)).toList());
-        Assert.assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), this.classUnderTest().asLazy().collectFloat(e -> (float) (e + 1)).toList());
-        Assert.assertEquals(LongLists.immutable.of(2L, 3L, 4L), this.classUnderTest().asLazy().collectLong(e -> (long) (e + 1)).toList());
-        Assert.assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), this.classUnderTest().asLazy().collectDouble(e -> (double) (e + 1)).toList());
+        assertEquals(BooleanLists.immutable.of(false, true, false), this.classUnderTest().collectBoolean(e -> e % 2 == 0).toList());
+        assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), this.classUnderTest().asLazy().collectChar(e -> (char) (e + 1)).toList());
+        assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), this.classUnderTest().asLazy().collectByte(e -> (byte) (e + 1)).toList());
+        assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), this.classUnderTest().asLazy().collectShort(e -> (short) (e + 1)).toList());
+        assertEquals(IntLists.immutable.of(2, 3, 4), this.classUnderTest().asLazy().collectInt(e -> (int) (e + 1)).toList());
+        assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), this.classUnderTest().asLazy().collectFloat(e -> (float) (e + 1)).toList());
+        assertEquals(LongLists.immutable.of(2L, 3L, 4L), this.classUnderTest().asLazy().collectLong(e -> (long) (e + 1)).toList());
+        assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), this.classUnderTest().asLazy().collectDouble(e -> (double) (e + 1)).toList());
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, this.classUnderTest().sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["0", "33"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, this.classUnderTest().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.newWith(<["0", "1"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("33")>, this.newWith(<["0", "33"]:(literal.(type))(); separator=", ">).sum()<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_emptyIterable()
     {
-        this.getEmptyIterable().max();
+        assertThrows(NoSuchElementException.class, () -> this.getEmptyIterable().max());
     }
 
     @Test
@@ -247,27 +248,27 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("33")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("100")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("2")>, this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("33")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("100")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">).max()<(wideDelta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.newWith(<["2", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("0")>, this.newWith(<["33", "0"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.newWith(<["100", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.newWith(<["2", "1"]:(literal.(type))(); separator=", ">).min()<(wideDelta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.classUnderTest().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.classUnderTest().select(<name>Predicates.lessThan(<(literal.(type))("0")>)).minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -275,17 +276,17 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(literal.(type))("3")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("5")>, this.getEmptyIterable().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("3")>, this.classUnderTest().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.classUnderTest().select(<name>Predicates.lessThan(<(literal.(type))("0")>)).maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void maxThrowsOnEmpty()
     {
-        new Lazy<name>IterableAdapter(new <name>ArrayList()).max();
+        assertThrows(NoSuchElementException.class, () -> new Lazy<name>IterableAdapter(new <name>ArrayList()).max());
     }
 
     @Test
@@ -297,7 +298,7 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void average()
     {
-        Assert.assertEquals(2.0d, this.classUnderTest().average(), 0.0);
+        assertEquals(2.0d, this.classUnderTest().average(), 0.0);
     }
 
     @Test
@@ -309,8 +310,8 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void median()
     {
-        Assert.assertEquals(2.0d, this.classUnderTest().median(), 0.0);
-        Assert.assertEquals(16.0d, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).median(), 0.0);
+        assertEquals(2.0d, this.classUnderTest().median(), 0.0);
+        assertEquals(16.0d, this.newWith(<["1", "31"]:(literal.(type))(); separator=", ">).median(), 0.0);
     }
 
     @Test
@@ -451,7 +452,7 @@ public abstract class AbstractLazy<name>IterableTestCase
                 || "<["2", "1"]:(toStringLiteral.(type))(); separator="/">".equals(appendable3.toString()));
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         Lazy<name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
@@ -503,26 +504,26 @@ public abstract class AbstractLazy<name>IterableTestCase
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.classUnderTest().toBag());
     }
 
     @Test
     public void asLazy()
     {
         Lazy<name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(iterable.toSet(), iterable.asLazy().toSet());
+        assertEquals(iterable.toSet(), iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
         Assert.assertSame(iterable, iterable.asLazy());
     }

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/collectPrimitiveIterableTest.stg
@@ -37,6 +37,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -55,13 +56,13 @@ public class Collect<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum<(delta.(type))>);
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(3L, this.<type>Iterable.size());
+        assertEquals(3L, this.<type>Iterable.size());
     }
 
     @Test
@@ -79,15 +80,15 @@ public class Collect<name>IterableTest
         {
             value[0] += each;
         });
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, value[0]<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, value[0]<(delta.(type))>);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1, this.<type>Iterable.count(<name>Predicates.equal(<(literal.(type))("1")>)));
-        Assert.assertEquals(3, this.<type>Iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
-        Assert.assertEquals(2, this.<type>Iterable.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
+        assertEquals(1, this.<type>Iterable.count(<name>Predicates.equal(<(literal.(type))("1")>)));
+        assertEquals(3, this.<type>Iterable.count(<name>Predicates.lessThan(<(literal.(type))("4")>)));
+        assertEquals(2, this.<type>Iterable.count(<name>Predicates.greaterThan(<(literal.(type))("1")>)));
     }
 
     @Test
@@ -115,28 +116,28 @@ public class Collect<name>IterableTest
     @Test
     public void select()
     {
-        Assert.assertEquals(3L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
-        Assert.assertEquals(2L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
+        assertEquals(3L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
+        assertEquals(2L, this.<type>Iterable.select(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(0L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
-        Assert.assertEquals(1L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
+        assertEquals(0L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("4")>)).size());
+        assertEquals(1L, this.<type>Iterable.reject(<name>Predicates.lessThan(<(literal.(type))("3")>)).size());
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.<type>Iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, this.<type>Iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.<type>Iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, this.<type>Iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, this.<type>Iterable.sum()<(delta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, this.<type>Iterable.sum()<(delta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -149,7 +150,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -163,7 +164,7 @@ public void sumConsistentRounding()
             .shuffleThis()
             .collect<name>(i -> <["1.0"]:(decimalLiteral.(type))()> / (i.<type>Value() * i.<type>Value() * i.<type>Value() * i.<type>Value()));
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -173,27 +174,27 @@ public void sumConsistentRounding()
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max()<(delta.(type))>);
+        assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).max()<(delta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min()<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).min()<(delta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).minIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
-        Assert.assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("3")>, Interval.fromTo(0, 3).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
+        assertEquals(<(literal.(type))("0")>, FastList.\<Integer>newList().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).maxIfEmpty(<(literal.(type))("0")>)<(delta.(type))>);
     }
 
     @Test
@@ -213,7 +214,7 @@ public void sumConsistentRounding()
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average(), 0.001);
+        assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).average(), 0.001);
     }
 
     @Test
@@ -226,14 +227,15 @@ public void sumConsistentRounding()
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
-        Assert.assertEquals(4.0, Interval.oneTo(7).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
+        assertEquals(2.5, Interval.oneTo(4).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
+        assertEquals(4.0, Interval.oneTo(7).collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median(), 0.001);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median();
+        assertThrows(ArithmeticException.class,
+                () -> Lists.mutable.\<Integer>of().asLazy().collect<name>(PrimitiveFunctions.unboxIntegerTo<name>()).median());
     }
 
     @Test
@@ -283,21 +285,21 @@ public void sumConsistentRounding()
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("2")>", "<(toStringLiteral.(type))("3")>"), this.<type>Iterable.collect(String::valueOf).toList());
+        assertEquals(FastList.newListWith("<(toStringLiteral.(type))("1")>", "<(toStringLiteral.(type))("2")>", "<(toStringLiteral.(type))("3")>"), this.<type>Iterable.collect(String::valueOf).toList());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.<type>Iterable.makeString());
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.<type>Iterable.makeString("/"));
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.makeString("[", ", ", "]"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", this.<type>Iterable.makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", this.<type>Iterable.makeString("/"));
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", this.<type>Iterable.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -305,43 +307,43 @@ public void sumConsistentRounding()
     {
         StringBuilder appendable = new StringBuilder();
         this.<type>Iterable.appendString(appendable);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         this.<type>Iterable.appendString(appendable2, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.<type>Iterable.appendString(appendable3, "[", ", ", "]");
-        Assert.assertEquals(this.<type>Iterable.toString(), appendable3.toString());
+        assertEquals(this.<type>Iterable.toString(), appendable3.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), this.<type>Iterable.toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.<type>Iterable.toSet(), this.<type>Iterable.asLazy().toSet());
+        assertEquals(this.<type>Iterable.toSet(), this.<type>Iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, this.<type>Iterable.asLazy());
     }
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveSelectIterableTest.stg
@@ -32,6 +32,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -51,7 +52,7 @@ public class Select<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, sum<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, sum<(wideDelta.(type))>);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class Select<name>IterableTest
     {
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.iterable.forEach((<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -78,8 +79,8 @@ public class Select<name>IterableTest
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(0L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
+        assertEquals(1L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(0L, this.iterable.count(<name>Predicates.lessThan(<(literal.(type))("0")>)));
     }
 
     @Test
@@ -124,8 +125,8 @@ public class Select<name>IterableTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, this.iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -137,7 +138,7 @@ public class Select<name>IterableTest
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.iterable.sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.iterable.sum()<(wideDelta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -153,7 +154,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -170,7 +171,7 @@ public void sumConsistentRounding()
                     .toArray());
     Select<name>Iterable iterable = new Select<name>Iterable(list, <name>Predicates.alwaysTrue());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -180,20 +181,20 @@ public void sumConsistentRounding()
     @Test
     public void max()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.iterable.max()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("2")>, this.iterable.max()<(wideDelta.(type))>);
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.iterable.min()<(wideDelta.(type))>);
+        assertEquals(<(literal.(type))("1")>, this.iterable.min()<(wideDelta.(type))>);
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("1")>, this.iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("1")>, this.iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.iterable.select(<name>Predicates.lessThan(<(literal.(type))("0")>)).minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -201,8 +202,8 @@ public void sumConsistentRounding()
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(literal.(type))("2")>, this.iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(
+        assertEquals(<(literal.(type))("2")>, this.iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(
                 <(literal.(type))("0")>,
                 this.iterable.select(<name>Predicates.lessThan(<(literal.(type))("0")>)).maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
     }
@@ -214,16 +215,17 @@ public void sumConsistentRounding()
             new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).max());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void minThrowsOnEmpty()
     {
-        new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).min();
+        assertThrows(NoSuchElementException.class,
+                () -> new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).min());
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(1.5d, this.iterable.average(), 0.0);
+        assertEquals(1.5d, this.iterable.average(), 0.0);
     }
 
     @Test
@@ -236,13 +238,14 @@ public void sumConsistentRounding()
     @Test
     public void median()
     {
-        Assert.assertEquals(1.5d, this.iterable.median(), 0.0);
+        assertEquals(1.5d, this.iterable.median(), 0.0);
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).median();
+        assertThrows(ArithmeticException.class,
+                () -> new Select<name>Iterable(new <name>ArrayList(), <name>Predicates.lessThan(<(literal.(type))("3")>)).median());
     }
 
     @Test
@@ -288,31 +291,31 @@ public void sumConsistentRounding()
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2"]:(literal.(type))(); separator=", ">), this.iterable.toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
+        assertEquals(this.iterable.toSet(), this.iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, this.iterable.asLazy());
         Assert.assertSame(this.iterable, this.iterable.asLazy());
     }
@@ -321,7 +324,7 @@ public void sumConsistentRounding()
     public void injectInto()
     {
         Mutable<wrapperName> result = this.iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("3")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("3")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/primitiveTapIterableTest.stg
@@ -33,6 +33,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -54,8 +55,8 @@ public class Tap<name>IterableTest
         {
             sum += iterator.next();
         }
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, sum<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, sum<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -66,8 +67,8 @@ public class Tap<name>IterableTest
 
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         iterable.forEach((<type> each) -> sum[0] += each);
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, sum[0]<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -77,7 +78,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Verify.assertSize(5, iterable);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -88,7 +89,7 @@ public class Tap<name>IterableTest
 
         Assert.assertTrue(iterable.notEmpty());
         Verify.assertNotEmpty(iterable);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -97,8 +98,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(1L, iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(1L, iterable.count(<name>Predicates.lessThan(<(literal.(type))("2")>)));
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -161,8 +162,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("4")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("4")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -172,7 +173,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Verify.assertIterableSize(5, iterable.collect(String::valueOf));
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -181,8 +182,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(wideLiteral.(type))("15")>, iterable.sum()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(wideLiteral.(type))("15")>, iterable.sum()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -191,8 +192,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("5")>, iterable.max()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("5")>, iterable.max()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -201,8 +202,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("1")>, iterable.min()<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("1")>, iterable.min()<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -211,8 +212,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("1")>, iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("1")>, iterable.minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -221,8 +222,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<(literal.(type))("5")>, iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<(literal.(type))("5")>, iterable.maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -245,8 +246,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(3.0d, iterable.average(), 0.0);
-        Assert.assertEquals(list.makeString("") + list.makeString(""), builder.toString());
+        assertEquals(3.0d, iterable.average(), 0.0);
+        assertEquals(list.makeString("") + list.makeString(""), builder.toString());
     }
 
     @Test
@@ -262,14 +263,14 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(3.0d, iterable.median(), 0.0);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(3.0d, iterable.median(), 0.0);
+        assertEquals(list.makeString(""), builder.toString());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void medianThrowsOnEmpty()
     {
-        new Tap<name>Iterable(new <name>ArrayList(), System.out::println).median();
+        assertThrows(ArithmeticException.class, () -> new Tap<name>Iterable(new <name>ArrayList(), System.out::println).median());
     }
 
     @Test
@@ -279,7 +280,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Assert.assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toArray()<(delta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -326,7 +327,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Assert.assertArrayEquals(new <type>[]{1, 2, 3, 4, 5}, iterable.toSortedArray()<(delta.(type))>);
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -335,8 +336,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toList());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toList());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -345,8 +346,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSortedList());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSortedList());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -355,8 +356,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSet());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toSet());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -365,8 +366,8 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toBag());
-        Assert.assertEquals(list.makeString(""), builder.toString());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">), iterable.toBag());
+        assertEquals(list.makeString(""), builder.toString());
     }
 
     @Test
@@ -375,7 +376,7 @@ public class Tap<name>IterableTest
         StringBuilder builder = new StringBuilder();
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
-        Assert.assertEquals(iterable.toSet(), iterable.asLazy().toSet());
+        assertEquals(iterable.toSet(), iterable.asLazy().toSet());
         Verify.assertInstanceOf(Lazy<name>Iterable.class, iterable.asLazy());
         Assert.assertSame(iterable, iterable.asLazy());
     }
@@ -387,7 +388,7 @@ public class Tap<name>IterableTest
         Tap<name>Iterable iterable = new Tap<name>Iterable(this.list, builder::append);
 
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("15")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("15")>), result);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/lazy/reversePrimitiveIterableTest.stg
@@ -31,6 +31,7 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -79,11 +80,11 @@ public class Reverse<name>IterableTest
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
         <name>Iterator iterator = iterable.<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterator.next()<(wideDelta.(type))>);
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("2")>, iterator.next()<(wideDelta.(type))>);
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("3")>, iterator.next()<(wideDelta.(type))>);
         Assert.assertFalse(iterator.hasNext());
     }
 
@@ -107,7 +108,7 @@ public class Reverse<name>IterableTest
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         iterable.forEach((<type> each) -> sum[0] += each);
 
-        Assert.assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("6")>, sum[0]<(wideDelta.(type))>);
     }
 
     @Test
@@ -129,7 +130,7 @@ public class Reverse<name>IterableTest
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, <name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().count(<name>Predicates.greaterThan(<zero.(type)>)));
+        assertEquals(2L, <name>ArrayList.newListWith(<["1", "0", "2"]:(literal.(type))(); separator=", ">).asReversed().count(<name>Predicates.greaterThan(<zero.(type)>)));
     }
 
     @Test
@@ -173,8 +174,8 @@ public class Reverse<name>IterableTest
     public void detectIfNone()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, iterable.detectIfNone(<name>Predicates.lessThan(<(literal.(type))("4")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, iterable.detectIfNone(<name>Predicates.greaterThan(<(literal.(type))("3")>), <(literal.(type))("0")>)<(wideDelta.(type))>);
     }
 
     @Test
@@ -187,19 +188,19 @@ public class Reverse<name>IterableTest
     @Test
     public void max()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().max()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().max()<(wideDelta.(type))>);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max_throws_emptyList()
     {
-        new <name>ArrayList().asReversed().max();
+        assertThrows(NoSuchElementException.class, () -> new <name>ArrayList().asReversed().max());
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().min()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().min()<(wideDelta.(type))>);
     }
 
     @Test
@@ -211,23 +212,23 @@ public class Reverse<name>IterableTest
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().minIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().minIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("5")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, new <name>ArrayList().asReversed().maxIfEmpty(<(literal.(type))("0")>)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, <name>ArrayList.newListWith(<["1", "0", "9", "7"]:(literal.(type))(); separator=", ">).asReversed().maxIfEmpty(<(literal.(type))("5")>)<(wideDelta.(type))>);
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("10")>, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().sum()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("10")>, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().sum()<(wideDelta.(type))>);
     }
 
     <if(primitive.floatPrimitive)>@Test
@@ -242,7 +243,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             iterable.sum(),
             1.0e-15);
@@ -258,7 +259,7 @@ public void sumConsistentRounding()
             .asReversed()
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             iterable.sum(),
             1.0e-15);
@@ -268,14 +269,14 @@ public void sumConsistentRounding()
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().average(), 0.0);
+        assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().average(), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
-        Assert.assertEquals(3.0, <name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
+        assertEquals(2.5, <name>ArrayList.newListWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
+        assertEquals(3.0, <name>ArrayList.newListWith(<["1", "2", "3", "4", "5"]:(literal.(type))(); separator=", ">).asReversed().median(), 0.0);
     }
 
     @Test
@@ -294,19 +295,19 @@ public void sumConsistentRounding()
     public void testToString()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", iterable.toString());
-        Assert.assertEquals("[]", new <name>ArrayList().asReversed().toString());
+        assertEquals("[<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">]", iterable.toString());
+        assertEquals("[]", new <name>ArrayList().asReversed().toString());
     }
 
     @Test
     public void makeString()
     {
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", iterable.makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", <name>ArrayList.newListWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", iterable.makeString("/"));
-        Assert.assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
-        Assert.assertEquals("", new <name>ArrayList().asReversed().makeString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", iterable.makeString());
+        assertEquals("<(toStringLiteral.(type))("1")>", <name>ArrayList.newListWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", iterable.makeString("/"));
+        assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
+        assertEquals("", new <name>ArrayList().asReversed().makeString());
     }
 
     @Test
@@ -315,46 +316,46 @@ public void sumConsistentRounding()
         <name>Iterable iterable = <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed();
         StringBuilder appendable = new StringBuilder();
         new <name>ArrayList().asReversed().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         iterable.appendString(appendable2);
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator=", ">", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
+        assertEquals("<["1", "2", "3"]:(toStringLiteral.(type))(); separator="/">", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["2", "1"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">).asReversed().toList());
+        assertEquals(<name>ArrayList.newListWith(<["2", "1"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">).asReversed().toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toSet());
+        assertEquals(<name>HashSet.newSetWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toBag());
+        assertEquals(<name>HashBag.newBagWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().asLazy().toList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["3", "2", "1"]:(literal.(type))(); separator=", ">).asReversed().asLazy().toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["2", "3", "1"]:(literal.(type))(); separator=", ">).asReversed().toSortedList());
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), <name>ArrayList.newListWith(<["2", "3", "1"]:(literal.(type))(); separator=", ">).asReversed().toSortedList());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/abstractImmutablePrimitiveListTestCase.stg
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.Collections;<endif>
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Abstract JUnit test for {@link Immutable<name>List}.
@@ -76,33 +78,33 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i + 1, list.get(i)<(wideDelta.(type))>);
+            assertEquals(i + 1, list.get(i)<(wideDelta.(type))>);
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void get_throws_index_greater_than_size()
     {
-        this.classUnderTest().get(this.classUnderTest().size());
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(this.classUnderTest().size()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void get_throws_index_negative()
     {
-        this.classUnderTest().get(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(-1));
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("1")>, this.classUnderTest().getFirst()<(wideDelta.(type))>);
     }
 
     @Test
     public void getLast()
     {
         Immutable<name>List list = this.classUnderTest();
-        Assert.assertEquals(list.size(), list.getLast()<(wideDelta.(type))>);
+        assertEquals(list.size(), list.getLast()<(wideDelta.(type))>);
     }
 
     @Test
@@ -111,14 +113,14 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
+            assertEquals(i, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
         }
-        Assert.assertEquals(-1L, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
+        assertEquals(-1L, list.indexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
 
         Immutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
+        assertEquals(0L, arrayList.indexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.indexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.indexOf(<(literal.(type))("9")>));
     }
 
     @Test
@@ -127,14 +129,14 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(i, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
+            assertEquals(i, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("i + 1")>));
         }
-        Assert.assertEquals(-1L, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
+        assertEquals(-1L, list.lastIndexOf(<(castIntToNarrowTypeWithParens.(type))("list.size() + 1")>)<(wideDelta.(type))>);
 
         Immutable<name>List arrayList = this.newWith(<["1", "2", "1"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
-        Assert.assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
-        Assert.assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
+        assertEquals(2L, arrayList.lastIndexOf(<(literal.(type))("1")>));
+        assertEquals(1L, arrayList.lastIndexOf(<(literal.(type))("2")>));
+        assertEquals(-1L, arrayList.lastIndexOf(<(literal.(type))("9")>));
     }
 
     @Override
@@ -144,15 +146,15 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         <name>Iterator iterator = this.classUnderTest().<type>Iterator();
         for (int i = 0; iterator.hasNext(); i++)
         {
-            Assert.assertEquals(i + 1, iterator.next()<(wideDelta.(type))>);
+            assertEquals(i + 1, iterator.next()<(wideDelta.(type))>);
         }
         Assert.assertFalse(iterator.hasNext());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void subList()
     {
-        this.classUnderTest().subList(0, 1);
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().subList(0, 1));
     }
 
     @Override
@@ -162,10 +164,10 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         super.toArray();
         Immutable<name>List list = this.classUnderTest();
         <type>[] array = list.toArray();
-        Assert.assertEquals(list.size(), array.length);
+        assertEquals(list.size(), array.length);
         for (int i = 0; i \< list.size(); i++)
         {
-            Assert.assertEquals(list.get(i), array[i]<(wideDelta.(type))>);
+            assertEquals(list.get(i), array[i]<(wideDelta.(type))>);
         }
     }
 
@@ -177,7 +179,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
 
         Immutable<name>List iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("6")>), result);
     }
 
     @Test
@@ -187,7 +189,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>),
                 (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("14")>), result);
     }
 
     /**
@@ -199,7 +201,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Immutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -211,7 +213,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List selected = list.selectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
+        assertEquals(<name>Lists.immutable.with(<["3", "9"]:(literal.(type))(); separator=", ">), selected);
     }
 
     /**
@@ -223,7 +225,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Immutable<name>List rejected = list.rejectWithIndex((value, i) -> i % 2 == 0);
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -235,7 +237,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">);
         Mutable<name>List rejected = list.rejectWithIndex((value, i) -> i % 2 == 0, <name>Lists.mutable.empty());
 
-        Assert.assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
+        assertEquals(<name>Lists.immutable.with(<["1", "7"]:(literal.(type))(); separator=", ">), rejected);
     }
 
     /**
@@ -246,10 +248,10 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         ImmutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
     }
@@ -262,17 +264,17 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         MutableList\<<name>IntPair> pairs = this.newWith(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">)
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Lists.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Lists.mutable.empty()));
 
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(<name>IntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 <name>Sets.mutable.with(<["3", "1", "9", "7"]:(literal.(type))(); separator=", ">),
                 pairs.collect<name>(<name>IntPair::getOne, <name>Sets.mutable.empty()));
     }
@@ -282,16 +284,16 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     {
         Immutable<name>List list1 = this.newWith(<["1", "2", "2", "3", "3", "3", "4", "4", "4", "4"]:(literal.(type))(); separator=", ">).distinct();
         Immutable<name>List list2 = this.newWith(<["1", "2", "3", "4"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(list1, list2);
+        assertEquals(list1, list2);
     }
 
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(Immutable<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>), this.newWith(<(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
+        assertEquals(Immutable<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>), this.newWith(<(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
         Immutable<name>List list1 = this.newWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>);
         Assert.assertNotSame(list1, list1.toReversed());
-        Assert.assertEquals(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>), this.newWith(<(literal.(type))("8")>, <(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
+        assertEquals(<name>ArrayList.newListWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>), this.newWith(<(literal.(type))("8")>, <(literal.(type))("7")>, <(literal.(type))("9")>, <(literal.(type))("1")>, <(literal.(type))("3")>).toReversed());
         Immutable<name>List list2 = this.newWith(<(literal.(type))("3")>, <(literal.(type))("1")>, <(literal.(type))("9")>, <(literal.(type))("7")>, <(literal.(type))("8")>);
         Assert.assertNotSame(list2, list2.toReversed());
     }
@@ -302,7 +304,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("9")>, sum[0]<wideDelta.(type)>);
     }
 
     @Override
@@ -328,7 +330,7 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
             expectedString.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : ", ");
         }
         expectedString.append(']');
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Override
@@ -347,9 +349,9 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
             expectedString.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : ", ");
             expectedString1.append(<(castRealTypeToInt.(type))("each")> == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), list.makeString());
-        Assert.assertEquals(expectedString1.toString(), list.makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals(expectedString.toString(), list.makeString());
+        assertEquals(expectedString1.toString(), list.makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Override
@@ -370,13 +372,13 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list = this.classUnderTest();
         StringBuilder appendable2 = new StringBuilder();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -396,36 +398,36 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         Immutable<name>List list1 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>List list2 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
         ImmutableList\<<name><name>Pair> zipSame = list1.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSame);
         ImmutableList\<<name><name>Pair> zipSameLazy = list1.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["2", "2"]:(literal.(type))(); separator=", ">),
                         PrimitiveTuples.pair(<["3", "3"]:(literal.(type))(); separator=", ">)),
                 zipSameLazy);
         ImmutableList\<<name><name>Pair> zipLess = list1.zip<name>(list2);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipLess);
         ImmutableList\<<name><name>Pair> zipLessLazy = list1.zip<name>(list2.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipLessLazy);
         ImmutableList\<<name><name>Pair> zipMore = list2.zip<name>(list1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipMore);
         ImmutableList\<<name><name>Pair> zipMoreLazy = list2.zip<name>(list1.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<["1", "1"]:(literal.(type))(); separator=", ">)),
                 zipMoreLazy);
@@ -443,36 +445,36 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
         ImmutableList\<String> list3 = Lists.immutable.with("1", "2", "3");
         ImmutableList\<String> list4 = Lists.immutable.with("1");
         ImmutableList\<<name>ObjectPair\<String\>> zipSame = list1.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSame);
         ImmutableList\<<name>ObjectPair\<String\>> zipSameLazy = list1.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1"),
                         PrimitiveTuples.pair(<(literal.(type))("2")>, "2"),
                         PrimitiveTuples.pair(<(literal.(type))("3")>, "3")),
                 zipSameLazy);
         ImmutableList\<<name>ObjectPair\<String\>> zipLess = list1.zip(list4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipLess);
         ImmutableList\<<name>ObjectPair\<String\>> zipLessLazy = list1.zip(list4.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipLessLazy);
         ImmutableList\<<name>ObjectPair\<String\>> zipMore = list2.zip(list3);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipMore);
         ImmutableList\<<name>ObjectPair\<String\>> zipMoreLazy = list2.zip(list3.asLazy());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(<(literal.(type))("1")>, "1")),
                 zipMoreLazy);
@@ -486,17 +488,17 @@ public abstract class AbstractImmutable<name>ListTestCase extends AbstractImmuta
     @Test
     public void stream()
     {
-        Assert.assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void parallelStream()
     {
-        Assert.assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.emptyList(), <name>Lists.immutable.empty().primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Collections.singletonList(<(literal.(type))("1")>), this.newWith(<["1"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 <endif>
 }

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveArrayListTest.stg
@@ -23,8 +23,10 @@ import org.eclipse.collections.impl.factory.primitive.<name>Lists;
 import org.eclipse.collections.impl.factory.primitive.<name>Stacks;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Immutable<name>ArrayList}.
@@ -43,19 +45,19 @@ public class Immutable<name>ArrayListTest extends AbstractImmutable<name>ListTes
     public void newCollection()
     {
         super.newCollection();
-        Assert.assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newList(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
+        assertEquals(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">), Immutable<name>ArrayList.newList(<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newCollection_throws_empty()
     {
-        Immutable<name>ArrayList.newListWith();
+        assertThrows(IllegalArgumentException.class, () -> Immutable<name>ArrayList.newListWith());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newCollection_throws_single()
     {
-        Immutable<name>ArrayList.newListWith(<(literal.(type))("42")>);
+        assertThrows(IllegalArgumentException.class, () -> Immutable<name>ArrayList.newListWith(<(literal.(type))("42")>));
     }
 
     @Override
@@ -71,38 +73,38 @@ public class Immutable<name>ArrayListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>ArrayList list1 = Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>ArrayList list2 = Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("14")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void dotProduct_throwsOnListsOfDifferentSizes()
     {
         Immutable<name>ArrayList list1 = Immutable<name>ArrayList.newListWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Immutable<name>ArrayList list2 = Immutable<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        list1.dotProduct(list2);
+        assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Test
     public void binarySearch()
     {
         Immutable<name>ArrayList list = Immutable<name>ArrayList.newListWith(<["2", "3", "5", "6", "9"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
-        Assert.assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
-        Assert.assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
-        Assert.assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
-        Assert.assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
-        Assert.assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
-        Assert.assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
-        Assert.assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
-        Assert.assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
+        assertEquals(-1, list.binarySearch(<(literal.(type))("1")>));
+        assertEquals(0, list.binarySearch(<(literal.(type))("2")>));
+        assertEquals(1, list.binarySearch(<(literal.(type))("3")>));
+        assertEquals(-3, list.binarySearch(<(literal.(type))("4")>));
+        assertEquals(2, list.binarySearch(<(literal.(type))("5")>));
+        assertEquals(3, list.binarySearch(<(literal.(type))("6")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("7")>));
+        assertEquals(-5, list.binarySearch(<(literal.(type))("8")>));
+        assertEquals(4, list.binarySearch(<(literal.(type))("9")>));
+        assertEquals(-6, list.binarySearch(<(literal.(type))("10")>));
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = <name>Stacks.mutable.withAll(this.classUnderTest());
-        Assert.assertEquals(stack, this.classUnderTest().toStack());
+        assertEquals(stack, this.classUnderTest().toStack());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveEmptyListTest.stg
@@ -29,6 +29,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Immutable<name>EmptyList}.
  * This file was automatically generated from template file immutablePrimitiveEmptyListTest.stg.
@@ -42,10 +45,10 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     }
 
     @Override
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void get()
     {
-        this.classUnderTest().get(1);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().get(1));
     }
 
     @Override
@@ -54,23 +57,23 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>Collection emptyCollection = this.classUnderTest();
         Immutable<name>Collection newCollection = emptyCollection.newWithout(<(literal.(type))("9")>);
-        Assert.assertEquals(this.newMutableCollectionWith(), newCollection);
+        assertEquals(this.newMutableCollectionWith(), newCollection);
         Assert.assertSame(emptyCollection, newCollection);
-        Assert.assertEquals(this.newMutableCollectionWith(), emptyCollection);
+        assertEquals(this.newMutableCollectionWith(), emptyCollection);
     }
 
     @Override
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getFirst()
     {
-        this.classUnderTest().getFirst();
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().getFirst());
     }
 
     @Override
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLast()
     {
-        this.classUnderTest().getLast();
+        assertThrows(IndexOutOfBoundsException.class, () -> this.classUnderTest().getLast());
     }
 
     @Override
@@ -123,45 +126,45 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void average()
     {
-        this.classUnderTest().average();
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().average());
     }
 
     @Override
     @Test
     public void averageIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().averageIfEmpty(1.2), 0.0);
     }
 
     @Override
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void median()
     {
-        this.classUnderTest().median();
+        assertThrows(ArithmeticException.class, () -> this.classUnderTest().median());
     }
 
     @Override
     @Test
     public void medianIfEmpty()
     {
-        Assert.assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
+        assertEquals(1.2, this.classUnderTest().medianIfEmpty(1.2), 0.0);
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void max()
     {
-        this.classUnderTest().max();
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().max());
     }
 
     @Override
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void min()
     {
-        this.classUnderTest().min();
+        assertThrows(NoSuchElementException.class, () -> this.classUnderTest().min());
     }
 
     @Test
@@ -169,15 +172,15 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
     {
         Immutable<name>EmptyList list1 = new Immutable<name>EmptyList();
         Immutable<name>EmptyList list2 = new Immutable<name>EmptyList();
-        Assert.assertEquals(<(wideLiteral.(type))("0")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("0")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void dotProduct_throwsOnListsOfDifferentSizes()
     {
         Immutable<name>EmptyList list1 = new Immutable<name>EmptyList();
         Immutable<name>ArrayList list2 = Immutable<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        list1.dotProduct(list2);
+        assertThrows(IllegalArgumentException.class, () -> list1.dotProduct(list2));
     }
 
     @Override
@@ -188,7 +191,7 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
 
         Immutable<name>EmptyList iterable = new Immutable<name>EmptyList();
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("0")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 
     @Override
@@ -198,14 +201,14 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         Immutable<name>List list1 = this.newWith();
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("0")>), result);
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(<name>Lists.immutable.of(), this.classUnderTest().toReversed());
+        assertEquals(<name>Lists.immutable.of(), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -215,16 +218,16 @@ public class Immutable<name>EmptyListTest extends AbstractImmutable<name>ListTes
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(0, sum[0], <(literal.(type))("0")>);
+        assertEquals(0, sum[0], <(literal.(type))("0")>);
     }
 
     @Test
     public void binarySearch()
     {
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("7")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("100")>));
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("-1")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("7")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("100")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("-1")>));
     }
 
     @Test

--- a/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/list/immutable/immutablePrimitiveSingletonListTest.stg
@@ -24,6 +24,9 @@ import org.eclipse.collections.impl.math.Mutable<wrapperName>;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Immutable<name>SingletonList}.
  * This file was automatically generated from template file immutablePrimitiveSingletonListTest.stg.
@@ -49,14 +52,14 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
     {
         Immutable<name>SingletonList list1 = new Immutable<name>SingletonList(<(literal.(type))("3")>);
         Immutable<name>SingletonList list2 = new Immutable<name>SingletonList(<(literal.(type))("3")>);
-        Assert.assertEquals(<(wideLiteral.(type))("9")>, list1.dotProduct(list2)<(wideDelta.(type))>);
+        assertEquals(<(wideLiteral.(type))("9")>, list1.dotProduct(list2)<(wideDelta.(type))>);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void dotProduct_throwsOnListsOfDifferentSizes()
     {
         Immutable<name>ArrayList list = Immutable<name>ArrayList.newListWith(<["1", "2"]:(literal.(type))(); separator=", ">);
-        this.classUnderTest().dotProduct(list);
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().dotProduct(list));
     }
 
     @Override
@@ -67,7 +70,7 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
 
         Immutable<name>SingletonList iterable = new Immutable<name>SingletonList(<(literal.(type))("1")>);
         Mutable<wrapperName> result = iterable.injectInto(new Mutable<wrapperName>(<(literal.(type))("1")>), Mutable<wrapperName>::add);
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("2")>), result);
     }
 
     @Override
@@ -77,14 +80,14 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
         Immutable<name>List list1 = this.newWith(<["1"]:(literal.(type))(); separator=", ">);
         Immutable<name>List list2 = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
         Mutable<wrapperName> result = list1.injectIntoWithIndex(new Mutable<wrapperName>(<(literal.(type))("0")>), (Mutable<wrapperName> object, <type> value, int index) -> object.add(<(castIntToNarrowTypeWithParens.(type))("value * list2.get(index)")>));
-        Assert.assertEquals(new Mutable<wrapperName>(<(literal.(type))("1")>), result);
+        assertEquals(new Mutable<wrapperName>(<(literal.(type))("1")>), result);
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(<name>Lists.immutable.of(<(literal.(type))("1")>), this.classUnderTest().toReversed());
+        assertEquals(<name>Lists.immutable.of(<(literal.(type))("1")>), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -94,22 +97,22 @@ public class Immutable<name>SingletonListTest extends AbstractImmutable<name>Lis
         <wideType.(type)>[] sum = new <wideType.(type)>[1];
         this.classUnderTest().forEachWithIndex((<type> each, int index) -> sum[0] += each + index);
 
-        Assert.assertEquals(1, sum[0], <(literal.(type))("0")>);
+        assertEquals(1, sum[0], <(literal.(type))("0")>);
     }
 
     @Test
     public void binarySearch()
     {
-        Assert.assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
-        Assert.assertEquals(0, this.classUnderTest().binarySearch(<(literal.(type))("1")>));
-        Assert.assertEquals(-2, this.classUnderTest().binarySearch(<(literal.(type))("5")>));
+        assertEquals(-1, this.classUnderTest().binarySearch(<(literal.(type))("0")>));
+        assertEquals(0, this.classUnderTest().binarySearch(<(literal.(type))("1")>));
+        assertEquals(-2, this.classUnderTest().binarySearch(<(literal.(type))("5")>));
     }
 
     @Test
     public void toStack()
     {
         Mutable<name>Stack stack = this.classUnderTest().toStack();
-        Assert.assertEquals(<name>Stacks.mutable.with(<(literal.(type))("1")>), stack);
+        assertEquals(<name>Stacks.mutable.with(<(literal.(type))("1")>), stack);
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapValuesTest.stg
@@ -20,7 +20,13 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Object<name>HashMap#values()}.
@@ -32,6 +38,19 @@ public class Object<name>HashMapValuesTest extends Object<name>HashMapValuesTest
     public Object<name>HashMap\<String> newMapWithKeysValues(String key1, <type> value1)
     {
         return Object<name>HashMap.newWithKeysValues(key1, value1);
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/objectPrimitiveHashMapWithHashingStrategyValuesTest.stg
@@ -20,9 +20,15 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.map.primitive.MutableObject<name>Map;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Object<name>HashMapWithHashingStrategyWithHashingStrategy#values()}.
@@ -42,6 +48,19 @@ public class Object<name>HashMapWithHashingStrategyValuesTest extends Object<nam
                 return object1.equals(object2);
             }
         });
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
+    }
 
     @Override
     public MutableObject<name>Map\<String> newMapWithKeysValues(String key1, <type> value1)

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveBooleanHashMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.MutableSet;
@@ -32,6 +35,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link <name>BooleanHashMap#keySet()}.
  *
@@ -43,6 +49,19 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     protected Mutable<name>Set classUnderTest()
     {
         return <name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true).keySet();
+    }
+
+    @Override
+    @Test
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -142,7 +161,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -151,8 +170,8 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -160,7 +179,7 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -179,11 +198,11 @@ public class <name>BooleanHashMapKeySetTest extends Abstract<name>SetTestCase
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitiveObjectHashMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.MutableSet;
@@ -32,6 +35,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link <name>ObjectHashMap#keySet()}.
  *
@@ -43,6 +49,19 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     protected Mutable<name>Set classUnderTest()
     {
         return <name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -135,7 +154,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -143,8 +162,8 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -152,7 +171,7 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -171,11 +190,11 @@ public class <name>ObjectHashMapKeySetTest extends Abstract<name>SetTestCase
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapKeySetTest.stg
@@ -22,6 +22,9 @@ body(type1, type2, name1, name2, wrapperName1) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name1>Collection;
+import org.eclipse.collections.api.iterator.<name1>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name1>Set;
 import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
@@ -29,6 +32,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTest
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link <name1><name2>HashMap#keySet()}.
@@ -41,6 +47,19 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     protected Mutable<name1>Set classUnderTest()
     {
         return <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">).keySet();
+    }
+
+    @Override
+    @Test
+    public void <type1>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name1>Collection collection = this.classUnderTest();
+        <name1>Iterator iterator = collection.<type1>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -133,7 +152,7 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     @Override
@@ -141,8 +160,8 @@ public class <name1><name2>HashMapKeySetTest extends Abstract<name1>SetTestCase
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/primitivePrimitiveHashMapValuesTest.stg
@@ -43,6 +43,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link <name1><name2>HashMap#values()}.
  * This file was automatically generated from template file primitivePrimitiveHashMapValuesTest.stg.
@@ -53,6 +56,19 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     protected Mutable<name2>Collection classUnderTest()
     {
         return <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">).values();
+    }
+
+    @Override
+    @Test
+    public void <type2>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name2>Collection collection = this.classUnderTest();
+        <name2>Iterator iterator = collection.<type2>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -468,23 +484,23 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     public void collect()
     {
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         Assert.assertTrue(
@@ -533,14 +549,14 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
@@ -554,11 +570,11 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
@@ -623,7 +639,7 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -642,11 +658,11 @@ public class <name1><name2>HashMapValuesTest extends AbstractMutable<name2>Colle
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
@@ -697,7 +713,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -717,7 +733,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedObjectPrimitiveMapValuesTest.stg
@@ -40,6 +40,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link SynchronizedObject<name>Map#values()}.
  * This file was automatically generated from template file synchronizedObjectPrimitiveMapValuesTest.stg.
@@ -50,6 +53,19 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     protected Mutable<name>Collection classUnderTest()
     {
         return new SynchronizedObject<name>Map\<>(Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">)).values();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -90,21 +106,21 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         Verify.assertEmpty(list);
         Assert.assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -112,21 +128,21 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -137,8 +153,8 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         Mutable<name>Collection collectionWithout = collection.without(<(literal.(type))("2")>);
         Assert.assertSame(collection, collectionWithout);
         Mutable<name>Collection expectedCollection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -149,7 +165,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
         Mutable<name>Collection collectionWithout = collection.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
         Assert.assertSame(collection, collectionWithout);
         Mutable<name>Collection expectedCollection = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -379,23 +395,23 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = (<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(
@@ -444,14 +460,14 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
@@ -465,11 +481,11 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
@@ -551,7 +567,7 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -570,16 +586,16 @@ public class SynchronizedObject<name>MapValuesTest extends AbstractMutable<name>
                         <name>Bags.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveBooleanMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.api.set.MutableSet;
@@ -32,6 +35,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Synchronized<name>BooleanMap#keySet()}.
  *
@@ -43,6 +49,19 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     protected Mutable<name>Set classUnderTest()
     {
         return new Synchronized<name>BooleanMap(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true)).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -60,14 +79,14 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -75,21 +94,21 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
@@ -100,8 +119,8 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Mutable<name>Set setWithout = set.without(<(literal.(type))("2")>);
         Assert.assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -112,13 +131,13 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Mutable<name>Set setWithout = set.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
         Assert.assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Test
     public void freeze()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
@@ -150,7 +169,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -159,8 +178,8 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -168,7 +187,7 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -187,16 +206,16 @@ public class Synchronized<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -207,14 +226,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -222,7 +241,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitiveObjectMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name>ArrayList;
@@ -27,6 +30,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestC
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Synchronized<name>ObjectMap#keySet()}.
@@ -39,6 +45,19 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     protected Mutable<name>Set classUnderTest()
     {
         return new Synchronized<name>ObjectMap\<>(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -97,8 +116,8 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
         Mutable<name>Set setWithout = set.without(<(literal.(type))("2")>);
         Assert.assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type))("4")>).toList());
     }
 
     @Override
@@ -109,7 +128,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
         Mutable<name>Set setWithout = set.withoutAll(new <name>ArrayList(<(literal.(type))("2")>, <(literal.(type))("4")>));
         Assert.assertSame(set, setWithout);
         Mutable<name>Set expectedSet = this.newWith(<(literal.(type))("1")>, <(literal.(type))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Override
@@ -141,7 +160,7 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -149,8 +168,8 @@ public class Synchronized<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapKeySetTest.stg
@@ -22,6 +22,9 @@ body(type1, type2, name1, name2, wrapperName1) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name1>Collection;
+import org.eclipse.collections.api.iterator.<name1>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name1>Set;
 import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
 import org.eclipse.collections.impl.list.mutable.primitive.<name1>ArrayList;
@@ -29,6 +32,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTest
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#keySet()}.
@@ -41,6 +47,19 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     protected Mutable<name1>Set classUnderTest()
     {
         return new Synchronized<name1><name2>Map(<name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">)).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type1>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name1>Collection collection = this.classUnderTest();
+        <name1>Iterator iterator = collection.<type1>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -58,14 +77,14 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type1))("0")>));
     }
 
     <if(primitive1.floatingPoint)><NaNTests()><endif>
@@ -73,21 +92,21 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type1))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
@@ -98,8 +117,8 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
         Mutable<name1>Set setWithout = set.without(<(literal.(type1))("2")>);
         Assert.assertSame(set, setWithout);
         Mutable<name1>Set expectedSet = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type1))("4")>).toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.without(<(literal.(type1))("4")>).toList());
     }
 
     @Override
@@ -110,7 +129,7 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
         Mutable<name1>Set setWithout = set.withoutAll(new <name1>ArrayList(<(literal.(type1))("2")>, <(literal.(type1))("4")>));
         Assert.assertSame(set, setWithout);
         Mutable<name1>Set expectedSet = this.newWith(<(literal.(type1))("1")>, <(literal.(type1))("3")>);
-        Assert.assertEquals(expectedSet.toList(), setWithout.toList());
+        assertEquals(expectedSet.toList(), setWithout.toList());
     }
 
     @Override
@@ -142,7 +161,7 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     @Override
@@ -150,8 +169,8 @@ public class Synchronized<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 }
 
@@ -166,14 +185,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
@@ -181,7 +200,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/synchronizedPrimitivePrimitiveMapValuesTest.stg
@@ -43,6 +43,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Synchronized<name1><name2>Map#values()}.
  * This file was automatically generated from template file synchronizedPrimitivePrimitiveMapValuesTest.stg.
@@ -53,6 +56,19 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     protected Mutable<name2>Collection classUnderTest()
     {
         return new Synchronized<name1><name2>Map(<name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">)).values();
+    }
+
+    @Override
+    @Test
+    public void <type2>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name2>Collection collection = this.classUnderTest();
+        <name2>Iterator iterator = collection.<type2>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -140,8 +156,8 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
         Mutable<name2>Collection collectionWithout = collection.without(<(literal.(type2))("2")>);
         Assert.assertSame(collection, collectionWithout);
         Mutable<name2>Collection expectedCollection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type2))("4")>).toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.without(<(literal.(type2))("4")>).toList());
     }
 
     @Override
@@ -152,7 +168,7 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
         Mutable<name2>Collection collectionWithout = collection.withoutAll(new <name2>ArrayList(<(literal.(type2))("2")>, <(literal.(type2))("4")>));
         Assert.assertSame(collection, collectionWithout);
         Mutable<name2>Collection expectedCollection = this.newWith(<(literal.(type2))("1")>, <(literal.(type2))("3")>);
-        Assert.assertEquals(expectedCollection.toList(), collectionWithout.toList());
+        assertEquals(expectedCollection.toList(), collectionWithout.toList());
     }
 
     @Override
@@ -403,23 +419,23 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void collect()
     {
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         Assert.assertTrue(
@@ -468,14 +484,14 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
@@ -489,11 +505,11 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
@@ -558,7 +574,7 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -578,11 +594,11 @@ public class Synchronized<name1><name2>MapValuesTest extends AbstractMutable<nam
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
@@ -633,7 +649,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -653,7 +669,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiableObjectPrimitiveMapValuesTest.stg
@@ -41,6 +41,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link UnmodifiableObject<name>Map#values()}.
  * This file was automatically generated from template file unmodifiableObjectPrimitiveMapValuesTest.stg.
@@ -51,6 +54,19 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     protected Mutable<name>Collection classUnderTest()
     {
         return new UnmodifiableObject<name>Map\<>(Object<name>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">)).values();
+    }
+
+    @Override
+    @Test
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -91,21 +107,21 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
         Verify.assertEmpty(list);
         Assert.assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()>
@@ -114,21 +130,21 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
@@ -136,7 +152,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
@@ -144,7 +160,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -152,14 +168,14 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().remove(<(literal.(type))("3")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().remove(<(literal.(type))("3")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.newWith().removeIf(<name>Predicates.equal(<(literal.(type))("3")>)));
     }
 
@@ -167,28 +183,28 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name>ArrayList()));
     }
 
     @Override
@@ -196,7 +212,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void clear()
     {
         Mutable<name>Collection emptyCollection = this.newWith();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
+        assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override
@@ -240,23 +256,23 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void collect()
     {
         <name>ToObjectFunction\<<wrapperName>\> function = (<type> parameter) -> <(castIntToNarrowTypeWithParens.(type))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">).collect(function).toBag());
         <name>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("2")>), this.newWith(<(literal.(type))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type))("1")>", this.newWith(<(literal.(type))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type))("31")>", this.newWith(<(literal.(type))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type))("32")>", this.newWith(<(literal.(type))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
         Assert.assertTrue(
@@ -305,14 +321,14 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
@@ -326,11 +342,11 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type))(); separator=", ">);
@@ -412,7 +428,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -420,7 +436,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -434,7 +450,7 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -453,16 +469,16 @@ public class UnmodifiableObject<name>MapValuesTest extends AbstractMutable<name>
                         <name>Bags.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Bags.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Bags.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveBooleanMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.<name>Iterable;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
@@ -33,6 +36,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Unmodifiable<name>BooleanMap#keySet()}.
  *
@@ -44,6 +50,19 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     protected Mutable<name>Set classUnderTest()
     {
         return new Unmodifiable<name>BooleanMap(<name>BooleanHashMap.newWithKeysValues(<(literal.(type))("1")>, true, <(literal.(type))("2")>, false, <(literal.(type))("3")>, true)).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -61,7 +80,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
@@ -69,7 +88,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -77,42 +96,42 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<["0", "1"]:(literal.(type))(); separator=", ">));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Test
     public void freeze()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().freeze());
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -120,7 +139,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -134,42 +153,42 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -201,7 +220,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type))(); separator=", ">).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -210,8 +229,8 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">);
         Mutable<name>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -221,7 +240,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -230,7 +249,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -245,7 +264,7 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
     public void chunk()
     {
         <name>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">),
@@ -264,16 +283,16 @@ public class Unmodifiable<name>BooleanMapKeySetTest extends Abstract<name>SetTes
                         <name>Sets.mutable.with(<["1", "3"]:(literal.(type))(); separator=", ">),
                         <name>Sets.mutable.with(<["2"]:(literal.(type))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name>Sets.mutable.with(<["1", "2", "3"]:(literal.(type))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -284,14 +303,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -299,7 +318,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitiveObjectMapKeySetTest.stg
@@ -20,6 +20,9 @@ body(type, name, wrapperName) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name>Collection;
+import org.eclipse.collections.api.iterator.<name>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name>Set;
 import org.eclipse.collections.impl.block.factory.primitive.<name>Predicates;
@@ -28,6 +31,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name>SetTestC
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name>ObjectMap#keySet()}.
@@ -40,6 +46,19 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     protected Mutable<name>Set classUnderTest()
     {
         return new Unmodifiable<name>ObjectMap\<>(<name>ObjectHashMap.newWithKeysValues(<(literal.(type))("1")>, 1, <(literal.(type))("2")>, 2, <(literal.(type))("3")>, 3)).keySet();
+    }
+
+    @Test
+    @Override
+    public void <type>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name>Collection collection = this.classUnderTest();
+        <name>Iterator iterator = collection.<type>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -57,14 +76,14 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(<(literal.(type))("0")>));
     }
 
     <if(primitive.floatingPoint)><NaNTests()><endif>
@@ -72,35 +91,35 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().addAll(<(literal.(type))("0")>, <(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().withoutAll(new <name>ArrayList()));
     }
 
@@ -108,7 +127,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -122,14 +141,14 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                  this.classUnderTest().removeIf(<name>Predicates.equal(<(literal.(type))("1")>)));
     }
 
@@ -137,7 +156,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeAll(new <name>ArrayList()));
     }
 
@@ -145,14 +164,14 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().retainAll(new <name>ArrayList()));
     }
 
@@ -160,7 +179,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
@@ -192,7 +211,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
+        assertEquals(<(wideLiteral.(type))("3")>, this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("2")>).sum()<wideDelta.(type)>);
     }
 
     @Override
@@ -200,8 +219,8 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Set set1 = this.newWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>);
         Mutable<name>Set set2 = this.newWith(<(literal.(type))("32")>, <(literal.(type))("31")>, <(literal.(type))("1")>, <(literal.(type))("0")>);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<(literal.(type))("0")>, <(literal.(type))("1")>, <(literal.(type))("31")>, <(literal.(type))("32")>).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -210,7 +229,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -218,7 +237,7 @@ public class Unmodifiable<name>ObjectMapKeySetTest extends Abstract<name>SetTest
     {
         Mutable<name>Iterator iterator = this.classUnderTest().<type>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -235,14 +254,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName>.NaN).add(<wrapperName>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.POSITIVE_INFINITY).add(<wrapperName>.POSITIVE_INFINITY));
 }
 
@@ -250,7 +269,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName>.NEGATIVE_INFINITY).add(<wrapperName>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapKeySetTest.stg
@@ -22,6 +22,9 @@ body(type1, type2, name1, name2, wrapperName1) ::= <<
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
+import java.util.NoSuchElementException;
+import org.eclipse.collections.api.collection.primitive.Mutable<name1>Collection;
+import org.eclipse.collections.api.iterator.<name1>Iterator;
 import org.eclipse.collections.api.iterator.Mutable<name1>Iterator;
 import org.eclipse.collections.api.set.primitive.Mutable<name1>Set;
 import org.eclipse.collections.impl.block.factory.primitive.<name1>Predicates;
@@ -31,6 +34,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.Abstract<name1>SetTest
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#keySet()}.
@@ -43,6 +49,19 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     protected Mutable<name1>Set classUnderTest()
     {
         return new Unmodifiable<name1><name2>Map(<name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">)).keySet();
+    }
+
+    @Override
+    @Test
+    public void <type1>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name1>Collection collection = this.classUnderTest();
+        <name1>Iterator iterator = collection.<type1>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -82,42 +101,42 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().with(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().without(<(literal.(type1))("0")>));
     }
 
     @Override
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().withoutAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type1))("1")>));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(<(literal.(type1))("1")>));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().removeIf(<name1>Predicates.equal(<(literal.(type1))("1")>)));
     }
 
@@ -125,35 +144,35 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().removeAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name1>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll(new <name1>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().retainAll());
     }
 
     @Override
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
@@ -192,7 +211,7 @@ public class Unmodifiable<name1><name2>MapKeySetTest extends Abstract<name1>SetT
     public void sum()
     {
         super.sum();
-        Assert.assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
+        assertEquals(<(wideLiteral.(type1))("3")>, this.newWith(<["0", "1", "2"]:(literal.(type1))(); separator=", ">).sum()<wideDelta.(type1)>);
     }
 
     <if(primitive1.floatPrimitive)>@Test
@@ -206,7 +225,7 @@ public void sumConsistentRounding()
 
     // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
     // Indeed the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-    Assert.assertEquals(
+    assertEquals(
             1.082323233761663,
             set.sum(),
             1.0e-15);
@@ -221,7 +240,7 @@ public void sumConsistentRounding()
             .collect<name1>(i -> <["1.0"]:(decimalLiteral.(type1))()> / (i.<type1>Value() * i.<type1>Value() * i.<type1>Value() * i.<type1>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             1.082323233711138,
             set.sum(),
             1.0e-15);
@@ -233,8 +252,8 @@ public void sumConsistentRounding()
     {
         Mutable<name1>Set set1 = this.newWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">);
         Mutable<name1>Set set2 = this.newWith(<["32", "31", "1", "0"]:(literal.(type1))(); separator=", ">);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "31", "32"]:(literal.(type1))(); separator=", ">).hashCode(), set1.hashCode());
     }
 
     @Override
@@ -243,7 +262,7 @@ public void sumConsistentRounding()
         Mutable<name1>Iterator iterator = this.classUnderTest().<type1>Iterator();
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -251,7 +270,7 @@ public void sumConsistentRounding()
     {
         Mutable<name1>Iterator iterator = this.classUnderTest().<type1>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -272,14 +291,14 @@ NaNTests() ::= <<
 @Test
 public void add_NaN()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
+    assertThrows(UnsupportedOperationException.class, () -> this.newWith(<wrapperName1>.NaN).add(<wrapperName1>.NaN));
 }
 
 @Override
 @Test
 public void add_POSITIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.POSITIVE_INFINITY).add(<wrapperName1>.POSITIVE_INFINITY));
 }
 
@@ -287,7 +306,7 @@ public void add_POSITIVE_INFINITY()
 @Test
 public void add_NEGATIVE_INFINITY()
 {
-    Assert.assertThrows(UnsupportedOperationException.class, () ->
+    assertThrows(UnsupportedOperationException.class, () ->
             this.newWith(<wrapperName1>.NEGATIVE_INFINITY).add(<wrapperName1>.NEGATIVE_INFINITY));
 }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/mutable/unmodifiablePrimitivePrimitiveMapValuesTest.stg
@@ -44,6 +44,9 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link Unmodifiable<name1><name2>Map#values()}.
  * This file was automatically generated from template file unmodifiablePrimitivePrimitiveMapValuesTest.stg.
@@ -54,6 +57,19 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     protected Mutable<name2>Collection classUnderTest()
     {
         return <name1><name2>HashMap.newWithKeysValues(<["1", "2", "3"]:keyValue(); separator=", ">).values().asUnmodifiable();
+    }
+
+    @Override
+    @Test
+    public void <type2>Iterator_throws_non_empty_collection()
+    {
+        Mutable<name2>Collection collection = this.classUnderTest();
+        <name2>Iterator iterator = collection.<type2>Iterator();
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Override
@@ -94,7 +110,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         Verify.assertEmpty(list);
         Assert.assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -105,7 +121,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         Mutable<name2>Iterator iterator = <type2>Iterable.<type2>Iterator();
         Assert.assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -115,7 +131,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         Mutable<name2>Collection <type2>Iterable = this.classUnderTest();
         Mutable<name2>Iterator iterator = <type2>Iterable.<type2>Iterator();
         Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -129,7 +145,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().addAll(new <name2>ArrayList()));
     }
 
@@ -137,7 +153,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                 this.classUnderTest().add(<(literal.(type2))("0")>));
     }
 
@@ -146,7 +162,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void addAllArray()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().addAll(<["0", "1"]:(literal.(type2))(); separator=", ">));
     }
 
@@ -154,7 +170,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void with()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().with(<(literal.(type2))("0")>));
     }
 
@@ -162,7 +178,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void without()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().without(<(literal.(type2))("0")>));
     }
 
@@ -170,7 +186,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void withAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().withAll(new <name2>ArrayList()));
     }
 
@@ -178,7 +194,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void withoutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().withoutAll(new <name2>ArrayList()));
     }
 
@@ -186,7 +202,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().remove(<(literal.(type2))("0")>));
     }
 
@@ -194,7 +210,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
                     this.classUnderTest().removeIf(<name2>Predicates.equal(<(literal.(type2))("0")>)));
     }
 
@@ -211,28 +227,28 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().removeAll(new <name2>ArrayList()));
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name2>ArrayList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().retainAll(new <name2>ArrayList()));
     }
 
     @Override
@@ -240,7 +256,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void clear()
     {
         Mutable<name2>Collection emptyCollection = this.newWith();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
+        assertThrows(UnsupportedOperationException.class, () -> emptyCollection.clear());
     }
 
     @Override
@@ -286,23 +302,23 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
         super.collect();
 
         <name2>ToObjectFunction\<<wrapperName2>\> function = (<type2> parameter) -> <(castIntToNarrowTypeWithParens.(type2))("parameter - 1")>;
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">).collect(function).toBag());
         <name2>Iterable iterable = this.newWith(<["1", "2", "3"]:(literal.(type2))(); separator=", ">);
-        Assert.assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
-        Assert.assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
+        assertEquals(this.newObjectCollectionWith(<["0", "1", "2"]:(literal.(type2))(); separator=", ">).toBag(), iterable.collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(<(literal.(type2))("2")>), this.newWith(<(literal.(type2))("3")>).collect(function));
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
+        assertEquals("<(toStringLiteral.(type2))("1")>", this.newWith(<(literal.(type2))("1")>).makeString("/"));
+        assertEquals("<(toStringLiteral.(type2))("31")>", this.newWith(<(literal.(type2))("31")>).makeString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", this.newWith(<(literal.(type2))("32")>).makeString());
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", ", ", "]"));
 
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
         Assert.assertTrue(
@@ -351,14 +367,14 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", ", ", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(<(literal.(type2))("1")>).appendString(appendable1);
-        Assert.assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
+        assertEquals("<(toStringLiteral.(type2))("1")>", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
 
         <name2>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type2))(); separator=", ">);
@@ -372,11 +388,11 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
 
         StringBuilder appendable5 = new StringBuilder();
         this.newWith(<(literal.(type2))("31")>).appendString(appendable5);
-        Assert.assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
+        assertEquals("<(toStringLiteral.(type2))("31")>", appendable5.toString());
 
         StringBuilder appendable6 = new StringBuilder();
         this.newWith(<(literal.(type2))("32")>).appendString(appendable6);
-        Assert.assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
+        assertEquals("<(toStringLiteral.(type2))("32")>", appendable6.toString());
 
         StringBuilder appendable7 = new StringBuilder();
         <name2>Iterable iterable1 = this.newWith(<["0", "31"]:(literal.(type2))(); separator=", ">);
@@ -452,7 +468,7 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
     public void chunk()
     {
         <name2>Iterable iterable = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">),
@@ -471,16 +487,16 @@ public class Unmodifiable<name1><name2>MapValuesTest extends AbstractMutable<nam
                         <name2>Bags.mutable.with(<["1", "3"]:(literal.(type2))(); separator=", ">),
                         <name2>Bags.mutable.with(<["2"]:(literal.(type2))(); separator=", ">)).toSet().equals(chunked));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         <name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(3).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(<name2>Bags.mutable.with(<["1", "2", "3"]:(literal.(type2))(); separator=", ">)).toSet(),
                 iterable.chunk(4).toSet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> iterable.chunk(-1));
     }
 }
 
@@ -526,7 +542,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(floatResults.(type1))()>,
             iterable.sum(),
             1.0e-15);
@@ -546,7 +562,7 @@ public void sumConsistentRounding()
             .collect<name2>(i -> <["1.0"]:(decimalLiteral.(type2))()> / (i.<type2>Value() * i.<type2>Value() * i.<type2>Value() * i.<type2>Value()))
             .toArray());
 
-    Assert.assertEquals(
+    assertEquals(
             <(doubleResults.(type1))()>,
             iterable.sum(),
             1.0e-15);


### PR DESCRIPTION
Part of the Junit5 migration preparation.

- Moves imports to static to reduce change size for future PRs
- Fixes a bug in an iterator test explained in [here](https://github.com/eclipse/eclipse-collections/pull/1577)
- Removes any junit4 syntax like @Test(expected = ) as it's not supported in junit5