### PR TITLE
Use static imports for Assert methods.

### DIFF
--- a/eclipse-collections-forkjoin/src/test/java/org/eclipse/collections/impl/forkjoin/FJIterateTest.java
+++ b/eclipse-collections-forkjoin/src/test/java/org/eclipse/collections/impl/forkjoin/FJIterateTest.java
@@ -63,9 +63,14 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class FJIterateTest
 {
@@ -141,25 +146,25 @@ public class FJIterateTest
         IntegerSum sum = new IntegerSum(0);
         MutableSet<Integer> set = Interval.toSet(1, 100);
         FJIterate.forEach(set, new SumProcedure(sum), new SumCombiner(sum));
-        Assert.assertEquals(5050, sum.getSum());
+        assertEquals(5050, sum.getSum());
 
         //Testing batch size 1
         IntegerSum sum2 = new IntegerSum(0);
         UnifiedSet<Integer> set2 = UnifiedSet.newSet(Interval.oneTo(100));
         FJIterate.forEach(set2, new SumProcedure(sum2), new SumCombiner(sum2), 1, set2.getBatchCount(set2.size()));
-        Assert.assertEquals(5050, sum2.getSum());
+        assertEquals(5050, sum2.getSum());
 
         //Testing an uneven batch size
         IntegerSum sum3 = new IntegerSum(0);
         UnifiedSet<Integer> set3 = UnifiedSet.newSet(Interval.oneTo(100));
         FJIterate.forEach(set3, new SumProcedure(sum3), new SumCombiner(sum3), 1, set3.getBatchCount(13));
-        Assert.assertEquals(5050, sum3.getSum());
+        assertEquals(5050, sum3.getSum());
 
         //Testing divideByZero exception by passing 1 as batchSize
         IntegerSum sum4 = new IntegerSum(0);
         UnifiedSet<Integer> set4 = UnifiedSet.newSet(Interval.oneTo(100));
         FJIterate.forEach(set4, new SumProcedure(sum4), new SumCombiner(sum4), 1);
-        Assert.assertEquals(5050, sum4.getSum());
+        assertEquals(5050, sum4.getSum());
     }
 
     @Test
@@ -169,19 +174,19 @@ public class FJIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         MutableMap<String, Integer> map1 = Interval.fromTo(1, 100).toMap(Functions.getToString(), Functions.getIntegerPassThru());
         FJIterate.forEach(map1, new SumProcedure(sum1), new SumCombiner(sum1));
-        Assert.assertEquals(5050, sum1.getSum());
+        assertEquals(5050, sum1.getSum());
 
         //Testing batch size 1
         IntegerSum sum2 = new IntegerSum(0);
         UnifiedMap<String, Integer> map2 = (UnifiedMap<String, Integer>) Interval.fromTo(1, 100).toMap(Functions.getToString(), Functions.getIntegerPassThru());
         FJIterate.forEach(map2, new SumProcedure(sum2), new SumCombiner(sum2), 1, map2.getBatchCount(map2.size()));
-        Assert.assertEquals(5050, sum2.getSum());
+        assertEquals(5050, sum2.getSum());
 
         //Testing an uneven batch size
         IntegerSum sum3 = new IntegerSum(0);
         UnifiedMap<String, Integer> set3 = (UnifiedMap<String, Integer>) Interval.fromTo(1, 100).toMap(Functions.getToString(), Functions.getIntegerPassThru());
         FJIterate.forEach(set3, new SumProcedure(sum3), new SumCombiner(sum3), 1, set3.getBatchCount(13));
-        Assert.assertEquals(5050, sum3.getSum());
+        assertEquals(5050, sum3.getSum());
     }
 
     @Test
@@ -190,37 +195,37 @@ public class FJIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         List<Integer> list1 = FJIterateTest.createIntegerList(16);
         FJIterate.forEach(list1, new SumProcedure(sum1), new SumCombiner(sum1), 1, list1.size() / 2);
-        Assert.assertEquals(16, sum1.getSum());
+        assertEquals(16, sum1.getSum());
 
         IntegerSum sum2 = new IntegerSum(0);
         List<Integer> list2 = FJIterateTest.createIntegerList(7);
         FJIterate.forEach(list2, new SumProcedure(sum2), new SumCombiner(sum2));
-        Assert.assertEquals(7, sum2.getSum());
+        assertEquals(7, sum2.getSum());
 
         IntegerSum sum3 = new IntegerSum(0);
         List<Integer> list3 = FJIterateTest.createIntegerList(15);
         FJIterate.forEach(list3, new SumProcedure(sum3), new SumCombiner(sum3), 1, list3.size() / 2);
-        Assert.assertEquals(15, sum3.getSum());
+        assertEquals(15, sum3.getSum());
 
         IntegerSum sum4 = new IntegerSum(0);
         List<Integer> list4 = FJIterateTest.createIntegerList(35);
         FJIterate.forEach(list4, new SumProcedure(sum4), new SumCombiner(sum4));
-        Assert.assertEquals(35, sum4.getSum());
+        assertEquals(35, sum4.getSum());
 
         IntegerSum sum5 = new IntegerSum(0);
         MutableList<Integer> list5 = FastList.newList(list4);
         FJIterate.forEach(list5, new SumProcedure(sum5), new SumCombiner(sum5));
-        Assert.assertEquals(35, sum5.getSum());
+        assertEquals(35, sum5.getSum());
 
         IntegerSum sum6 = new IntegerSum(0);
         List<Integer> list6 = FJIterateTest.createIntegerList(40);
         FJIterate.forEach(list6, new SumProcedure(sum6), new SumCombiner(sum6), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum6.getSum());
+        assertEquals(40, sum6.getSum());
 
         IntegerSum sum7 = new IntegerSum(0);
         MutableList<Integer> list7 = FastList.newList(list6);
         FJIterate.forEach(list7, new SumProcedure(sum7), new SumCombiner(sum7), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum7.getSum());
+        assertEquals(40, sum7.getSum());
     }
 
     @Test
@@ -229,43 +234,43 @@ public class FJIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         ImmutableList<Integer> list1 = Lists.immutable.ofAll(FJIterateTest.createIntegerList(16));
         FJIterate.forEach(list1, new SumProcedure(sum1), new SumCombiner(sum1), 1, list1.size() / 2);
-        Assert.assertEquals(16, sum1.getSum());
+        assertEquals(16, sum1.getSum());
 
         IntegerSum sum2 = new IntegerSum(0);
         ImmutableList<Integer> list2 = Lists.immutable.ofAll(FJIterateTest.createIntegerList(7));
         FJIterate.forEach(list2, new SumProcedure(sum2), new SumCombiner(sum2));
-        Assert.assertEquals(7, sum2.getSum());
+        assertEquals(7, sum2.getSum());
 
         IntegerSum sum3 = new IntegerSum(0);
         ImmutableList<Integer> list3 = Lists.immutable.ofAll(FJIterateTest.createIntegerList(15));
         FJIterate.forEach(list3, new SumProcedure(sum3), new SumCombiner(sum3), 1, list3.size() / 2);
-        Assert.assertEquals(15, sum3.getSum());
+        assertEquals(15, sum3.getSum());
 
         IntegerSum sum4 = new IntegerSum(0);
         ImmutableList<Integer> list4 = Lists.immutable.ofAll(FJIterateTest.createIntegerList(35));
         FJIterate.forEach(list4, new SumProcedure(sum4), new SumCombiner(sum4));
-        Assert.assertEquals(35, sum4.getSum());
+        assertEquals(35, sum4.getSum());
 
         IntegerSum sum5 = new IntegerSum(0);
         ImmutableList<Integer> list5 = FastList.newList(list4).toImmutable();
         FJIterate.forEach(list5, new SumProcedure(sum5), new SumCombiner(sum5));
-        Assert.assertEquals(35, sum5.getSum());
+        assertEquals(35, sum5.getSum());
 
         IntegerSum sum6 = new IntegerSum(0);
         ImmutableList<Integer> list6 = Lists.immutable.ofAll(FJIterateTest.createIntegerList(40));
         FJIterate.forEach(list6, new SumProcedure(sum6), new SumCombiner(sum6), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum6.getSum());
+        assertEquals(40, sum6.getSum());
 
         IntegerSum sum7 = new IntegerSum(0);
         ImmutableList<Integer> list7 = FastList.newList(list6).toImmutable();
         FJIterate.forEach(list7, new SumProcedure(sum7), new SumCombiner(sum7), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum7.getSum());
+        assertEquals(40, sum7.getSum());
     }
 
     @Test
     public void testForEachWithException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> FJIterate.forEach(
+        assertThrows(RuntimeException.class, () -> FJIterate.forEach(
                 FJIterateTest.createIntegerList(5),
                 new PassThruProcedureFactory<>(EXCEPTION_PROCEDURE),
                 new PassThruCombiner<>(),
@@ -278,9 +283,9 @@ public class FJIterateTest
     {
         Integer[] array = new Integer[200];
         MutableList<Integer> list = new FastList<>(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         FJIterate.forEachWithIndex(list, (each, index) -> array[index] = each);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -288,9 +293,9 @@ public class FJIterateTest
     {
         Integer[] array = new Integer[200];
         MutableList<Integer> list = new FastList<>(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         FJIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -298,9 +303,9 @@ public class FJIterateTest
     {
         Integer[] array = new Integer[200];
         ImmutableList<Integer> list = Interval.oneTo(200).toList().toImmutable();
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         FJIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -308,25 +313,25 @@ public class FJIterateTest
     {
         Integer[] array = new Integer[200];
         MutableList<Integer> list = FastList.newList(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         FJIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
     public void testForEachWithIndexToArrayUsingFixedArrayList()
     {
         Integer[] array = new Integer[10];
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         FJIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 1, 2);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[list.size()]));
+        assertArrayEquals(array, list.toArray(new Integer[list.size()]));
     }
 
     @Test
     public void testForEachWithIndexException()
     {
-        Assert.assertThrows(RuntimeException.class, () -> FJIterate.forEachWithIndex(
+        assertThrows(RuntimeException.class, () -> FJIterate.forEachWithIndex(
                 FJIterateTest.createIntegerList(5),
                 new PassThruObjectIntProcedureFactory<>(EXCEPTION_OBJECT_INT_PROCEDURE),
                 new PassThruCombiner<>(),
@@ -346,9 +351,9 @@ public class FJIterateTest
         Collection<Integer> actual2 = FJIterate.select(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = FJIterate.select(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -358,10 +363,10 @@ public class FJIterateTest
         Collection<Integer> actual1 = FJIterate.select(iterable, Predicates.greaterThan(100));
         Collection<Integer> actual2 = FJIterate.select(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
-        Assert.assertSame(expected.getClass(), actual1.getClass());
-        Assert.assertSame(expected.getClass(), actual2.getClass());
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
+        assertSame(expected.getClass(), actual1.getClass());
+        assertSame(expected.getClass(), actual2.getClass());
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
     }
 
     @Test
@@ -374,8 +379,8 @@ public class FJIterateTest
     {
         int actual1 = FJIterate.count(iterable, Predicates.greaterThan(100));
         int actual2 = FJIterate.count(iterable, Predicates.greaterThan(100), 6, this.executor);
-        Assert.assertEquals(100, actual1);
-        Assert.assertEquals(100, actual2);
+        assertEquals(100, actual1);
+        assertEquals(100, actual2);
     }
 
     @Test
@@ -390,9 +395,9 @@ public class FJIterateTest
         Collection<Integer> actual2 = FJIterate.reject(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = FJIterate.reject(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.reject(Predicates.greaterThan(100));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -409,9 +414,9 @@ public class FJIterateTest
         RichIterable<String> expected = iterable.collect(Functions.getToString());
         Verify.assertSize(200, actual1);
         Verify.assertContains(String.valueOf(200), actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected.toBag(), HashBag.newBag(actual3));
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected.toBag(), HashBag.newBag(actual3));
     }
 
     @Test
@@ -431,9 +436,9 @@ public class FJIterateTest
         Verify.assertNotContains(String.valueOf(90), actual1);
         Verify.assertNotContains(String.valueOf(210), actual1);
         Verify.assertContains(String.valueOf(159), actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, HashBag.newBag(actual1));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, HashBag.newBag(actual1));
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -451,15 +456,15 @@ public class FJIterateTest
         Multimap<String, Integer> result7 = FJIterate.groupBy(iterable.toBag(), Functions.getToString(), SynchronizedPutHashBagMultimap.newMultimap(), 100);
         Multimap<String, Integer> result8 = FJIterate.groupBy(iterable.toBag(), Functions.getToString(), SynchronizedPutHashBagMultimap.newMultimap());
         Multimap<String, Integer> result9 = FJIterate.groupBy(iterable.toList().toImmutable(), Functions.getToString());
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result1));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result2));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result9));
-        Assert.assertEquals(expectedAsSet, result3);
-        Assert.assertEquals(expectedAsSet, result4);
-        Assert.assertEquals(expectedAsSet, result5);
-        Assert.assertEquals(expectedAsSet, result6);
-        Assert.assertEquals(expected, result7);
-        Assert.assertEquals(expected, result8);
+        assertEquals(expected, HashBagMultimap.newMultimap(result1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result2));
+        assertEquals(expected, HashBagMultimap.newMultimap(result9));
+        assertEquals(expectedAsSet, result3);
+        assertEquals(expectedAsSet, result4);
+        assertEquals(expectedAsSet, result5);
+        assertEquals(expectedAsSet, result6);
+        assertEquals(expected, result7);
+        assertEquals(expected, result8);
     }
 
     @Test
@@ -481,16 +486,16 @@ public class FJIterateTest
         expected.put('M', "Mary");
         expected.put('B', "Bob");
         expected.put('S', "Sara");
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result1));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result2));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result3));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result4));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result5));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result6));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result7));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result8));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result9));
-        Assert.assertThrows(IllegalArgumentException.class, () -> FJIterate.groupBy(null, null, 1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result2));
+        assertEquals(expected, HashBagMultimap.newMultimap(result3));
+        assertEquals(expected, HashBagMultimap.newMultimap(result4));
+        assertEquals(expected, HashBagMultimap.newMultimap(result5));
+        assertEquals(expected, HashBagMultimap.newMultimap(result6));
+        assertEquals(expected, HashBagMultimap.newMultimap(result7));
+        assertEquals(expected, HashBagMultimap.newMultimap(result8));
+        assertEquals(expected, HashBagMultimap.newMultimap(result9));
+        assertThrows(IllegalArgumentException.class, () -> FJIterate.groupBy(null, null, 1));
     }
 
     @Test
@@ -500,11 +505,11 @@ public class FJIterateTest
         List<Integer> list = Interval.oneTo(2000);
         MutableMap<String, AtomicInteger> aggregation =
                 FJIterate.aggregateInPlaceBy(list, EVEN_OR_ODD, ATOMIC_INTEGER_NEW, countAggregator);
-        Assert.assertEquals(1000, aggregation.get("Even").intValue());
-        Assert.assertEquals(1000, aggregation.get("Odd").intValue());
+        assertEquals(1000, aggregation.get("Even").intValue());
+        assertEquals(1000, aggregation.get("Odd").intValue());
         FJIterate.aggregateInPlaceBy(list, EVEN_OR_ODD, ATOMIC_INTEGER_NEW, countAggregator, aggregation);
-        Assert.assertEquals(2000, aggregation.get("Even").intValue());
-        Assert.assertEquals(2000, aggregation.get("Odd").intValue());
+        assertEquals(2000, aggregation.get("Even").intValue());
+        assertEquals(2000, aggregation.get("Odd").intValue());
     }
 
     @Test
@@ -518,9 +523,9 @@ public class FJIterateTest
                 .shuffleThis();
         MapIterable<String, AtomicInteger> aggregation =
                 FJIterate.aggregateInPlaceBy(list, Functions.getToString(), ATOMIC_INTEGER_NEW, sumAggregator, 50);
-        Assert.assertEquals(100, aggregation.get("1").intValue());
-        Assert.assertEquals(400, aggregation.get("2").intValue());
-        Assert.assertEquals(900, aggregation.get("3").intValue());
+        assertEquals(100, aggregation.get("1").intValue());
+        assertEquals(400, aggregation.get("2").intValue());
+        assertEquals(900, aggregation.get("3").intValue());
     }
 
     @Test
@@ -530,11 +535,11 @@ public class FJIterateTest
         List<Integer> list = Interval.oneTo(20000);
         MutableMap<String, Integer> aggregation =
                 FJIterate.aggregateBy(list, EVEN_OR_ODD, INTEGER_NEW, countAggregator);
-        Assert.assertEquals(10000, aggregation.get("Even").intValue());
-        Assert.assertEquals(10000, aggregation.get("Odd").intValue());
+        assertEquals(10000, aggregation.get("Even").intValue());
+        assertEquals(10000, aggregation.get("Odd").intValue());
         FJIterate.aggregateBy(list, EVEN_OR_ODD, INTEGER_NEW, countAggregator, aggregation);
-        Assert.assertEquals(20000, aggregation.get("Even").intValue());
-        Assert.assertEquals(20000, aggregation.get("Odd").intValue());
+        assertEquals(20000, aggregation.get("Even").intValue());
+        assertEquals(20000, aggregation.get("Odd").intValue());
     }
 
     @Test
@@ -548,9 +553,9 @@ public class FJIterateTest
                 .shuffleThis();
         MapIterable<String, Integer> aggregation =
                 FJIterate.aggregateBy(list, Functions.getToString(), INTEGER_NEW, sumAggregator, 100);
-        Assert.assertEquals(1000, aggregation.get("1").intValue());
-        Assert.assertEquals(4000, aggregation.get("2").intValue());
-        Assert.assertEquals(9000, aggregation.get("3").intValue());
+        assertEquals(1000, aggregation.get("1").intValue());
+        assertEquals(4000, aggregation.get("2").intValue());
+        assertEquals(9000, aggregation.get("3").intValue());
     }
 
     private static List<Integer> createIntegerList(int size)
@@ -572,9 +577,9 @@ public class FJIterateTest
         RichIterable<String> expected1 = iterable.flatCollect(INT_TO_TWO_STRINGS);
         RichIterable<String> expected2 = iterable.flatCollect(INT_TO_TWO_STRINGS, HashBag.newBag());
         Verify.assertContains(String.valueOf(200), actual1);
-        Assert.assertEquals(expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected1, actual1);
-        Assert.assertEquals(expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected2, actual2);
-        Assert.assertEquals(expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected1, actual3);
+        assertEquals(expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected1, actual1);
+        assertEquals(expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected2, actual2);
+        assertEquals(expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected1, actual3);
     }
 
     public static final class IntegerSum

--- a/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
+++ b/eclipse-collections-testutils/src/main/java/org/eclipse/collections/impl/test/Verify.java
@@ -67,6 +67,16 @@ import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.Assert;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * An extension of the {@link Assert} class, which adds useful additional "assert" methods.
  * You can import this class instead of Assert, and use it thus, e.g.:
@@ -225,15 +235,15 @@ public final class Verify extends Assert
 
             if (Iterate.notEmpty(actualIterable))
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
             }
             if (!Iterate.isEmpty(actualIterable))
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
             }
             if (Iterate.sizeOf(actualIterable) != 0)
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualIterable) + '>');
             }
         }
         catch (AssertionError e)
@@ -268,35 +278,35 @@ public final class Verify extends Assert
 
             if (Iterate.notEmpty(actualMutableMapIterable))
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
             }
             if (!Iterate.isEmpty(actualMutableMapIterable))
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
             }
             if (!actualMutableMapIterable.isEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
             }
             if (actualMutableMapIterable.notEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + Iterate.sizeOf(actualMutableMapIterable) + '>');
             }
             if (!actualMutableMapIterable.isEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.size() + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.size() + '>');
             }
             if (!actualMutableMapIterable.keySet().isEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.keySet().size() + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.keySet().size() + '>');
             }
             if (!actualMutableMapIterable.values().isEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.values().size() + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.values().size() + '>');
             }
             if (!actualMutableMapIterable.entrySet().isEmpty())
             {
-                Assert.fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.entrySet().size() + '>');
+                fail(mutableMapIterableName + " should be empty; actual size:<" + actualMutableMapIterable.entrySet().size() + '>');
             }
         }
         catch (AssertionError e)
@@ -332,15 +342,15 @@ public final class Verify extends Assert
 
             if (primitiveIterable.notEmpty())
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
+                fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
             }
             if (!primitiveIterable.isEmpty())
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
+                fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
             }
             if (primitiveIterable.size() != 0)
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
+                fail(iterableName + " should be empty; actual size:<" + primitiveIterable.size() + '>');
             }
         }
         catch (AssertionError e)
@@ -375,15 +385,15 @@ public final class Verify extends Assert
 
             if (Iterate.notEmpty(iterable))
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
             }
             if (!Iterate.isEmpty(iterable))
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
             }
             if (Iterate.sizeOf(iterable) != 0)
             {
-                Assert.fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
+                fail(iterableName + " should be empty; actual size:<" + Iterate.sizeOf(iterable) + '>');
             }
         }
         catch (AssertionError e)
@@ -416,7 +426,7 @@ public final class Verify extends Assert
         {
             if (!expectedClassType.isInstance(actualObject))
             {
-                Assert.fail(objectName + " is not an instance of " + expectedClassType.getName());
+                fail(objectName + " is not an instance of " + expectedClassType.getName());
             }
         }
         catch (AssertionError e)
@@ -449,7 +459,7 @@ public final class Verify extends Assert
         {
             if (expectedClassType.isInstance(actualObject))
             {
-                Assert.fail(objectName + " is an instance of " + expectedClassType.getName());
+                fail(objectName + " is an instance of " + expectedClassType.getName());
             }
         }
         catch (AssertionError e)
@@ -500,39 +510,39 @@ public final class Verify extends Assert
 
             if (actualMultimap.notEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
             }
             if (!actualMultimap.isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
             }
             if (actualMultimap.size() != 0)
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
             }
             if (actualMultimap.sizeDistinct() != 0)
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.size() + '>');
             }
             if (!actualMultimap.keyBag().isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyBag().size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyBag().size() + '>');
             }
             if (!actualMultimap.keysView().isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keysView().size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.keysView().size() + '>');
             }
             if (!actualMultimap.valuesView().isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.valuesView().size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.valuesView().size() + '>');
             }
             if (!actualMultimap.keyValuePairsView().isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyValuePairsView().size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyValuePairsView().size() + '>');
             }
             if (!actualMultimap.keyMultiValuePairsView().isEmpty())
             {
-                Assert.fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyMultiValuePairsView().size() + '>');
+                fail(multimapName + " should be empty; actual size:<" + actualMultimap.keyMultiValuePairsView().size() + '>');
             }
         }
         catch (AssertionError e)
@@ -553,23 +563,23 @@ public final class Verify extends Assert
 
             if (!actualMap.isEmpty())
             {
-                Assert.fail(mapName + " should be empty; actual size:<" + actualMap.size() + '>');
+                fail(mapName + " should be empty; actual size:<" + actualMap.size() + '>');
             }
             if (actualMap.size() != 0)
             {
-                Assert.fail(mapName + " should be empty; actual size:<" + actualMap.size() + '>');
+                fail(mapName + " should be empty; actual size:<" + actualMap.size() + '>');
             }
             if (!actualMap.keySet().isEmpty())
             {
-                Assert.fail(mapName + " should be empty; actual size:<" + actualMap.keySet().size() + '>');
+                fail(mapName + " should be empty; actual size:<" + actualMap.keySet().size() + '>');
             }
             if (!actualMap.values().isEmpty())
             {
-                Assert.fail(mapName + " should be empty; actual size:<" + actualMap.values().size() + '>');
+                fail(mapName + " should be empty; actual size:<" + actualMap.values().size() + '>');
             }
             if (!actualMap.entrySet().isEmpty())
             {
-                Assert.fail(mapName + " should be empty; actual size:<" + actualMap.entrySet().size() + '>');
+                fail(mapName + " should be empty; actual size:<" + actualMap.entrySet().size() + '>');
             }
         }
         catch (AssertionError e)
@@ -601,9 +611,9 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(iterableName, actualIterable);
-            Assert.assertFalse(iterableName + " should be non-empty, but was empty", Iterate.isEmpty(actualIterable));
-            Assert.assertTrue(iterableName + " should be non-empty, but was empty", Iterate.notEmpty(actualIterable));
-            Assert.assertNotEquals(iterableName + " should be non-empty, but was empty", 0, Iterate.sizeOf(actualIterable));
+            assertFalse(iterableName + " should be non-empty, but was empty", Iterate.isEmpty(actualIterable));
+            assertTrue(iterableName + " should be non-empty, but was empty", Iterate.notEmpty(actualIterable));
+            assertNotEquals(iterableName + " should be non-empty, but was empty", 0, Iterate.sizeOf(actualIterable));
         }
         catch (AssertionError e)
         {
@@ -634,13 +644,13 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(mutableMapIterableName, actualMutableMapIterable);
-            Assert.assertFalse(mutableMapIterableName + " should be non-empty, but was empty", Iterate.isEmpty(actualMutableMapIterable));
-            Assert.assertTrue(mutableMapIterableName + " should be non-empty, but was empty", Iterate.notEmpty(actualMutableMapIterable));
-            Assert.assertTrue(mutableMapIterableName + " should be non-empty, but was empty", actualMutableMapIterable.notEmpty());
-            Assert.assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.size());
-            Assert.assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.keySet().size());
-            Assert.assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.values().size());
-            Assert.assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.entrySet().size());
+            assertFalse(mutableMapIterableName + " should be non-empty, but was empty", Iterate.isEmpty(actualMutableMapIterable));
+            assertTrue(mutableMapIterableName + " should be non-empty, but was empty", Iterate.notEmpty(actualMutableMapIterable));
+            assertTrue(mutableMapIterableName + " should be non-empty, but was empty", actualMutableMapIterable.notEmpty());
+            assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.size());
+            assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.keySet().size());
+            assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.values().size());
+            assertNotEquals(mutableMapIterableName + " should be non-empty, but was empty", 0, actualMutableMapIterable.entrySet().size());
         }
         catch (AssertionError e)
         {
@@ -671,9 +681,9 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(iterableName, primitiveIterable);
-            Assert.assertFalse(iterableName + " should be non-empty, but was empty", primitiveIterable.isEmpty());
-            Assert.assertTrue(iterableName + " should be non-empty, but was empty", primitiveIterable.notEmpty());
-            Assert.assertNotEquals(iterableName + " should be non-empty, but was empty", 0, primitiveIterable.size());
+            assertFalse(iterableName + " should be non-empty, but was empty", primitiveIterable.isEmpty());
+            assertTrue(iterableName + " should be non-empty, but was empty", primitiveIterable.notEmpty());
+            assertNotEquals(iterableName + " should be non-empty, but was empty", 0, primitiveIterable.size());
         }
         catch (AssertionError e)
         {
@@ -704,9 +714,9 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(iterableName, iterable);
-            Assert.assertFalse(iterableName + " should be non-empty, but was empty", Iterate.isEmpty(iterable));
-            Assert.assertTrue(iterableName + " should be non-empty, but was empty", Iterate.notEmpty(iterable));
-            Assert.assertNotEquals(iterableName + " should be non-empty, but was empty", 0, Iterate.sizeOf(iterable));
+            assertFalse(iterableName + " should be non-empty, but was empty", Iterate.isEmpty(iterable));
+            assertTrue(iterableName + " should be non-empty, but was empty", Iterate.notEmpty(iterable));
+            assertNotEquals(iterableName + " should be non-empty, but was empty", 0, Iterate.sizeOf(iterable));
         }
         catch (AssertionError e)
         {
@@ -737,11 +747,11 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(mapName, actualMap);
-            Assert.assertFalse(mapName + " should be non-empty, but was empty", actualMap.isEmpty());
-            Assert.assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.size());
-            Assert.assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.keySet().size());
-            Assert.assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.values().size());
-            Assert.assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.entrySet().size());
+            assertFalse(mapName + " should be non-empty, but was empty", actualMap.isEmpty());
+            assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.size());
+            assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.keySet().size());
+            assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.values().size());
+            assertNotEquals(mapName + " should be non-empty, but was empty", 0, actualMap.entrySet().size());
         }
         catch (AssertionError e)
         {
@@ -772,15 +782,15 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(multimapName, actualMultimap);
-            Assert.assertTrue(multimapName + " should be non-empty, but was empty", actualMultimap.notEmpty());
-            Assert.assertFalse(multimapName + " should be non-empty, but was empty", actualMultimap.isEmpty());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.size());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.sizeDistinct());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyBag().size());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keysView().size());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.valuesView().size());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyValuePairsView().size());
-            Assert.assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyMultiValuePairsView().size());
+            assertTrue(multimapName + " should be non-empty, but was empty", actualMultimap.notEmpty());
+            assertFalse(multimapName + " should be non-empty, but was empty", actualMultimap.isEmpty());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.size());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.sizeDistinct());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyBag().size());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keysView().size());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.valuesView().size());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyValuePairsView().size());
+            assertNotEquals(multimapName + " should be non-empty, but was empty", 0, actualMultimap.keyMultiValuePairsView().size());
         }
         catch (AssertionError e)
         {
@@ -793,7 +803,7 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(itemsName, items);
-            Assert.assertNotEquals(itemsName, 0, items.length);
+            assertNotEquals(itemsName, 0, items.length);
         }
         catch (AssertionError e)
         {
@@ -835,12 +845,12 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(arrayName + " should not be null", actualArray);
+            assertNotNull(arrayName + " should not be null", actualArray);
 
             int actualSize = actualArray.length;
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + arrayName
                         + "; expected:<"
                         + expectedSize
@@ -885,7 +895,7 @@ public final class Verify extends Assert
             int actualSize = Iterate.sizeOf(actualIterable);
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + iterableName
                         + "; expected:<"
                         + expectedSize
@@ -930,7 +940,7 @@ public final class Verify extends Assert
             int actualSize = actualPrimitiveIterable.size();
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + primitiveIterableName
                         + "; expected:<"
                         + expectedSize
@@ -975,7 +985,7 @@ public final class Verify extends Assert
             int actualSize = Iterate.sizeOf(actualIterable);
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + iterableName
                         + "; expected:<"
                         + expectedSize
@@ -1045,7 +1055,7 @@ public final class Verify extends Assert
             int actualSize = actualMultimap.size();
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + multimapName
                         + "; expected:<"
                         + expectedSize
@@ -1085,22 +1095,22 @@ public final class Verify extends Assert
             int actualSize = mutableMapIterable.size();
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for " + mapName + "; expected:<" + expectedSize + "> but was:<" + actualSize + '>');
+                fail("Incorrect size for " + mapName + "; expected:<" + expectedSize + "> but was:<" + actualSize + '>');
             }
             int keySetSize = mutableMapIterable.keySet().size();
             if (keySetSize != expectedSize)
             {
-                Assert.fail("Incorrect size for " + mapName + ".keySet(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
+                fail("Incorrect size for " + mapName + ".keySet(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
             }
             int valuesSize = mutableMapIterable.values().size();
             if (valuesSize != expectedSize)
             {
-                Assert.fail("Incorrect size for " + mapName + ".values(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
+                fail("Incorrect size for " + mapName + ".values(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
             }
             int entrySetSize = mutableMapIterable.entrySet().size();
             if (entrySetSize != expectedSize)
             {
-                Assert.fail("Incorrect size for " + mapName + ".entrySet(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
+                fail("Incorrect size for " + mapName + ".entrySet(); expected:<" + expectedSize + "> but was:<" + actualSize + '>');
             }
         }
         catch (AssertionError e)
@@ -1134,7 +1144,7 @@ public final class Verify extends Assert
             int actualSize = actualImmutableSet.size();
             if (actualSize != expectedSize)
             {
-                Assert.fail("Incorrect size for "
+                fail("Incorrect size for "
                         + immutableSetName
                         + "; expected:<"
                         + expectedSize
@@ -1186,12 +1196,12 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull("stringToFind should not be null", stringToFind);
-            Assert.assertNotNull("stringToSearch should not be null", stringToSearch);
+            assertNotNull("stringToFind should not be null", stringToFind);
+            assertNotNull("stringToSearch should not be null", stringToSearch);
 
             if (!stringToSearch.contains(stringToFind))
             {
-                Assert.fail(stringName
+                fail(stringName
                         + " did not contain stringToFind:<"
                         + stringToFind
                         + "> in stringToSearch:<"
@@ -1212,12 +1222,12 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull("unexpectedString should not be null", unexpectedString);
-            Assert.assertNotNull("stringToSearch should not be null", stringToSearch);
+            assertNotNull("unexpectedString should not be null", unexpectedString);
+            assertNotNull("stringToSearch should not be null", stringToSearch);
 
             if (stringToSearch.contains(unexpectedString))
             {
-                Assert.fail(stringName
+                fail(stringName
                         + " contains unexpectedString:<"
                         + unexpectedString
                         + "> in stringToSearch:<"
@@ -1236,7 +1246,7 @@ public final class Verify extends Assert
             Iterable<T> iterable,
             Predicate<? super T> predicate)
     {
-        Assert.assertEquals(expectedCount, Iterate.count(iterable, predicate));
+        assertEquals(expectedCount, Iterate.count(iterable, predicate));
     }
 
     public static <T> void assertAllSatisfy(Iterable<T> iterable, Predicate<? super T> predicate)
@@ -1270,7 +1280,7 @@ public final class Verify extends Assert
             MutableList<T> unacceptable = Iterate.reject(iterable, predicate, Lists.mutable.of());
             if (unacceptable.notEmpty())
             {
-                Assert.fail(message + " <" + unacceptable + '>');
+                fail(message + " <" + unacceptable + '>');
             }
         }
         catch (AssertionError e)
@@ -1307,7 +1317,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertTrue(message, Predicates.<T>anySatisfy(predicate).accept(iterable));
+            assertTrue(message, Predicates.<T>anySatisfy(predicate).accept(iterable));
         }
         catch (AssertionError e)
         {
@@ -1346,7 +1356,7 @@ public final class Verify extends Assert
             MutableList<T> unacceptable = Iterate.select(iterable, predicate, Lists.mutable.empty());
             if (unacceptable.notEmpty())
             {
-                Assert.fail(message + " <" + unacceptable + '>');
+                fail(message + " <" + unacceptable + '>');
             }
         }
         catch (AssertionError e)
@@ -1384,7 +1394,7 @@ public final class Verify extends Assert
 
             if (expectedKeyValues.length % 2 != 0)
             {
-                Assert.fail("Odd number of keys and values (every key must have a value)");
+                fail("Odd number of keys and values (every key must have a value)");
             }
 
             Verify.assertObjectNotNull(mapName, actualMap);
@@ -1426,7 +1436,7 @@ public final class Verify extends Assert
 
             if (expectedKeyValues.length % 2 != 0)
             {
-                Assert.fail("Odd number of keys and values (every key must have a value)");
+                fail("Odd number of keys and values (every key must have a value)");
             }
 
             Verify.assertObjectNotNull(mapIterableName, mapIterable);
@@ -1468,7 +1478,7 @@ public final class Verify extends Assert
 
             if (expectedKeyValues.length % 2 != 0)
             {
-                Assert.fail("Odd number of keys and values (every key must have a value)");
+                fail("Odd number of keys and values (every key must have a value)");
             }
 
             Verify.assertObjectNotNull(mutableMapIterableName, mutableMapIterable);
@@ -1510,7 +1520,7 @@ public final class Verify extends Assert
 
             if (expectedKeyValues.length % 2 != 0)
             {
-                Assert.fail("Odd number of keys and values (every key must have a value)");
+                fail("Odd number of keys and values (every key must have a value)");
             }
 
             Verify.assertObjectNotNull(immutableMapIterableName, immutableMapIterable);
@@ -1576,7 +1586,7 @@ public final class Verify extends Assert
 
             if (!actualCollection.contains(expectedItem))
             {
-                Assert.fail(collectionName + " did not contain expectedItem:<" + expectedItem + '>');
+                fail(collectionName + " did not contain expectedItem:<" + expectedItem + '>');
             }
         }
         catch (AssertionError e)
@@ -1614,7 +1624,7 @@ public final class Verify extends Assert
 
             if (!actualImmutableCollection.contains(expectedItem))
             {
-                Assert.fail(immutableCollectionName + " did not contain expectedItem:<" + expectedItem + '>');
+                fail(immutableCollectionName + " did not contain expectedItem:<" + expectedItem + '>');
             }
         }
         catch (AssertionError e)
@@ -1653,7 +1663,7 @@ public final class Verify extends Assert
             if (!ArrayIterate.allSatisfy(items, containsPredicate))
             {
                 ImmutableList<Object> result = Lists.immutable.of(items).newWithoutAll(iterable);
-                Assert.fail(collectionName + " did not contain these items" + ":<" + result + '>');
+                fail(collectionName + " did not contain these items" + ":<" + result + '>');
             }
         }
         catch (AssertionError e)
@@ -1682,9 +1692,9 @@ public final class Verify extends Assert
             {
                 return;
             }
-            Assert.assertNotNull(expectedList);
-            Assert.assertNotNull(actualList);
-            Assert.assertEquals(listName + " size", expectedList.size(), actualList.size());
+            assertNotNull(expectedList);
+            assertNotNull(actualList);
+            assertEquals(listName + " size", expectedList.size(), actualList.size());
             for (int index = 0; index < actualList.size(); index++)
             {
                 Object eachExpected = expectedList.get(index);
@@ -1719,7 +1729,7 @@ public final class Verify extends Assert
         {
             if (expectedSet == null)
             {
-                Assert.assertNull(setName + " should be null", actualSet);
+                assertNull(setName + " should be null", actualSet);
                 return;
             }
 
@@ -1736,7 +1746,7 @@ public final class Verify extends Assert
 
                 if (numberDifferences > MAX_DIFFERENCES)
                 {
-                    Assert.fail(message);
+                    fail(message);
                 }
 
                 MutableSet<?> inActualOnlySet = UnifiedSet.newSet(actualSet);
@@ -1768,7 +1778,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertEquals(setName, expectedSet, actualSet);
+            assertEquals(setName, expectedSet, actualSet);
             Verify.assertIterablesEqual(setName, expectedSet, actualSet);
         }
         catch (AssertionError e)
@@ -1793,7 +1803,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertEquals(bagName, expectedBag, actualBag);
+            assertEquals(bagName, expectedBag, actualBag);
             Verify.assertIterablesEqual(bagName, expectedBag, actualBag);
         }
         catch (AssertionError e)
@@ -1818,7 +1828,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertEquals(mapName, expectedMap, actualMap);
+            assertEquals(mapName, expectedMap, actualMap);
             Verify.assertIterablesEqual(mapName, expectedMap, actualMap);
         }
         catch (AssertionError e)
@@ -1845,7 +1855,7 @@ public final class Verify extends Assert
         {
             if (expectedIterable == null)
             {
-                Assert.assertNull(iterableName + " should be null", actualIterable);
+                assertNull(iterableName + " should be null", actualIterable);
                 return;
             }
 
@@ -1878,8 +1888,8 @@ public final class Verify extends Assert
                     index++;
                 }
 
-                Assert.assertFalse("Actual " + iterableName + " had " + index + " elements but expected " + iterableName + " had more.", expectedIterator.hasNext());
-                Assert.assertFalse("Expected " + iterableName + " had " + index + " elements but actual " + iterableName + " had more.", actualIterator.hasNext());
+                assertFalse("Actual " + iterableName + " had " + index + " elements but expected " + iterableName + " had more.", expectedIterator.hasNext());
+                assertFalse("Expected " + iterableName + " had " + index + " elements but actual " + iterableName + " had more.", actualIterator.hasNext());
             }
         }
         catch (AssertionError e)
@@ -1906,11 +1916,11 @@ public final class Verify extends Assert
         {
             if (expectedMap == null)
             {
-                Assert.assertNull(mapName + " should be null", actualMap);
+                assertNull(mapName + " should be null", actualMap);
                 return;
             }
 
-            Assert.assertNotNull(mapName + " should not be null", actualMap);
+            assertNotNull(mapName + " should not be null", actualMap);
 
             Set<? extends Map.Entry<?, ?>> expectedEntries = expectedMap.entrySet();
             for (Map.Entry<?, ?> expectedEntry : expectedEntries)
@@ -1920,7 +1930,7 @@ public final class Verify extends Assert
                 Object actualValue = actualMap.get(expectedKey);
                 if (!Objects.equals(actualValue, expectedValue))
                 {
-                    Assert.fail("Values differ at key " + expectedKey + " expected " + expectedValue + " but was " + actualValue);
+                    fail("Values differ at key " + expectedKey + " expected " + expectedValue + " but was " + actualValue);
                 }
             }
             Verify.assertSetsEqual(mapName + " keys", expectedMap.keySet(), actualMap.keySet());
@@ -1950,19 +1960,19 @@ public final class Verify extends Assert
         {
             if (expectedBag == null)
             {
-                Assert.assertNull(bagName + " should be null", actualBag);
+                assertNull(bagName + " should be null", actualBag);
                 return;
             }
 
-            Assert.assertNotNull(bagName + " should not be null", actualBag);
+            assertNotNull(bagName + " should not be null", actualBag);
 
-            Assert.assertEquals(bagName + " size", expectedBag.size(), actualBag.size());
-            Assert.assertEquals(bagName + " sizeDistinct", expectedBag.sizeDistinct(), actualBag.sizeDistinct());
+            assertEquals(bagName + " size", expectedBag.size(), actualBag.size());
+            assertEquals(bagName + " sizeDistinct", expectedBag.sizeDistinct(), actualBag.sizeDistinct());
 
             expectedBag.forEachWithOccurrences((expectedKey, expectedValue) ->
             {
                 int actualValue = actualBag.occurrencesOf(expectedKey);
-                Assert.assertEquals("Occurrences of " + expectedKey, expectedValue, actualValue);
+                assertEquals("Occurrences of " + expectedKey, expectedValue, actualValue);
             });
         }
         catch (AssertionError e)
@@ -1989,20 +1999,20 @@ public final class Verify extends Assert
         {
             if (expectedListMultimap == null)
             {
-                Assert.assertNull(multimapName + " should be null", actualListMultimap);
+                assertNull(multimapName + " should be null", actualListMultimap);
                 return;
             }
 
-            Assert.assertNotNull(multimapName + " should not be null", actualListMultimap);
+            assertNotNull(multimapName + " should not be null", actualListMultimap);
 
-            Assert.assertEquals(multimapName + " size", expectedListMultimap.size(), actualListMultimap.size());
+            assertEquals(multimapName + " size", expectedListMultimap.size(), actualListMultimap.size());
             Verify.assertBagsEqual(multimapName + " keyBag", expectedListMultimap.keyBag(), actualListMultimap.keyBag());
 
             for (K key : expectedListMultimap.keysView())
             {
                 Verify.assertListsEqual(multimapName + " value list for key:" + key, (List<V>) expectedListMultimap.get(key), (List<V>) actualListMultimap.get(key));
             }
-            Assert.assertEquals(multimapName, expectedListMultimap, actualListMultimap);
+            assertEquals(multimapName, expectedListMultimap, actualListMultimap);
         }
         catch (AssertionError e)
         {
@@ -2028,20 +2038,20 @@ public final class Verify extends Assert
         {
             if (expectedSetMultimap == null)
             {
-                Assert.assertNull(multimapName + " should be null", actualSetMultimap);
+                assertNull(multimapName + " should be null", actualSetMultimap);
                 return;
             }
 
-            Assert.assertNotNull(multimapName + " should not be null", actualSetMultimap);
+            assertNotNull(multimapName + " should not be null", actualSetMultimap);
 
-            Assert.assertEquals(multimapName + " size", expectedSetMultimap.size(), actualSetMultimap.size());
+            assertEquals(multimapName + " size", expectedSetMultimap.size(), actualSetMultimap.size());
             Verify.assertBagsEqual(multimapName + " keyBag", expectedSetMultimap.keyBag(), actualSetMultimap.keyBag());
 
             for (K key : expectedSetMultimap.keysView())
             {
                 Verify.assertSetsEqual(multimapName + " value set for key:" + key, (Set<V>) expectedSetMultimap.get(key), (Set<V>) actualSetMultimap.get(key));
             }
-            Assert.assertEquals(multimapName, expectedSetMultimap, actualSetMultimap);
+            assertEquals(multimapName, expectedSetMultimap, actualSetMultimap);
         }
         catch (AssertionError e)
         {
@@ -2067,20 +2077,20 @@ public final class Verify extends Assert
         {
             if (expectedBagMultimap == null)
             {
-                Assert.assertNull(multimapName + " should be null", actualBagMultimap);
+                assertNull(multimapName + " should be null", actualBagMultimap);
                 return;
             }
 
-            Assert.assertNotNull(multimapName + " should not be null", actualBagMultimap);
+            assertNotNull(multimapName + " should not be null", actualBagMultimap);
 
-            Assert.assertEquals(multimapName + " size", expectedBagMultimap.size(), actualBagMultimap.size());
+            assertEquals(multimapName + " size", expectedBagMultimap.size(), actualBagMultimap.size());
             Verify.assertBagsEqual(multimapName + " keyBag", expectedBagMultimap.keyBag(), actualBagMultimap.keyBag());
 
             for (K key : expectedBagMultimap.keysView())
             {
                 Verify.assertBagsEqual(multimapName + " value bag for key:" + key, expectedBagMultimap.get(key), actualBagMultimap.get(key));
             }
-            Assert.assertEquals(multimapName, expectedBagMultimap, actualBagMultimap);
+            assertEquals(multimapName, expectedBagMultimap, actualBagMultimap);
         }
         catch (AssertionError e)
         {
@@ -2106,20 +2116,20 @@ public final class Verify extends Assert
         {
             if (expectedSortedSetMultimap == null)
             {
-                Assert.assertNull(multimapName + " should be null", actualSortedSetMultimap);
+                assertNull(multimapName + " should be null", actualSortedSetMultimap);
                 return;
             }
 
-            Assert.assertNotNull(multimapName + " should not be null", actualSortedSetMultimap);
+            assertNotNull(multimapName + " should not be null", actualSortedSetMultimap);
 
-            Assert.assertEquals(multimapName + " size", expectedSortedSetMultimap.size(), actualSortedSetMultimap.size());
+            assertEquals(multimapName + " size", expectedSortedSetMultimap.size(), actualSortedSetMultimap.size());
             Verify.assertBagsEqual(multimapName + " keyBag", expectedSortedSetMultimap.keyBag(), actualSortedSetMultimap.keyBag());
 
             for (K key : expectedSortedSetMultimap.keysView())
             {
                 Verify.assertSortedSetsEqual(multimapName + " value set for key:" + key, (SortedSet<V>) expectedSortedSetMultimap.get(key), (SortedSet<V>) actualSortedSetMultimap.get(key));
             }
-            Assert.assertEquals(multimapName, expectedSortedSetMultimap, actualSortedSetMultimap);
+            assertEquals(multimapName, expectedSortedSetMultimap, actualSortedSetMultimap);
         }
         catch (AssertionError e)
         {
@@ -2145,20 +2155,20 @@ public final class Verify extends Assert
         {
             if (expectedSortedBagMultimap == null)
             {
-                Assert.assertNull(multimapName + " should be null", actualSortedBagMultimap);
+                assertNull(multimapName + " should be null", actualSortedBagMultimap);
                 return;
             }
 
-            Assert.assertNotNull(multimapName + " should not be null", actualSortedBagMultimap);
+            assertNotNull(multimapName + " should not be null", actualSortedBagMultimap);
 
-            Assert.assertEquals(multimapName + " size", expectedSortedBagMultimap.size(), actualSortedBagMultimap.size());
+            assertEquals(multimapName + " size", expectedSortedBagMultimap.size(), actualSortedBagMultimap.size());
             Verify.assertBagsEqual(multimapName + " keyBag", expectedSortedBagMultimap.keyBag(), actualSortedBagMultimap.keyBag());
 
             for (K key : expectedSortedBagMultimap.keysView())
             {
                 Verify.assertSortedBagsEqual(multimapName + " value set for key:" + key, expectedSortedBagMultimap.get(key), actualSortedBagMultimap.get(key));
             }
-            Assert.assertEquals(multimapName, expectedSortedBagMultimap, actualSortedBagMultimap);
+            assertEquals(multimapName, expectedSortedBagMultimap, actualSortedBagMultimap);
         }
         catch (AssertionError e)
         {
@@ -2224,7 +2234,7 @@ public final class Verify extends Assert
                             .append("> ");
                 }
                 buf.append(']');
-                Assert.fail(buf.toString());
+                fail(buf.toString());
             }
         }
         catch (AssertionError e)
@@ -2400,11 +2410,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(multimapName, actualMultimap);
+            assertNotNull(multimapName, actualMultimap);
 
             if (!actualMultimap.containsKeyAndValue(expectedKey, expectedValue))
             {
-                Assert.fail(multimapName + " did not contain entry: <" + expectedKey + ", " + expectedValue + '>');
+                fail(multimapName + " did not contain entry: <" + expectedKey + ", " + expectedValue + '>');
             }
         }
         catch (AssertionError e)
@@ -2442,7 +2452,7 @@ public final class Verify extends Assert
 
             if (expectedKeyValues.length % 2 != 0)
             {
-                Assert.fail("Odd number of keys and values (every key must have a value)");
+                fail("Odd number of keys and values (every key must have a value)");
             }
 
             Verify.assertObjectNotNull(multimapName, actualMultimap);
@@ -2461,7 +2471,7 @@ public final class Verify extends Assert
 
             if (!missingEntries.isEmpty())
             {
-                Assert.fail(multimapName + " is missing entries: " + missingEntries);
+                fail(multimapName + " is missing entries: " + missingEntries);
             }
         }
         catch (AssertionError e)
@@ -2484,7 +2494,7 @@ public final class Verify extends Assert
             MutableSet<Object> intersection = Sets.intersect(UnifiedSet.newSet(actualCollection), UnifiedSet.newSetWith(items));
             if (intersection.notEmpty())
             {
-                Assert.fail(collectionName
+                fail(collectionName
                         + " has an intersection with these items and should not :<" + intersection + '>');
             }
         }
@@ -2516,11 +2526,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(mapName, actualMap);
+            assertNotNull(mapName, actualMap);
 
             if (!actualMap.containsKey(expectedKey))
             {
-                Assert.fail(mapName + " did not contain expectedKey:<" + expectedKey + '>');
+                fail(mapName + " did not contain expectedKey:<" + expectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -2554,11 +2564,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(mapIterableName, mapIterable);
+            assertNotNull(mapIterableName, mapIterable);
 
             if (!mapIterable.containsKey(expectedKey))
             {
-                Assert.fail(mapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
+                fail(mapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -2592,11 +2602,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(mutableMapIterableName, mutableMapIterable);
+            assertNotNull(mutableMapIterableName, mutableMapIterable);
 
             if (!mutableMapIterable.containsKey(expectedKey))
             {
-                Assert.fail(mutableMapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
+                fail(mutableMapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -2630,11 +2640,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(immutableMapIterableName, immutableMapIterable);
+            assertNotNull(immutableMapIterableName, immutableMapIterable);
 
             if (!immutableMapIterable.containsKey(expectedKey))
             {
-                Assert.fail(immutableMapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
+                fail(immutableMapIterableName + " did not contain expectedKey:<" + expectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -2665,11 +2675,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(mapName, actualMap);
+            assertNotNull(mapName, actualMap);
 
             if (actualMap.containsKey(unexpectedKey))
             {
-                Assert.fail(mapName + " contained unexpectedKey:<" + unexpectedKey + '>');
+                fail(mapName + " contained unexpectedKey:<" + unexpectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -2712,7 +2722,7 @@ public final class Verify extends Assert
             Object actualValue = actualMap.get(expectedKey);
             if (!Objects.equals(actualValue, expectedValue))
             {
-                Assert.fail(
+                fail(
                         mapName
                                 + " entry with expectedKey:<"
                                 + expectedKey
@@ -2765,7 +2775,7 @@ public final class Verify extends Assert
             Object actualValue = mapIterable.get(expectedKey);
             if (!Objects.equals(actualValue, expectedValue))
             {
-                Assert.fail(
+                fail(
                         mapIterableName
                                 + " entry with expectedKey:<"
                                 + expectedKey
@@ -2818,7 +2828,7 @@ public final class Verify extends Assert
             Object actualValue = mutableMapIterable.get(expectedKey);
             if (!Objects.equals(actualValue, expectedValue))
             {
-                Assert.fail(
+                fail(
                         mapIterableName
                                 + " entry with expectedKey:<"
                                 + expectedKey
@@ -2871,7 +2881,7 @@ public final class Verify extends Assert
             Object actualValue = immutableMapIterable.get(expectedKey);
             if (!Objects.equals(actualValue, expectedValue))
             {
-                Assert.fail(
+                fail(
                         mapIterableName
                                 + " entry with expectedKey:<"
                                 + expectedKey
@@ -2919,7 +2929,7 @@ public final class Verify extends Assert
 
             if (actualCollection.contains(unexpectedItem))
             {
-                Assert.fail(collectionName + " should not contain unexpectedItem:<" + unexpectedItem + '>');
+                fail(collectionName + " should not contain unexpectedItem:<" + unexpectedItem + '>');
             }
         }
         catch (AssertionError e)
@@ -2957,7 +2967,7 @@ public final class Verify extends Assert
 
             if (Iterate.contains(iterable, unexpectedItem))
             {
-                Assert.fail(collectionName + " should not contain unexpectedItem:<" + unexpectedItem + '>');
+                fail(collectionName + " should not contain unexpectedItem:<" + unexpectedItem + '>');
             }
         }
         catch (AssertionError e)
@@ -2992,7 +3002,7 @@ public final class Verify extends Assert
 
             if (actualMap.containsKey(unexpectedKey))
             {
-                Assert.fail(mapName + " should not contain unexpectedItem:<" + unexpectedKey + '>');
+                fail(mapName + " should not contain unexpectedItem:<" + unexpectedKey + '>');
             }
         }
         catch (AssertionError e)
@@ -3031,7 +3041,7 @@ public final class Verify extends Assert
         try
         {
             Verify.assertObjectNotNull(listName, actualList);
-            Assert.assertNotEquals(
+            assertNotEquals(
                     "Bad test, formerItem and latterItem are equal, listName:<" + listName + '>',
                     formerItem,
                     latterItem);
@@ -3040,7 +3050,7 @@ public final class Verify extends Assert
             int latterPosition = actualList.indexOf(latterItem);
             if (latterPosition < formerPosition)
             {
-                Assert.fail("Items in "
+                fail("Items in "
                         + listName
                         + " are in incorrect order; "
                         + "expected formerItem:<"
@@ -3061,7 +3071,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(objectName + " should not be null", actualObject);
+            assertNotNull(objectName + " should not be null", actualObject);
         }
         catch (AssertionError e)
         {
@@ -3199,7 +3209,7 @@ public final class Verify extends Assert
             Object actualItem = list.get(index);
             if (!Objects.equals(expectedItem, actualItem))
             {
-                Assert.assertEquals(
+                assertEquals(
                         listName + " has incorrect element at index:<" + index + '>',
                         expectedItem,
                         actualItem);
@@ -3222,11 +3232,11 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertNotNull(array);
+            assertNotNull(array);
             Object actualItem = array[index];
             if (!Objects.equals(expectedItem, actualItem))
             {
-                Assert.assertEquals(
+                assertEquals(
                         arrayName + " has incorrect element at index:<" + index + '>',
                         expectedItem,
                         actualItem);
@@ -3244,7 +3254,7 @@ public final class Verify extends Assert
         {
             Object deserialized = SerializeTestHelper.serializeDeserialize(object);
             Verify.assertEqualsAndHashCode("objects", object, deserialized);
-            Assert.assertNotSame("not same object", object, deserialized);
+            assertNotSame("not same object", object, deserialized);
         }
         catch (AssertionError e)
         {
@@ -3258,8 +3268,8 @@ public final class Verify extends Assert
         {
             Object deserialized = SerializeTestHelper.serializeDeserialize(object);
             Verify.assertEqualsAndHashCode("objects", object, deserialized);
-            Assert.assertNotSame("not same object", object, deserialized);
-            Assert.assertEquals("not same toString", object.toString(), deserialized.toString());
+            assertNotSame("not same object", object, deserialized);
+            assertEquals("not same toString", object.toString(), deserialized.toString());
         }
         catch (AssertionError e)
         {
@@ -3273,7 +3283,7 @@ public final class Verify extends Assert
         {
             Object deserialized = SerializeTestHelper.serializeDeserialize(object);
             Verify.assertEqualsAndHashCode("objects", object, deserialized);
-            Assert.assertSame("same object", object, deserialized);
+            assertSame("same object", object, deserialized);
         }
         catch (AssertionError e)
         {
@@ -3286,7 +3296,7 @@ public final class Verify extends Assert
         try
         {
             Verify.assertInstanceOf(Serializable.class, actualObject);
-            Assert.assertEquals(
+            assertEquals(
                     "Serialization was broken.",
                     expectedBase64Form,
                     Verify.encodeObject(actualObject));
@@ -3306,14 +3316,14 @@ public final class Verify extends Assert
         {
             Verify.assertInstanceOf(Serializable.class, actualObject);
 
-            Assert.assertEquals(
+            assertEquals(
                     "Serialization was broken.",
                     expectedBase64Form,
                     Verify.encodeObject(actualObject));
 
             Object decodeToObject = Verify.decodeObject(expectedBase64Form);
 
-            Assert.assertEquals(
+            assertEquals(
                     "serialVersionUID's differ",
                     expectedSerialVersionUID,
                     ObjectStreamClass.lookup(decodeToObject.getClass()).getSerialVersionUID());
@@ -3331,7 +3341,7 @@ public final class Verify extends Assert
             Verify.assertInstanceOf(Serializable.class, actualObject);
 
             Object decodeToObject = Verify.decodeObject(expectedBase64Form);
-            Assert.assertEquals("Serialization was broken.", decodeToObject, actualObject);
+            assertEquals("Serialization was broken.", decodeToObject, actualObject);
         }
         catch (AssertionError e)
         {
@@ -3419,7 +3429,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertTrue(value + " is not negative", value < 0);
+            assertTrue(value + " is not negative", value < 0);
         }
         catch (AssertionError e)
         {
@@ -3434,7 +3444,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertTrue(value + " is not positive", value > 0);
+            assertTrue(value + " is not positive", value > 0);
         }
         catch (AssertionError e)
         {
@@ -3449,7 +3459,7 @@ public final class Verify extends Assert
     {
         try
         {
-            Assert.assertEquals(0, value);
+            assertEquals(0, value);
         }
         catch (AssertionError e)
         {
@@ -3467,18 +3477,18 @@ public final class Verify extends Assert
         {
             if (objectA == null || objectB == null)
             {
-                Assert.fail("Neither item should be null: <" + objectA + "> <" + objectB + '>');
+                fail("Neither item should be null: <" + objectA + "> <" + objectB + '>');
             }
 
-            Assert.assertFalse("Neither item should equal null", objectA.equals(null));
-            Assert.assertFalse("Neither item should equal null", objectB.equals(null));
-            Assert.assertNotEquals("Neither item should equal new Object()", objectA.equals(new Object()));
-            Assert.assertNotEquals("Neither item should equal new Object()", objectB.equals(new Object()));
-            Assert.assertEquals("Expected " + itemNames + " to be equal.", objectA, objectA);
-            Assert.assertEquals("Expected " + itemNames + " to be equal.", objectB, objectB);
-            Assert.assertEquals("Expected " + itemNames + " to be equal.", objectA, objectB);
-            Assert.assertEquals("Expected " + itemNames + " to be equal.", objectB, objectA);
-            Assert.assertEquals(
+            assertFalse("Neither item should equal null", objectA.equals(null));
+            assertFalse("Neither item should equal null", objectB.equals(null));
+            assertNotEquals("Neither item should equal new Object()", objectA.equals(new Object()));
+            assertNotEquals("Neither item should equal new Object()", objectB.equals(new Object()));
+            assertEquals("Expected " + itemNames + " to be equal.", objectA, objectA);
+            assertEquals("Expected " + itemNames + " to be equal.", objectB, objectB);
+            assertEquals("Expected " + itemNames + " to be equal.", objectA, objectB);
+            assertEquals("Expected " + itemNames + " to be equal.", objectB, objectA);
+            assertEquals(
                     "Expected " + itemNames + " to have the same hashCode().",
                     objectA.hashCode(),
                     objectB.hashCode());
@@ -3517,7 +3527,7 @@ public final class Verify extends Assert
             method.setAccessible(true);
             Object clone = method.invoke(object);
             String prefix = itemName + " and its clone";
-            Assert.assertNotSame(prefix, object, clone);
+            assertNotSame(prefix, object, clone);
             Verify.assertEqualsAndHashCode(prefix, object, clone);
         }
         catch (IllegalArgumentException | IllegalAccessException | NoSuchMethodException | SecurityException | InvocationTargetException e)
@@ -3537,7 +3547,7 @@ public final class Verify extends Assert
             try
             {
                 aClass.newInstance();
-                Assert.fail("Expected class '" + aClass + "' to be non-instantiable");
+                fail("Expected class '" + aClass + "' to be non-instantiable");
             }
             catch (InstantiationException e)
             {
@@ -3547,7 +3557,7 @@ public final class Verify extends Assert
             {
                 if (Verify.canInstantiateThroughReflection(aClass))
                 {
-                    Assert.fail("Expected constructor of non-instantiable class '" + aClass + "' to throw an exception, but didn't");
+                    fail("Expected constructor of non-instantiable class '" + aClass + "' to throw an exception, but didn't");
                 }
             }
         }
@@ -3582,7 +3592,7 @@ public final class Verify extends Assert
         {
             try
             {
-                Assert.assertSame(
+                assertSame(
                         "Caught error of type <"
                                 + ex.getClass().getName()
                                 + ">, expected one of type <"
@@ -3600,7 +3610,7 @@ public final class Verify extends Assert
 
         try
         {
-            Assert.fail("Block did not throw an error of type " + expectedErrorClass.getName());
+            fail("Block did not throw an error of type " + expectedErrorClass.getName());
         }
         catch (AssertionError e)
         {
@@ -3641,7 +3651,7 @@ public final class Verify extends Assert
         {
             try
             {
-                Assert.assertSame(
+                assertSame(
                         "Caught exception of type <"
                                 + ex.getClass().getName()
                                 + ">, expected one of type <"
@@ -3662,7 +3672,7 @@ public final class Verify extends Assert
 
         try
         {
-            Assert.fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
+            fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
         }
         catch (AssertionError e)
         {
@@ -3712,7 +3722,7 @@ public final class Verify extends Assert
         {
             try
             {
-                Assert.assertSame(
+                assertSame(
                         "Caught exception of type <"
                                 + ex.getClass().getName()
                                 + ">, expected one of type <"
@@ -3721,12 +3731,12 @@ public final class Verify extends Assert
                         expectedExceptionClass,
                         ex.getClass());
                 Throwable actualCauseClass = ex.getCause();
-                Assert.assertNotNull(
+                assertNotNull(
                         "Caught exception with null cause, expected cause of type <"
                                 + expectedCauseClass.getName()
                                 + '>',
                         actualCauseClass);
-                Assert.assertSame(
+                assertSame(
                         "Caught exception with cause of type<"
                                 + actualCauseClass.getClass().getName()
                                 + ">, expected cause of type <"
@@ -3744,7 +3754,7 @@ public final class Verify extends Assert
 
         try
         {
-            Assert.fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
+            fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
         }
         catch (AssertionError e)
         {
@@ -3793,7 +3803,7 @@ public final class Verify extends Assert
         {
             try
             {
-                Assert.assertSame(
+                assertSame(
                         "Caught exception of type <"
                                 + ex.getClass().getName()
                                 + ">, expected one of type <"
@@ -3802,12 +3812,12 @@ public final class Verify extends Assert
                         expectedExceptionClass,
                         ex.getClass());
                 Throwable actualCauseClass = ex.getCause();
-                Assert.assertNotNull(
+                assertNotNull(
                         "Caught exception with null cause, expected cause of type <"
                                 + expectedCauseClass.getName()
                                 + '>',
                         actualCauseClass);
-                Assert.assertSame(
+                assertSame(
                         "Caught exception with cause of type<"
                                 + actualCauseClass.getClass().getName()
                                 + ">, expected cause of type <"
@@ -3825,7 +3835,7 @@ public final class Verify extends Assert
 
         try
         {
-            Assert.fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
+            fail("Block did not throw an exception of type " + expectedExceptionClass.getName());
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/ClassComparerTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/ClassComparerTest.java
@@ -20,8 +20,11 @@ import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.api.tuple.Triplet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ClassComparerTest
 {
@@ -31,12 +34,12 @@ public class ClassComparerTest
         ClassComparer comparer = new ClassComparer();
         MutableSortedSet<String> methods1 = comparer.getMethodNames(Runnable.class);
         MutableSortedSet<String> methods2 = comparer.getMethodNames(Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), methods1);
-        Assert.assertEquals(SortedSets.mutable.with("call"), methods2);
+        assertEquals(SortedSets.mutable.with("run"), methods1);
+        assertEquals(SortedSets.mutable.with("call"), methods2);
         MutableSortedSet<String> methods3 = comparer.getMethodNames(java.util.function.Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("identity", "apply", "compose", "andThen"), methods3);
+        assertEquals(SortedSets.mutable.with("identity", "apply", "compose", "andThen"), methods3);
         MutableSortedSet<String> methods4 = comparer.getMethodNames(Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("valueOf", "apply", "compose", "andThen"), methods4);
+        assertEquals(SortedSets.mutable.with("valueOf", "apply", "compose", "andThen"), methods4);
     }
 
     @Test
@@ -45,7 +48,7 @@ public class ClassComparerTest
         CollectingAppendable out1 = new CollectingAppendable();
         ClassComparer comparer1 = new ClassComparer(out1);
         MutableSortedSet<String> methods1 = comparer1.printClass(Runnable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), methods1);
+        assertEquals(SortedSets.mutable.with("run"), methods1);
         MutableList<Object> expectedOutput1 = Lists.mutable.with(
                 "Class: Runnable",
                 System.lineSeparator(),
@@ -54,12 +57,12 @@ public class ClassComparerTest
                 "r:[run]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput1, out1.getContents());
+        assertEquals(expectedOutput1, out1.getContents());
 
         CollectingAppendable out2 = new CollectingAppendable();
         ClassComparer comparer2 = new ClassComparer(out2);
         MutableSortedSet<String> methods2 = comparer2.printClass(java.util.function.Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("identity", "apply", "compose", "andThen"), methods2);
+        assertEquals(SortedSets.mutable.with("identity", "apply", "compose", "andThen"), methods2);
         MutableList<Object> expectedOutput2 = Lists.mutable.with(
                 "Class: Function",
                 System.lineSeparator(),
@@ -72,7 +75,7 @@ public class ClassComparerTest
                 + "i:[identity]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput2, out2.getContents());
+        assertEquals(expectedOutput2, out2.getContents());
     }
 
     @Test
@@ -81,7 +84,7 @@ public class ClassComparerTest
         CollectingAppendable out1 = new CollectingAppendable();
         ClassComparer comparer1 = new ClassComparer(out1, false, false, true);
         MutableSortedSet<String> methods1 = comparer1.printClass(Runnable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), methods1);
+        assertEquals(SortedSets.mutable.with("run"), methods1);
         MutableList<Object> expectedOutput1 = Lists.mutable.with(
                 "Class: java.lang.Runnable",
                 System.lineSeparator(),
@@ -90,7 +93,7 @@ public class ClassComparerTest
                 "r:[run]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput1, out1.getContents());
+        assertEquals(expectedOutput1, out1.getContents());
     }
 
     @Test
@@ -99,12 +102,12 @@ public class ClassComparerTest
         ClassComparer comparer = new ClassComparer();
         MutableSortedSet<String> difference1 = comparer.difference(Runnable.class, Callable.class);
         MutableSortedSet<String> difference2 = comparer.difference(Callable.class, Runnable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), difference1);
-        Assert.assertEquals(SortedSets.mutable.with("call"), difference2);
+        assertEquals(SortedSets.mutable.with("run"), difference1);
+        assertEquals(SortedSets.mutable.with("call"), difference2);
         MutableSortedSet<String> difference3 = comparer.difference(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("identity"), difference3);
+        assertEquals(SortedSets.mutable.with("identity"), difference3);
         MutableSortedSet<String> difference4 = comparer.difference(Function.class, java.util.function.Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("valueOf"), difference4);
+        assertEquals(SortedSets.mutable.with("valueOf"), difference4);
     }
 
     @Test
@@ -113,7 +116,7 @@ public class ClassComparerTest
         CollectingAppendable out = new CollectingAppendable();
         ClassComparer comparer = new ClassComparer(out);
         MutableSortedSet<String> difference1 = comparer.printDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), difference1);
+        assertEquals(SortedSets.mutable.with("run"), difference1);
         MutableList<Object> expectedOutput = Lists.mutable.with(
                 "Difference (Runnable, Callable)",
                 System.lineSeparator(),
@@ -122,7 +125,7 @@ public class ClassComparerTest
                 "r:[run]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput, out.getContents());
+        assertEquals(expectedOutput, out.getContents());
     }
 
     @Test
@@ -131,7 +134,7 @@ public class ClassComparerTest
         CollectingAppendable out = new CollectingAppendable();
         ClassComparer comparer = new ClassComparer(out, false, false, true);
         MutableSortedSet<String> difference1 = comparer.printDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run"), difference1);
+        assertEquals(SortedSets.mutable.with("run"), difference1);
         MutableList<Object> expectedOutput = Lists.mutable.with(
                 "Difference (java.lang.Runnable, java.util.concurrent.Callable)",
                 System.lineSeparator(),
@@ -140,7 +143,7 @@ public class ClassComparerTest
                 "r:[run]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput, out.getContents());
+        assertEquals(expectedOutput, out.getContents());
     }
 
     @Test
@@ -149,12 +152,12 @@ public class ClassComparerTest
         ClassComparer comparer = new ClassComparer(true, false, false);
         MutableSortedSet<String> difference1 = comparer.difference(Runnable.class, Callable.class);
         MutableSortedSet<String> difference2 = comparer.difference(Callable.class, Runnable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run()"), difference1);
-        Assert.assertEquals(SortedSets.mutable.with("call()"), difference2);
+        assertEquals(SortedSets.mutable.with("run()"), difference1);
+        assertEquals(SortedSets.mutable.with("call()"), difference2);
         MutableSortedSet<String> difference3 = comparer.difference(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("identity()"), difference3);
+        assertEquals(SortedSets.mutable.with("identity()"), difference3);
         MutableSortedSet<String> difference4 = comparer.difference(Function.class, java.util.function.Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("valueOf(Object)"), difference4);
+        assertEquals(SortedSets.mutable.with("valueOf(Object)"), difference4);
     }
 
     @Test
@@ -163,12 +166,12 @@ public class ClassComparerTest
         ClassComparer comparer = new ClassComparer(true, true, false);
         MutableSortedSet<String> difference1 = comparer.difference(Runnable.class, Callable.class);
         MutableSortedSet<String> difference2 = comparer.difference(Callable.class, Runnable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run():void"), difference1);
-        Assert.assertEquals(SortedSets.mutable.with("call():Object"), difference2);
+        assertEquals(SortedSets.mutable.with("run():void"), difference1);
+        assertEquals(SortedSets.mutable.with("call():Object"), difference2);
         MutableSortedSet<String> difference3 = comparer.difference(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("identity():Function"), difference3);
+        assertEquals(SortedSets.mutable.with("identity():Function"), difference3);
         MutableSortedSet<String> difference4 = comparer.difference(Function.class, java.util.function.Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("valueOf(Object):Object"), difference4);
+        assertEquals(SortedSets.mutable.with("valueOf(Object):Object"), difference4);
     }
 
     @Test
@@ -176,7 +179,7 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer();
         MutableSortedSet<String> symmetricDifference = comparer.symmetricDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run", "call"), symmetricDifference);
+        assertEquals(SortedSets.mutable.with("run", "call"), symmetricDifference);
     }
 
     @Test
@@ -185,7 +188,7 @@ public class ClassComparerTest
         CollectingAppendable out = new CollectingAppendable();
         ClassComparer comparer = new ClassComparer(out);
         MutableSortedSet<String> symmetricDifference = comparer.printSymmetricDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run", "call"), symmetricDifference);
+        assertEquals(SortedSets.mutable.with("run", "call"), symmetricDifference);
         MutableList<Object> expectedOutput = Lists.mutable.with(
                 "Symmetric Difference (Runnable, Callable)",
                 System.lineSeparator(),
@@ -194,7 +197,7 @@ public class ClassComparerTest
                 "c:[call]" + System.lineSeparator() + "r:[run]",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput, out.getContents());
+        assertEquals(expectedOutput, out.getContents());
     }
 
     @Test
@@ -202,7 +205,7 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer(true, false, false);
         MutableSortedSet<String> symmetricDifference = comparer.symmetricDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run()", "call()"), symmetricDifference);
+        assertEquals(SortedSets.mutable.with("run()", "call()"), symmetricDifference);
     }
 
     @Test
@@ -210,10 +213,10 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer(true, true, false);
         MutableSortedSet<String> symmetricDifference = comparer.symmetricDifference(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.with("run():void", "call():Object"), symmetricDifference);
+        assertEquals(SortedSets.mutable.with("run():void", "call():Object"), symmetricDifference);
         MutableSortedSet<String> symmetricDifference2 =
                 comparer.symmetricDifference(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(
+        assertEquals(
                 SortedSets.mutable.with("identity():Function", "valueOf(Object):Object"),
                 symmetricDifference2);
     }
@@ -223,9 +226,9 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer();
         MutableSortedSet<String> intersection1 = comparer.intersect(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.empty(), intersection1);
+        assertEquals(SortedSets.mutable.empty(), intersection1);
         MutableSortedSet<String> intersection2 = comparer.intersect(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(SortedSets.mutable.with("apply", "compose", "andThen"), intersection2);
+        assertEquals(SortedSets.mutable.with("apply", "compose", "andThen"), intersection2);
     }
 
     @Test
@@ -234,7 +237,7 @@ public class ClassComparerTest
         CollectingAppendable out = new CollectingAppendable();
         ClassComparer comparer = new ClassComparer(out);
         MutableSortedSet<String> intersection = comparer.printIntersection(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.empty(), intersection);
+        assertEquals(SortedSets.mutable.empty(), intersection);
         MutableList<Object> expectedOutput = Lists.mutable.with(
                 "Intersection (Runnable, Callable)",
                 System.lineSeparator(),
@@ -243,7 +246,7 @@ public class ClassComparerTest
                 "",
                 System.lineSeparator(),
                 System.lineSeparator());
-        Assert.assertEquals(expectedOutput, out.getContents());
+        assertEquals(expectedOutput, out.getContents());
     }
 
     @Test
@@ -251,9 +254,9 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer(true, false, false);
         MutableSortedSet<String> intersection1 = comparer.intersect(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.empty(), intersection1);
+        assertEquals(SortedSets.mutable.empty(), intersection1);
         MutableSortedSet<String> intersection2 = comparer.intersect(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(
+        assertEquals(
                 SortedSets.mutable.with("apply(Object)", "compose(Function)", "andThen(Function)"),
                 intersection2);
     }
@@ -263,9 +266,9 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer(true, true, false);
         MutableSortedSet<String> intersection1 = comparer.intersect(Runnable.class, Callable.class);
-        Assert.assertEquals(SortedSets.mutable.empty(), intersection1);
+        assertEquals(SortedSets.mutable.empty(), intersection1);
         MutableSortedSet<String> intersection2 = comparer.intersect(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(
+        assertEquals(
                 SortedSets.mutable.with(
                         "apply(Object):Object",
                         "compose(Function):Function",
@@ -278,9 +281,9 @@ public class ClassComparerTest
     {
         ClassComparer comparer = new ClassComparer();
         Triplet<MutableSortedSet<String>> compare = comparer.compare(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(comparer.intersect(java.util.function.Function.class, Function.class), compare.getOne());
-        Assert.assertEquals(comparer.difference(java.util.function.Function.class, Function.class), compare.getTwo());
-        Assert.assertEquals(comparer.difference(Function.class, java.util.function.Function.class), compare.getThree());
+        assertEquals(comparer.intersect(java.util.function.Function.class, Function.class), compare.getOne());
+        assertEquals(comparer.difference(java.util.function.Function.class, Function.class), compare.getTwo());
+        assertEquals(comparer.difference(Function.class, java.util.function.Function.class), compare.getThree());
     }
 
     @Test
@@ -291,24 +294,24 @@ public class ClassComparerTest
         ClassComparer expected = new ClassComparer(expectedOut, true, true, false);
         ClassComparer actual = new ClassComparer(actualOut, true, true, false);
         Triplet<MutableSortedSet<String>> compare = actual.compareAndPrint(java.util.function.Function.class, Function.class);
-        Assert.assertEquals(expected.printIntersection(java.util.function.Function.class, Function.class), compare.getOne());
-        Assert.assertEquals(expected.printDifference(java.util.function.Function.class, Function.class), compare.getTwo());
-        Assert.assertEquals(expected.printDifference(Function.class, java.util.function.Function.class), compare.getThree());
-        Assert.assertEquals(expectedOut.getContents(), actualOut.getContents());
+        assertEquals(expected.printIntersection(java.util.function.Function.class, Function.class), compare.getOne());
+        assertEquals(expected.printDifference(java.util.function.Function.class, Function.class), compare.getTwo());
+        assertEquals(expected.printDifference(Function.class, java.util.function.Function.class), compare.getThree());
+        assertEquals(expectedOut.getContents(), actualOut.getContents());
     }
 
     @Test
     public void isProperSupersetOf()
     {
-        Assert.assertTrue(ClassComparer.isProperSupersetOf(Stack.class, Vector.class));
-        Assert.assertFalse(ClassComparer.isProperSupersetOf(Vector.class, Stack.class));
+        assertTrue(ClassComparer.isProperSupersetOf(Stack.class, Vector.class));
+        assertFalse(ClassComparer.isProperSupersetOf(Vector.class, Stack.class));
     }
 
     @Test
     public void isProperSubsetOf()
     {
-        Assert.assertTrue(ClassComparer.isProperSubsetOf(Vector.class, Stack.class));
-        Assert.assertFalse(ClassComparer.isProperSubsetOf(Stack.class, Vector.class));
+        assertTrue(ClassComparer.isProperSubsetOf(Vector.class, Stack.class));
+        assertFalse(ClassComparer.isProperSubsetOf(Stack.class, Vector.class));
     }
 
     private static class CollectingAppendable implements Appendable

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/CollectionsEqualTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/CollectionsEqualTest.java
@@ -16,12 +16,12 @@ import java.util.Set;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mList;
 import static org.eclipse.collections.impl.factory.Iterables.mMap;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test to make sure that the methods {@link Verify#assertListsEqual(String, List, List)},
@@ -61,7 +61,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual("assertListsEqual(nullList, list)", nullList, this.list);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -71,7 +71,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual(nullList, this.list);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -81,7 +81,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual("assertListsEqual(list, nullList)", this.list, nullList);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -91,7 +91,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual(this.list, nullList);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -113,7 +113,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual("assertSetsEqual(nullSet, set)", nullSet, this.set);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -123,7 +123,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual(nullSet, this.set);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -133,7 +133,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual("assertSetsEqual(set, nullSet)", this.set, nullSet);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -143,7 +143,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual(this.set, nullSet);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -165,7 +165,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(nullMap, map)", nullMap, this.map);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -175,7 +175,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(nullMap, this.map);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -185,7 +185,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(map, nullMap)", this.map, nullMap);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -195,7 +195,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(this.map, nullMap);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -209,7 +209,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual("assertListsEqual(list, list3)", this.list, this.list3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -219,7 +219,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual(this.list, this.list3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -233,7 +233,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual("assertListsEqual(list, list2)", this.list, this.list2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -243,7 +243,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertListsEqual(this.list, this.list2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -257,7 +257,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual("assertSetsEqual(set, set2)", this.set, this.set2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -267,7 +267,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual(this.set, this.set2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -281,7 +281,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual("assertSetsEqual(set, set3)", this.set, this.set3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -291,7 +291,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual(this.set, this.set3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -305,7 +305,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(map, map2)", this.map, this.map2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -315,7 +315,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(this.map, this.map2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -329,7 +329,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(map, map3)", this.map, this.map3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -339,7 +339,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(this.map, this.map3);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -353,7 +353,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(map, map4)", this.map, this.map4);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -363,7 +363,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(this.map, this.map4);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -377,7 +377,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual("assertMapsEqual(map, map5)", this.map, this.map5);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -387,7 +387,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertMapsEqual(this.map, this.map5);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -401,7 +401,7 @@ public class CollectionsEqualTest
         try
         {
             Verify.assertSetsEqual(this.bigSet1, this.bigSet2);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/ExceptionThrownTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/ExceptionThrownTest.java
@@ -16,6 +16,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
 /**
  * JUnit test to make sure that methods like {@link Assert#assertThrows(Class, ThrowingRunnable)} really throw when
  * they ought to.
@@ -27,8 +30,8 @@ public class ExceptionThrownTest
     {
         try
         {
-            Verify.assertThrows(NullPointerException.class, new EmptyRunnable());
-            Assert.fail("AssertionError expected");
+            assertThrows(NullPointerException.class, new EmptyRunnable());
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -42,7 +45,7 @@ public class ExceptionThrownTest
         try
         {
             Verify.assertThrows(NullPointerException.class, new EmptyCallable());
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -62,7 +65,7 @@ public class ExceptionThrownTest
                     {
                         throw new IllegalStateException();
                     });
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/SerializeTestHelperTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/SerializeTestHelperTest.java
@@ -10,8 +10,11 @@
 
 package org.eclipse.collections.impl.test;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 
 public class SerializeTestHelperTest
 {
@@ -20,8 +23,8 @@ public class SerializeTestHelperTest
     {
         String input = "Test";
         String output = SerializeTestHelper.serializeDeserialize(input);
-        Assert.assertEquals(input, output);
-        Assert.assertNotSame(input, output);
+        assertEquals(input, output);
+        assertNotSame(input, output);
     }
 
     @Test
@@ -37,7 +40,7 @@ public class SerializeTestHelperTest
             return;
         }
 
-        Assert.fail();
+        fail();
     }
 
     @Test
@@ -53,7 +56,7 @@ public class SerializeTestHelperTest
             return;
         }
 
-        Assert.fail();
+        fail();
     }
 
     @Test

--- a/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
+++ b/eclipse-collections-testutils/src/test/java/org/eclipse/collections/impl/test/VerifyTest.java
@@ -48,8 +48,10 @@ import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for our extensions to JUnit. These tests make sure that methods in {@link Verify} really fail when they
@@ -338,7 +340,7 @@ public class VerifyTest
             {
             };
             Verify.assertShallowClone(unclonable);
-            Assert.fail("AssertionError expected");
+            fail("AssertionError expected");
         }
         catch (AssertionError e)
         {
@@ -378,7 +380,7 @@ public class VerifyTest
         try
         {
             Verify.assertEqualsAndHashCode(new ConstantHashCode(), new ConstantHashCode());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -388,7 +390,7 @@ public class VerifyTest
         try
         {
             Verify.assertEqualsAndHashCode(new AlwaysEqualWithHashCodeOf(1), new AlwaysEqualWithHashCodeOf(2));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -434,7 +436,7 @@ public class VerifyTest
         {
             MutableListMultimap<String, Integer> multimap = FastListMultimap.newMultimap(Tuples.pair("one", 1), Tuples.pair("two", 2));
             Verify.assertContainsAllEntries(multimap, "one", 1, "three", 3);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -449,7 +451,7 @@ public class VerifyTest
         {
             MutableListMultimap<String, Integer> multimap = FastListMultimap.newMultimap(Tuples.pair("one", 1), Tuples.pair("two", 2));
             Verify.assertContainsAllEntries(multimap, "one", 1, "three");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -464,7 +466,7 @@ public class VerifyTest
         {
             Collection<String> list = FastList.newListWith("One", "Two", "Three");
             Verify.assertContainsAll(list, "Foo", "Bar", "Baz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -478,7 +480,7 @@ public class VerifyTest
         try
         {
             Verify.assertInstanceOf(Integer.class, 1L);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -494,7 +496,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotInstanceOf(Integer.class, 1);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -515,7 +517,7 @@ public class VerifyTest
         try
         {
             Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(1, 2, 3), new TreeSet<>(FastList.newListWith()));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -525,7 +527,7 @@ public class VerifyTest
         try
         {
             Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(1, 2, 3), integers);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -535,7 +537,7 @@ public class VerifyTest
         try
         {
             Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5), integers);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -545,7 +547,7 @@ public class VerifyTest
         try
         {
             Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 3, 4), integers);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError e)
         {
@@ -559,7 +561,7 @@ public class VerifyTest
         try
         {
             Verify.assertEmpty(FastList.newListWith("foo"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -574,7 +576,7 @@ public class VerifyTest
         try
         {
             Verify.assertEmpty(IntArrayList.newListWith(1));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -589,7 +591,7 @@ public class VerifyTest
         try
         {
             Verify.assertIterableEmpty(FastList.newListWith("foo"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -604,7 +606,7 @@ public class VerifyTest
         try
         {
             Verify.assertEmpty(UnifiedMap.newWithKeysValues("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -619,7 +621,7 @@ public class VerifyTest
         try
         {
             Verify.assertEmpty(Maps.immutable.of("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -634,7 +636,7 @@ public class VerifyTest
         try
         {
             Verify.assertEmpty(FastListMultimap.newMultimap(Tuples.pair("foo", "1"), Tuples.pair("foo", "2")));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -649,7 +651,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotEmpty(Lists.mutable.of());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -664,7 +666,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotEmpty(new IntArrayList());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -679,7 +681,7 @@ public class VerifyTest
         try
         {
             Verify.assertIterableNotEmpty(Lists.mutable.of());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -694,7 +696,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotEmpty(UnifiedMap.newMap());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -709,7 +711,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotEmpty(FastListMultimap.newMultimap());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -725,7 +727,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotEmpty(new Object[0]);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -740,7 +742,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, FastList.newListWith("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -755,7 +757,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, FastList.newListWith("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -770,7 +772,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, new Object[]{new Object()});
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -785,7 +787,7 @@ public class VerifyTest
         try
         {
             Verify.assertIterableSize(3, FastList.newListWith("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -800,7 +802,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, IntArrayList.newListWith(1, 2));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -815,7 +817,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, UnifiedMap.newWithKeysValues("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -830,7 +832,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, FastListMultimap.newMultimap());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -845,7 +847,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, Maps.immutable.of("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -860,7 +862,7 @@ public class VerifyTest
         try
         {
             Verify.assertSize(3, Sets.immutable.of("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -875,7 +877,7 @@ public class VerifyTest
         try
         {
             Verify.assertContains("foo", "bar");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -890,7 +892,7 @@ public class VerifyTest
         try
         {
             Verify.assertAllSatisfy(FastList.newListWith(1, 3), IntegerPredicates.isEven());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -905,7 +907,7 @@ public class VerifyTest
         try
         {
             Verify.assertAllSatisfy((Map<?, Integer>) UnifiedMap.newWithKeysValues(1, 1, 3, 3), IntegerPredicates.isEven());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -920,7 +922,7 @@ public class VerifyTest
         try
         {
             Verify.assertNoneSatisfy(FastList.newListWith(1, 3), IntegerPredicates.isOdd());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -935,7 +937,7 @@ public class VerifyTest
         try
         {
             Verify.assertNoneSatisfy((Map<?, Integer>) UnifiedMap.newWithKeysValues(1, 1, 3, 3), IntegerPredicates.isOdd());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -950,7 +952,7 @@ public class VerifyTest
         try
         {
             Verify.assertAnySatisfy(FastList.newListWith(1, 3), IntegerPredicates.isEven());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -965,7 +967,7 @@ public class VerifyTest
         try
         {
             Verify.assertAnySatisfy((Map<?, Integer>) UnifiedMap.newWithKeysValues(1, 1, 3, 3), IntegerPredicates.isEven());
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -980,7 +982,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(UnifiedMap.newWithKeysValues("foo", "bar"), "baz", "quaz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -995,7 +997,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(UnifiedMap.newWithKeysValues("foo", "bar"), "foo", "quaz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1010,7 +1012,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(UnifiedMap.newWithKeysValues("foo", "bar"), "baz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1025,7 +1027,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(Maps.immutable.of("foo", "bar"), "baz", "quaz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1040,7 +1042,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(Maps.immutable.of("foo", "bar"), "foo", "quaz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1055,7 +1057,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsAllKeyValues(Maps.immutable.of("foo", "bar"), "baz");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1070,7 +1072,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsNone(FastList.newListWith("foo", "bar"), "foo", "bar");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1085,7 +1087,7 @@ public class VerifyTest
         try
         {
             Verify.denyContainsAny(FastList.newListWith("foo", "bar"), "foo", "bar");
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1100,7 +1102,7 @@ public class VerifyTest
         try
         {
             Verify.assertContains("baz", FastList.newListWith("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1115,7 +1117,7 @@ public class VerifyTest
         try
         {
             Verify.assertContains("bar", Sets.immutable.of("foo"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1130,7 +1132,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsEntry("foo", "bar", FastListMultimap.newMultimap(Tuples.pair("foo", "baz")));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1145,7 +1147,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKey("foo", UnifiedMap.newWithKeysValues("foozle", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1160,7 +1162,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKey("foo", Maps.immutable.of("foozle", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1175,7 +1177,7 @@ public class VerifyTest
         try
         {
             Verify.denyContainsKey("foo", UnifiedMap.newWithKeysValues("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1190,7 +1192,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKeyValue("foo", "bar", UnifiedMap.newWithKeysValues("baz", "quaz"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1205,7 +1207,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKeyValue("foo", "bar", UnifiedMap.newWithKeysValues("foo", "quaz"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1220,7 +1222,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKeyValue("foo", "bar", Maps.immutable.of("baz", "quaz"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1235,7 +1237,7 @@ public class VerifyTest
         try
         {
             Verify.assertContainsKeyValue("foo", "bar", Maps.immutable.of("baz", "quaz"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1250,7 +1252,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotContains("foo", FastList.newListWith("foo"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1265,7 +1267,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotContains("foo", (Iterable<?>) FastList.newListWith("foo"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1280,7 +1282,7 @@ public class VerifyTest
         try
         {
             Verify.assertNotContainsKey("foo", UnifiedMap.newWithKeysValues("foo", "bar"));
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1297,7 +1299,7 @@ public class VerifyTest
         try
         {
             Verify.assertClassNonInstantiable(VerifyTest.class);
-            Assert.fail();
+            fail();
         }
         catch (AssertionError ex)
         {
@@ -1317,7 +1319,7 @@ public class VerifyTest
         }
         catch (AssertionError ex)
         {
-            Assert.assertEquals("Block did not throw an exception of type java.io.NotSerializableException", ex.getMessage());
+            assertEquals("Block did not throw an exception of type java.io.NotSerializableException", ex.getMessage());
             Verify.assertContains(VerifyTest.class.getName(), ex.getStackTrace()[0].toString());
         }
     }
@@ -1332,7 +1334,7 @@ public class VerifyTest
         }
         catch (AssertionError ex)
         {
-            Assert.assertEquals("Failed to marshal an object", ex.getMessage());
+            assertEquals("Failed to marshal an object", ex.getMessage());
             Verify.assertContains(VerifyTest.class.getName(), ex.getStackTrace()[0].toString());
         }
     }
@@ -1347,7 +1349,7 @@ public class VerifyTest
         }
         catch (AssertionError ex)
         {
-            Assert.assertEquals("Failed to marshal an object", ex.getMessage());
+            assertEquals("Failed to marshal an object", ex.getMessage());
             Verify.assertContains(VerifyTest.class.getName(), ex.getStackTrace()[0].toString());
         }
         try
@@ -1356,7 +1358,7 @@ public class VerifyTest
         }
         catch (AssertionError ex)
         {
-            Assert.assertEquals("not same toString", ex.getMessage());
+            assertEquals("not same toString", ex.getMessage());
             Verify.assertContains(VerifyTest.class.getName(), ex.getStackTrace()[0].toString());
         }
     }

--- a/serialization-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableCharHashBagSerializationTest.java
+++ b/serialization-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableCharHashBagSerializationTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.bag.immutable.primitive;
 
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableCharHashBagSerializationTest
 {
@@ -32,7 +33,7 @@ public class ImmutableCharHashBagSerializationTest
     public void deserialize()
     {
         ImmutableCharHashBag immutableCharHashBag = SerializeTestHelper.serializeDeserialize(ImmutableCharHashBag.newBagWith('a', 'b'));
-        Assert.assertEquals(ImmutableCharHashBag.newBagWith('a', 'b'), immutableCharHashBag);
+        assertEquals(ImmutableCharHashBag.newBagWith('a', 'b'), immutableCharHashBag);
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/ImmutableUnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/ImmutableUnorderedIterableTestCase.java
@@ -12,7 +12,6 @@ package org.eclipse.collections.test;
 
 import java.util.Iterator;
 
-import org.eclipse.collections.impl.test.Verify;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/ImmutableUnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/ImmutableUnorderedIterableTestCase.java
@@ -15,6 +15,8 @@ import java.util.Iterator;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public interface ImmutableUnorderedIterableTestCase extends UnorderedIterableTestCase
 {
     @Override
@@ -23,6 +25,6 @@ public interface ImmutableUnorderedIterableTestCase extends UnorderedIterableTes
     {
         Iterator<Integer> iterator = this.newWith(3, 2, 1).iterator();
         iterator.next();
-        Verify.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -48,9 +48,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertIterablesEqual;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -48,7 +48,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
@@ -70,6 +70,7 @@ import static org.eclipse.collections.impl.test.Verify.assertPostSerializedEqual
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.eclipse.collections.test.IterableTestCase.assertNotEquals;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -90,7 +91,7 @@ public interface RichIterableUniqueTestCase
     {
         Iterable<Integer> iterable = this.newWith(3, 2, 1);
         Object deserialized = SerializeTestHelper.serializeDeserialize(iterable);
-        Assert.assertNotSame(iterable, deserialized);
+        assertNotSame(iterable, deserialized);
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
@@ -281,7 +281,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
                     (float) (each % 10)), target);
             assertEquals(
                     this.newFloatForTransform(
-                    1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f, 1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f),
+                            1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f, 1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f),
                     result);
             assertSame(target, result);
         }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
@@ -13,11 +13,11 @@ package org.eclipse.collections.test.bag.mutable.sorted;
 import org.eclipse.collections.api.bag.MutableBagIterable;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.test.collection.mutable.MutableCollectionTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public interface MutableBagIterableTestCase extends MutableCollectionTestCase
@@ -34,7 +34,7 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
         assertEquals(3, mutableBag.addOccurrences(1, 2));
         assertEquals(Bags.immutable.with(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> mutableBag.addOccurrences(4, -1));
     }
@@ -52,7 +52,7 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
         assertTrue(mutableBag.removeOccurrences(2, 1));
         assertEquals(Bags.immutable.with(2, 3), mutableBag);
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> mutableBag.removeOccurrences(4, -1));
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
@@ -18,11 +18,12 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.test.CollectionTestCase;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.RichIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public interface MutableCollectionTestCase extends CollectionTestCase, RichIterableTestCase
 {
@@ -59,7 +60,7 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
         String s = "";
 
         MutableCollection<String> collection = this.newWith();
-        Assert.assertTrue(collection.add(s));
+        assertTrue(collection.add(s));
         IterableTestCase.assertEquals(this.allowsDuplicates(), collection.add(s));
         IterableTestCase.assertEquals(this.allowsDuplicates() ? 2 : 1, collection.size());
     }
@@ -75,44 +76,44 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
     default void MutableCollection_removeIf()
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 5, 4, 4, 3, 3, 2, 2, 1, 1);
-        Assert.assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
+        assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(5, 5, 3, 3, 1, 1), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3);
-        Assert.assertFalse(collection2.removeIf(Predicates.cast(each -> each > 4)));
+        assertFalse(collection2.removeIf(Predicates.cast(each -> each > 4)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(1, 2, 3), collection2);
-        Assert.assertTrue(collection2.removeIf(Predicates.cast(each -> each > 0)));
+        assertTrue(collection2.removeIf(Predicates.cast(each -> each > 0)));
 
         MutableCollection<Integer> collection3 = this.newWith();
-        Assert.assertFalse(collection3.removeIf(Predicates.cast(each -> each % 2 == 0)));
+        assertFalse(collection3.removeIf(Predicates.cast(each -> each % 2 == 0)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(), collection3);
 
         MutableCollection<Integer> collection4 = this.newWith(2, 2, 4, 6);
-        Assert.assertTrue(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
+        assertTrue(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(), collection4);
-        Assert.assertFalse(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
+        assertFalse(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
     }
 
     @Test
     default void MutableCollection_removeIfWith()
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 5, 4, 4, 3, 3, 2, 2, 1, 1);
-        Assert.assertTrue(collection1.removeIfWith(Predicates2.in(), Lists.immutable.with(5, 3, 1)));
+        assertTrue(collection1.removeIfWith(Predicates2.in(), Lists.immutable.with(5, 3, 1)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(4, 4, 2, 2), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3);
-        Assert.assertFalse(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(4)));
+        assertFalse(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(4)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(1, 2, 3), collection2);
-        Assert.assertTrue(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(1, 2, 3)));
+        assertTrue(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(1, 2, 3)));
 
         MutableCollection<Integer> collection3 = this.newWith();
-        Assert.assertFalse(collection3.removeIfWith(Predicates2.in(), Lists.immutable.with()));
+        assertFalse(collection3.removeIfWith(Predicates2.in(), Lists.immutable.with()));
         IterableTestCase.assertEquals(this.getExpectedFiltered(), collection3);
 
         MutableCollection<Integer> collection4 = this.newWith(2, 2, 4, 6);
-        Assert.assertTrue(collection4.removeIfWith(Predicates2.greaterThan(), 1));
+        assertTrue(collection4.removeIfWith(Predicates2.greaterThan(), 1));
         IterableTestCase.assertEquals(this.getExpectedFiltered(), collection4);
-        Assert.assertFalse(collection4.removeIfWith(Predicates2.greaterThan(), 1));
+        assertFalse(collection4.removeIfWith(Predicates2.greaterThan(), 1));
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionUniqueTestCase.java
@@ -17,8 +17,11 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.RichIterableUniqueTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCase, RichIterableUniqueTestCase
 {
@@ -30,19 +33,19 @@ public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCa
     default void MutableCollection_removeIf()
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 4, 3, 2, 1);
-        Assert.assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
+        assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
         IterableTestCase.assertEquals(this.getExpectedFiltered(5, 3, 1), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
-        Assert.assertFalse(collection2.removeIf(Predicates.equal(5)));
-        Assert.assertTrue(collection2.removeIf(Predicates.greaterThan(0)));
-        Assert.assertFalse(collection2.removeIf(Predicates.greaterThan(2)));
+        assertFalse(collection2.removeIf(Predicates.equal(5)));
+        assertTrue(collection2.removeIf(Predicates.greaterThan(0)));
+        assertFalse(collection2.removeIf(Predicates.greaterThan(2)));
 
         MutableCollection<Integer> collection3 = this.newWith();
-        Assert.assertFalse(collection3.removeIf(Predicates.equal(5)));
+        assertFalse(collection3.removeIf(Predicates.equal(5)));
 
         Predicate<Object> predicate = null;
-        Assert.assertThrows(NullPointerException.class, () -> this.newWith(7, 4, 5, 1).removeIf(predicate));
+        assertThrows(NullPointerException.class, () -> this.newWith(7, 4, 5, 1).removeIf(predicate));
     }
 
     @Override
@@ -54,14 +57,14 @@ public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCa
         IterableTestCase.assertEquals(this.getExpectedFiltered(4, 2), collection);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
-        Assert.assertFalse(collection2.removeIf(Predicates.equal(5)));
-        Assert.assertTrue(collection2.removeIf(Predicates.greaterThan(0)));
-        Assert.assertFalse(collection2.removeIf(Predicates.greaterThan(2)));
+        assertFalse(collection2.removeIf(Predicates.equal(5)));
+        assertTrue(collection2.removeIf(Predicates.greaterThan(0)));
+        assertFalse(collection2.removeIf(Predicates.greaterThan(2)));
 
         MutableCollection<Integer> collection3 = this.newWith();
-        Assert.assertFalse(collection3.removeIf(Predicates.equal(5)));
+        assertFalse(collection3.removeIf(Predicates.equal(5)));
 
-        Assert.assertThrows(NullPointerException.class, () -> this.newWith(7, 4, 5, 1).removeIf(Predicates.cast(null)));
+        assertThrows(NullPointerException.class, () -> this.newWith(7, 4, 5, 1).removeIf(Predicates.cast(null)));
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
@@ -20,7 +20,9 @@ import org.junit.Test;
 import static org.eclipse.collections.test.IterableTestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public interface MapTestCase
 {
@@ -148,19 +150,19 @@ public interface MapTestCase
         Map<Integer, String> map = this.newWithKeysValues(1, "1", 2, "2", 3, "3");
 
         // null value
-        Assert.assertThrows(NullPointerException.class, () -> map.merge(1, null, (v1, v2) -> {
-            Assert.fail("Expected no merge to be performed since the value is null");
+        assertThrows(NullPointerException.class, () -> map.merge(1, null, (v1, v2) -> {
+            fail("Expected no merge to be performed since the value is null");
             return null;
         }));
         Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
 
         // null remapping function
-        Assert.assertThrows(NullPointerException.class, () -> map.merge(1, "4", null));
+        assertThrows(NullPointerException.class, () -> map.merge(1, "4", null));
         Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
 
         // new key, remapping function isn't called
         String value1 = map.merge(4, "4", (v1, v2) -> {
-            Assert.fail("Expected no merge to be performed since the key is not present in the map");
+            fail("Expected no merge to be performed since the key is not present in the map");
             return null;
         });
         Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
@@ -186,7 +188,7 @@ public interface MapTestCase
         Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
 
         // existing key, remapping function throws exception
-        Assert.assertThrows(IllegalArgumentException.class, () -> map.merge(4, "Four", (v1, v2) -> {
+        assertThrows(IllegalArgumentException.class, () -> map.merge(4, "Four", (v1, v2) -> {
             throw new IllegalArgumentException();
         }));
         Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/MutableOrderedMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/MutableOrderedMapTestCase.java
@@ -17,8 +17,12 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.test.MutableOrderedIterableTestCase;
 import org.eclipse.collections.test.map.OrderedMapIterableTestCase;
 import org.eclipse.collections.test.map.mutable.MutableMapIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public interface MutableOrderedMapTestCase extends OrderedMapIterableTestCase, MutableMapIterableTestCase, MutableOrderedIterableTestCase
 {
@@ -33,21 +37,21 @@ public interface MutableOrderedMapTestCase extends OrderedMapIterableTestCase, M
     {
         MutableOrderedMap<Integer, String> map = this.newWithKeysValues(1, "1", 2, "Two", 3, "Three");
 
-        Assert.assertThrows(NullPointerException.class, () -> map.removeAllKeys(null));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.empty()));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4)));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6)));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6, 7, 8, 9)));
+        assertThrows(NullPointerException.class, () -> map.removeAllKeys(null));
+        assertFalse(map.removeAllKeys(Sets.mutable.empty()));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4)));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6)));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6, 7, 8, 9)));
 
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(1)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(1)));
         Verify.denyContainsKey(1, map);
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(3, 4, 5, 6, 7)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(3, 4, 5, 6, 7)));
         Verify.denyContainsKey(3, map);
 
         map.putAll(Maps.mutable.with(4, "Four", 5, "Five", 6, "Six", 7, "Seven"));
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(2, 3, 9, 10)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(2, 3, 9, 10)));
         Verify.denyContainsKey(2, map);
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(5, 3, 7, 8, 9)));
-        Assert.assertEquals(this.newWithKeysValues(4, "Four", 6, "Six"), map);
+        assertTrue(map.removeAllKeys(Sets.mutable.with(5, 3, 7, 8, 9)));
+        assertEquals(this.newWithKeysValues(4, "Four", 6, "Six"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/SortedMapAdapterTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/sorted/SortedMapAdapterTest.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.map.ordered.mutable.OrderedMapAdapter;
 import org.eclipse.collections.impl.map.sorted.mutable.SortedMapAdapter;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
-import org.junit.Assert;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(Java8Runner.class)
@@ -62,6 +62,6 @@ public class SortedMapAdapterTest implements MutableSortedMapIterableTestCase
     public void MapIterable_flipUniqueValues()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);
-        Assert.assertThrows(UnsupportedOperationException.class, map::flipUniqueValues);
+        assertThrows(UnsupportedOperationException.class, map::flipUniqueValues);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
@@ -18,7 +18,6 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.test.CollectionTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertPostSerializedEqualsAndHashCode;
@@ -28,6 +27,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 public interface SetTestCase extends CollectionTestCase
@@ -47,7 +47,7 @@ public interface SetTestCase extends CollectionTestCase
     {
         Iterable<Integer> iterable = this.newWith(3, 2, 1);
         Object deserialized = SerializeTestHelper.serializeDeserialize(iterable);
-        Assert.assertNotSame(iterable, deserialized);
+        assertNotSame(iterable, deserialized);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/function/Function0Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/function/Function0Test.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.api.block.function;
 
 import org.eclipse.collections.impl.block.factory.Functions0;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Function0Test
 {
@@ -20,9 +22,9 @@ public class Function0Test
     public void get()
     {
         Function0<Boolean> alwaysTrueFunction = Functions0.getTrue();
-        Assert.assertTrue(alwaysTrueFunction.get());
+        assertTrue(alwaysTrueFunction.get());
 
         Function0<Boolean> alwaysFalseFunction = Functions0.getFalse();
-        Assert.assertFalse(alwaysFalseFunction.get());
+        assertFalse(alwaysFalseFunction.get());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/Predicate2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/Predicate2Test.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.api.block.predicate;
 
 import org.eclipse.collections.impl.block.factory.Predicates2;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Predicate2Test
 {
@@ -20,9 +22,9 @@ public class Predicate2Test
     public void test()
     {
         Predicate2<Object, Object> alwaysTruePredicate = Predicates2.alwaysTrue();
-        Assert.assertTrue(alwaysTruePredicate.test("A", "B"));
+        assertTrue(alwaysTruePredicate.test("A", "B"));
 
         Predicate2<Object, Object> alwaysFalsePredicate = Predicates2.alwaysFalse();
-        Assert.assertFalse(alwaysFalsePredicate.test("C", "D"));
+        assertFalse(alwaysFalsePredicate.test("C", "D"));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/PredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/PredicateTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.api.block.predicate;
 
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PredicateTest
 {
@@ -20,11 +22,11 @@ public class PredicateTest
     public void test()
     {
         Predicate<Object> alwaysTrue = Predicates.alwaysTrue();
-        Assert.assertTrue(alwaysTrue.test(Boolean.TRUE));
-        Assert.assertTrue(alwaysTrue.test(Boolean.FALSE));
+        assertTrue(alwaysTrue.test(Boolean.TRUE));
+        assertTrue(alwaysTrue.test(Boolean.FALSE));
 
         Predicate<Object> alwaysFalse = Predicates.alwaysFalse();
-        Assert.assertFalse(alwaysFalse.test(Boolean.TRUE));
-        Assert.assertFalse(alwaysFalse.test(Boolean.FALSE));
+        assertFalse(alwaysFalse.test(Boolean.TRUE));
+        assertFalse(alwaysFalse.test(Boolean.FALSE));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/procedure/Procedure2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/procedure/Procedure2Test.java
@@ -15,8 +15,9 @@ import java.util.List;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Procedures2;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class Procedure2Test
 {
@@ -26,8 +27,8 @@ public class Procedure2Test
         Procedure2<String, Collection<String>> addToCollection = Procedures2.addToCollection();
         List<String> list = Lists.mutable.empty();
         addToCollection.accept("A", list);
-        Assert.assertEquals(list, Lists.mutable.of("A"));
+        assertEquals(list, Lists.mutable.of("A"));
         addToCollection.accept("B", list);
-        Assert.assertEquals(list, Lists.mutable.of("A", "B"));
+        assertEquals(list, Lists.mutable.of("A", "B"));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/api/factory/stack/MutableStackFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/factory/stack/MutableStackFactoryTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class MutableStackFactoryTest
 {
@@ -25,7 +27,7 @@ public class MutableStackFactoryTest
     public void with()
     {
         MutableStack<Object> stack = this.mutableStackFactory.with();
-        Verify.assertNotNull(stack);
+        assertNotNull(stack);
         Verify.assertEmpty(stack);
     }
 
@@ -33,15 +35,15 @@ public class MutableStackFactoryTest
     public void of()
     {
         MutableStack<Integer> stack = this.mutableStackFactory.of();
-        Verify.assertNotNull(stack);
+        assertNotNull(stack);
         Verify.assertEmpty(stack);
 
         MutableStack<Integer> intStack = this.mutableStackFactory.of(1, 2, 3);
         Verify.assertSize(3, intStack);
         Verify.assertContainsAll(intStack, 1, 2, 3);
-        Assert.assertEquals(3, (long) intStack.pop());
-        Assert.assertEquals(2, (long) intStack.pop());
-        Assert.assertEquals(1, (long) intStack.pop());
+        assertEquals(3, (long) intStack.pop());
+        assertEquals(2, (long) intStack.pop());
+        assertEquals(1, (long) intStack.pop());
     }
 
     @Test
@@ -49,8 +51,8 @@ public class MutableStackFactoryTest
     {
         MutableStack<Integer> intStack = this.mutableStackFactory.ofAll(Lists.mutable.of(4, 5));
         Verify.assertSize(2, intStack);
-        Assert.assertEquals(5, (long) intStack.pop());
-        Assert.assertEquals(4, (long) intStack.pop());
+        assertEquals(5, (long) intStack.pop());
+        assertEquals(4, (long) intStack.pop());
         Verify.assertEmpty(intStack);
     }
 
@@ -59,8 +61,8 @@ public class MutableStackFactoryTest
     {
         MutableStack<Integer> intStack = this.mutableStackFactory.ofAllReversed(Lists.mutable.of(4, 5));
         Verify.assertSize(2, intStack);
-        Assert.assertEquals(4, (long) intStack.pop());
-        Assert.assertEquals(5, (long) intStack.pop());
+        assertEquals(4, (long) intStack.pop());
+        assertEquals(5, (long) intStack.pop());
         Verify.assertEmpty(intStack);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -171,8 +171,16 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractRichIterableTestCase
 {
@@ -190,16 +198,16 @@ public abstract class AbstractRichIterableTestCase
     public void equalsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(this.newWith(1, 2, 3), this.newWith(1, 2, 3));
-        Assert.assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2));
+        assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2));
     }
 
     @Test
     public void contains()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.contains(1));
-        Assert.assertTrue(collection.contains(4));
-        Assert.assertFalse(collection.contains(5));
+        assertTrue(collection.contains(1));
+        assertTrue(collection.contains(4));
+        assertFalse(collection.contains(5));
     }
 
     @Test
@@ -211,19 +219,19 @@ public abstract class AbstractRichIterableTestCase
                         Tuples.pair(2, "2"),
                         Tuples.pair(3, null));
 
-        Assert.assertTrue(
+        assertTrue(
                 list.containsBy(Pair::getTwo, "2"));
-        Assert.assertFalse(
+        assertFalse(
                 list.containsBy(Pair::getTwo, "3"));
-        Assert.assertTrue(
+        assertTrue(
                 list.containsBy(Pair::getTwo, null));
-        Assert.assertFalse(
+        assertFalse(
                 list.containsBy(Pair::getOne, null));
-        Assert.assertFalse(
+        assertFalse(
                 list.newEmpty().containsBy(Pair::getOne, null));
-        Assert.assertFalse(
+        assertFalse(
                 list.newEmpty().containsBy(Pair::getOne, "2"));
-        Assert.assertThrows(NullPointerException.class, () ->
+        assertThrows(NullPointerException.class, () ->
                 list.newEmpty().containsBy(null, "2"));
     }
 
@@ -231,84 +239,84 @@ public abstract class AbstractRichIterableTestCase
     public void containsAllIterable()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAllIterable(Lists.mutable.with(1, 2)));
-        Assert.assertFalse(collection.containsAllIterable(Lists.mutable.with(1, 5)));
+        assertTrue(collection.containsAllIterable(Lists.mutable.with(1, 2)));
+        assertFalse(collection.containsAllIterable(Lists.mutable.with(1, 5)));
     }
 
     @Test
     public void containsAnyIterable()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAnyIterable(Lists.mutable.with(0, 1)));
-        Assert.assertTrue(collection.containsAnyIterable(Arrays.asList(0, 1)));
-        Assert.assertFalse(collection.containsAnyIterable(Lists.mutable.with(5, 6)));
-        Assert.assertFalse(collection.containsAnyIterable(Arrays.asList(5, 6)));
-        Assert.assertTrue(collection.containsAnyIterable(Interval.oneTo(100)));
-        Assert.assertFalse(collection.containsAnyIterable(Interval.fromTo(5, 100)));
-        Assert.assertTrue(Interval.oneTo(100).containsAnyIterable(collection));
-        Assert.assertFalse(Interval.fromTo(5, 100).containsAnyIterable(collection));
-        Assert.assertTrue(this.newWith(Interval.oneTo(100).toArray()).containsAnyIterable(Interval.oneTo(50)));
-        Assert.assertFalse(this.newWith(Interval.fromTo(5, 100).toArray()).containsAnyIterable(Interval.fromTo(200, 250)));
+        assertTrue(collection.containsAnyIterable(Lists.mutable.with(0, 1)));
+        assertTrue(collection.containsAnyIterable(Arrays.asList(0, 1)));
+        assertFalse(collection.containsAnyIterable(Lists.mutable.with(5, 6)));
+        assertFalse(collection.containsAnyIterable(Arrays.asList(5, 6)));
+        assertTrue(collection.containsAnyIterable(Interval.oneTo(100)));
+        assertFalse(collection.containsAnyIterable(Interval.fromTo(5, 100)));
+        assertTrue(Interval.oneTo(100).containsAnyIterable(collection));
+        assertFalse(Interval.fromTo(5, 100).containsAnyIterable(collection));
+        assertTrue(this.newWith(Interval.oneTo(100).toArray()).containsAnyIterable(Interval.oneTo(50)));
+        assertFalse(this.newWith(Interval.fromTo(5, 100).toArray()).containsAnyIterable(Interval.fromTo(200, 250)));
     }
 
     @Test
     public void containsNoneIterable()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsNoneIterable(Lists.mutable.with(0, 5, 6, 7)));
-        Assert.assertTrue(collection.containsNoneIterable(Arrays.asList(0, 5, 6, 7)));
-        Assert.assertFalse(collection.containsNoneIterable(Lists.mutable.with(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNoneIterable(Arrays.asList(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNoneIterable(Interval.oneTo(100)));
-        Assert.assertTrue(collection.containsNoneIterable(Interval.fromTo(5, 100)));
-        Assert.assertFalse(Interval.oneTo(100).containsNoneIterable(collection));
-        Assert.assertTrue(Interval.fromTo(5, 100).containsNoneIterable(collection));
-        Assert.assertFalse(this.newWith(Interval.oneTo(100).toArray()).containsNoneIterable(Interval.oneTo(50)));
-        Assert.assertTrue(this.newWith(Interval.fromTo(5, 100).toArray()).containsNoneIterable(Interval.fromTo(200, 250)));
+        assertTrue(collection.containsNoneIterable(Lists.mutable.with(0, 5, 6, 7)));
+        assertTrue(collection.containsNoneIterable(Arrays.asList(0, 5, 6, 7)));
+        assertFalse(collection.containsNoneIterable(Lists.mutable.with(0, 1, 5, 6)));
+        assertFalse(collection.containsNoneIterable(Arrays.asList(0, 1, 5, 6)));
+        assertFalse(collection.containsNoneIterable(Interval.oneTo(100)));
+        assertTrue(collection.containsNoneIterable(Interval.fromTo(5, 100)));
+        assertFalse(Interval.oneTo(100).containsNoneIterable(collection));
+        assertTrue(Interval.fromTo(5, 100).containsNoneIterable(collection));
+        assertFalse(this.newWith(Interval.oneTo(100).toArray()).containsNoneIterable(Interval.oneTo(50)));
+        assertTrue(this.newWith(Interval.fromTo(5, 100).toArray()).containsNoneIterable(Interval.fromTo(200, 250)));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAllArguments(1, 2));
-        Assert.assertFalse(collection.containsAllArguments(1, 5));
+        assertTrue(collection.containsAllArguments(1, 2));
+        assertFalse(collection.containsAllArguments(1, 5));
     }
 
     @Test
     public void containsAnyCollection()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAny(Lists.mutable.with(0, 1)));
-        Assert.assertTrue(collection.containsAny(Arrays.asList(0, 1)));
-        Assert.assertFalse(collection.containsAny(Lists.mutable.with(5, 6)));
-        Assert.assertFalse(collection.containsAny(Arrays.asList(5, 6)));
-        Assert.assertTrue(collection.containsAny(Interval.oneTo(100)));
-        Assert.assertFalse(collection.containsAny(Interval.fromTo(5, 100)));
-        Assert.assertTrue(this.newWith(Interval.oneTo(100).toArray()).containsAny(Interval.oneTo(50)));
-        Assert.assertFalse(this.newWith(Interval.fromTo(5, 100).toArray()).containsAny(Interval.fromTo(200, 250)));
+        assertTrue(collection.containsAny(Lists.mutable.with(0, 1)));
+        assertTrue(collection.containsAny(Arrays.asList(0, 1)));
+        assertFalse(collection.containsAny(Lists.mutable.with(5, 6)));
+        assertFalse(collection.containsAny(Arrays.asList(5, 6)));
+        assertTrue(collection.containsAny(Interval.oneTo(100)));
+        assertFalse(collection.containsAny(Interval.fromTo(5, 100)));
+        assertTrue(this.newWith(Interval.oneTo(100).toArray()).containsAny(Interval.oneTo(50)));
+        assertFalse(this.newWith(Interval.fromTo(5, 100).toArray()).containsAny(Interval.fromTo(200, 250)));
     }
 
     @Test
     public void containsNoneCollection()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsNone(Lists.mutable.with(0, 5, 6, 7)));
-        Assert.assertTrue(collection.containsNone(Arrays.asList(0, 5, 6, 7)));
-        Assert.assertFalse(collection.containsNone(Lists.mutable.with(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNone(Arrays.asList(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNone(Interval.oneTo(100)));
-        Assert.assertTrue(collection.containsNone(Interval.fromTo(5, 100)));
-        Assert.assertFalse(this.newWith(Interval.oneTo(100).toArray()).containsNone(Interval.oneTo(50)));
-        Assert.assertTrue(this.newWith(Interval.fromTo(5, 100).toArray()).containsNone(Interval.fromTo(200, 250)));
+        assertTrue(collection.containsNone(Lists.mutable.with(0, 5, 6, 7)));
+        assertTrue(collection.containsNone(Arrays.asList(0, 5, 6, 7)));
+        assertFalse(collection.containsNone(Lists.mutable.with(0, 1, 5, 6)));
+        assertFalse(collection.containsNone(Arrays.asList(0, 1, 5, 6)));
+        assertFalse(collection.containsNone(Interval.oneTo(100)));
+        assertTrue(collection.containsNone(Interval.fromTo(5, 100)));
+        assertFalse(this.newWith(Interval.oneTo(100).toArray()).containsNone(Interval.oneTo(50)));
+        assertTrue(this.newWith(Interval.fromTo(5, 100).toArray()).containsNone(Interval.fromTo(200, 250)));
     }
 
     @Test
     public void containsAllCollection()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAll(Lists.mutable.with(1, 2)));
-        Assert.assertFalse(collection.containsAll(Lists.mutable.with(1, 5)));
+        assertTrue(collection.containsAll(Lists.mutable.with(1, 2)));
+        assertFalse(collection.containsAll(Lists.mutable.with(1, 5)));
     }
 
     @Test
@@ -316,8 +324,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
         RichIterable<Integer> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     private void forEach(Function<Collection<Integer>, Consumer<Integer>> adderProvider)
@@ -374,8 +382,8 @@ public abstract class AbstractRichIterableTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3, 4), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2, 3), indexes);
+        assertEquals(Bags.mutable.of(1, 2, 3, 4), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2, 3), indexes);
     }
 
     @Test
@@ -444,8 +452,8 @@ public abstract class AbstractRichIterableTestCase
     public void selectInstancesOf()
     {
         RichIterable<Number> numbers = this.newWith(1, 2.0, 3, 4.0, 5);
-        Assert.assertEquals(HashBag.newBagWith(1, 3, 5), numbers.selectInstancesOf(Integer.class).toBag());
-        Assert.assertEquals(HashBag.newBagWith(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class).toBag());
+        assertEquals(HashBag.newBagWith(1, 3, 5), numbers.selectInstancesOf(Integer.class).toBag());
+        assertEquals(HashBag.newBagWith(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class).toBag());
     }
 
     @Test
@@ -458,25 +466,25 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void collectTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collect(each -> each + 1, Lists.mutable.empty()).toBag());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 Bags.mutable.withAll(this.newWith(1, 2, 3).collect(each -> each + 1, new ArrayList<>())));
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 Bags.mutable.withAll(this.newWith(1, 2, 3).collect(each -> each + 1, new CopyOnWriteArrayList<>())));
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collect(each -> each + 1, Bags.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collect(each -> each + 1, Sets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collect(each -> each + 1, new HashSet<>()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collect(each -> each + 1, new CopyOnWriteArraySet<>()));
     }
@@ -485,8 +493,8 @@ public abstract class AbstractRichIterableTestCase
     public void collectBoolean()
     {
         BooleanIterable result = this.newWith(1, 0).collectBoolean(PrimitiveFunctions.integerIsPositive());
-        Assert.assertEquals(BooleanBags.mutable.of(true, false), result.toBag());
-        Assert.assertEquals(BooleanBags.mutable.of(true, false), BooleanBags.mutable.ofAll(result));
+        assertEquals(BooleanBags.mutable.of(true, false), result.toBag());
+        assertEquals(BooleanBags.mutable.of(true, false), BooleanBags.mutable.ofAll(result));
     }
 
     @Test
@@ -494,8 +502,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableBooleanCollection target = new BooleanArrayList();
         BooleanIterable result = this.newWith(1, 0).collectBoolean(PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(BooleanBags.mutable.of(true, false), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(BooleanBags.mutable.of(true, false), result.toBag());
     }
 
     @Test
@@ -503,16 +511,16 @@ public abstract class AbstractRichIterableTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newWith(1, 0).collectBoolean(PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(BooleanHashBag.newBagWith(true, false), result);
     }
 
     @Test
     public void collectByte()
     {
         ByteIterable result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte());
-        Assert.assertEquals(ByteBags.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), result.toBag());
-        Assert.assertEquals(ByteBags.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), ByteBags.mutable.ofAll(result));
+        assertEquals(ByteBags.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), result.toBag());
+        assertEquals(ByteBags.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), ByteBags.mutable.ofAll(result));
     }
 
     @Test
@@ -520,8 +528,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableByteCollection target = new ByteArrayList();
         ByteIterable result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result.toBag());
     }
 
     @Test
@@ -529,16 +537,16 @@ public abstract class AbstractRichIterableTestCase
     {
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result);
     }
 
     @Test
     public void collectChar()
     {
         CharIterable result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar());
-        Assert.assertEquals(CharBags.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), result.toBag());
-        Assert.assertEquals(CharBags.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), CharBags.mutable.ofAll(result));
+        assertEquals(CharBags.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), result.toBag());
+        assertEquals(CharBags.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), CharBags.mutable.ofAll(result));
     }
 
     @Test
@@ -546,8 +554,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableCharCollection target = new CharArrayList();
         CharIterable result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result.toBag());
     }
 
     @Test
@@ -555,16 +563,16 @@ public abstract class AbstractRichIterableTestCase
     {
         CharHashBag target = new CharHashBag();
         CharHashBag result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result);
     }
 
     @Test
     public void collectDouble()
     {
         DoubleIterable result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble());
-        Assert.assertEquals(DoubleBags.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), result.toBag());
-        Assert.assertEquals(DoubleBags.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), DoubleBags.mutable.ofAll(result));
+        assertEquals(DoubleBags.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), result.toBag());
+        assertEquals(DoubleBags.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), DoubleBags.mutable.ofAll(result));
     }
 
     @Test
@@ -572,8 +580,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableDoubleCollection target = new DoubleArrayList();
         DoubleIterable result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result.toBag());
     }
 
     @Test
@@ -581,16 +589,16 @@ public abstract class AbstractRichIterableTestCase
     {
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result);
     }
 
     @Test
     public void collectFloat()
     {
         FloatIterable result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat());
-        Assert.assertEquals(FloatBags.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), result.toBag());
-        Assert.assertEquals(FloatBags.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), FloatBags.mutable.ofAll(result));
+        assertEquals(FloatBags.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), result.toBag());
+        assertEquals(FloatBags.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), FloatBags.mutable.ofAll(result));
     }
 
     @Test
@@ -598,8 +606,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableFloatCollection target = new FloatArrayList();
         FloatIterable result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result.toBag());
     }
 
     @Test
@@ -607,16 +615,16 @@ public abstract class AbstractRichIterableTestCase
     {
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result);
     }
 
     @Test
     public void collectInt()
     {
         IntIterable result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt());
-        Assert.assertEquals(IntBags.mutable.of(1, 2, 3, 4), result.toBag());
-        Assert.assertEquals(IntBags.mutable.of(1, 2, 3, 4), IntBags.mutable.ofAll(result));
+        assertEquals(IntBags.mutable.of(1, 2, 3, 4), result.toBag());
+        assertEquals(IntBags.mutable.of(1, 2, 3, 4), IntBags.mutable.ofAll(result));
     }
 
     @Test
@@ -624,8 +632,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableIntCollection target = new IntArrayList();
         IntIterable result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result.toBag());
     }
 
     @Test
@@ -633,16 +641,16 @@ public abstract class AbstractRichIterableTestCase
     {
         IntHashBag target = new IntHashBag();
         IntHashBag result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result);
     }
 
     @Test
     public void collectLong()
     {
         LongIterable result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong());
-        Assert.assertEquals(LongBags.mutable.of(1, 2, 3, 4), result.toBag());
-        Assert.assertEquals(LongBags.mutable.of(1, 2, 3, 4), LongBags.mutable.ofAll(result));
+        assertEquals(LongBags.mutable.of(1, 2, 3, 4), result.toBag());
+        assertEquals(LongBags.mutable.of(1, 2, 3, 4), LongBags.mutable.ofAll(result));
     }
 
     @Test
@@ -650,8 +658,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableLongCollection target = new LongArrayList();
         LongIterable result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result.toBag());
     }
 
     @Test
@@ -659,16 +667,16 @@ public abstract class AbstractRichIterableTestCase
     {
         LongHashBag target = new LongHashBag();
         LongHashBag result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result);
     }
 
     @Test
     public void collectShort()
     {
         ShortIterable result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort());
-        Assert.assertEquals(ShortBags.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), result.toBag());
-        Assert.assertEquals(ShortBags.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), ShortBags.mutable.ofAll(result));
+        assertEquals(ShortBags.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), result.toBag());
+        assertEquals(ShortBags.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), ShortBags.mutable.ofAll(result));
     }
 
     @Test
@@ -676,8 +684,8 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableShortCollection target = new ShortArrayList();
         ShortIterable result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result.toBag());
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result.toBag());
     }
 
     @Test
@@ -685,8 +693,8 @@ public abstract class AbstractRichIterableTestCase
     {
         ShortHashBag target = new ShortHashBag();
         ShortHashBag result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result);
+        assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result);
     }
 
     @Test
@@ -732,8 +740,8 @@ public abstract class AbstractRichIterableTestCase
         MutableBooleanSet set = iterable.flatCollectBoolean(function, new BooleanHashSet());
 
         BooleanBag expected = BooleanBags.mutable.with(true, false, false, true);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -751,8 +759,8 @@ public abstract class AbstractRichIterableTestCase
         MutableByteSet set = iterable.flatCollectByte(function, new ByteHashSet());
 
         ByteBag expected = ByteBags.mutable.with((byte) 1, (byte) 2, (byte) 3, (byte) 4);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -770,8 +778,8 @@ public abstract class AbstractRichIterableTestCase
         MutableShortSet set = iterable.flatCollectShort(function, new ShortHashSet());
 
         ShortBag expected = ShortBags.mutable.with((short) 1, (short) 2, (short) 3, (short) 4);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -789,8 +797,8 @@ public abstract class AbstractRichIterableTestCase
         MutableIntSet set = iterable.flatCollectInt(function, new IntHashSet());
 
         IntBag expected = IntBags.mutable.with(1, 2, 3, 4);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -808,8 +816,8 @@ public abstract class AbstractRichIterableTestCase
         MutableCharSet set = iterable.flatCollectChar(function, new CharHashSet());
 
         CharBag expected = CharBags.mutable.with('a', 'b', 'c', 'd');
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -827,8 +835,8 @@ public abstract class AbstractRichIterableTestCase
         MutableLongSet set = iterable.flatCollectLong(function, new LongHashSet());
 
         LongBag expected = LongBags.mutable.with(1L, 2L, 3L, 4L);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -846,8 +854,8 @@ public abstract class AbstractRichIterableTestCase
         MutableDoubleSet set = iterable.flatCollectDouble(function, new DoubleHashSet());
 
         DoubleBag expected = DoubleBags.mutable.with(1.0, 2.0, 3.0, 4.0);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
@@ -865,23 +873,23 @@ public abstract class AbstractRichIterableTestCase
         MutableFloatSet set = iterable.flatCollectFloat(function, new FloatHashSet());
 
         FloatBag expected = FloatBags.mutable.with(1, 2, 3, 4);
-        Assert.assertEquals(expected, bag);
-        Assert.assertEquals(expected.toSet(), set);
+        assertEquals(expected, bag);
+        assertEquals(expected.toSet(), set);
     }
 
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detect(Integer.valueOf(3)::equals));
-        Assert.assertNull(this.newWith(1, 2, 3, 4, 5).detect(Integer.valueOf(6)::equals));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detect(Integer.valueOf(3)::equals));
+        assertNull(this.newWith(1, 2, 3, 4, 5).detect(Integer.valueOf(6)::equals));
     }
 
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(3)::equals).get());
-        Assert.assertNotNull(this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(6)::equals));
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(6)::equals).get());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(3)::equals).get());
+        assertNotNull(this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(6)::equals));
+        assertThrows(NoSuchElementException.class, () -> this.newWith(1, 2, 3, 4, 5).detectOptional(Integer.valueOf(6)::equals).get());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -911,42 +919,42 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).min(Integer::compareTo));
     }
 
     @Test
     public void minOptional()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newWith(1, 3, 2).minOptional().get());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newWith(1, 3, 2).minOptional(Integer::compareTo).get());
-        Assert.assertFalse(
+        assertFalse(
                 this.<Integer>newWith().minOptional().isPresent());
-        Assert.assertFalse(
+        assertFalse(
                 this.<Integer>newWith().minOptional(Integer::compareTo).isPresent());
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max(Integer::compareTo));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max(Integer::compareTo));
     }
 
     @Test
     public void maxOptional()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 this.newWith(1, 3, 2).maxOptional().get());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 this.newWith(1, 3, 2).maxOptional(Integer::compareTo).get());
-        Assert.assertFalse(
+        assertFalse(
                 this.<Integer>newWith().maxOptional().isPresent());
-        Assert.assertFalse(
+        assertFalse(
                 this.<Integer>newWith().maxOptional(Integer::compareTo).isPresent());
     }
 
@@ -965,55 +973,55 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(3, 1, 2).min());
+        assertEquals(Integer.valueOf(1), this.newWith(3, 1, 2).min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max());
     }
 
     @Test
     public void min_null_safe()
     {
         RichIterable<Integer> integers = this.newWith(1, 3, 2, null);
-        Assert.assertEquals(Integer.valueOf(1), integers.min(Comparators.safeNullsHigh(Integer::compareTo)));
-        Assert.assertNull(integers.min(Comparators.safeNullsLow(Integer::compareTo)));
+        assertEquals(Integer.valueOf(1), integers.min(Comparators.safeNullsHigh(Integer::compareTo)));
+        assertNull(integers.min(Comparators.safeNullsLow(Integer::compareTo)));
     }
 
     @Test
     public void max_null_safe()
     {
         RichIterable<Integer> integers = this.newWith(1, 3, 2, null);
-        Assert.assertEquals(Integer.valueOf(3), integers.max(Comparators.safeNullsLow(Integer::compareTo)));
-        Assert.assertNull(integers.max(Comparators.safeNullsHigh(Integer::compareTo)));
+        assertEquals(Integer.valueOf(3), integers.max(Comparators.safeNullsLow(Integer::compareTo)));
+        assertNull(integers.max(Comparators.safeNullsHigh(Integer::compareTo)));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minBy(String::valueOf));
     }
 
     @Test
     public void minByOptional()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minByOptional(String::valueOf).get());
-        Assert.assertFalse(this.newWith().minByOptional(String::valueOf).isPresent());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minByOptional(String::valueOf).get());
+        assertFalse(this.newWith().minByOptional(String::valueOf).isPresent());
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxBy(String::valueOf));
     }
 
     @Test
     public void maxByOptional()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxByOptional(String::valueOf).get());
-        Assert.assertFalse(this.newWith().maxByOptional(String::valueOf).isPresent());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxByOptional(String::valueOf).get());
+        assertFalse(this.newWith().maxByOptional(String::valueOf).isPresent());
     }
 
     @Test(expected = NullPointerException.class)
@@ -1031,36 +1039,36 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 3));
-        Assert.assertNull(this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 3));
+        assertNull(this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
     }
 
     @Test
     public void detectWithOptional()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 3).get());
-        Assert.assertNotNull(this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 6));
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 6).get());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 3).get());
+        assertNotNull(this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 6));
+        assertThrows(NoSuchElementException.class, () -> this.newWith(1, 2, 3, 4, 5).detectWithOptional(Object::equals, 6).get());
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, () -> 6));
-        Assert.assertEquals(Integer.valueOf(6), this.newWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, () -> 6));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, () -> 6));
+        assertEquals(Integer.valueOf(6), this.newWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, () -> 6));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0<Integer> function = new PassThruFunction0<>(-42);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(5),
                 this.newWith(1, 2, 3, 4, 5).detectWithIfNone(
                         Predicates2.greaterThan(),
                         4,
                         function));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(-42),
                 this.newWith(1, 2, 3, 4, 5).detectWithIfNone(
                         Predicates2.lessThan(),
@@ -1071,56 +1079,56 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(this.newWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
+        assertFalse(this.newWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, 2, 3).allSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(this.newWith(1, 2, 3).allSatisfyWith(Object::equals, 1));
+        assertTrue(this.newWith(1, 2, 3).allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.newWith(1, 2, 3).allSatisfyWith(Object::equals, 1));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, 2, 3).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(1, 1, 3).noneSatisfy(Integer.valueOf(1)::equals));
-        Assert.assertTrue(this.newWith(1, 2, 3).noneSatisfy(Integer.valueOf(4)::equals));
+        assertTrue(this.newWith(1, 2, 3).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(1, 1, 3).noneSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newWith(1, 2, 3).noneSatisfy(Integer.valueOf(4)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, 2, 3).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(1, 2, 3).noneSatisfyWith(Object::equals, 1));
+        assertTrue(this.newWith(1, 2, 3).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(1, 2, 3).noneSatisfyWith(Object::equals, 1));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.newWith(1, 2, 3).anySatisfy(String.class::isInstance));
-        Assert.assertTrue(this.newWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
+        assertFalse(this.newWith(1, 2, 3).anySatisfy(String.class::isInstance));
+        assertTrue(this.newWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.newWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertTrue(this.newWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.newWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(this.newWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(3, this.newWith(1, 2, 3).count(Integer.class::isInstance));
+        assertEquals(3, this.newWith(1, 2, 3).count(Integer.class::isInstance));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(3, this.newWith(1, 2, 3).countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(3, this.newWith(1, 2, 3).countWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
@@ -1142,7 +1150,7 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1).toBag());
     }
@@ -1150,25 +1158,25 @@ public abstract class AbstractRichIterableTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, Lists.mutable.empty()).toBag());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 Bags.mutable.withAll(this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, new ArrayList<>())));
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 Bags.mutable.withAll(this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, new CopyOnWriteArrayList<>())));
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, Bags.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, Sets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, new HashSet<>()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.of(2, 3, 4),
                 this.newWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, new CopyOnWriteArraySet<>()));
     }
@@ -1177,30 +1185,30 @@ public abstract class AbstractRichIterableTestCase
     public void getAny()
     {
         RichIterable<Integer> distinctElements = this.newWith(1, 2, 3);
-        Assert.assertTrue(distinctElements.contains(distinctElements.getAny()));
+        assertTrue(distinctElements.contains(distinctElements.getAny()));
         RichIterable<String> duplicateElements = this.newWith("a", "a", "b");
-        Assert.assertTrue(duplicateElements.contains(duplicateElements.getAny()));
+        assertTrue(duplicateElements.contains(duplicateElements.getAny()));
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
-        Assert.assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
+        assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
+        assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.newWith(2).getOnly());
-        Assert.assertNotEquals(Integer.valueOf(2), this.newWith(1).getOnly());
+        assertEquals(Integer.valueOf(2), this.newWith(2).getOnly());
+        assertNotEquals(Integer.valueOf(2), this.newWith(1).getOnly());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1220,7 +1228,7 @@ public abstract class AbstractRichIterableTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(1, 2));
-        Assert.assertTrue(this.newWith(1, 2).notEmpty());
+        assertTrue(this.newWith(1, 2).notEmpty());
     }
 
     @Test
@@ -1230,11 +1238,11 @@ public abstract class AbstractRichIterableTestCase
         Iterator<Integer> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             Integer integer = iterator.next();
-            Assert.assertEquals(3, integer.intValue() + i);
+            assertEquals(3, integer.intValue() + i);
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -1244,10 +1252,10 @@ public abstract class AbstractRichIterableTestCase
         Iterator<Integer> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         iterator.next();
     }
 
@@ -1256,9 +1264,9 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         Integer result = objects.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
         int sum = objects.injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(6, sum);
+        assertEquals(6, sum);
     }
 
     @Test
@@ -1266,9 +1274,9 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         int result = objects.injectIntoInt(1, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(7, result);
+        assertEquals(7, result);
         int sum = objects.injectIntoInt(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(6, sum);
+        assertEquals(6, sum);
     }
 
     @Test
@@ -1276,9 +1284,9 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         long result = objects.injectIntoLong(1, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(7, result);
+        assertEquals(7, result);
         long sum = objects.injectIntoLong(0, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(6, sum);
+        assertEquals(6, sum);
     }
 
     @Test
@@ -1286,9 +1294,9 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         double result = objects.injectIntoDouble(1, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(7.0d, result, 0.001);
+        assertEquals(7.0d, result, 0.001);
         double sum = objects.injectIntoDouble(0, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(6.0d, sum, 0.001);
+        assertEquals(6.0d, sum, 0.001);
     }
 
     @Test
@@ -1296,9 +1304,9 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         float result = objects.injectIntoFloat(1, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(7.0f, result, 0.001f);
+        assertEquals(7.0f, result, 0.001f);
         float sum = objects.injectIntoFloat(0, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(6.0f, sum, 0.001f);
+        assertEquals(6.0f, sum, 0.001f);
     }
 
     @Test
@@ -1307,7 +1315,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         float expected = objects.injectInto(0, AddFunction.INTEGER_TO_FLOAT);
         double actual = objects.sumOfFloat(Integer::floatValue);
-        Assert.assertEquals(expected, actual, 0.001);
+        assertEquals(expected, actual, 0.001);
     }
 
     @Test
@@ -1315,8 +1323,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         DoubleSummaryStatistics expected = objects.summarizeFloat(Integer::floatValue);
-        Assert.assertEquals(6.0d, expected.getSum(), 0.0);
-        Assert.assertEquals(3, expected.getCount());
+        assertEquals(6.0d, expected.getSum(), 0.0);
+        assertEquals(3, expected.getCount());
     }
 
     @Test
@@ -1326,7 +1334,7 @@ public abstract class AbstractRichIterableTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 this.newWith(list.toArray(new Integer[]{})).sumOfFloat(i -> 1.0f / (i.floatValue() * i.floatValue() * i.floatValue() * i.floatValue())),
                 1.0e-15);
@@ -1339,7 +1347,7 @@ public abstract class AbstractRichIterableTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 33333.00099340081,
                 this.newWith(list.toArray(new Integer[]{})).sumOfFloat(i -> 1.0f / 3.0f),
                 0.0);
@@ -1351,7 +1359,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         double expected = objects.injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
         double actual = objects.sumOfDouble(Integer::doubleValue);
-        Assert.assertEquals(expected, actual, 0.001);
+        assertEquals(expected, actual, 0.001);
     }
 
     @Test
@@ -1359,8 +1367,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         DoubleSummaryStatistics expected = objects.summarizeDouble(Integer::doubleValue);
-        Assert.assertEquals(6.0d, expected.getSum(), 0.0);
-        Assert.assertEquals(3, expected.getCount());
+        assertEquals(6.0d, expected.getSum(), 0.0);
+        assertEquals(3, expected.getCount());
     }
 
     @Test
@@ -1368,7 +1376,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableList<Integer> list = Interval.oneTo(100_000).toList().shuffleThis();
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 this.newWith(list.toArray(new Integer[]{})).sumOfDouble(i -> 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue())),
                 1.0e-15);
@@ -1379,7 +1387,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableList<Integer> list = Interval.oneTo(99_999).toList().shuffleThis();
 
-        Assert.assertEquals(
+        assertEquals(
                 33333.0,
                 this.newWith(list.toArray(new Integer[]{})).sumOfDouble(i -> 1.0d / 3.0d),
                 0.0);
@@ -1391,7 +1399,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         long expected = objects.injectInto(0L, AddFunction.INTEGER_TO_LONG);
         long actual = objects.sumOfInt(integer -> integer);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -1399,8 +1407,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         IntSummaryStatistics expected = objects.summarizeInt(Integer::intValue);
-        Assert.assertEquals(6, expected.getSum());
-        Assert.assertEquals(3, expected.getCount());
+        assertEquals(6, expected.getSum());
+        assertEquals(3, expected.getCount());
     }
 
     @Test
@@ -1409,7 +1417,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         long expected = objects.injectInto(0L, AddFunction.INTEGER_TO_LONG);
         long actual = objects.sumOfLong(Integer::longValue);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -1417,8 +1425,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         LongSummaryStatistics expected = objects.summarizeLong(Integer::longValue);
-        Assert.assertEquals(6, expected.getSum());
-        Assert.assertEquals(3, expected.getCount());
+        assertEquals(6, expected.getSum());
+        assertEquals(3, expected.getCount());
     }
 
     @Test
@@ -1426,8 +1434,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> values = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ObjectLongMap<Integer> result = values.sumByInt(i -> i % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -1435,8 +1443,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> values = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ObjectDoubleMap<Integer> result = values.sumByFloat(f -> f % 2, e -> e);
-        Assert.assertEquals(25.0f, result.get(1), 0.0);
-        Assert.assertEquals(30.0f, result.get(0), 0.0);
+        assertEquals(25.0f, result.get(1), 0.0);
+        assertEquals(30.0f, result.get(0), 0.0);
     }
 
     @Test
@@ -1455,11 +1463,11 @@ public abstract class AbstractRichIterableTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(1),
                 1.0e-15);
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(2),
                 1.0e-15);
@@ -1470,8 +1478,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> values = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ObjectLongMap<Integer> result = values.sumByLong(l -> l % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -1479,8 +1487,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> values = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ObjectDoubleMap<Integer> result = values.sumByDouble(d -> d % 2, e -> e);
-        Assert.assertEquals(25.0d, result.get(1), 0.0);
-        Assert.assertEquals(30.0d, result.get(0), 0.0);
+        assertEquals(25.0d, result.get(1), 0.0);
+        assertEquals(30.0d, result.get(0), 0.0);
     }
 
     @Test
@@ -1497,11 +1505,11 @@ public abstract class AbstractRichIterableTestCase
                     return 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue());
                 });
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(1),
                 1.0e-15);
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(2),
                 1.0e-15);
@@ -1522,8 +1530,8 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionIterable<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(this.newWith(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(this.newWith(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(this.newWith(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(this.newWith(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Test
@@ -1531,15 +1539,15 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionIterable<Integer> result = integers.partitionWith(Predicates2.in(), Lists.mutable.with(-2, 0, 2, 4, 6, 8));
-        Assert.assertEquals(this.newWith(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(this.newWith(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(this.newWith(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(this.newWith(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Test
     public void toList()
     {
         MutableList<Integer> list = this.newWith(1, 2, 3, 4).toList();
-        Assert.assertEquals(Lists.immutable.with(1, 2, 3, 4), list);
+        assertEquals(Lists.immutable.with(1, 2, 3, 4), list);
     }
 
     @Test
@@ -1548,9 +1556,9 @@ public abstract class AbstractRichIterableTestCase
         ImmutableList<Integer> list = this.newWith(1, 2, 3, 4).toImmutableList();
         Verify.assertContainsAll(list, 1, 2, 3, 4);
         ImmutableList<Integer> singletonList = this.newWith(1).toImmutableList();
-        Assert.assertEquals(Lists.mutable.with(1), singletonList);
+        assertEquals(Lists.mutable.with(1), singletonList);
         ImmutableList<Integer> emptyList = this.<Integer>newWith().toImmutableList();
-        Assert.assertEquals(Lists.immutable.empty(), emptyList);
+        assertEquals(Lists.immutable.empty(), emptyList);
     }
 
     @Test
@@ -1564,18 +1572,18 @@ public abstract class AbstractRichIterableTestCase
     public void toBag()
     {
         MutableBag<Integer> bag = this.newWith(1, 2, 3, 4).toBag();
-        Assert.assertEquals(Bags.immutable.with(1, 2, 3, 4), bag);
+        assertEquals(Bags.immutable.with(1, 2, 3, 4), bag);
     }
 
     @Test
     public void toImmutableBag()
     {
         ImmutableBag<Integer> bag = this.newWith(1, 2, 3, 4).toImmutableBag();
-        Assert.assertEquals(Bags.mutable.with(1, 2, 3, 4), bag);
+        assertEquals(Bags.mutable.with(1, 2, 3, 4), bag);
         ImmutableBag<Integer> singletonBag = this.newWith(1).toImmutableBag();
-        Assert.assertEquals(Bags.mutable.with(1), singletonBag);
+        assertEquals(Bags.mutable.with(1), singletonBag);
         ImmutableBag<Integer> emptyBag = this.<Integer>newWith().toImmutableBag();
-        Assert.assertEquals(Bags.immutable.empty(), emptyBag);
+        assertEquals(Bags.immutable.empty(), emptyBag);
     }
 
     @Test
@@ -1590,11 +1598,11 @@ public abstract class AbstractRichIterableTestCase
     public void toImmutableSortedList_natural_ordering()
     {
         ImmutableList<Integer> list = this.newWith(4, 2, 1, 3).toImmutableSortedList();
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
+        assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
         ImmutableList<Integer> singletonList = this.newWith(1).toImmutableSortedList();
-        Assert.assertEquals(Lists.mutable.with(1), singletonList);
+        assertEquals(Lists.mutable.with(1), singletonList);
         ImmutableList<Integer> emptyList = this.<Integer>newWith().toImmutableSortedList();
-        Assert.assertEquals(Lists.immutable.empty(), emptyList);
+        assertEquals(Lists.immutable.empty(), emptyList);
     }
 
     @Test
@@ -1602,7 +1610,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
+        assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
     }
 
     @Test
@@ -1610,7 +1618,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         ImmutableList<Integer> list = integers.toImmutableSortedList(Collections.reverseOrder());
-        Assert.assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
+        assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
     }
 
     @Test(expected = NullPointerException.class)
@@ -1631,11 +1639,11 @@ public abstract class AbstractRichIterableTestCase
     public void toImmutableSortedBag_natural_ordering()
     {
         ImmutableSortedBag<Integer> bag = this.newWith(4, 1, 2, 3).toImmutableSortedBag();
-        Assert.assertEquals(SortedBags.mutable.with(1, 2, 3, 4), bag);
+        assertEquals(SortedBags.mutable.with(1, 2, 3, 4), bag);
         ImmutableSortedBag<Integer> singletonBag = this.newWith(1).toImmutableSortedBag();
-        Assert.assertEquals(SortedBags.mutable.with(1), singletonBag);
+        assertEquals(SortedBags.mutable.with(1), singletonBag);
         ImmutableSortedBag<Integer> emptyBag = this.<Integer>newWith().toImmutableSortedBag();
-        Assert.assertEquals(SortedBags.immutable.empty(), emptyBag);
+        assertEquals(SortedBags.immutable.empty(), emptyBag);
     }
 
     @Test
@@ -1681,7 +1689,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
+        assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
     }
 
     @Test
@@ -1689,7 +1697,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         ImmutableList<Integer> list = integers.toImmutableSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
+        assertEquals(Lists.mutable.with(1, 2, 3, 4), list);
     }
 
     @Test
@@ -1704,11 +1712,11 @@ public abstract class AbstractRichIterableTestCase
     public void toImmutableSortSet_natural_ordering()
     {
         ImmutableSortedSet<Integer> set = this.newWith(2, 1, 4, 3).toImmutableSortedSet();
-        Assert.assertEquals(SortedSets.mutable.with(1, 2, 3, 4), set);
+        assertEquals(SortedSets.mutable.with(1, 2, 3, 4), set);
         ImmutableSortedSet<Integer> singletonSet = this.newWith(1).toImmutableSortedSet();
-        Assert.assertEquals(SortedSets.mutable.with(1), singletonSet);
+        assertEquals(SortedSets.mutable.with(1), singletonSet);
         ImmutableSortedSet<Integer> emptySet = this.<Integer>newWith().toImmutableSortedSet();
-        Assert.assertEquals(SortedSets.immutable.empty(), emptySet);
+        assertEquals(SortedSets.immutable.empty(), emptySet);
     }
 
     @Test
@@ -1754,18 +1762,18 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableSet<Integer> set = integers.toSet();
-        Assert.assertEquals(Sets.immutable.with(1, 2, 3, 4), set);
+        assertEquals(Sets.immutable.with(1, 2, 3, 4), set);
     }
 
     @Test
     public void toImmutableSet()
     {
         ImmutableSet<Integer> set = this.newWith(1, 2, 3, 4).toImmutableSet();
-        Assert.assertEquals(Sets.mutable.with(1, 2, 3, 4), set);
+        assertEquals(Sets.mutable.with(1, 2, 3, 4), set);
         ImmutableSet<Integer> singletonSet = this.newWith(1).toImmutableSet();
-        Assert.assertEquals(Sets.mutable.with(1), singletonSet);
+        assertEquals(Sets.mutable.with(1), singletonSet);
         ImmutableSet<Integer> emptySet = this.<Integer>newWith().toImmutableSet();
-        Assert.assertEquals(Sets.immutable.empty(), emptySet);
+        assertEquals(Sets.immutable.empty(), emptySet);
     }
 
     @Test
@@ -1774,7 +1782,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableMap<String, String> map =
                 integers.toMap(Object::toString, Object::toString);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -1783,11 +1791,11 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4);
         ImmutableMap<String, String> map =
                 integers.toImmutableMap(Object::toString, Object::toString);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
         RichIterable<Integer> empty = this.newWith();
         ImmutableMap<String, String> emptyMap =
                 empty.toImmutableMap(Object::toString, Object::toString);
-        Assert.assertSame(Maps.immutable.empty(), emptyMap);
+        assertSame(Maps.immutable.empty(), emptyMap);
     }
 
     @Test
@@ -1801,8 +1809,8 @@ public abstract class AbstractRichIterableTestCase
         jdkMap.put("4", "4");
         Map<String, String> targetMap =
                 integers.toMap(Object::toString, Object::toString, new HashMap<>());
-        Assert.assertEquals(jdkMap, targetMap);
-        Assert.assertTrue(targetMap instanceof HashMap);
+        assertEquals(jdkMap, targetMap);
+        assertTrue(targetMap instanceof HashMap);
     }
 
     @Test
@@ -1839,17 +1847,17 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3);
 
-        Assert.assertEquals(
+        assertEquals(
                 Maps.mutable.with("1", "1", "2", "2", "3", "3"),
                 integers.toBiMap(Object::toString, Object::toString));
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toBiMap(i -> "Constant Key", Objects::toString));
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toBiMap(Object::toString, i -> "Constant Value"));
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toBiMap(i -> "Constant Key", i -> "Constant Value"));
     }
@@ -1859,17 +1867,17 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3);
 
-        Assert.assertEquals(
+        assertEquals(
                 Maps.mutable.with("1", "1", "2", "2", "3", "3"),
                 integers.toImmutableBiMap(Object::toString, Object::toString));
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toImmutableBiMap(i -> "Constant Key", Objects::toString));
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toImmutableBiMap(Object::toString, i -> "Constant Value"));
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> integers.toImmutableBiMap(i -> "Constant Key", i -> "Constant Value"));
     }
@@ -1878,35 +1886,35 @@ public abstract class AbstractRichIterableTestCase
     public void testToString()
     {
         RichIterable<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals("[1, 2, 3]", collection.toString());
+        assertEquals("[1, 2, 3]", collection.toString());
     }
 
     @Test
     public void makeString()
     {
         RichIterable<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
     public void fusedCollectMakeString()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 collection.asLazy().collect(Integer::toUnsignedString).makeString("[", ", ", "]"),
                 collection.makeString(Integer::toUnsignedString, "[", ", ", "]"));
     }
@@ -1917,7 +1925,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -1926,7 +1934,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -1935,21 +1943,21 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
     public void appendStringThrows()
     {
-        Verify.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.newWith(1, 2, 3)
                         .appendString(new ThrowingAppendable()));
-        Verify.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.newWith(1, 2, 3)
                         .appendString(new ThrowingAppendable(), ", "));
-        Verify.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.newWith(1, 2, 3)
                         .appendString(new ThrowingAppendable(), "[", ", ", "]"));
@@ -1963,11 +1971,11 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4, 5, 6);
         Bag<Integer> evensAndOdds = integers.countBy(each -> Integer.valueOf(each % 2));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(0));
+        assertEquals(3, evensAndOdds.occurrencesOf(1));
+        assertEquals(3, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 = integers.countBy(each -> Integer.valueOf(each % 2), Bags.mutable.empty());
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(0));
+        assertEquals(3, evensAndOdds2.occurrencesOf(1));
+        assertEquals(3, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1978,11 +1986,11 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4, 5, 6);
         Bag<Integer> evensAndOdds = integers.countByWith((each, parm) -> Integer.valueOf(each % parm), 2);
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(0));
+        assertEquals(3, evensAndOdds.occurrencesOf(1));
+        assertEquals(3, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 = integers.countByWith((each, parm) -> Integer.valueOf(each % parm), 2, Bags.mutable.empty());
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(0));
+        assertEquals(3, evensAndOdds2.occurrencesOf(1));
+        assertEquals(3, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1993,17 +2001,17 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<Integer> integerList = this.newWith(1, 2, 4);
         Bag<Integer> integerBag1 = integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i));
-        Assert.assertEquals(1, integerBag1.occurrencesOf(1));
-        Assert.assertEquals(2, integerBag1.occurrencesOf(2));
-        Assert.assertEquals(3, integerBag1.occurrencesOf(4));
-        Assert.assertEquals(2, integerBag1.occurrencesOf(8));
-        Assert.assertEquals(1, integerBag1.occurrencesOf(12));
+        assertEquals(1, integerBag1.occurrencesOf(1));
+        assertEquals(2, integerBag1.occurrencesOf(2));
+        assertEquals(3, integerBag1.occurrencesOf(4));
+        assertEquals(2, integerBag1.occurrencesOf(8));
+        assertEquals(1, integerBag1.occurrencesOf(12));
         Bag<Integer> integerBag2 = integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i), Bags.mutable.empty());
-        Assert.assertEquals(1, integerBag2.occurrencesOf(1));
-        Assert.assertEquals(2, integerBag2.occurrencesOf(2));
-        Assert.assertEquals(3, integerBag2.occurrencesOf(4));
-        Assert.assertEquals(2, integerBag2.occurrencesOf(8));
-        Assert.assertEquals(1, integerBag2.occurrencesOf(12));
+        assertEquals(1, integerBag2.occurrencesOf(1));
+        assertEquals(2, integerBag2.occurrencesOf(2));
+        assertEquals(3, integerBag2.occurrencesOf(4));
+        assertEquals(2, integerBag2.occurrencesOf(8));
+        assertEquals(1, integerBag2.occurrencesOf(12));
     }
 
     @Test
@@ -2018,13 +2026,13 @@ public abstract class AbstractRichIterableTestCase
                         Boolean.FALSE, this.newWith(2, 4, 6));
 
         Multimap<Boolean, Integer> multimap = collection.groupBy(isOddFunction);
-        Assert.assertEquals(expected, multimap.toMap());
+        assertEquals(expected, multimap.toMap());
 
         Function<Integer, Boolean> function = (Integer object) -> true;
         MutableMultimap<Boolean, Integer> multimap2 = collection.groupBy(
                 isOddFunction,
                 this.<Integer>newWith().groupBy(function).toMutable());
-        Assert.assertEquals(expected, multimap2.toMap());
+        assertEquals(expected, multimap2.toMap());
     }
 
     @Test
@@ -2041,18 +2049,18 @@ public abstract class AbstractRichIterableTestCase
 
         Multimap<Integer, Integer> actual =
                 collection.groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 collection.groupByEach(function, this.<Integer>newWith().groupByEach(function).toMutable());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
     public void groupByUniqueKey()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), collection.groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), collection.groupByUniqueKey(id -> id));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -2066,7 +2074,7 @@ public abstract class AbstractRichIterableTestCase
     public void groupByUniqueKey_target()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3),
                 collection.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
@@ -2075,7 +2083,7 @@ public abstract class AbstractRichIterableTestCase
     public void groupByUniqueKey_target_throws_for_duplicate()
     {
         RichIterable<Integer> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3),
                 collection.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(2, 2)));
     }
@@ -2089,24 +2097,24 @@ public abstract class AbstractRichIterableTestCase
         List<Object> nullsMinusOne = Collections.nCopies(collection.size() - 1, null);
 
         RichIterable<Pair<String, Object>> pairs = collection.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsPlusOne = collection.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsMinusOne = collection.zip(nullsMinusOne);
-        Assert.assertEquals(collection.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(collection.containsAllIterable(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
+        assertEquals(collection.size() - 1, pairsMinusOne.size());
+        assertTrue(collection.containsAllIterable(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.zip(nulls).toSet(),
                 collection.zip(nulls, UnifiedSet.newSet()));
     }
@@ -2117,14 +2125,14 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<String> collection = this.newWith("1", "2", "3", "4", "5", "6", "7");
         RichIterable<Pair<String, Integer>> pairs = collection.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(collection.size() - 1).toSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.zipWithIndex().toSet(),
                 collection.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -2135,7 +2143,7 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<String> collection = this.newWith("1", "2", "3", "4", "5", "6", "7");
         RichIterable<RichIterable<String>> groups = collection.chunk(2);
         RichIterable<Integer> sizes = groups.collect(RichIterable::size);
-        Assert.assertEquals(Lists.mutable.with(2, 2, 2, 1), sizes);
+        assertEquals(Lists.mutable.with(2, 2, 2, 1), sizes);
     }
 
     @Test
@@ -2143,7 +2151,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<String> collection = this.newWith();
         RichIterable<RichIterable<String>> groups = collection.chunk(2);
-        Assert.assertEquals(groups.size(), 0);
+        assertEquals(groups.size(), 0);
     }
 
     @Test
@@ -2151,7 +2159,7 @@ public abstract class AbstractRichIterableTestCase
     {
         RichIterable<String> collection = this.newWith("1");
         RichIterable<RichIterable<String>> groups = collection.chunk(2);
-        Assert.assertEquals(Lists.mutable.with(1), groups.collect(RichIterable::size));
+        assertEquals(Lists.mutable.with(1), groups.collect(RichIterable::size));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2165,15 +2173,15 @@ public abstract class AbstractRichIterableTestCase
     public void chunk_large_size()
     {
         RichIterable<String> collection = this.newWith("1", "2", "3", "4", "5", "6", "7");
-        Assert.assertEquals(collection, collection.chunk(10).getOnly());
+        assertEquals(collection, collection.chunk(10).getOnly());
     }
 
     @Test
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -2190,15 +2198,15 @@ public abstract class AbstractRichIterableTestCase
         MapIterable<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, AtomicInteger::new, AtomicInteger::addAndGet);
         if (collection instanceof Set)
         {
-            Assert.assertEquals(1, aggregation.get("1").intValue());
-            Assert.assertEquals(2, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(1, aggregation.get("1").intValue());
+            assertEquals(2, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
         else
         {
-            Assert.assertEquals(3, aggregation.get("1").intValue());
-            Assert.assertEquals(4, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(3, aggregation.get("1").intValue());
+            assertEquals(4, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
     }
 
@@ -2213,15 +2221,15 @@ public abstract class AbstractRichIterableTestCase
 
         if (this.newWith(1, 1, 1, 2, 2, 3) instanceof Set)
         {
-            Assert.assertEquals(1, aggregation.get("1").intValue());
-            Assert.assertEquals(2, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(1, aggregation.get("1").intValue());
+            assertEquals(2, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
         else
         {
-            Assert.assertEquals(3, aggregation.get("1").intValue());
-            Assert.assertEquals(4, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(3, aggregation.get("1").intValue());
+            assertEquals(4, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
     }
 
@@ -2231,24 +2239,24 @@ public abstract class AbstractRichIterableTestCase
         RichIterable<Integer> littleIterable = this.newWith(1, 2, 3);
         Optional<Integer> result =
                 littleIterable.reduce(Integer::sum);
-        Assert.assertEquals(6, result.get().intValue());
+        assertEquals(6, result.get().intValue());
 
         RichIterable<Integer> bigIterable = this.newWith(Interval.oneTo(20).toArray());
         Optional<Integer> bigResult =
                 bigIterable.reduce(Integer::max);
-        Assert.assertEquals(20, bigResult.get().intValue());
+        assertEquals(20, bigResult.get().intValue());
 
         Optional<Integer> max =
                 littleIterable.reduce(Integer::max);
-        Assert.assertEquals(3, max.get().intValue());
+        assertEquals(3, max.get().intValue());
 
         Optional<Integer> min =
                 littleIterable.reduce(Integer::min);
-        Assert.assertEquals(1, min.get().intValue());
+        assertEquals(1, min.get().intValue());
 
         RichIterable<Integer> iterableEmpty = this.newWith();
         Optional<Integer> resultEmpty =
                 iterableEmpty.reduce(Integer::sum);
-        Assert.assertFalse(resultEmpty.isPresent());
+        assertFalse(resultEmpty.isPresent());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
@@ -22,10 +22,11 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class tests various algorithms for calculating anagrams from a list of words.
@@ -133,7 +134,7 @@ public class AnagramTest
                         .sortThisByInt(iterable -> -iterable.size());
         Procedure<String> procedure = Procedures.cast(LOGGER::info);
         results.forEach(Functions.bind(procedure, iterable -> iterable.size() + ": " + iterable));
-        Assert.assertTrue(this.listContainsTestGroupAtElementsOneOrTwo(results));
+        assertTrue(this.listContainsTestGroupAtElementsOneOrTwo(results));
         Verify.assertSize(SIZE_THRESHOLD, results.getLast());
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/CounterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/CounterTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class CounterTest
 {
@@ -23,32 +25,32 @@ public class CounterTest
     {
         Counter counter = new Counter();
 
-        Assert.assertEquals(0, counter.getCount());
+        assertEquals(0, counter.getCount());
         counter.increment();
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
         counter.increment();
-        Assert.assertEquals(2, counter.getCount());
+        assertEquals(2, counter.getCount());
         counter.add(16);
-        Assert.assertEquals(18, counter.getCount());
+        assertEquals(18, counter.getCount());
         Interval.oneTo(1000).forEach(Procedures.cast(each -> counter.increment()));
-        Assert.assertEquals(1018, counter.getCount());
-        Assert.assertEquals("1018", counter.toString());
+        assertEquals(1018, counter.getCount());
+        assertEquals("1018", counter.toString());
 
         counter.reset();
-        Assert.assertEquals(0, counter.getCount());
+        assertEquals(0, counter.getCount());
         counter.add(4);
-        Assert.assertEquals(4, counter.getCount());
+        assertEquals(4, counter.getCount());
         counter.increment();
-        Assert.assertEquals(5, counter.getCount());
+        assertEquals(5, counter.getCount());
 
-        Assert.assertEquals("5", counter.toString());
+        assertEquals("5", counter.toString());
     }
 
     @Test
     public void equalsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(new Counter(1), new Counter(1));
-        Assert.assertNotEquals(new Counter(1), new Counter(2));
+        assertNotEquals(new Counter(1), new Counter(2));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/EmptyIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/EmptyIteratorTest.java
@@ -12,9 +12,12 @@ package org.eclipse.collections.impl;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 public class EmptyIteratorTest
 {
@@ -29,36 +32,36 @@ public class EmptyIteratorTest
     @Test
     public void hasPrevious()
     {
-        Assert.assertFalse(this.emptyIterator.hasPrevious());
+        assertFalse(this.emptyIterator.hasPrevious());
     }
 
     @Test
     public void previous()
     {
-        Assert.assertThrows(NoSuchElementException.class, this.emptyIterator::previous);
+        assertThrows(NoSuchElementException.class, this.emptyIterator::previous);
     }
 
     @Test
     public void previousIndex()
     {
-        Assert.assertEquals(-1, this.emptyIterator.previousIndex());
+        assertEquals(-1, this.emptyIterator.previousIndex());
     }
 
     @Test
     public void set()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.emptyIterator.set(1));
+        assertThrows(UnsupportedOperationException.class, () -> this.emptyIterator.set(1));
     }
 
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.emptyIterator.add(1));
+        assertThrows(UnsupportedOperationException.class, () -> this.emptyIterator.add(1));
     }
 
     @Test
     public void nextIndex()
     {
-        Assert.assertEquals(0, (long) this.emptyIterator.nextIndex());
+        assertEquals(0, (long) this.emptyIterator.nextIndex());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/PersonAndPetKataTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/PersonAndPetKataTest.java
@@ -52,9 +52,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class PersonAndPetKataTest
 {
@@ -81,18 +85,18 @@ public class PersonAndPetKataTest
     public void doAnyPeopleHaveCats()
     {
         boolean resultEager = this.people.anySatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertTrue(resultEager);
+        assertTrue(resultEager);
 
         boolean resultEagerMR = this.people.anySatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertTrue(resultEagerMR);
+        assertTrue(resultEagerMR);
 
         boolean resultLazy = this.people.asLazy()
                 .anySatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertTrue(resultLazy);
+        assertTrue(resultLazy);
 
         boolean resultLazyMR = this.people.asLazy()
                 .anySatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertTrue(resultLazyMR);
+        assertTrue(resultLazyMR);
     }
 
     @Test
@@ -100,25 +104,25 @@ public class PersonAndPetKataTest
     {
         boolean result = this.people.stream()
                 .anyMatch(person -> person.hasPet(PetType.CAT));
-        Assert.assertTrue(result);
+        assertTrue(result);
     }
 
     @Test
     public void doAllPeopleHaveCats()
     {
         boolean resultEager = this.people.allSatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultEager);
+        assertFalse(resultEager);
 
         boolean resultEagerMR = this.people.allSatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertFalse(resultEagerMR);
+        assertFalse(resultEagerMR);
 
         boolean resultLazy = this.people.asLazy()
                 .allSatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultLazy);
+        assertFalse(resultLazy);
 
         boolean resultLazyMR = this.people.asLazy()
                 .allSatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertFalse(resultLazyMR);
+        assertFalse(resultLazyMR);
     }
 
     @Test
@@ -126,25 +130,25 @@ public class PersonAndPetKataTest
     {
         boolean resultStream = this.people.stream()
                 .allMatch(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultStream);
+        assertFalse(resultStream);
     }
 
     @Test
     public void doNoPeopleHaveCats()
     {
         boolean resultEager = this.people.noneSatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultEager);
+        assertFalse(resultEager);
 
         boolean resultEagerMR = this.people.noneSatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertFalse(resultEagerMR);
+        assertFalse(resultEagerMR);
 
         boolean resultLazy = this.people.asLazy()
                 .noneSatisfy(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultLazy);
+        assertFalse(resultLazy);
 
         boolean resultLazyMR = this.people.asLazy()
                 .noneSatisfyWith(Person::hasPet, PetType.CAT);
-        Assert.assertFalse(resultLazyMR);
+        assertFalse(resultLazyMR);
     }
 
     @Test
@@ -152,25 +156,25 @@ public class PersonAndPetKataTest
     {
         boolean resultStream = this.people.stream()
                 .noneMatch(person -> person.hasPet(PetType.CAT));
-        Assert.assertFalse(resultStream);
+        assertFalse(resultStream);
     }
 
     @Test
     public void howManyPeopleHaveCats()
     {
         int countEager = this.people.count(person -> person.hasPet(PetType.CAT));
-        Assert.assertEquals(2, countEager);
+        assertEquals(2, countEager);
 
         int countEagerMR = this.people.countWith(Person::hasPet, PetType.CAT);
-        Assert.assertEquals(2, countEagerMR);
+        assertEquals(2, countEagerMR);
 
         int countLazy = this.people.asLazy()
                 .count(person -> person.hasPet(PetType.CAT));
-        Assert.assertEquals(2, countLazy);
+        assertEquals(2, countLazy);
 
         int countLazyMR = this.people.asLazy()
                 .countWith(Person::hasPet, PetType.CAT);
-        Assert.assertEquals(2, countLazyMR);
+        assertEquals(2, countLazyMR);
     }
 
     @Test
@@ -179,7 +183,7 @@ public class PersonAndPetKataTest
         long countStream = this.people.stream()
                 .filter(person -> person.hasPet(PetType.CAT))
                 .count();
-        Assert.assertEquals(2, countStream);
+        assertEquals(2, countStream);
     }
 
     @Test
@@ -283,22 +287,22 @@ public class PersonAndPetKataTest
     public void findPersonNamedMarySmith()
     {
         Person resultEager = this.people.detect(person -> person.named("Mary Smith"));
-        Assert.assertEquals("Mary", resultEager.getFirstName());
-        Assert.assertEquals("Smith", resultEager.getLastName());
+        assertEquals("Mary", resultEager.getFirstName());
+        assertEquals("Smith", resultEager.getLastName());
 
         Person resultEagerMR = this.people.detectWith(Person::named, "Mary Smith");
-        Assert.assertEquals("Mary", resultEagerMR.getFirstName());
-        Assert.assertEquals("Smith", resultEagerMR.getLastName());
+        assertEquals("Mary", resultEagerMR.getFirstName());
+        assertEquals("Smith", resultEagerMR.getLastName());
 
         Person resultLazy = this.people.asLazy()
                 .detect(person -> person.named("Mary Smith"));
-        Assert.assertEquals("Mary", resultLazy.getFirstName());
-        Assert.assertEquals("Smith", resultLazy.getLastName());
+        assertEquals("Mary", resultLazy.getFirstName());
+        assertEquals("Smith", resultLazy.getLastName());
 
         Person resultLazyMR = this.people.asLazy()
                 .detectWith(Person::named, "Mary Smith");
-        Assert.assertEquals("Mary", resultLazyMR.getFirstName());
-        Assert.assertEquals("Smith", resultLazyMR.getLastName());
+        assertEquals("Mary", resultLazyMR.getFirstName());
+        assertEquals("Smith", resultLazyMR.getLastName());
     }
 
     @Test
@@ -308,8 +312,8 @@ public class PersonAndPetKataTest
                 .filter(person -> person.named("Mary Smith"))
                 .findFirst()
                 .orElse(null);
-        Assert.assertEquals("Mary", resultStream.getFirstName());
-        Assert.assertEquals("Smith", resultStream.getLastName());
+        assertEquals("Mary", resultStream.getFirstName());
+        assertEquals("Smith", resultStream.getLastName());
     }
 
     @Test
@@ -319,8 +323,8 @@ public class PersonAndPetKataTest
         MutableList<String> names = personEager.getPets().collect(Pet::getName);
 
         MutableList<String> expected = Lists.mutable.with("Dolly", "Spot");
-        Assert.assertEquals(expected, names);
-        Assert.assertEquals("Dolly & Spot", names.makeString(" & "));
+        assertEquals(expected, names);
+        assertEquals("Dolly & Spot", names.makeString(" & "));
     }
 
     @Test
@@ -333,8 +337,8 @@ public class PersonAndPetKataTest
         List<String> names = personStream.getPets().stream()
                 .map(Pet::getName)
                 .collect(Collectors.toList());
-        Assert.assertEquals(Lists.mutable.with("Dolly", "Spot"), names);
-        Assert.assertEquals("Dolly & Spot", names.stream().collect(Collectors.joining(" & ")));
+        assertEquals(Lists.mutable.with("Dolly", "Spot"), names);
+        assertEquals("Dolly & Spot", names.stream().collect(Collectors.joining(" & ")));
     }
 
     @Test
@@ -344,22 +348,22 @@ public class PersonAndPetKataTest
                 this.people.flatCollect(Person::getPetTypes).toSet();
 
         MutableSet<PetType> expected = Sets.mutable.with(PetType.values());
-        Assert.assertEquals(expected, allPetTypesEager);
+        assertEquals(expected, allPetTypesEager);
 
         MutableSet<PetType> allPetTypesEagerTarget =
                 this.people.flatCollect(Person::getPetTypes, Sets.mutable.empty());
 
-        Assert.assertEquals(expected, allPetTypesEagerTarget);
+        assertEquals(expected, allPetTypesEagerTarget);
 
         MutableSet<PetType> allPetTypesLazy = this.people.asLazy()
                 .flatCollect(Person::getPetTypes).toSet();
 
-        Assert.assertEquals(expected, allPetTypesLazy);
+        assertEquals(expected, allPetTypesLazy);
 
         MutableSet<PetType> allPetTypesLazyTarget = this.people.asLazy()
                 .flatCollect(Person::getPetTypes, Sets.mutable.empty());
 
-        Assert.assertEquals(expected, allPetTypesLazyTarget);
+        assertEquals(expected, allPetTypesLazyTarget);
     }
 
     @Test
@@ -368,7 +372,7 @@ public class PersonAndPetKataTest
         Set<PetType> allPetTypesStream = this.people.stream()
                 .flatMap(person -> person.getPetTypes().stream())
                 .collect(Collectors.toSet());
-        Assert.assertEquals(
+        assertEquals(
                 new HashSet<>(Arrays.asList(PetType.values())),
                 allPetTypesStream);
     }
@@ -413,11 +417,11 @@ public class PersonAndPetKataTest
         Multimap<PetType, Person> peopleByPetsEager =
                 this.people.groupByEach(Person::getPetTypes);
         RichIterable<Person> catPeople = peopleByPetsEager.get(PetType.CAT);
-        Assert.assertEquals(
+        assertEquals(
                 "Mary, Bob",
                 catPeople.collect(Person::getFirstName).makeString());
         RichIterable<Person> dogPeople = peopleByPetsEager.get(PetType.DOG);
-        Assert.assertEquals(
+        assertEquals(
                 "Bob, Ted",
                 dogPeople.collect(Person::getFirstName).makeString());
     }
@@ -430,11 +434,11 @@ public class PersonAndPetKataTest
                 person -> person.getPetTypes().stream().forEach(
                         petType -> peopleByPetsStream.computeIfAbsent(petType, e -> new ArrayList<>()).add(person)));
         List<Person> catPeople = peopleByPetsStream.get(PetType.CAT);
-        Assert.assertEquals(
+        assertEquals(
                 "Mary, Bob",
                 catPeople.stream().map(Person::getFirstName).collect(Collectors.joining(", ")));
         List<Person> dogPeople = peopleByPetsStream.get(PetType.DOG);
-        Assert.assertEquals(
+        assertEquals(
                 "Bob, Ted",
                 dogPeople.stream().map(Person::getFirstName).collect(Collectors.joining(", ")));
     }
@@ -443,11 +447,11 @@ public class PersonAndPetKataTest
     public void getTotalNumberOfPets()
     {
         long numberOfPetsEager = this.people.sumOfInt(Person::getNumberOfPets);
-        Assert.assertEquals(9, numberOfPetsEager);
+        assertEquals(9, numberOfPetsEager);
 
         long numberOfPetsLazy = this.people.asLazy()
                 .sumOfInt(Person::getNumberOfPets);
-        Assert.assertEquals(9, numberOfPetsLazy);
+        assertEquals(9, numberOfPetsLazy);
     }
 
     @Test
@@ -456,33 +460,33 @@ public class PersonAndPetKataTest
         int numberOfPetsStream = this.people.stream()
                 .mapToInt(Person::getNumberOfPets)
                 .sum();
-        Assert.assertEquals(9, numberOfPetsStream);
+        assertEquals(9, numberOfPetsStream);
     }
 
     @Test
     public void testStrings()
     {
-        Assert.assertEquals(
+        assertEquals(
                 "HELLO",
                 "h1e2l3l4o"
                         .chars()
                         .filter(Character::isLetter)
                         .map(Character::toUpperCase)
                         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString());
-        Assert.assertEquals(
+        assertEquals(
                 "HELLO",
                 "h1e2l3l4o"
                         .codePoints()
                         .filter(Character::isLetter)
                         .map(Character::toUpperCase)
                         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString());
-        Assert.assertEquals(
+        assertEquals(
                 "HELLO",
                 StringIterate.asCharAdapter("h1e2l3l4o")
                         .select(Character::isLetter)
                         .collectChar(Character::toUpperCase)
                         .toString());
-        Assert.assertEquals(
+        assertEquals(
                 "HELLO",
                 StringIterate.asCodePointAdapter("h1e2l3l4o")
                         .select(Character::isLetter)
@@ -496,19 +500,19 @@ public class PersonAndPetKataTest
         IntList ages = this.people.flatCollectInt(Person::getPetAges, IntLists.mutable.empty());
         IntSet uniqueAges = ages.toSet();
         IntSummaryStatistics stats = ages.summaryStatistics();
-        Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4), uniqueAges);
-        Assert.assertEquals(stats.getMin(), ages.minIfEmpty(0));
-        Assert.assertEquals(stats.getMax(), ages.maxIfEmpty(0));
-        Assert.assertEquals(stats.getSum(), ages.sum());
-        Assert.assertEquals(stats.getAverage(), ages.averageIfEmpty(0.0), 0.0);
-        Assert.assertEquals(stats.getCount(), ages.size());
-        Assert.assertTrue(ages.allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(ages.allSatisfy(i -> i > 0));
-        Assert.assertFalse(ages.anySatisfy(IntPredicates.equal(0)));
-        Assert.assertFalse(ages.anySatisfy(i -> i == 0));
-        Assert.assertTrue(ages.noneSatisfy(IntPredicates.lessThan(0)));
-        Assert.assertTrue(ages.noneSatisfy(i -> i < 0));
-        Assert.assertEquals(2.0d, ages.median(), 0.0);
+        assertEquals(IntSets.mutable.with(1, 2, 3, 4), uniqueAges);
+        assertEquals(stats.getMin(), ages.minIfEmpty(0));
+        assertEquals(stats.getMax(), ages.maxIfEmpty(0));
+        assertEquals(stats.getSum(), ages.sum());
+        assertEquals(stats.getAverage(), ages.averageIfEmpty(0.0), 0.0);
+        assertEquals(stats.getCount(), ages.size());
+        assertTrue(ages.allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(ages.allSatisfy(i -> i > 0));
+        assertFalse(ages.anySatisfy(IntPredicates.equal(0)));
+        assertFalse(ages.anySatisfy(i -> i == 0));
+        assertTrue(ages.noneSatisfy(IntPredicates.lessThan(0)));
+        assertTrue(ages.noneSatisfy(i -> i < 0));
+        assertEquals(2.0d, ages.median(), 0.0);
     }
 
     @Test
@@ -521,15 +525,15 @@ public class PersonAndPetKataTest
         Set<Integer> uniqueAges = new HashSet<>(agesStream);
         IntSummaryStatistics stats = agesStream.stream()
                 .collect(Collectors.summarizingInt(i -> i));
-        Assert.assertEquals(Sets.mutable.with(1, 2, 3, 4), uniqueAges);
-        Assert.assertEquals(stats.getMin(), agesStream.stream().mapToInt(i -> i).min().orElse(0));
-        Assert.assertEquals(stats.getMax(), agesStream.stream().mapToInt(i -> i).max().orElse(0));
-        Assert.assertEquals(stats.getSum(), agesStream.stream().mapToInt(i -> i).sum());
-        Assert.assertEquals(stats.getAverage(), agesStream.stream().mapToInt(i -> i).average().orElse(0.0), 0.0);
-        Assert.assertEquals(stats.getCount(), agesStream.size());
-        Assert.assertTrue(agesStream.stream().allMatch(i -> i > 0));
-        Assert.assertFalse(agesStream.stream().anyMatch(i -> i == 0));
-        Assert.assertTrue(agesStream.stream().noneMatch(i -> i < 0));
+        assertEquals(Sets.mutable.with(1, 2, 3, 4), uniqueAges);
+        assertEquals(stats.getMin(), agesStream.stream().mapToInt(i -> i).min().orElse(0));
+        assertEquals(stats.getMax(), agesStream.stream().mapToInt(i -> i).max().orElse(0));
+        assertEquals(stats.getSum(), agesStream.stream().mapToInt(i -> i).sum());
+        assertEquals(stats.getAverage(), agesStream.stream().mapToInt(i -> i).average().orElse(0.0), 0.0);
+        assertEquals(stats.getCount(), agesStream.size());
+        assertTrue(agesStream.stream().allMatch(i -> i > 0));
+        assertFalse(agesStream.stream().anyMatch(i -> i == 0));
+        assertTrue(agesStream.stream().noneMatch(i -> i < 0));
     }
 
     @Test
@@ -537,12 +541,12 @@ public class PersonAndPetKataTest
     {
         Bag<PetType> counts = this.people.countByEach(Person::getPetTypes)
                 .toImmutable();
-        Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
-        Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
-        Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
-        Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
-        Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
-        Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
+        assertEquals(2, counts.occurrencesOf(PetType.CAT));
+        assertEquals(2, counts.occurrencesOf(PetType.DOG));
+        assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
+        assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
+        assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
+        assertEquals(1, counts.occurrencesOf(PetType.BIRD));
     }
 
     @Test
@@ -555,12 +559,12 @@ public class PersonAndPetKataTest
                                 .collect(Collectors.groupingBy(
                                         Pet::getType,
                                         Collectors.counting())));
-        Assert.assertEquals(Long.valueOf(2L), countsStream.get(PetType.CAT));
-        Assert.assertEquals(Long.valueOf(2L), countsStream.get(PetType.DOG));
-        Assert.assertEquals(Long.valueOf(2L), countsStream.get(PetType.HAMSTER));
-        Assert.assertEquals(Long.valueOf(1L), countsStream.get(PetType.SNAKE));
-        Assert.assertEquals(Long.valueOf(1L), countsStream.get(PetType.TURTLE));
-        Assert.assertEquals(Long.valueOf(1L), countsStream.get(PetType.BIRD));
+        assertEquals(Long.valueOf(2L), countsStream.get(PetType.CAT));
+        assertEquals(Long.valueOf(2L), countsStream.get(PetType.DOG));
+        assertEquals(Long.valueOf(2L), countsStream.get(PetType.HAMSTER));
+        assertEquals(Long.valueOf(1L), countsStream.get(PetType.SNAKE));
+        assertEquals(Long.valueOf(1L), countsStream.get(PetType.TURTLE));
+        assertEquals(Long.valueOf(1L), countsStream.get(PetType.BIRD));
     }
 
     @Test
@@ -569,7 +573,7 @@ public class PersonAndPetKataTest
         ListIterable<ObjectIntPair<PetType>> top3 = this.people.countByEach(Person::getPetTypes)
                 .topOccurrences(3);
         Verify.assertSize(3, top3);
-        Assert.assertTrue(top3.containsAllArguments(
+        assertTrue(top3.containsAllArguments(
                 PrimitiveTuples.pair(PetType.CAT, 2),
                 PrimitiveTuples.pair(PetType.DOG, 2),
                 PrimitiveTuples.pair(PetType.HAMSTER, 2)));
@@ -613,11 +617,11 @@ public class PersonAndPetKataTest
         ImmutableIntBag countsLazy =
                 this.people.flatCollectInt(Person::getPetAges, new IntHashBag())
                         .toImmutable();
-        Assert.assertEquals(4, countsLazy.occurrencesOf(1));
-        Assert.assertEquals(3, countsLazy.occurrencesOf(2));
-        Assert.assertEquals(1, countsLazy.occurrencesOf(3));
-        Assert.assertEquals(1, countsLazy.occurrencesOf(4));
-        Assert.assertEquals(0, countsLazy.occurrencesOf(5));
+        assertEquals(4, countsLazy.occurrencesOf(1));
+        assertEquals(3, countsLazy.occurrencesOf(2));
+        assertEquals(1, countsLazy.occurrencesOf(3));
+        assertEquals(1, countsLazy.occurrencesOf(4));
+        assertEquals(0, countsLazy.occurrencesOf(5));
     }
 
     @Test
@@ -630,11 +634,11 @@ public class PersonAndPetKataTest
                                 .collect(Collectors.groupingBy(
                                         Pet::getAge,
                                         Collectors.counting())));
-        Assert.assertEquals(Long.valueOf(4), countsStream.get(1));
-        Assert.assertEquals(Long.valueOf(3), countsStream.get(2));
-        Assert.assertEquals(Long.valueOf(1), countsStream.get(3));
-        Assert.assertEquals(Long.valueOf(1), countsStream.get(4));
-        Assert.assertNull(countsStream.get(5));
+        assertEquals(Long.valueOf(4), countsStream.get(1));
+        assertEquals(Long.valueOf(3), countsStream.get(2));
+        assertEquals(Long.valueOf(1), countsStream.get(3));
+        assertEquals(Long.valueOf(1), countsStream.get(4));
+        assertNull(countsStream.get(5));
     }
 
     public static final class Person

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
@@ -10,78 +10,79 @@
 
 package org.eclipse.collections.impl;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class SpreadFunctionsTest
 {
     @Test
     public void doubleSpreadOne()
     {
-        Assert.assertEquals(-7831749829746778771L, SpreadFunctions.doubleSpreadOne(25.0d));
-        Assert.assertEquals(3020681792480265713L, SpreadFunctions.doubleSpreadOne(-25.0d));
+        assertEquals(-7831749829746778771L, SpreadFunctions.doubleSpreadOne(25.0d));
+        assertEquals(3020681792480265713L, SpreadFunctions.doubleSpreadOne(-25.0d));
     }
 
     @Test
     public void doubleSpreadTwo()
     {
-        Assert.assertEquals(-7260239113076190123L, SpreadFunctions.doubleSpreadTwo(25.0d));
-        Assert.assertEquals(-2923962723742798781L, SpreadFunctions.doubleSpreadTwo(-25.0d));
+        assertEquals(-7260239113076190123L, SpreadFunctions.doubleSpreadTwo(25.0d));
+        assertEquals(-2923962723742798781L, SpreadFunctions.doubleSpreadTwo(-25.0d));
     }
 
     @Test
     public void longSpreadOne()
     {
-        Assert.assertEquals(7972739338299824895L, SpreadFunctions.longSpreadOne(12345L));
-        Assert.assertEquals(5629574755565220972L, SpreadFunctions.longSpreadOne(23456L));
+        assertEquals(7972739338299824895L, SpreadFunctions.longSpreadOne(12345L));
+        assertEquals(5629574755565220972L, SpreadFunctions.longSpreadOne(23456L));
     }
 
     @Test
     public void longSpreadTwo()
     {
-        Assert.assertEquals(-3823225069572514692L, SpreadFunctions.longSpreadTwo(12345L));
-        Assert.assertEquals(7979914854381881740L, SpreadFunctions.longSpreadTwo(23456L));
+        assertEquals(-3823225069572514692L, SpreadFunctions.longSpreadTwo(12345L));
+        assertEquals(7979914854381881740L, SpreadFunctions.longSpreadTwo(23456L));
     }
 
     @Test
     public void intSpreadOne()
     {
-        Assert.assertEquals(-540084185L, SpreadFunctions.intSpreadOne(100));
-        Assert.assertEquals(1432552655L, SpreadFunctions.intSpreadOne(101));
+        assertEquals(-540084185L, SpreadFunctions.intSpreadOne(100));
+        assertEquals(1432552655L, SpreadFunctions.intSpreadOne(101));
     }
 
     @Test
     public void intSpreadTwo()
     {
-        Assert.assertEquals(961801704L, SpreadFunctions.intSpreadTwo(100));
-        Assert.assertEquals(662527578L, SpreadFunctions.intSpreadTwo(101));
+        assertEquals(961801704L, SpreadFunctions.intSpreadTwo(100));
+        assertEquals(662527578L, SpreadFunctions.intSpreadTwo(101));
     }
 
     @Test
     public void floatSpreadOne()
     {
-        Assert.assertEquals(-1053442875L, SpreadFunctions.floatSpreadOne(9876.0F));
-        Assert.assertEquals(-640291382L, SpreadFunctions.floatSpreadOne(-9876.0F));
+        assertEquals(-1053442875L, SpreadFunctions.floatSpreadOne(9876.0F));
+        assertEquals(-640291382L, SpreadFunctions.floatSpreadOne(-9876.0F));
     }
 
     @Test
     public void floatSpreadTwo()
     {
-        Assert.assertEquals(-1971373820L, SpreadFunctions.floatSpreadTwo(9876.0F));
-        Assert.assertEquals(-1720924552L, SpreadFunctions.floatSpreadTwo(-9876.0F));
+        assertEquals(-1971373820L, SpreadFunctions.floatSpreadTwo(9876.0F));
+        assertEquals(-1720924552L, SpreadFunctions.floatSpreadTwo(-9876.0F));
     }
 
     @Test
     public void shortSpreadOne()
     {
-        Assert.assertEquals(-1526665035L, SpreadFunctions.shortSpreadOne((short) 123));
-        Assert.assertEquals(-1120388305L, SpreadFunctions.shortSpreadOne((short) 234));
+        assertEquals(-1526665035L, SpreadFunctions.shortSpreadOne((short) 123));
+        assertEquals(-1120388305L, SpreadFunctions.shortSpreadOne((short) 234));
     }
 
     @Test
     public void shortSpreadTwo()
     {
-        Assert.assertEquals(-474242978L, SpreadFunctions.shortSpreadTwo((short) 123));
-        Assert.assertEquals(-1572485272L, SpreadFunctions.shortSpreadTwo((short) 234));
+        assertEquals(-474242978L, SpreadFunctions.shortSpreadTwo((short) 123));
+        assertEquals(-1572485272L, SpreadFunctions.shortSpreadTwo((short) 234));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
@@ -21,10 +21,11 @@ import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
 {
@@ -48,8 +49,8 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionIterable<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Override
@@ -58,14 +59,14 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionIterable<Integer> result = integers.partitionWith(Predicates2.in(), FastList.newListWith(-2, 0, 2, 4, 6, 8));
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Override
     public void equalsAndHashCode()
     {
-        Assert.assertNotEquals(this.newWith(), this.newWith());
+        assertNotEquals(this.newWith(), this.newWith());
     }
 
     @Override
@@ -75,8 +76,8 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
         RichIterable<Integer> list = this.newWith(1, 2, 3, 4, 5, 6, 7);
         Multimap<Boolean, Integer> multimap = list.groupBy(object -> IntegerPredicates.isOdd().accept(object));
 
-        Assert.assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
-        Assert.assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
+        assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
+        assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
     }
 
     @Test
@@ -86,8 +87,8 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
         MutableMultimap<Boolean, Integer> multimap = new FastListMultimap<>();
         list.groupBy(object -> IntegerPredicates.isOdd().accept(object), multimap);
 
-        Assert.assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
-        Assert.assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
+        assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
+        assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
     }
 
     @Test
@@ -96,8 +97,8 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
         RichIterable<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9).asLazy();
         Verify.assertInstanceOf(LazyIterableAdapter.class, integers);
         PartitionIterable<Integer> result = integers.partitionWith(Predicates2.in(), FastList.newListWith(-2, 0, 2, 4, 6, 8));
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapEntrySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapEntrySetTest.java
@@ -33,8 +33,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.ShortHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMap#entrySet()} .
@@ -134,7 +139,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     public void equalsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(this.newWith(1, 2, 3), this.newWith(1, 2, 3));
-        Assert.assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2));
+        assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2));
     }
 
     @Override
@@ -144,7 +149,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
         MutableSet<Map.Entry<String, String>> collection = this.newCollection().newEmpty();
         Verify.assertEmpty(collection);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.notEmpty());
+        assertFalse(collection.notEmpty());
     }
 
     @Test
@@ -221,16 +226,16 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     public void containsAllIterable()
     {
         MutableSet<Map.Entry<Integer, Integer>> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAllIterable(Lists.immutable.of(this.entry(1), this.entry(2))));
-        Assert.assertFalse(collection.containsAllIterable(Lists.immutable.of(this.entry(1), this.entry(5))));
+        assertTrue(collection.containsAllIterable(Lists.immutable.of(this.entry(1), this.entry(2))));
+        assertFalse(collection.containsAllIterable(Lists.immutable.of(this.entry(1), this.entry(5))));
     }
 
     @Test
     public void containsAllArray()
     {
         MutableSet<Map.Entry<Integer, Integer>> collection = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAllArguments(this.entry(1), this.entry(2)));
-        Assert.assertFalse(collection.containsAllArguments(this.entry(1), this.entry(5)));
+        assertTrue(collection.containsAllArguments(this.entry(1), this.entry(2)));
+        assertFalse(collection.containsAllArguments(this.entry(1), this.entry(5)));
     }
 
     @Test
@@ -248,7 +253,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     {
         Verify.assertEmpty(this.newCollection());
         Verify.assertNotEmpty(this.newWith(1, 2));
-        Assert.assertTrue(this.newWith(1, 2).notEmpty());
+        assertTrue(this.newWith(1, 2).notEmpty());
     }
 
     @Test
@@ -259,8 +264,8 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
         for (int i = objects.size(); i-- > 0; )
         {
             Map.Entry<Integer, Integer> entry = iterator.next();
-            Assert.assertEquals(ImmutableEntry.of(3 - i, 3 - i), entry);
-            Assert.assertThrows(UnsupportedOperationException.class, () -> entry.setValue(0));
+            assertEquals(ImmutableEntry.of(3 - i, 3 - i), entry);
+            assertThrows(UnsupportedOperationException.class, () -> entry.setValue(0));
         }
     }
 
@@ -283,7 +288,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectBoolean()
     {
-        Assert.assertEquals(
+        assertEquals(
                 BooleanHashSet.newSetWith(false),
                 this.getCollection().collectBoolean(entry -> Boolean.parseBoolean(entry.getValue())));
     }
@@ -292,7 +297,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectByte()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ByteHashSet.newSetWith((byte) 1, (byte) 2),
                 this.getCollection().collectByte(entry -> Byte.parseByte(entry.getValue())));
     }
@@ -301,7 +306,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectChar()
     {
-        Assert.assertEquals(
+        assertEquals(
                 CharHashSet.newSetWith((char) 1, (char) 2),
                 this.getCollection().collectChar(entry -> (char) Integer.parseInt(entry.getValue())));
     }
@@ -310,7 +315,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashSet.newSetWith(1.0d, 2.0d),
                 this.getCollection().collectDouble(entry -> Double.parseDouble(entry.getValue())));
     }
@@ -319,7 +324,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashSet.newSetWith(1.0f, 2.0f),
                 this.getCollection().collectFloat(entry -> Float.parseFloat(entry.getValue())));
     }
@@ -328,7 +333,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 IntHashSet.newSetWith(1, 2),
                 this.getCollection().collectInt(entry -> Integer.parseInt(entry.getValue())));
     }
@@ -337,7 +342,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LongHashSet.newSetWith(1L, 2L),
                 this.getCollection().collectLong(entry -> Long.parseLong(entry.getValue())));
     }
@@ -346,7 +351,7 @@ public class UnmodifiableMapEntrySetTest extends UnmodifiableMutableCollectionTe
     @Test
     public void collectShort()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ShortHashSet.newSetWith((short) 1, (short) 2),
                 this.getCollection().collectShort(entry -> Short.parseShort(entry.getValue())));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapTest.java
@@ -17,9 +17,12 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class UnmodifiableMapTest
 {
@@ -42,7 +45,7 @@ public class UnmodifiableMapTest
     @Test
     public void testNullConstructorArgument()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new UnmodifiableMap<>(null));
+        assertThrows(NullPointerException.class, () -> new UnmodifiableMap<>(null));
     }
 
     @Test
@@ -54,55 +57,55 @@ public class UnmodifiableMapTest
     @Test
     public void testIsEmpty()
     {
-        Assert.assertEquals(this.mutableMap.isEmpty(), this.unmodifiableMap.isEmpty());
+        assertEquals(this.mutableMap.isEmpty(), this.unmodifiableMap.isEmpty());
     }
 
     @Test
     public void testContainsKey()
     {
-        Assert.assertTrue(this.unmodifiableMap.containsKey(ROCK_OUT));
+        assertTrue(this.unmodifiableMap.containsKey(ROCK_OUT));
     }
 
     @Test
     public void testContainsValue()
     {
-        Assert.assertTrue(this.unmodifiableMap.containsValue(MASTERS_OF_ROCK));
+        assertTrue(this.unmodifiableMap.containsValue(MASTERS_OF_ROCK));
     }
 
     @Test
     public void testGet()
     {
-        Assert.assertEquals(MASTERS_OF_ROCK, this.unmodifiableMap.get(ROCK_OUT));
+        assertEquals(MASTERS_OF_ROCK, this.unmodifiableMap.get(ROCK_OUT));
     }
 
     @Test
     public void testPut()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.put("foo", Lists.mutable.of()));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.put("foo", Lists.mutable.of()));
     }
 
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.remove(ROCK_OUT));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.remove(ROCK_OUT));
     }
 
     @Test
     public void testPutAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.putAll(Maps.mutable.of()));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableMap.putAll(Maps.mutable.of()));
     }
 
     @Test
     public void testClear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, this.unmodifiableMap::clear);
+        assertThrows(UnsupportedOperationException.class, this.unmodifiableMap::clear);
     }
 
     @Test
     public void testKeySet()
     {
-        Assert.assertEquals(this.mutableMap.keySet(), this.unmodifiableMap.keySet());
+        assertEquals(this.mutableMap.keySet(), this.unmodifiableMap.keySet());
     }
 
     @Test
@@ -114,13 +117,13 @@ public class UnmodifiableMapTest
     @Test
     public void testEntrySet()
     {
-        Assert.assertEquals(this.mutableMap.entrySet(), this.unmodifiableMap.entrySet());
+        assertEquals(this.mutableMap.entrySet(), this.unmodifiableMap.entrySet());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals(this.mutableMap.toString(), this.unmodifiableMap.toString());
+        assertEquals(this.mutableMap.toString(), this.unmodifiableMap.toString());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableRichIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableRichIterableTest.java
@@ -18,9 +18,14 @@ import org.eclipse.collections.api.partition.PartitionIterable;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableRichIterable}.
@@ -60,31 +65,31 @@ public class UnmodifiableRichIterableTest extends AbstractRichIterableTestCase
     @Test
     public void testDelegatingMethods()
     {
-        Assert.assertTrue(this.mutableCollection.notEmpty());
-        Assert.assertTrue(this.unmodifiableCollection.notEmpty());
-        Assert.assertFalse(this.mutableCollection.isEmpty());
-        Assert.assertFalse(this.unmodifiableCollection.isEmpty());
+        assertTrue(this.mutableCollection.notEmpty());
+        assertTrue(this.unmodifiableCollection.notEmpty());
+        assertFalse(this.mutableCollection.isEmpty());
+        assertFalse(this.unmodifiableCollection.isEmpty());
         Verify.assertIterableSize(this.mutableCollection.size(), this.unmodifiableCollection);
-        Assert.assertEquals(this.mutableCollection.getFirst(), this.unmodifiableCollection.getFirst());
-        Assert.assertEquals(this.mutableCollection.getLast(), this.unmodifiableCollection.getLast());
+        assertEquals(this.mutableCollection.getFirst(), this.unmodifiableCollection.getFirst());
+        assertEquals(this.mutableCollection.getLast(), this.unmodifiableCollection.getLast());
     }
 
     @Test
     public void converters()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.mutableCollection.toBag(),
                 this.unmodifiableCollection.toBag());
-        Assert.assertEquals(
+        assertEquals(
                 this.mutableCollection.asLazy().toBag(),
                 this.unmodifiableCollection.asLazy().toBag());
-        Assert.assertArrayEquals(
+        assertArrayEquals(
                 this.mutableCollection.toArray(),
                 this.unmodifiableCollection.toArray());
-        Assert.assertArrayEquals(
+        assertArrayEquals(
                 this.mutableCollection.toArray(EMPTY_STRING_ARRAY),
                 this.unmodifiableCollection.toArray(EMPTY_STRING_ARRAY));
-        Assert.assertEquals(this.mutableCollection.toList(), this.unmodifiableCollection.toList());
+        assertEquals(this.mutableCollection.toList(), this.unmodifiableCollection.toList());
         Verify.assertListsEqual(
                 Lists.mutable.of(BON_JOVI, EUROPE, METALLICA, SCORPIONS),
                 this.unmodifiableCollection.toSortedList());
@@ -108,8 +113,8 @@ public class UnmodifiableRichIterableTest extends AbstractRichIterableTestCase
     @Override
     public void equalsAndHashCode()
     {
-        Assert.assertNotEquals(this.newWith(1, 2, 3).hashCode(), this.newWith(1, 2, 3).hashCode());
-        Assert.assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2, 3));
+        assertNotEquals(this.newWith(1, 2, 3).hashCode(), this.newWith(1, 2, 3).hashCode());
+        assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2, 3));
     }
 
     @Test
@@ -118,8 +123,8 @@ public class UnmodifiableRichIterableTest extends AbstractRichIterableTestCase
     {
         PartitionIterable<String> partition = this.mutableCollection.partition(ignored -> true);
         PartitionIterable<String> unmodifiablePartition = this.unmodifiableCollection.partition(ignored -> true);
-        Assert.assertEquals(partition.getSelected(), unmodifiablePartition.getSelected());
-        Assert.assertEquals(partition.getRejected(), unmodifiablePartition.getRejected());
+        assertEquals(partition.getSelected(), unmodifiablePartition.getSelected());
+        assertEquals(partition.getRejected(), unmodifiablePartition.getRejected());
     }
 
     @Test
@@ -128,15 +133,15 @@ public class UnmodifiableRichIterableTest extends AbstractRichIterableTestCase
     {
         PartitionIterable<String> partition = this.mutableCollection.partitionWith((ignored1, ignored2) -> true, null);
         PartitionIterable<String> unmodifiablePartition = this.unmodifiableCollection.partitionWith((ignored1, ignored2) -> true, null);
-        Assert.assertEquals(partition.getSelected(), unmodifiablePartition.getSelected());
-        Assert.assertEquals(partition.getRejected(), unmodifiablePartition.getRejected());
+        assertEquals(partition.getSelected(), unmodifiablePartition.getSelected());
+        assertEquals(partition.getRejected(), unmodifiablePartition.getRejected());
     }
 
     @Test
     @Override
     public void groupBy()
     {
-        Assert.assertEquals(this.mutableCollection.groupBy(Functions.getStringPassThru()), this.unmodifiableCollection.groupBy(Functions.getStringPassThru()));
-        Assert.assertEquals(this.mutableCollection.groupBy(Functions.getStringPassThru(), FastListMultimap.newMultimap()), this.unmodifiableCollection.groupBy(Functions.getStringPassThru(), FastListMultimap.newMultimap()));
+        assertEquals(this.mutableCollection.groupBy(Functions.getStringPassThru()), this.unmodifiableCollection.groupBy(Functions.getStringPassThru()));
+        assertEquals(this.mutableCollection.groupBy(Functions.getStringPassThru(), FastListMultimap.newMultimap()), this.unmodifiableCollection.groupBy(Functions.getStringPassThru(), FastListMultimap.newMultimap()));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBagTest.java
@@ -24,10 +24,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableArrayBagTest extends ImmutableBagTestCase
 {
@@ -82,26 +85,26 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         super.newWithout();
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> newBag2 = bag.newWithout("2").newWithout("2");
-        Assert.assertNotEquals(bag, newBag2);
-        Assert.assertEquals(newBag2.size(), bag.size() - 2);
-        Assert.assertEquals(3, newBag2.sizeDistinct());
+        assertNotEquals(bag, newBag2);
+        assertEquals(newBag2.size(), bag.size() - 2);
+        assertEquals(3, newBag2.sizeDistinct());
         ImmutableBag<String> newBag3 = bag.newWithout("3").newWithout("3").newWithout("3");
-        Assert.assertNotEquals(bag, newBag3);
-        Assert.assertEquals(newBag3.size(), bag.size() - 3);
-        Assert.assertEquals(3, newBag3.sizeDistinct());
+        assertNotEquals(bag, newBag3);
+        assertEquals(newBag3.size(), bag.size() - 3);
+        assertEquals(3, newBag3.sizeDistinct());
         ImmutableBag<String> newBag4 = bag.newWithout("4").newWithout("4").newWithout("4").newWithout("4");
-        Assert.assertNotEquals(bag, newBag4);
-        Assert.assertEquals(newBag4.size(), bag.size() - 4);
-        Assert.assertEquals(3, newBag4.sizeDistinct());
+        assertNotEquals(bag, newBag4);
+        assertEquals(newBag4.size(), bag.size() - 4);
+        assertEquals(3, newBag4.sizeDistinct());
         ImmutableBag<String> newBag5 = bag.newWithout("5");
-        Assert.assertEquals(bag, newBag5);
+        assertEquals(bag, newBag5);
     }
 
     @Override
     public void toStringOfItemToCount()
     {
         String actual = ImmutableArrayBag.newBagWith("1", "2", "2").toStringOfItemToCount();
-        Assert.assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
+        assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
     }
 
     @Override
@@ -112,7 +115,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         ImmutableBag<String> integers = this.newBag();
         MutableMap<String, String> map =
                 integers.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -124,7 +127,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
             Verify.assertEqualsAndHashCode(HashBag.newBag(interval), Bags.immutable.ofAll(interval));
         }
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ImmutableArrayBag<>(new Integer[]{2, 3}, new int[]{2}));
+        assertThrows(IllegalArgumentException.class, () -> new ImmutableArrayBag<>(new Integer[]{2, 3}, new int[]{2}));
     }
 
     @Override
@@ -134,8 +137,8 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         super.selectInstancesOf();
 
         ImmutableBag<Number> numbers = ImmutableArrayBag.newBagWith(1, 2.0, 2.0, 3, 3, 3, 4.0, 4.0, 4.0, 4.0);
-        Assert.assertEquals(iBag(1, 3, 3, 3), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iBag(2.0, 2.0, 4.0, 4.0, 4.0, 4.0), numbers.selectInstancesOf(Double.class));
+        assertEquals(iBag(1, 3, 3, 3), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iBag(2.0, 2.0, 4.0, 4.0, 4.0, 4.0), numbers.selectInstancesOf(Double.class));
     }
 
     @Override
@@ -144,7 +147,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
     {
         // Only works on bags without duplicates
         ImmutableBag<Integer> immutableBag = ImmutableArrayBag.newBagWith(1, 2, 3);
-        Assert.assertEquals(Maps.immutable.of(1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id));
+        assertEquals(Maps.immutable.of(1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id));
     }
 
     @Override
@@ -153,7 +156,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
     {
         // Only works on bags without duplicates
         ImmutableBag<Integer> immutableBag = ImmutableArrayBag.newBagWith(1, 2, 3);
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
 
     @Test
@@ -173,10 +176,10 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         ImmutableBag<String> strings = ImmutableArrayBag.copyFrom(mutable);
         ImmutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertIterableSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertIterableSize(0, ImmutableArrayBag.newBagWith().topOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -188,7 +191,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         Verify.assertIterableSize(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1));
         Verify.assertIterableSize(0, this.newWith("one").newWithout("one").topOccurrences(0));
         Verify.assertIterableSize(0, this.newWith("one").topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith("one").topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith("one").topOccurrences(-1));
     }
 
     @Test
@@ -208,10 +211,10 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         ImmutableBag<String> strings = ImmutableArrayBag.copyFrom(mutable);
         ImmutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertIterableSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertIterableSize(0, ImmutableArrayBag.newBagWith().bottomOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").bottomOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").bottomOccurrences(1));
@@ -223,7 +226,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         Verify.assertIterableSize(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1));
         Verify.assertIterableSize(0, this.newWith("one").newWithout("one").bottomOccurrences(0));
         Verify.assertIterableSize(0, this.newWith("one").bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith("one").bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith("one").bottomOccurrences(-1));
     }
 
     @Override
@@ -235,7 +238,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         ImmutableBag<String> bag = this.newBag();
         ImmutableSet<String> expected = Sets.immutable.of("1");
         ImmutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Override
@@ -246,7 +249,7 @@ public class ImmutableArrayBagTest extends ImmutableBagTestCase
         RichIterable<String> expected = bag.toSet();
         RichIterable<String> actual = bag.distinctView();
         // this assertion is a reminder to get rid of this test override once distinctView returns a set
-        Assert.assertNotEquals(expected, actual);
+        assertNotEquals(expected, actual);
         Verify.assertIterablesEqual(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagFactoryTest.java
@@ -15,8 +15,12 @@ import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableBagFactoryTest
 {
@@ -27,8 +31,8 @@ public class ImmutableBagFactoryTest
         Verify.assertIterableSize(0, immutableBag);
         Verify.assertIterableSize(4, Bags.immutable.of(1, 2, 2, 3));
         ImmutableBag<Object> actual = Bags.immutable.ofAll(immutableBag);
-        Assert.assertSame(immutableBag, actual);
-        Assert.assertEquals(immutableBag, actual);
+        assertSame(immutableBag, actual);
+        assertEquals(immutableBag, actual);
     }
 
     private static class StringIntPair implements ObjectIntPair<String>
@@ -69,9 +73,9 @@ public class ImmutableBagFactoryTest
                 Bags.immutable.ofOccurrences(new StringIntPair("a", 5),
                         new StringIntPair("b", 10));
 
-        Assert.assertTrue(immutableBag.contains("a"));
-        Assert.assertTrue(immutableBag.contains("b"));
-        Assert.assertFalse(immutableBag.contains("c"));
+        assertTrue(immutableBag.contains("a"));
+        assertTrue(immutableBag.contains("b"));
+        assertFalse(immutableBag.contains("c"));
     }
 
     @Test
@@ -81,9 +85,9 @@ public class ImmutableBagFactoryTest
                 Bags.immutable.withOccurrences(new StringIntPair("a", 5),
                         new StringIntPair("b", 10));
 
-        Assert.assertTrue(immutableBag.contains("a"));
-        Assert.assertTrue(immutableBag.contains("b"));
-        Assert.assertFalse(immutableBag.contains("c"));
+        assertTrue(immutableBag.contains("a"));
+        assertTrue(immutableBag.contains("b"));
+        assertFalse(immutableBag.contains("c"));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
@@ -84,8 +84,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 {
@@ -117,44 +125,44 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> immutable = this.newBag();
         MutableBag<String> mutable = HashBag.newBag(immutable);
         Verify.assertEqualsAndHashCode(immutable, mutable);
-        Assert.assertNotEquals(immutable, FastList.newList(mutable));
-        Assert.assertEquals(this.newBag().toMapOfItemToCount().hashCode(), this.newBag().hashCode());
-        Assert.assertNotEquals(immutable, mutable.with("5").without("1"));
+        assertNotEquals(immutable, FastList.newList(mutable));
+        assertEquals(this.newBag().toMapOfItemToCount().hashCode(), this.newBag().hashCode());
+        assertNotEquals(immutable, mutable.with("5").without("1"));
     }
 
     @Test
     public void anySatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2")));
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2") && value == 2));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2") && value == 6));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals("20")));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2")));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2") && value == 2));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals("2") && value == 6));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals("20")));
     }
 
     @Test
     public void allSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> Integer.parseInt(object) > 0));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals("1") && value == 1));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> Integer.parseInt(object) > 0));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals("1") && value == 1));
     }
 
     @Test
     public void noneSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> Integer.parseInt(object) > 100));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals("1") && value == 1));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> Integer.parseInt(object) > 100));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals("1") && value == 1));
     }
 
     @Test
     public void detectWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertEquals("1", bag.detectWithOccurrences((object, value) -> object.equals("1") && value == 1));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals("100")));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals("1") && value == 100));
+        assertEquals("1", bag.detectWithOccurrences((object, value) -> object.equals("1") && value == 1));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals("100")));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals("1") && value == 100));
     }
 
     @Test
@@ -162,13 +170,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> newBag = bag.newWith("1");
-        Assert.assertNotEquals(bag, newBag);
-        Assert.assertEquals(bag.size() + 1, newBag.size());
-        Assert.assertEquals(bag.sizeDistinct(), newBag.sizeDistinct());
+        assertNotEquals(bag, newBag);
+        assertEquals(bag.size() + 1, newBag.size());
+        assertEquals(bag.sizeDistinct(), newBag.sizeDistinct());
         ImmutableBag<String> newBag2 = bag.newWith("0");
-        Assert.assertNotEquals(bag, newBag2);
-        Assert.assertEquals(bag.size() + 1, newBag2.size());
-        Assert.assertEquals(newBag.sizeDistinct() + 1, newBag2.sizeDistinct());
+        assertNotEquals(bag, newBag2);
+        assertEquals(bag.size() + 1, newBag2.size());
+        assertEquals(newBag.sizeDistinct() + 1, newBag2.sizeDistinct());
     }
 
     @Test
@@ -176,13 +184,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> newBag = bag.newWithout("1");
-        Assert.assertNotEquals(bag, newBag);
-        Assert.assertEquals(bag.size() - 1, newBag.size());
-        Assert.assertEquals(bag.sizeDistinct() - 1, newBag.sizeDistinct());
+        assertNotEquals(bag, newBag);
+        assertEquals(bag.size() - 1, newBag.size());
+        assertEquals(bag.sizeDistinct() - 1, newBag.sizeDistinct());
         ImmutableBag<String> newBag2 = bag.newWithout("0");
-        Assert.assertEquals(bag, newBag2);
-        Assert.assertEquals(bag.size(), newBag2.size());
-        Assert.assertEquals(bag.sizeDistinct(), newBag2.sizeDistinct());
+        assertEquals(bag, newBag2);
+        assertEquals(bag.size(), newBag2.size());
+        assertEquals(bag.sizeDistinct(), newBag2.sizeDistinct());
     }
 
     @Test
@@ -190,9 +198,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> newBag = bag.newWithAll(Bags.mutable.of("0"));
-        Assert.assertNotEquals(bag, newBag);
-        Assert.assertEquals(HashBag.newBag(bag).with("0"), newBag);
-        Assert.assertEquals(newBag.size(), bag.size() + 1);
+        assertNotEquals(bag, newBag);
+        assertEquals(HashBag.newBag(bag).with("0"), newBag);
+        assertEquals(newBag.size(), bag.size() + 1);
     }
 
     @Test
@@ -203,13 +211,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> withoutAll = bag.newWithoutAll(UnifiedSet.newSet(this.newBag()));
-        Assert.assertEquals(Bags.immutable.of(), withoutAll);
+        assertEquals(Bags.immutable.of(), withoutAll);
 
         ImmutableBag<String> newBag =
                 bag.newWithAll(Lists.fixedSize.of("0", "0", "0"))
                         .newWithoutAll(Lists.fixedSize.of("0"));
 
-        Assert.assertEquals(0, newBag.occurrencesOf("0"));
+        assertEquals(0, newBag.occurrencesOf("0"));
     }
 
     @Override
@@ -222,12 +230,12 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         for (int i = 1; i <= this.numKeys(); i++)
         {
             String key = String.valueOf(i);
-            Assert.assertTrue(bag.contains(key));
-            Assert.assertEquals(i, bag.occurrencesOf(key));
+            assertTrue(bag.contains(key));
+            assertEquals(i, bag.occurrencesOf(key));
         }
         String missingKey = "0";
-        Assert.assertFalse(bag.contains(missingKey));
-        Assert.assertEquals(0, bag.occurrencesOf(missingKey));
+        assertFalse(bag.contains(missingKey));
+        assertEquals(0, bag.occurrencesOf(missingKey));
     }
 
     @Override
@@ -236,7 +244,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.containsAllArray();
 
-        Assert.assertTrue(this.newBag().containsAllArguments(this.newBag().toArray()));
+        assertTrue(this.newBag().containsAllArguments(this.newBag().toArray()));
     }
 
     @Override
@@ -245,13 +253,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.containsAllIterable();
 
-        Assert.assertTrue(this.newBag().containsAllIterable(this.newBag()));
+        assertTrue(this.newBag().containsAllIterable(this.newBag()));
     }
 
     @Test
     public void add()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Collection<String>) this.newBag()).add("1"));
     }
@@ -259,7 +267,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     @Test
     public void remove()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Collection<String>) this.newBag()).remove("1"));
     }
@@ -267,7 +275,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     @Test
     public void addAll()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Collection<String>) this.newBag()).addAll(FastList.newListWith("1", "2", "3")));
     }
@@ -275,7 +283,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Collection<String>) this.newBag()).removeAll(FastList.newListWith("1", "2", "3")));
     }
@@ -283,7 +291,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Collection<String>) this.newBag()).retainAll(FastList.newListWith("1", "2", "3")));
     }
@@ -291,7 +299,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<String>) this.newBag()).clear());
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<String>) this.newBag()).clear());
     }
 
     @Override
@@ -302,8 +310,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         MutableList<String> tapResult = Lists.mutable.of();
         ImmutableBag<String> collection = this.newBag();
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Override
@@ -315,7 +323,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         MutableBag<String> result = Bags.mutable.of();
         ImmutableBag<String> collection = this.newBag();
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Override
@@ -327,7 +335,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         MutableBag<String> result = Bags.mutable.of();
         ImmutableBag<String> bag = this.newBag();
         bag.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), "");
-        Assert.assertEquals(bag, result);
+        assertEquals(bag, result);
     }
 
     @Override
@@ -339,7 +347,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         MutableBag<String> result = Bags.mutable.of();
         ImmutableBag<String> strings = this.newBag();
         strings.forEachWithIndex(ObjectIntProcedures.fromProcedure(result::add));
-        Assert.assertEquals(strings, result);
+        assertEquals(strings, result);
     }
 
     /**
@@ -357,7 +365,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
                         PrimitiveTuples.pair("3", 3),
                         PrimitiveTuples.pair("2", 2),
                         PrimitiveTuples.pair("1", 1));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<String>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
@@ -367,7 +375,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
                         PrimitiveTuples.pair("3", 3),
                         PrimitiveTuples.pair("2", 2),
                         PrimitiveTuples.pair("1", 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Test
@@ -408,7 +416,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
 
-        Assert.assertEquals(strings, strings.selectWith(Predicates2.greaterThan(), "0"));
+        assertEquals(strings, strings.selectWith(Predicates2.greaterThan(), "0"));
     }
 
     @Test
@@ -416,7 +424,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         ImmutableBag<String> strings = this.newBag();
 
-        Assert.assertEquals(
+        assertEquals(
                 strings,
                 strings.selectWith(Predicates2.greaterThan(), "0", FastList.newList()).toBag());
     }
@@ -425,7 +433,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     public void selectToTarget()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(strings, strings.select(Predicates.greaterThan("0"), FastList.newList()).toBag());
+        assertEquals(strings, strings.select(Predicates.greaterThan("0"), FastList.newList()).toBag());
         Verify.assertEmpty(strings.select(Predicates.lessThan("0"), FastList.newList()));
     }
 
@@ -437,7 +445,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
         Verify.assertIterableEmpty(strings.reject(Predicates.greaterThan("0")));
-        Assert.assertEquals(strings, strings.reject(Predicates.lessThan("0")));
+        assertEquals(strings, strings.reject(Predicates.lessThan("0")));
         Verify.assertIterableSize(strings.size() - 1, strings.reject(Predicates.lessThan("2")));
     }
 
@@ -449,14 +457,14 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
 
-        Assert.assertEquals(strings, strings.rejectWith(Predicates2.lessThan(), "0"));
+        assertEquals(strings, strings.rejectWith(Predicates2.lessThan(), "0"));
     }
 
     @Test
     public void rejectWithToTarget()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(strings, strings.reject(Predicates.lessThan("0")));
+        assertEquals(strings, strings.reject(Predicates.lessThan("0")));
 
         Verify.assertEmpty(strings.rejectWith(Predicates2.greaterThan(), "0", FastList.newList()));
     }
@@ -465,7 +473,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     public void rejectToTarget()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(strings, strings.reject(Predicates.lessThan("0"), FastList.newList()).toBag());
+        assertEquals(strings, strings.reject(Predicates.lessThan("0"), FastList.newList()).toBag());
         Verify.assertEmpty(strings.reject(Predicates.greaterThan("0"), FastList.newList()));
     }
 
@@ -477,7 +485,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
         PartitionImmutableBag<String> partition = strings.partition(Predicates.greaterThan("0"));
-        Assert.assertEquals(strings, partition.getSelected());
+        assertEquals(strings, partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
 
         Verify.assertIterableSize(strings.size() - 1, strings.partition(Predicates.greaterThan("1")).getSelected());
@@ -491,7 +499,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
         PartitionImmutableBag<String> partition = strings.partitionWith(Predicates2.greaterThan(), "0");
-        Assert.assertEquals(strings, partition.getSelected());
+        assertEquals(strings, partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
 
         Verify.assertIterableSize(strings.size() - 1, strings.partitionWith(Predicates2.greaterThan(), "1").getSelected());
@@ -503,7 +511,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.collect();
 
-        Assert.assertEquals(this.newBag(), this.newBag().collect(Functions.getStringPassThru()));
+        assertEquals(this.newBag(), this.newBag().collect(Functions.getStringPassThru()));
     }
 
     @Override
@@ -513,9 +521,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectBoolean();
 
         ImmutableBooleanBag result = this.newBag().collectBoolean("4"::equals);
-        Assert.assertEquals(2, result.sizeDistinct());
-        Assert.assertEquals(4, result.occurrencesOf(true));
-        Assert.assertEquals(6, result.occurrencesOf(false));
+        assertEquals(2, result.sizeDistinct());
+        assertEquals(4, result.occurrencesOf(true));
+        assertEquals(6, result.occurrencesOf(false));
     }
 
     @Override
@@ -526,10 +534,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(2, result.sizeDistinct());
-        Assert.assertEquals(4, result.occurrencesOf(true));
-        Assert.assertEquals(6, result.occurrencesOf(false));
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(2, result.sizeDistinct());
+        assertEquals(4, result.occurrencesOf(true));
+        assertEquals(6, result.occurrencesOf(false));
     }
 
     @Override
@@ -539,10 +547,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectByte();
 
         ImmutableByteBag result = this.newBag().collectByte(Byte::parseByte);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((byte) i));
+            assertEquals(i, result.occurrencesOf((byte) i));
         }
     }
 
@@ -554,11 +562,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = this.newBag().collectByte(Byte::parseByte, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((byte) i));
+            assertEquals(i, result.occurrencesOf((byte) i));
         }
     }
 
@@ -569,10 +577,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectChar();
 
         ImmutableCharBag result = this.newBag().collectChar((CharFunction<String>) string -> string.charAt(0));
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((char) ('0' + i)));
+            assertEquals(i, result.occurrencesOf((char) ('0' + i)));
         }
     }
 
@@ -584,11 +592,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         CharHashBag target = new CharHashBag();
         CharHashBag result = this.newBag().collectChar((CharFunction<String>) string -> string.charAt(0), target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((char) ('0' + i)));
+            assertEquals(i, result.occurrencesOf((char) ('0' + i)));
         }
     }
 
@@ -599,10 +607,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectDouble();
 
         ImmutableDoubleBag result = this.newBag().collectDouble(Double::parseDouble);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -614,11 +622,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = this.newBag().collectDouble(Double::parseDouble, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -629,10 +637,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectFloat();
 
         ImmutableFloatBag result = this.newBag().collectFloat(Float::parseFloat);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -644,11 +652,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = this.newBag().collectFloat(Float::parseFloat, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -659,10 +667,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectInt();
 
         ImmutableIntBag result = this.newBag().collectInt(Integer::parseInt);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -674,11 +682,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         IntHashBag target = new IntHashBag();
         IntHashBag result = this.newBag().collectInt(Integer::parseInt, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -689,10 +697,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectLong();
 
         ImmutableLongBag result = this.newBag().collectLong(Long::parseLong);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -704,11 +712,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         LongHashBag target = new LongHashBag();
         LongHashBag result = this.newBag().collectLong(Long::parseLong, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf(i));
+            assertEquals(i, result.occurrencesOf(i));
         }
     }
 
@@ -719,10 +727,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectShort();
 
         ImmutableShortBag result = this.newBag().collectShort(Short::parseShort);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((short) i));
+            assertEquals(i, result.occurrencesOf((short) i));
         }
     }
 
@@ -734,10 +742,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ShortHashBag target = new ShortHashBag();
         ShortHashBag result = this.newBag().collectShort(Short::parseShort, target);
-        Assert.assertEquals(this.numKeys(), result.sizeDistinct());
+        assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
-            Assert.assertEquals(i, result.occurrencesOf((short) i));
+            assertEquals(i, result.occurrencesOf((short) i));
         }
     }
 
@@ -745,7 +753,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         return (argument1, argument2) ->
         {
-            Assert.assertEquals(valueToAssert, argument2);
+            assertEquals(valueToAssert, argument2);
             return argument1;
         };
     }
@@ -759,7 +767,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> strings = this.newBag();
 
         String argument = "thing";
-        Assert.assertEquals(strings, strings.collectWith(this.generateAssertingPassThroughFunction2(argument), argument));
+        assertEquals(strings, strings.collectWith(this.generateAssertingPassThroughFunction2(argument), argument));
     }
 
     @Override
@@ -773,8 +781,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         String argument = "thing";
         HashBag<String> targetCollection = HashBag.newBag();
         HashBag<String> actual = strings.collectWith(this.generateAssertingPassThroughFunction2(argument), argument, targetCollection);
-        Assert.assertEquals(strings, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(strings, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Test
@@ -783,9 +791,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> strings = this.newBag();
         HashBag<String> target = HashBag.newBag();
         HashBag<String> actual = strings.collect(Functions.getStringPassThru(), target);
-        Assert.assertEquals(strings, actual);
-        Assert.assertSame(target, actual);
-        Assert.assertEquals(strings, strings.collect(Functions.getStringPassThru(), FastList.newList()).toBag());
+        assertEquals(strings, actual);
+        assertSame(target, actual);
+        assertEquals(strings, strings.collect(Functions.getStringPassThru(), FastList.newList()).toBag());
     }
 
     @Override
@@ -798,7 +806,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> expected = this.newBag().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -808,7 +816,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> expected = this.newBag().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Override
@@ -818,8 +826,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.detect();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals("1", strings.detect("1"::equals));
-        Assert.assertNull(strings.detect(String.valueOf(this.numKeys() + 1)::equals));
+        assertEquals("1", strings.detect("1"::equals));
+        assertNull(strings.detect(String.valueOf(this.numKeys() + 1)::equals));
     }
 
     @Override
@@ -829,15 +837,15 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.detectWith();
 
         ImmutableBag<String> immutableStrings = this.newBag();
-        Assert.assertEquals("1", immutableStrings.detectWith(Object::equals, "1"));
+        assertEquals("1", immutableStrings.detectWith(Object::equals, "1"));
     }
 
     @Test
     public void detectWithIfNone()
     {
         ImmutableBag<String> immutableStrings = this.newBag();
-        Assert.assertEquals("1", immutableStrings.detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
-        Assert.assertEquals("Not Found", immutableStrings.detectWithIfNone(Object::equals, "10000", new PassThruFunction0<>("Not Found")));
+        assertEquals("1", immutableStrings.detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
+        assertEquals("Not Found", immutableStrings.detectWithIfNone(Object::equals, "10000", new PassThruFunction0<>("Not Found")));
     }
 
     @Override
@@ -852,26 +860,26 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         List<Object> nullsMinusOne = Collections.nCopies(immutableBag.size() - 1, null);
 
         ImmutableBag<Pair<String, Object>> pairs = immutableBag.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 immutableBag,
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBag(nulls),
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableBag<Pair<String, Object>> pairsPlusOne = immutableBag.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 immutableBag,
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBag(nulls),
                 pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableBag<Pair<String, Object>> pairsMinusOne = immutableBag.zip(nullsMinusOne);
-        Assert.assertEquals(immutableBag.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(immutableBag.containsAllIterable(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
+        assertEquals(immutableBag.size() - 1, pairsMinusOne.size());
+        assertTrue(immutableBag.containsAllIterable(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
 
-        Assert.assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, HashBag.newBag()));
+        assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, HashBag.newBag()));
     }
 
     @Override
@@ -883,10 +891,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> immutableBag = this.newBag();
         ImmutableSet<Pair<String, Integer>> pairs = immutableBag.zipWithIndex();
 
-        Assert.assertEquals(immutableBag, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne, HashBag.newBag()));
-        Assert.assertEquals(Interval.zeroTo(immutableBag.size() - 1).toSet(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
+        assertEquals(immutableBag, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne, HashBag.newBag()));
+        assertEquals(Interval.zeroTo(immutableBag.size() - 1).toSet(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(immutableBag.zipWithIndex(), immutableBag.zipWithIndex(UnifiedSet.newSet()));
+        assertEquals(immutableBag.zipWithIndex(), immutableBag.zipWithIndex(UnifiedSet.newSet()));
     }
 
     @Override
@@ -903,7 +911,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     public void chunk_large_size()
     {
         super.chunk_large_size();
-        Assert.assertEquals(this.newBag(), this.newBag().chunk(10).getOnly());
+        assertEquals(this.newBag(), this.newBag().chunk(10).getOnly());
         Verify.assertInstanceOf(ImmutableBag.class, this.newBag().chunk(10).getOnly());
     }
 
@@ -932,7 +940,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.min();
 
-        Assert.assertEquals("1", this.newBag().min(String::compareTo));
+        assertEquals("1", this.newBag().min(String::compareTo));
     }
 
     @Override
@@ -941,7 +949,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.max();
 
-        Assert.assertEquals(String.valueOf(this.numKeys()), this.newBag().max(String::compareTo));
+        assertEquals(String.valueOf(this.numKeys()), this.newBag().max(String::compareTo));
     }
 
     @Override
@@ -964,7 +972,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.min_without_comparator();
 
-        Assert.assertEquals("1", this.newBag().min());
+        assertEquals("1", this.newBag().min());
     }
 
     @Override
@@ -973,7 +981,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.max_without_comparator();
 
-        Assert.assertEquals(String.valueOf(this.numKeys()), this.newBag().max());
+        assertEquals(String.valueOf(this.numKeys()), this.newBag().max());
     }
 
     @Override
@@ -982,7 +990,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.minBy();
 
-        Assert.assertEquals("1", this.newBag().minBy(String::valueOf));
+        assertEquals("1", this.newBag().minBy(String::valueOf));
     }
 
     @Override
@@ -991,7 +999,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     {
         super.maxBy();
 
-        Assert.assertEquals(String.valueOf(this.numKeys()), this.newBag().maxBy(String::valueOf));
+        assertEquals(String.valueOf(this.numKeys()), this.newBag().maxBy(String::valueOf));
     }
 
     @Override
@@ -1002,8 +1010,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> strings = this.newBag();
         Function0<String> function = new PassThruFunction0<>(String.valueOf(this.numKeys() + 1));
-        Assert.assertEquals("1", strings.detectIfNone("1"::equals, function));
-        Assert.assertEquals(String.valueOf(this.numKeys() + 1), strings.detectIfNone(String.valueOf(this.numKeys() + 1)::equals, function));
+        assertEquals("1", strings.detectIfNone("1"::equals, function));
+        assertEquals(String.valueOf(this.numKeys() + 1), strings.detectIfNone(String.valueOf(this.numKeys() + 1)::equals, function));
     }
 
     @Override
@@ -1013,8 +1021,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.allSatisfy();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.allSatisfy(String.class::isInstance));
-        Assert.assertFalse(strings.allSatisfy("0"::equals));
+        assertTrue(strings.allSatisfy(String.class::isInstance));
+        assertFalse(strings.allSatisfy("0"::equals));
     }
 
     @Override
@@ -1024,8 +1032,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.anySatisfy();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertFalse(strings.anySatisfy(Integer.class::isInstance));
-        Assert.assertTrue(strings.anySatisfy(String.class::isInstance));
+        assertFalse(strings.anySatisfy(Integer.class::isInstance));
+        assertTrue(strings.anySatisfy(String.class::isInstance));
     }
 
     @Override
@@ -1035,8 +1043,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.noneSatisfy();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(strings.noneSatisfy("0"::equals));
+        assertTrue(strings.noneSatisfy(Integer.class::isInstance));
+        assertTrue(strings.noneSatisfy("0"::equals));
     }
 
     @Override
@@ -1046,8 +1054,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.count();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(strings.size(), strings.count(String.class::isInstance));
-        Assert.assertEquals(0, strings.count(Integer.class::isInstance));
+        assertEquals(strings.size(), strings.count(String.class::isInstance));
+        assertEquals(0, strings.count(Integer.class::isInstance));
     }
 
     @Override
@@ -1057,8 +1065,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.countWith();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(strings.size(), strings.countWith(Predicates2.instanceOf(), String.class));
-        Assert.assertEquals(0, strings.countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(strings.size(), strings.countWith(Predicates2.instanceOf(), String.class));
+        assertEquals(0, strings.countWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Override
@@ -1068,7 +1076,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.collectIf();
 
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(
+        assertEquals(
                 strings,
                 strings.collectIf(
                         String.class::isInstance,
@@ -1079,7 +1087,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
     public void collectIfWithTarget()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertEquals(
+        assertEquals(
                 strings,
                 strings.collectIf(
                         String.class::isInstance,
@@ -1095,7 +1103,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         // Cannot assert much here since there's no order.
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.contains(bag.getFirst()));
+        assertTrue(bag.contains(bag.getFirst()));
     }
 
     @Override
@@ -1106,7 +1114,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         // Cannot assert much here since there's no order.
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.contains(bag.getLast()));
+        assertTrue(bag.contains(bag.getLast()));
     }
 
     @Override
@@ -1116,8 +1124,8 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.isEmpty();
 
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertFalse(bag.isEmpty());
-        Assert.assertTrue(bag.notEmpty());
+        assertFalse(bag.isEmpty());
+        assertTrue(bag.notEmpty());
     }
 
     @Override
@@ -1134,9 +1142,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
             String string = iterator.next();
             result.add(string);
         }
-        Assert.assertEquals(strings, result);
+        assertEquals(strings, result);
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -1147,9 +1155,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         Integer result = integers.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
         String result1 = this.newBag().injectInto("0", String::concat);
-        Assert.assertEquals(FastList.newList(this.newBag()).injectInto("0", String::concat), result1);
+        assertEquals(FastList.newList(this.newBag()).injectInto("0", String::concat), result1);
     }
 
     @Override
@@ -1160,7 +1168,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         int result = integers.injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result);
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result);
     }
 
     @Override
@@ -1171,7 +1179,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         long result = integers.injectInto(0, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result);
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result);
     }
 
     @Override
@@ -1183,7 +1191,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         double result = integers.injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
         double expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(expected, result, 0.001);
+        assertEquals(expected, result, 0.001);
     }
 
     @Override
@@ -1195,7 +1203,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         float result = integers.injectInto(0, AddFunction.INTEGER_TO_FLOAT);
         float expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(expected, result, 0.001);
+        assertEquals(expected, result, 0.001);
     }
 
     @Override
@@ -1207,7 +1215,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         double result = integers.sumOfFloat(Integer::floatValue);
         float expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(expected, result, 0.001);
+        assertEquals(expected, result, 0.001);
     }
 
     @Override
@@ -1219,7 +1227,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         double result = integers.sumOfDouble(Integer::doubleValue);
         double expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(expected, result, 0.001);
+        assertEquals(expected, result, 0.001);
     }
 
     @Override
@@ -1231,7 +1239,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         long result = integers.sumOfInt(integer -> integer);
         int expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Override
@@ -1243,7 +1251,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         long result = integers.sumOfLong(Integer::longValue);
         long expected = FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Override
@@ -1258,7 +1266,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         String[] array2 = bag.toArray(new String[bag.size() + 1]);
         Verify.assertSize(bag.size() + 1, array2);
-        Assert.assertNull(array2[bag.size()]);
+        assertNull(array2[bag.size()]);
     }
 
     @Override
@@ -1270,7 +1278,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         String string = this.newBag().toString();
         for (int i = 1; i < this.numKeys(); i++)
         {
-            Assert.assertEquals(i, StringIterate.occurrencesOf(string, String.valueOf(i)));
+            assertEquals(i, StringIterate.occurrencesOf(string, String.valueOf(i)));
         }
     }
 
@@ -1291,9 +1299,9 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> strings = this.newBag();
         MutableList<String> copy = FastList.newList(strings);
         MutableList<String> list = strings.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(copy.sortThis(Collections.reverseOrder()), list);
+        assertEquals(copy.sortThis(Collections.reverseOrder()), list);
         MutableList<String> list2 = strings.toSortedList();
-        Assert.assertEquals(copy.sortThis(), list2);
+        assertEquals(copy.sortThis(), list2);
     }
 
     @Override
@@ -1306,7 +1314,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         Collections.sort(expected);
         ImmutableBag<String> immutableBag = this.newBag();
         MutableList<String> sortedList = immutableBag.toSortedListBy(String::valueOf);
-        Assert.assertEquals(expected, sortedList);
+        assertEquals(expected, sortedList);
     }
 
     @Test
@@ -1315,14 +1323,14 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> bag = this.newBag();
         for (String each : bag)
         {
-            Assert.assertNotNull(each);
+            assertNotNull(each);
         }
     }
 
     @Test
     public void iteratorRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newBag().iterator().remove());
+        assertThrows(UnsupportedOperationException.class, () -> this.newBag().iterator().remove());
     }
 
     @Test
@@ -1333,20 +1341,20 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         for (int i = 1; i <= this.numKeys(); i++)
         {
             String key = String.valueOf(i);
-            Assert.assertTrue(mapOfItemToCount.containsKey(key));
-            Assert.assertEquals(Integer.valueOf(i), mapOfItemToCount.get(key));
+            assertTrue(mapOfItemToCount.containsKey(key));
+            assertEquals(Integer.valueOf(i), mapOfItemToCount.get(key));
         }
 
         String missingKey = "0";
-        Assert.assertFalse(mapOfItemToCount.containsKey(missingKey));
-        Assert.assertNull(mapOfItemToCount.get(missingKey));
+        assertFalse(mapOfItemToCount.containsKey(missingKey));
+        assertNull(mapOfItemToCount.get(missingKey));
     }
 
     @Test
     public void toImmutable()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertSame(bag, bag.toImmutable());
+        assertSame(bag, bag.toImmutable());
     }
 
     /**
@@ -1431,11 +1439,11 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         });
         Multimap<Integer, Integer> actual =
                 immutableBag.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 immutableBag.groupByEach(new NegativeIntervalFunction(), HashBagMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     private void groupByAssertions(ImmutableBagMultimap<Boolean, String> multimap)
@@ -1449,10 +1457,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
             String key = String.valueOf(i);
             ImmutableBag<String> containingBag = IntegerPredicates.isOdd().accept(i) ? odds : evens;
             ImmutableBag<String> nonContainingBag = IntegerPredicates.isOdd().accept(i) ? evens : odds;
-            Assert.assertTrue(containingBag.contains(key));
-            Assert.assertFalse(nonContainingBag.contains(key));
+            assertTrue(containingBag.contains(key));
+            assertFalse(nonContainingBag.contains(key));
 
-            Assert.assertEquals(i, containingBag.occurrencesOf(key));
+            assertEquals(i, containingBag.occurrencesOf(key));
         }
     }
 
@@ -1485,7 +1493,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         MutableSet<String> expectedSet = this.numKeys() == 0
                 ? UnifiedSet.newSet()
                 : Interval.oneTo(this.numKeys()).collect(String::valueOf).toSet();
-        Assert.assertEquals(expectedSet, this.newBag().toSet());
+        assertEquals(expectedSet, this.newBag().toSet());
     }
 
     @Override
@@ -1496,7 +1504,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ImmutableBag<String> immutableBag = this.newBag();
         MutableBag<String> mutableBag = immutableBag.toBag();
-        Assert.assertEquals(immutableBag, mutableBag);
+        assertEquals(immutableBag, mutableBag);
     }
 
     @Override
@@ -1510,13 +1518,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         for (int i = 1; i <= this.numKeys(); i++)
         {
             String key = String.valueOf(i);
-            Assert.assertTrue(map.containsKey(key));
-            Assert.assertEquals(key, map.get(key));
+            assertTrue(map.containsKey(key));
+            assertEquals(key, map.get(key));
         }
 
         String missingKey = "0";
-        Assert.assertFalse(map.containsKey(missingKey));
-        Assert.assertNull(map.get(missingKey));
+        assertFalse(map.containsKey(missingKey));
+        assertNull(map.get(missingKey));
     }
 
     @Override
@@ -1530,13 +1538,13 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         for (int i = 1; i <= this.numKeys(); i++)
         {
             String key = String.valueOf(i);
-            Assert.assertTrue(map.containsKey(key));
-            Assert.assertEquals(key, map.get(key));
+            assertTrue(map.containsKey(key));
+            assertEquals(key, map.get(key));
         }
 
         String missingKey = "0";
-        Assert.assertFalse(map.containsKey(missingKey));
-        Assert.assertNull(map.get(missingKey));
+        assertFalse(map.containsKey(missingKey));
+        assertNull(map.get(missingKey));
     }
 
     @Override
@@ -1583,7 +1591,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> bag = this.newBag();
         LazyIterable<String> lazyIterable = bag.asLazy();
         Verify.assertInstanceOf(LazyIterable.class, lazyIterable);
-        Assert.assertEquals(bag, lazyIterable.toBag());
+        assertEquals(bag, lazyIterable.toBag());
     }
 
     @Override
@@ -1593,10 +1601,10 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         super.makeString();
 
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertEquals(FastList.newList(bag).makeString(), bag.makeString());
-        Assert.assertEquals(bag.toString(), '[' + bag.makeString() + ']');
-        Assert.assertEquals(bag.toString(), '[' + bag.makeString(", ") + ']');
-        Assert.assertEquals(bag.toString(), bag.makeString("[", ", ", "]"));
+        assertEquals(FastList.newList(bag).makeString(), bag.makeString());
+        assertEquals(bag.toString(), '[' + bag.makeString() + ']');
+        assertEquals(bag.toString(), '[' + bag.makeString(", ") + ']');
+        assertEquals(bag.toString(), bag.makeString("[", ", ", "]"));
     }
 
     @Override
@@ -1609,7 +1617,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         Appendable builder = new StringBuilder();
         bag.appendString(builder);
-        Assert.assertEquals(FastList.newList(bag).makeString(), builder.toString());
+        assertEquals(FastList.newList(bag).makeString(), builder.toString());
     }
 
     @Test
@@ -1619,7 +1627,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         Appendable builder = new StringBuilder();
         bag.appendString(builder, ", ");
-        Assert.assertEquals(bag.toString(), '[' + builder.toString() + ']');
+        assertEquals(bag.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -1629,7 +1637,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         Appendable builder = new StringBuilder();
         bag.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(bag.toString(), builder.toString());
+        assertEquals(bag.toString(), builder.toString());
     }
 
     @Test
@@ -1669,7 +1677,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> bag = Bags.immutable.with("1", "2", "2", "3", "3", "3", "3", "4", "5", "5", "6");
         ImmutableSet<String> expected = Sets.immutable.with("1", "4", "6");
         ImmutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -1678,6 +1686,6 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
         ImmutableBag<String> bag = this.newBag();
         RichIterable<String> expected = bag.toSet();
         RichIterable<String> actual = bag.distinctView();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
@@ -46,10 +46,16 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableEmptyBagTest extends ImmutableBagTestCase
 {
@@ -89,8 +95,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void anySatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> true));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> false));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> true));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -98,8 +104,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void allSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> true));
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> false));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> true));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -107,8 +113,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void noneSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> true));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> false));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> true));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -116,8 +122,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void detectWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> true));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> false));
+        assertNull(bag.detectWithOccurrences((object, value) -> true));
+        assertNull(bag.detectWithOccurrences((object, value) -> false));
     }
 
     @Test
@@ -126,19 +132,19 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     {
         ImmutableBag<String> bag = this.newBag();
         ImmutableBag<String> newBag = bag.newWith("1");
-        Assert.assertNotEquals(bag, newBag);
-        Assert.assertEquals(newBag.size(), bag.size() + 1);
+        assertNotEquals(bag, newBag);
+        assertEquals(newBag.size(), bag.size() + 1);
         ImmutableBag<String> newBag2 = bag.newWith("5");
-        Assert.assertNotEquals(bag, newBag2);
-        Assert.assertEquals(newBag2.size(), bag.size() + 1);
-        Assert.assertEquals(1, newBag2.sizeDistinct());
+        assertNotEquals(bag, newBag2);
+        assertEquals(newBag2.size(), bag.size() + 1);
+        assertEquals(1, newBag2.sizeDistinct());
     }
 
     @Override
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.empty(),
                 this.newBag().selectDuplicates());
     }
@@ -170,12 +176,12 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         Bag<ObjectIntPair<String>> actual =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
         Bag<ObjectIntPair<String>> expected = Bags.immutable.empty();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<String>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
         ImmutableSet<ObjectIntPair<String>> expected2 = Sets.immutable.empty();
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Override
@@ -199,9 +205,9 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void selectInstancesOf()
     {
         ImmutableBag<Number> numbers = Bags.immutable.of();
-        Assert.assertEquals(iBag(), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iBag(), numbers.selectInstancesOf(Double.class));
-        Assert.assertEquals(iBag(), numbers.selectInstancesOf(Number.class));
+        assertEquals(iBag(), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iBag(), numbers.selectInstancesOf(Double.class));
+        assertEquals(iBag(), numbers.selectInstancesOf(Number.class));
     }
 
     @Override
@@ -209,7 +215,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[]", this.newBag().toString());
+        assertEquals("[]", this.newBag().toString());
     }
 
     @Override
@@ -223,34 +229,34 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     @Test
     public void newWithout()
     {
-        Assert.assertSame(this.newBag(), this.newBag().newWithout("1"));
+        assertSame(this.newBag(), this.newBag().newWithout("1"));
     }
 
     @Override
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", Bags.immutable.of().toStringOfItemToCount());
+        assertEquals("{}", Bags.immutable.of().toStringOfItemToCount());
     }
 
     @Override
     @Test
     public void detect()
     {
-        Assert.assertNull(this.newBag().detect("1"::equals));
+        assertNull(this.newBag().detect("1"::equals));
     }
 
     @Override
     @Test
     public void detectWith()
     {
-        Assert.assertNull(this.newBag().detectWith(Predicates2.greaterThan(), "3"));
+        assertNull(this.newBag().detectWith(Predicates2.greaterThan(), "3"));
     }
 
     @Override
     @Test
     public void detectWithIfNone()
     {
-        Assert.assertEquals("Not Found", this.newBag().detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
+        assertEquals("Not Found", this.newBag().detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
     }
 
     @Override
@@ -258,7 +264,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     {
         super.detectIfNone();
 
-        Assert.assertEquals("Not Found", this.newBag().detectIfNone("2"::equals, new PassThruFunction0<>("Not Found")));
+        assertEquals("Not Found", this.newBag().detectIfNone("2"::equals, new PassThruFunction0<>("Not Found")));
     }
 
     @Override
@@ -266,7 +272,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void allSatisfy()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.allSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(strings.allSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
@@ -274,7 +280,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void anySatisfy()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertFalse(strings.anySatisfy(ERROR_THROWING_PREDICATE));
+        assertFalse(strings.anySatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
@@ -282,7 +288,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void noneSatisfy()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.noneSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(strings.noneSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
@@ -290,7 +296,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void allSatisfyWith()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(strings.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -298,7 +304,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void anySatisfyWith()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertFalse(strings.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertFalse(strings.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -306,28 +312,28 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void noneSatisfyWith()
     {
         ImmutableBag<String> strings = this.newBag();
-        Assert.assertTrue(strings.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(strings.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNull(this.newBag().getFirst());
+        assertNull(this.newBag().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNull(this.newBag().getLast());
+        assertNull(this.newBag().getLast());
     }
 
     @Override
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.newBag().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.newBag().getOnly());
     }
 
     @Override
@@ -335,8 +341,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void isEmpty()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.isEmpty());
-        Assert.assertFalse(bag.notEmpty());
+        assertTrue(bag.isEmpty());
+        assertFalse(bag.notEmpty());
     }
 
     @Override
@@ -420,22 +426,22 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         List<Object> nullsPlusOne = Collections.nCopies(immutableBag.size() + 1, null);
 
         ImmutableBag<Pair<String, Object>> pairs = immutableBag.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 immutableBag,
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBag(nulls),
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableBag<Pair<String, Object>> pairsPlusOne = immutableBag.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 immutableBag,
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBag(nulls),
                 pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
-        Assert.assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, HashBag.newBag()));
+        assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, HashBag.newBag()));
     }
 
     @Override
@@ -445,17 +451,17 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         ImmutableBag<String> immutableBag = this.newBag();
         ImmutableSet<Pair<String, Integer>> pairs = immutableBag.zipWithIndex();
 
-        Assert.assertEquals(UnifiedSet.<String>newSet(), pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(UnifiedSet.<Integer>newSet(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
+        assertEquals(UnifiedSet.<String>newSet(), pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
+        assertEquals(UnifiedSet.<Integer>newSet(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(immutableBag.zipWithIndex(), immutableBag.zipWithIndex(UnifiedSet.newSet()));
+        assertEquals(immutableBag.zipWithIndex(), immutableBag.zipWithIndex(UnifiedSet.newSet()));
     }
 
     @Override
     @Test
     public void chunk()
     {
-        Assert.assertEquals(this.newBag(), this.newBag().chunk(2));
+        assertEquals(this.newBag(), this.newBag().chunk(2));
     }
 
     @Override
@@ -469,7 +475,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.newBag(), this.newBag().chunk(10));
+        assertEquals(this.newBag(), this.newBag().chunk(10));
         Verify.assertInstanceOf(ImmutableBag.class, this.newBag().chunk(10));
     }
 
@@ -490,7 +496,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
                 Functions.getStringPassThru(), Functions.getStringPassThru());
         Verify.assertEmpty(map);
         Verify.assertInstanceOf(TreeSortedMap.class, map);
-        Assert.assertEquals(Comparators.<String>reverseNaturalOrder(), map.comparator());
+        assertEquals(Comparators.<String>reverseNaturalOrder(), map.comparator());
     }
 
     @Override
@@ -516,9 +522,9 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void collectBoolean()
     {
         ImmutableBooleanBag result = this.newBag().collectBoolean("4"::equals);
-        Assert.assertEquals(0, result.sizeDistinct());
-        Assert.assertEquals(0, result.occurrencesOf(true));
-        Assert.assertEquals(0, result.occurrencesOf(false));
+        assertEquals(0, result.sizeDistinct());
+        assertEquals(0, result.occurrencesOf(true));
+        assertEquals(0, result.occurrencesOf(false));
     }
 
     @Override
@@ -527,10 +533,10 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(0, result.sizeDistinct());
-        Assert.assertEquals(0, result.occurrencesOf(true));
-        Assert.assertEquals(0, result.occurrencesOf(false));
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(0, result.sizeDistinct());
+        assertEquals(0, result.occurrencesOf(true));
+        assertEquals(0, result.occurrencesOf(false));
     }
 
     @Override
@@ -542,8 +548,8 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         {
             throw new AssertionError();
         }, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Override
@@ -555,15 +561,15 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         {
             throw new AssertionError();
         }, 1, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Override
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newMap().toImmutable(), this.newBag().groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newMap().toImmutable(), this.newBag().groupByUniqueKey(id -> id));
     }
 
     @Override
@@ -571,14 +577,14 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void groupByUniqueKey_throws()
     {
         super.groupByUniqueKey_throws();
-        Assert.assertEquals(UnifiedMap.newMap().toImmutable(), this.newBag().groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newMap().toImmutable(), this.newBag().groupByUniqueKey(id -> id));
     }
 
     @Override
     @Test
     public void groupByUniqueKey_target()
     {
-        Assert.assertEquals(UnifiedMap.newMap(), this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
+        assertEquals(UnifiedMap.newMap(), this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
     }
 
     @Override
@@ -586,20 +592,20 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     public void groupByUniqueKey_target_throws()
     {
         super.groupByUniqueKey_target_throws();
-        Assert.assertEquals(UnifiedMap.newMap(), this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
+        assertEquals(UnifiedMap.newMap(), this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
     }
 
     @Test
     public void countByEach()
     {
-        Assert.assertEquals(Bags.immutable.empty(), this.newBag().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
+        assertEquals(Bags.immutable.empty(), this.newBag().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
     }
 
     @Test
     public void countByEach_target()
     {
         MutableBag<String> target = Bags.mutable.empty();
-        Assert.assertEquals(target, this.newBag().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
+        assertEquals(target, this.newBag().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
     }
 
     @Override
@@ -668,6 +674,6 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
         ImmutableBag<String> bag = this.newBag();
         ImmutableSet<String> expected = Sets.immutable.empty();
         ImmutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBagTest.java
@@ -27,10 +27,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableHashBagTest extends ImmutableBagTestCase
 {
@@ -56,10 +58,10 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
     @Override
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", ImmutableHashBag.newBag().toStringOfItemToCount());
-        Assert.assertEquals("{1=3}", ImmutableHashBag.newBagWith("1", "1", "1").toStringOfItemToCount());
+        assertEquals("{}", ImmutableHashBag.newBag().toStringOfItemToCount());
+        assertEquals("{1=3}", ImmutableHashBag.newBagWith("1", "1", "1").toStringOfItemToCount());
         String actual = ImmutableHashBag.newBagWith("1", "2", "2").toStringOfItemToCount();
-        Assert.assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
+        assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
     }
 
     @Override
@@ -69,8 +71,8 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         super.selectInstancesOf();
 
         ImmutableBag<Number> numbers = ImmutableHashBag.newBagWith(1, 2.0, 2.0, 3, 3, 3, 4.0, 4.0, 4.0, 4.0);
-        Assert.assertEquals(iBag(1, 3, 3, 3), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iBag(2.0, 2.0, 4.0, 4.0, 4.0, 4.0), numbers.selectInstancesOf(Double.class));
+        assertEquals(iBag(1, 3, 3, 3), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iBag(2.0, 2.0, 4.0, 4.0, 4.0, 4.0), numbers.selectInstancesOf(Double.class));
     }
 
     @Override
@@ -78,9 +80,9 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
     public void collectBoolean()
     {
         ImmutableBooleanBag result = this.newBag().collectBoolean("4"::equals);
-        Assert.assertEquals(2, result.sizeDistinct());
-        Assert.assertEquals(4, result.occurrencesOf(true));
-        Assert.assertEquals(6, result.occurrencesOf(false));
+        assertEquals(2, result.sizeDistinct());
+        assertEquals(4, result.occurrencesOf(true));
+        assertEquals(6, result.occurrencesOf(false));
     }
 
     @Test
@@ -88,7 +90,7 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
     {
         ImmutableHashBag<Object> immutableHashBag = ImmutableHashBag.newBagWith(HashBag.newBag().with(1, 2, 3, 4));
         Verify.assertSize(4, immutableHashBag);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), immutableHashBag.toSortedList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4), immutableHashBag.toSortedList());
     }
 
     @Override
@@ -107,11 +109,11 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         });
         Multimap<Integer, Integer> actual =
                 immutableBag.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 immutableBag.groupByEach(new NegativeIntervalFunction(), HashBagMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Override
@@ -119,7 +121,7 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
     public void groupByUniqueKey()
     {
         ImmutableBag<Integer> immutableBag = ImmutableHashBag.newBagWith(1, 2, 3);
-        Assert.assertEquals(Maps.immutable.of(1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id));
+        assertEquals(Maps.immutable.of(1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id));
     }
 
     @Override
@@ -127,7 +129,7 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
     public void groupByUniqueKey_target()
     {
         ImmutableBag<Integer> immutableBag = ImmutableHashBag.newBagWith(1, 2, 3);
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), immutableBag.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
 
     @Test
@@ -147,10 +149,10 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         ImmutableBag<String> strings = ImmutableHashBag.newBagWith(mutable);
         ImmutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertIterableSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertIterableSize(0, ImmutableHashBag.newBagWith().topOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -162,7 +164,7 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         Verify.assertIterableSize(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1));
         Verify.assertIterableSize(0, this.newWith("one").newWithout("one").topOccurrences(0));
         Verify.assertIterableSize(0, this.newWith("one").topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith("one").topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith("one").topOccurrences(-1));
     }
 
     @Test
@@ -182,10 +184,10 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         ImmutableBag<String> strings = ImmutableHashBag.newBagWith(mutable);
         ImmutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertIterableSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertIterableSize(0, ImmutableHashBag.newBagWith().bottomOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").bottomOccurrences(5));
         Verify.assertIterableSize(3, this.newWith("one", "two", "three").bottomOccurrences(1));
@@ -197,7 +199,7 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         Verify.assertIterableSize(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1));
         Verify.assertIterableSize(0, this.newWith("one").newWithout("one").bottomOccurrences(0));
         Verify.assertIterableSize(0, this.newWith("one").bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith("one").bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith("one").bottomOccurrences(-1));
     }
 
     @Override
@@ -209,6 +211,6 @@ public class ImmutableHashBagTest extends ImmutableBagTestCase
         ImmutableBag<String> bag = this.newBag();
         ImmutableSet<String> expected = Sets.immutable.of("1");
         ImmutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBagTest.java
@@ -39,10 +39,18 @@ import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableSingletonBagTest extends ImmutableBagTestCase
 {
@@ -69,14 +77,14 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     @Override
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{1=1}", new ImmutableSingletonBag<>(VAL).toStringOfItemToCount());
+        assertEquals("{1=1}", new ImmutableSingletonBag<>(VAL).toStringOfItemToCount());
     }
 
     @Override
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.empty(),
                 this.newBag().selectDuplicates());
     }
@@ -89,8 +97,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
         ImmutableBag<Integer> immutable = new ImmutableSingletonBag<>(1);
         Bag<Integer> mutable = Bags.mutable.of(1);
         Verify.assertEqualsAndHashCode(immutable, mutable);
-        Assert.assertNotEquals(immutable, FastList.newList(mutable));
-        Assert.assertNotEquals(immutable, Bags.mutable.of(1, 1));
+        assertNotEquals(immutable, FastList.newList(mutable));
+        assertNotEquals(immutable, Bags.mutable.of(1, 1));
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues(1, 1), immutable.toMapOfItemToCount());
     }
 
@@ -99,11 +107,11 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void anySatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL)));
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 10));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 10));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL)));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 10));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 10));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
     }
 
     @Override
@@ -111,11 +119,11 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void allSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL)));
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 10));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 10));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL)));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 10));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 10));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
     }
 
     @Override
@@ -123,10 +131,10 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void noneSatisfyWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(VAL)));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 1));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(VAL)));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL)));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 1));
     }
 
     @Override
@@ -134,10 +142,10 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void detectWithOccurrences()
     {
         ImmutableBag<String> bag = this.newBag();
-        Assert.assertEquals(VAL, bag.detectWithOccurrences((object, value) -> object.equals(VAL)));
-        Assert.assertEquals(VAL, bag.detectWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(NOT_VAL)));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 1));
+        assertEquals(VAL, bag.detectWithOccurrences((object, value) -> object.equals(VAL)));
+        assertEquals(VAL, bag.detectWithOccurrences((object, value) -> object.equals(VAL) && value == 1));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(NOT_VAL)));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(NOT_VAL) && value == 1));
     }
 
     @Override
@@ -145,8 +153,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void allSatisfy()
     {
         super.allSatisfy();
-        Assert.assertTrue(this.newBag().allSatisfy(ignored -> true));
-        Assert.assertFalse(this.newBag().allSatisfy(ignored -> false));
+        assertTrue(this.newBag().allSatisfy(ignored -> true));
+        assertFalse(this.newBag().allSatisfy(ignored -> false));
     }
 
     @Override
@@ -154,8 +162,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void noneSatisfy()
     {
         super.noneSatisfy();
-        Assert.assertFalse(this.newBag().noneSatisfy(ignored -> true));
-        Assert.assertTrue(this.newBag().noneSatisfy(ignored -> false));
+        assertFalse(this.newBag().noneSatisfy(ignored -> true));
+        assertTrue(this.newBag().noneSatisfy(ignored -> false));
     }
 
     @Override
@@ -163,7 +171,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void injectInto()
     {
         super.injectInto();
-        Assert.assertEquals(1, new ImmutableSingletonBag<>(1).injectInto(0, AddFunction.INTEGER).intValue());
+        assertEquals(1, new ImmutableSingletonBag<>(1).injectInto(0, AddFunction.INTEGER).intValue());
     }
 
     @Override
@@ -171,7 +179,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(FastList.newListWith(VAL), this.newBag().toList());
+        assertEquals(FastList.newListWith(VAL), this.newBag().toList());
     }
 
     @Override
@@ -180,13 +188,13 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.toSortedList();
 
-        Assert.assertEquals(FastList.newListWith(VAL), this.newBag().toSortedList());
+        assertEquals(FastList.newListWith(VAL), this.newBag().toSortedList());
     }
 
     @Test
     public void toSortedListWithComparator()
     {
-        Assert.assertEquals(FastList.newListWith(VAL), this.newBag().toSortedList(null));
+        assertEquals(FastList.newListWith(VAL), this.newBag().toSortedList(null));
     }
 
     @Override
@@ -195,7 +203,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.toSet();
 
-        Assert.assertEquals(UnifiedSet.newSetWith(VAL), this.newBag().toSet());
+        assertEquals(UnifiedSet.newSetWith(VAL), this.newBag().toSet());
     }
 
     @Override
@@ -204,7 +212,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.toBag();
 
-        Assert.assertEquals(Bags.mutable.of(VAL), this.newBag().toBag());
+        assertEquals(Bags.mutable.of(VAL), this.newBag().toBag());
     }
 
     @Override
@@ -213,7 +221,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.toMap();
 
-        Assert.assertEquals(
+        assertEquals(
                 Maps.fixedSize.of(String.class, VAL),
                 this.newBag().toMap(Object::getClass, String::valueOf));
     }
@@ -221,9 +229,9 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     @Test
     public void toArrayGivenArray()
     {
-        Assert.assertArrayEquals(new String[]{VAL}, this.newBag().toArray(new String[1]));
-        Assert.assertArrayEquals(new String[]{VAL}, this.newBag().toArray(new String[0]));
-        Assert.assertArrayEquals(new String[]{VAL, null}, this.newBag().toArray(new String[2]));
+        assertArrayEquals(new String[]{VAL}, this.newBag().toArray(new String[1]));
+        assertArrayEquals(new String[]{VAL}, this.newBag().toArray(new String[0]));
+        assertArrayEquals(new String[]{VAL, null}, this.newBag().toArray(new String[2]));
     }
 
     @Test
@@ -263,7 +271,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void newWith()
     {
         super.newWith();
-        Assert.assertEquals(Bags.immutable.of(VAL, NOT_VAL), this.newBag().newWith(NOT_VAL));
+        assertEquals(Bags.immutable.of(VAL, NOT_VAL), this.newBag().newWith(NOT_VAL));
     }
 
     @Override
@@ -271,8 +279,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void newWithout()
     {
         super.newWithout();
-        Assert.assertEquals(Bags.immutable.of(VAL), this.newBag().newWithout(NOT_VAL));
-        Assert.assertEquals(Bags.immutable.of(), this.newBag().newWithout(VAL));
+        assertEquals(Bags.immutable.of(VAL), this.newBag().newWithout(NOT_VAL));
+        assertEquals(Bags.immutable.of(), this.newBag().newWithout(VAL));
     }
 
     @Override
@@ -280,7 +288,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void newWithAll()
     {
         super.newWithAll();
-        Assert.assertEquals(Bags.immutable.of(VAL, NOT_VAL, "c"), this.newBag().newWithAll(FastList.newListWith(NOT_VAL, "c")));
+        assertEquals(Bags.immutable.of(VAL, NOT_VAL, "c"), this.newBag().newWithAll(FastList.newListWith(NOT_VAL, "c")));
     }
 
     @Override
@@ -288,9 +296,9 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void newWithoutAll()
     {
         super.newWithoutAll();
-        Assert.assertEquals(Bags.immutable.of(VAL), this.newBag().newWithoutAll(FastList.newListWith(NOT_VAL)));
-        Assert.assertEquals(Bags.immutable.of(), this.newBag().newWithoutAll(FastList.newListWith(VAL, NOT_VAL)));
-        Assert.assertEquals(Bags.immutable.of(), this.newBag().newWithoutAll(FastList.newListWith(VAL)));
+        assertEquals(Bags.immutable.of(VAL), this.newBag().newWithoutAll(FastList.newListWith(NOT_VAL)));
+        assertEquals(Bags.immutable.of(), this.newBag().newWithoutAll(FastList.newListWith(VAL, NOT_VAL)));
+        assertEquals(Bags.immutable.of(), this.newBag().newWithoutAll(FastList.newListWith(VAL)));
     }
 
     @Override
@@ -305,13 +313,13 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void isEmpty()
     {
         super.isEmpty();
-        Assert.assertFalse(this.newBag().isEmpty());
+        assertFalse(this.newBag().isEmpty());
     }
 
     @Test
     public void testNotEmpty()
     {
-        Assert.assertTrue(this.newBag().notEmpty());
+        assertTrue(this.newBag().notEmpty());
     }
 
     @Override
@@ -319,7 +327,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void getFirst()
     {
         super.getFirst();
-        Assert.assertEquals(VAL, this.newBag().getFirst());
+        assertEquals(VAL, this.newBag().getFirst());
     }
 
     @Override
@@ -327,7 +335,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void getLast()
     {
         super.getLast();
-        Assert.assertEquals(VAL, this.newBag().getLast());
+        assertEquals(VAL, this.newBag().getLast());
     }
 
     @Override
@@ -335,7 +343,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void getOnly()
     {
         super.getOnly();
-        Assert.assertEquals(VAL, this.newBag().getOnly());
+        assertEquals(VAL, this.newBag().getOnly());
     }
 
     @Override
@@ -343,8 +351,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void contains()
     {
         super.contains();
-        Assert.assertTrue(this.newBag().contains(VAL));
-        Assert.assertFalse(this.newBag().contains(NOT_VAL));
+        assertTrue(this.newBag().contains(VAL));
+        assertFalse(this.newBag().contains(NOT_VAL));
     }
 
     @Override
@@ -352,21 +360,21 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void containsAllIterable()
     {
         super.containsAllIterable();
-        Assert.assertTrue(this.newBag().containsAllIterable(FastList.newListWith()));
-        Assert.assertTrue(this.newBag().containsAllIterable(FastList.newListWith(VAL)));
-        Assert.assertFalse(this.newBag().containsAllIterable(FastList.newListWith(NOT_VAL)));
-        Assert.assertFalse(this.newBag().containsAllIterable(FastList.newListWith(42)));
-        Assert.assertFalse(this.newBag().containsAllIterable(FastList.newListWith(VAL, NOT_VAL)));
+        assertTrue(this.newBag().containsAllIterable(FastList.newListWith()));
+        assertTrue(this.newBag().containsAllIterable(FastList.newListWith(VAL)));
+        assertFalse(this.newBag().containsAllIterable(FastList.newListWith(NOT_VAL)));
+        assertFalse(this.newBag().containsAllIterable(FastList.newListWith(42)));
+        assertFalse(this.newBag().containsAllIterable(FastList.newListWith(VAL, NOT_VAL)));
     }
 
     @Test
     public void testContainsAllArguments()
     {
-        Assert.assertTrue(this.newBag().containsAllArguments());
-        Assert.assertTrue(this.newBag().containsAllArguments(VAL));
-        Assert.assertFalse(this.newBag().containsAllArguments(NOT_VAL));
-        Assert.assertFalse(this.newBag().containsAllArguments(42));
-        Assert.assertFalse(this.newBag().containsAllArguments(VAL, NOT_VAL));
+        assertTrue(this.newBag().containsAllArguments());
+        assertTrue(this.newBag().containsAllArguments(VAL));
+        assertFalse(this.newBag().containsAllArguments(NOT_VAL));
+        assertFalse(this.newBag().containsAllArguments(42));
+        assertFalse(this.newBag().containsAllArguments(VAL, NOT_VAL));
     }
 
     @Override
@@ -398,7 +406,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void collect()
     {
         super.collect();
-        Assert.assertEquals(Bags.immutable.of(VAL), this.newBag().collect(String::valueOf));
+        assertEquals(Bags.immutable.of(VAL), this.newBag().collect(String::valueOf));
     }
 
     @Override
@@ -416,8 +424,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void collectIf()
     {
         super.collectIf();
-        Assert.assertEquals(Bags.immutable.of(String.class), this.newBag().collectIf(ignored -> true, Object::getClass));
-        Assert.assertEquals(Bags.immutable.of(), this.newBag().collectIf(ignored -> false, Object::getClass));
+        assertEquals(Bags.immutable.of(String.class), this.newBag().collectIf(ignored -> true, Object::getClass));
+        assertEquals(Bags.immutable.of(), this.newBag().collectIf(ignored -> false, Object::getClass));
     }
 
     @Override
@@ -438,7 +446,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.flatCollect();
         ImmutableBag<Integer> result = this.newBag().flatCollect(object -> Bags.mutable.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(Bags.immutable.of(1, 2, 3, 4, 5), result);
+        assertEquals(Bags.immutable.of(1, 2, 3, 4, 5), result);
     }
 
     @Override
@@ -448,7 +456,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
         super.flatCollectWithTarget();
         MutableBag<Integer> target = Bags.mutable.of();
         MutableBag<Integer> result = this.newBag().flatCollect(object -> Bags.mutable.of(1, 2, 3, 4, 5), target);
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3, 4, 5), result);
+        assertEquals(Bags.mutable.of(1, 2, 3, 4, 5), result);
     }
 
     @Override
@@ -456,17 +464,17 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void detect()
     {
         super.detect();
-        Assert.assertEquals(VAL, this.newBag().detect(ignored -> true));
-        Assert.assertNull(this.newBag().detect(ignored -> false));
+        assertEquals(VAL, this.newBag().detect(ignored -> true));
+        assertNull(this.newBag().detect(ignored -> false));
     }
 
     @Override
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals("1", this.newBag().detectOptional("1"::equals).get());
-        Assert.assertNotNull(this.newBag().detectOptional("2"::equals));
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newBag().detectOptional("2"::equals).get());
+        assertEquals("1", this.newBag().detectOptional("1"::equals).get());
+        assertNotNull(this.newBag().detectOptional("2"::equals));
+        assertThrows(NoSuchElementException.class, () -> this.newBag().detectOptional("2"::equals).get());
     }
 
     @Override
@@ -475,16 +483,16 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.detectWith();
 
-        Assert.assertEquals(VAL, this.newBag().detectWith(Object::equals, "1"));
+        assertEquals(VAL, this.newBag().detectWith(Object::equals, "1"));
     }
 
     @Override
     @Test
     public void detectWithOptional()
     {
-        Assert.assertEquals("1", this.newBag().detectWithOptional(Object::equals, "1").get());
-        Assert.assertNotNull(this.newBag().detectWithOptional(Object::equals, "2"));
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newBag().detectWithOptional(Object::equals, "2").get());
+        assertEquals("1", this.newBag().detectWithOptional(Object::equals, "1").get());
+        assertNotNull(this.newBag().detectWithOptional(Object::equals, "2"));
+        assertThrows(NoSuchElementException.class, () -> this.newBag().detectWithOptional(Object::equals, "2").get());
     }
 
     @Override
@@ -493,8 +501,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.detectWithIfNone();
 
-        Assert.assertEquals(VAL, this.newBag().detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
-        Assert.assertEquals("Not Found", this.newBag().detectWithIfNone(Object::equals, "10000", new PassThruFunction0<>("Not Found")));
+        assertEquals(VAL, this.newBag().detectWithIfNone(Object::equals, "1", new PassThruFunction0<>("Not Found")));
+        assertEquals("Not Found", this.newBag().detectWithIfNone(Object::equals, "10000", new PassThruFunction0<>("Not Found")));
     }
 
     @Override
@@ -503,8 +511,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.detectIfNone();
 
-        Assert.assertEquals(VAL, this.newBag().detectIfNone(ignored -> true, new PassThruFunction0<>(NOT_VAL)));
-        Assert.assertEquals(NOT_VAL, this.newBag().detectIfNone(ignored -> false, new PassThruFunction0<>(NOT_VAL)));
+        assertEquals(VAL, this.newBag().detectIfNone(ignored -> true, new PassThruFunction0<>(NOT_VAL)));
+        assertEquals(NOT_VAL, this.newBag().detectIfNone(ignored -> false, new PassThruFunction0<>(NOT_VAL)));
     }
 
     @Override
@@ -512,8 +520,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void count()
     {
         super.count();
-        Assert.assertEquals(1, this.newBag().count(ignored -> true));
-        Assert.assertEquals(0, this.newBag().count(ignored -> false));
+        assertEquals(1, this.newBag().count(ignored -> true));
+        assertEquals(0, this.newBag().count(ignored -> false));
     }
 
     @Override
@@ -521,15 +529,15 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void anySatisfy()
     {
         super.anySatisfy();
-        Assert.assertTrue(this.newBag().anySatisfy(ignored -> true));
-        Assert.assertFalse(this.newBag().anySatisfy(ignored -> false));
+        assertTrue(this.newBag().anySatisfy(ignored -> true));
+        assertFalse(this.newBag().anySatisfy(ignored -> false));
     }
 
     @Test
     public void testGroupBy()
     {
         ImmutableBagMultimap<Class<?>, String> result = this.newBag().groupBy(Object::getClass);
-        Assert.assertEquals(VAL, result.get(String.class).getFirst());
+        assertEquals(VAL, result.get(String.class).getFirst());
     }
 
     @Test
@@ -537,14 +545,14 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         HashBagMultimap<Class<?>, String> target = HashBagMultimap.newMultimap();
         this.newBag().groupBy(Object::getClass, target);
-        Assert.assertEquals(VAL, target.get(String.class).getFirst());
+        assertEquals(VAL, target.get(String.class).getFirst());
     }
 
     @Override
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1").toImmutable(), this.newBag().groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1").toImmutable(), this.newBag().groupByUniqueKey(id -> id));
     }
 
     @Override
@@ -553,14 +561,14 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.groupByUniqueKey_throws();
 
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1").toImmutable(), this.newBag().groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1").toImmutable(), this.newBag().groupByUniqueKey(id -> id));
     }
 
     @Override
     @Test
     public void groupByUniqueKey_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues("0", "0", "1", "1"),
                 this.newBag().groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues("0", "0")));
     }
@@ -568,8 +576,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     @Test
     public void testOccurrencesOf()
     {
-        Assert.assertEquals(1, this.newBag().occurrencesOf(VAL));
-        Assert.assertEquals(0, this.newBag().occurrencesOf(NOT_VAL));
+        assertEquals(1, this.newBag().occurrencesOf(VAL));
+        assertEquals(0, this.newBag().occurrencesOf(NOT_VAL));
     }
 
     @Test
@@ -581,8 +589,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
             results[0] = each;
             results[1] = index;
         });
-        Assert.assertEquals(VAL, results[0]);
-        Assert.assertEquals(1, results[1]);
+        assertEquals(VAL, results[0]);
+        assertEquals(1, results[1]);
     }
 
     @Override
@@ -591,7 +599,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.toMapOfItemToCount();
 
-        Assert.assertEquals(Maps.fixedSize.of(VAL, 1), this.newBag().toMapOfItemToCount());
+        assertEquals(Maps.fixedSize.of(VAL, 1), this.newBag().toMapOfItemToCount());
     }
 
     @Override
@@ -601,7 +609,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
         super.toImmutable();
 
         ImmutableBag<String> immutableBag = this.newBag();
-        Assert.assertSame(immutableBag, immutableBag.toImmutable());
+        assertSame(immutableBag, immutableBag.toImmutable());
     }
 
     @Override
@@ -611,7 +619,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
         super.forEach();
         Object[] results = new Object[1];
         this.newBag().forEach(Procedures.cast(each -> results[0] = each));
-        Assert.assertEquals(VAL, results[0]);
+        assertEquals(VAL, results[0]);
     }
 
     @Override
@@ -625,8 +633,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
             results[0] = each;
             results[1] = index;
         });
-        Assert.assertEquals(VAL, results[0]);
-        Assert.assertEquals(0, results[1]);
+        assertEquals(VAL, results[0]);
+        assertEquals(0, results[1]);
     }
 
     /**
@@ -641,13 +649,13 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
         Bag<ObjectIntPair<String>> expected =
                 Bags.immutable.with(PrimitiveTuples.pair(VAL, 1));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<String>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
         ImmutableSet<ObjectIntPair<String>> expected2 =
                 Sets.immutable.with(PrimitiveTuples.pair(VAL, 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Override
@@ -661,8 +669,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
             results[0] = each;
             results[1] = index;
         }, "second");
-        Assert.assertEquals(VAL, results[0]);
-        Assert.assertEquals("second", results[1]);
+        assertEquals(VAL, results[0]);
+        assertEquals("second", results[1]);
     }
 
     @Override
@@ -671,15 +679,15 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         super.iterator();
         Iterator<String> iterator = this.newBag().iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(VAL, iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(VAL, iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void testSizeDistinct()
     {
-        Assert.assertEquals(1, this.newBag().sizeDistinct());
+        assertEquals(1, this.newBag().sizeDistinct());
     }
 
     @Override
@@ -687,8 +695,8 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void selectInstancesOf()
     {
         ImmutableBag<Number> numbers = new ImmutableSingletonBag<>(1);
-        Assert.assertEquals(iBag(1), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iBag(), numbers.selectInstancesOf(Double.class));
+        assertEquals(iBag(1), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iBag(), numbers.selectInstancesOf(Double.class));
     }
 
     @Override
@@ -696,9 +704,9 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     public void collectBoolean()
     {
         ImmutableBooleanBag result = this.newBag().collectBoolean("4"::equals);
-        Assert.assertEquals(1, result.sizeDistinct());
-        Assert.assertEquals(0, result.occurrencesOf(true));
-        Assert.assertEquals(1, result.occurrencesOf(false));
+        assertEquals(1, result.sizeDistinct());
+        assertEquals(0, result.occurrencesOf(true));
+        assertEquals(1, result.occurrencesOf(false));
     }
 
     @Override
@@ -707,10 +715,10 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(1, result.sizeDistinct());
-        Assert.assertEquals(0, result.occurrencesOf(true));
-        Assert.assertEquals(1, result.occurrencesOf(false));
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(1, result.sizeDistinct());
+        assertEquals(0, result.occurrencesOf(true));
+        assertEquals(1, result.occurrencesOf(false));
     }
 
     @Override
@@ -745,6 +753,6 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
         ImmutableBag<String> bag = this.newBag();
         ImmutableSet<String> expected = Sets.immutable.of(VAL);
         ImmutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/AbstractImmutableBooleanBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/AbstractImmutableBooleanBagTestCase.java
@@ -25,8 +25,13 @@ import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanBag}.
@@ -57,10 +62,10 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     @Test
     public void sizeDistinct()
     {
-        Assert.assertEquals(0L, this.newWith().sizeDistinct());
-        Assert.assertEquals(1L, this.newWith(true).sizeDistinct());
-        Assert.assertEquals(1L, this.newWith(true, true, true).sizeDistinct());
-        Assert.assertEquals(2L, this.newWith(true, false, true, false, true).sizeDistinct());
+        assertEquals(0L, this.newWith().sizeDistinct());
+        assertEquals(1L, this.newWith(true).sizeDistinct());
+        assertEquals(1L, this.newWith(true, true, true).sizeDistinct());
+        assertEquals(2L, this.newWith(true, false, true, false, true).sizeDistinct());
     }
 
     @Test
@@ -69,7 +74,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((argument1, argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertTrue("true2false1".equals(string)
+        assertTrue("true2false1".equals(string)
                 || "false1true2".equals(string));
     }
 
@@ -89,11 +94,11 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
         for (int i = 0; i < this.classUnderTest().size(); i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             bag.add(iterator.next());
         }
-        Assert.assertEquals(bag, this.classUnderTest());
-        Assert.assertFalse(iterator.hasNext());
+        assertEquals(bag, this.classUnderTest());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -103,11 +108,11 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         super.anySatisfy();
         long[] count = {0};
         ImmutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertTrue(bag.anySatisfy(value -> {
+        assertTrue(bag.anySatisfy(value -> {
             count[0]++;
             return value;
         }));
-        Assert.assertEquals(2L, count[0]);
+        assertEquals(2L, count[0]);
     }
 
     @Override
@@ -117,11 +122,11 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         super.allSatisfy();
         int[] count = {0};
         ImmutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertFalse(bag.allSatisfy(value -> {
+        assertFalse(bag.allSatisfy(value -> {
             count[0]++;
             return !value;
         }));
-        Assert.assertEquals(2L, count[0]);
+        assertEquals(2L, count[0]);
     }
 
     @Override
@@ -130,7 +135,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     {
         super.noneSatisfy();
         ImmutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertFalse(bag.noneSatisfy(value -> value));
+        assertFalse(bag.noneSatisfy(value -> value));
     }
 
     @Override
@@ -140,11 +145,11 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         super.collect();
         ImmutableBooleanBag bag = this.newWith(true, false, false, true, true, true);
         BooleanToObjectFunction<String> stringValueOf = parameter -> parameter ? "true" : "false";
-        Assert.assertEquals(HashBag.newBagWith("true", "false", "false", "true", "true", "true"), bag.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("true", "false", "false", "true", "true", "true"), bag.collect(stringValueOf));
         ImmutableBooleanBag bag1 = this.newWith(false, false);
-        Assert.assertEquals(HashBag.newBagWith("false", "false"), bag1.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("false", "false"), bag1.collect(stringValueOf));
         ImmutableBooleanBag bag2 = this.newWith(true, true);
-        Assert.assertEquals(HashBag.newBagWith("true", "true"), bag2.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("true", "true"), bag2.collect(stringValueOf));
     }
 
     @Override
@@ -156,12 +161,12 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         ImmutableBooleanCollection collection2 = this.newWith(true, false, false, true);
         ImmutableBooleanCollection collection3 = this.newWith(true, false);
         ImmutableBooleanCollection collection4 = this.newWith(true, true, false);
-        Assert.assertEquals(collection1, collection2);
+        assertEquals(collection1, collection2);
         Verify.assertPostSerializedIdentity(this.newWith());
-        Assert.assertNotEquals(collection3, collection4);
-        Assert.assertNotEquals(collection3, BooleanArrayList.newListWith(true, false));
-        Assert.assertNotEquals(this.newWith(true), BooleanArrayList.newListWith(true));
-        Assert.assertNotEquals(this.newWith(), BooleanArrayList.newListWith());
+        assertNotEquals(collection3, collection4);
+        assertNotEquals(collection3, BooleanArrayList.newListWith(true, false));
+        assertNotEquals(this.newWith(true), BooleanArrayList.newListWith(true));
+        assertNotEquals(this.newWith(), BooleanArrayList.newListWith());
     }
 
     @Override
@@ -174,7 +179,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         ImmutableBooleanCollection collection3 = this.newWith(true, false);
         ImmutableBooleanCollection collection4 = this.newWith(true, true, false);
         Verify.assertEqualsAndHashCode(collection1, collection2);
-        Assert.assertNotEquals(collection3.hashCode(), collection4.hashCode());
+        assertNotEquals(collection3.hashCode(), collection4.hashCode());
     }
 
     @Override
@@ -182,7 +187,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[true, true, true]", BooleanHashBag.newBagWith(true, true, true).toString());
+        assertEquals("[true, true, true]", BooleanHashBag.newBagWith(true, true, true).toString());
     }
 
     @Override
@@ -190,7 +195,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("true, true, true", BooleanHashBag.newBagWith(true, true, true).makeString());
+        assertEquals("true, true, true", BooleanHashBag.newBagWith(true, true, true).makeString());
     }
 
     @Override
@@ -200,12 +205,12 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true, true, true).appendString(appendable1);
-        Assert.assertEquals("true, true, true", appendable1.toString());
+        assertEquals("true, true, true", appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         ImmutableBooleanBag bag1 = this.newWith(false, false, true);
         bag1.appendString(appendable2);
-        Assert.assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
+        assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
                 || "true, false, false".equals(appendable2.toString())
                 || "false, true, false".equals(appendable2.toString()));
     }
@@ -216,7 +221,7 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     {
         super.toList();
         MutableBooleanList list = this.newWith(false, false, true).toList();
-        Assert.assertTrue(list.equals(BooleanArrayList.newListWith(false, false, true))
+        assertTrue(list.equals(BooleanArrayList.newListWith(false, false, true))
                 || list.equals(BooleanArrayList.newListWith(true, false, false))
                 || list.equals(BooleanArrayList.newListWith(false, true, false)));
     }
@@ -224,9 +229,9 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         ImmutableBooleanBag expected = this.classUnderTest();
-        Assert.assertSame(expected, expected.toImmutable());
+        assertSame(expected, expected.toImmutable());
     }
 
     @Test
@@ -235,11 +240,11 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         ImmutableBooleanBag bag = BooleanBags.immutable.with(false, false, true);
         ImmutableBooleanSet expected = BooleanSets.immutable.with(true);
         ImmutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         ImmutableBooleanBag bag2 = BooleanBags.immutable.with(false, false, true, true);
         ImmutableBooleanSet expected2 = BooleanSets.immutable.empty();
         ImmutableBooleanSet actual2 = bag2.selectUnique();
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanEmptyBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanEmptyBagTest.java
@@ -15,8 +15,10 @@ import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptyBag}.
@@ -33,7 +35,7 @@ public class ImmutableBooleanEmptyBagTest extends AbstractImmutableBooleanBagTes
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -57,14 +59,14 @@ public class ImmutableBooleanEmptyBagTest extends AbstractImmutableBooleanBagTes
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((argument1, argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertEquals("", string);
+        assertEquals("", string);
     }
 
     @Test
     public void occurrencesOf()
     {
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(true));
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(false));
+        assertEquals(0, this.classUnderTest().occurrencesOf(true));
+        assertEquals(0, this.classUnderTest().occurrencesOf(false));
     }
 
     @Override
@@ -76,6 +78,6 @@ public class ImmutableBooleanEmptyBagTest extends AbstractImmutableBooleanBagTes
         ImmutableBooleanBag bag = this.classUnderTest();
         ImmutableBooleanSet expected = BooleanSets.immutable.empty();
         ImmutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanHashBagTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.bag.immutable.primitive;
 import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableBooleanHashBagTest extends AbstractImmutableBooleanBagTestCase
 {
@@ -33,6 +34,6 @@ public class ImmutableBooleanHashBagTest extends AbstractImmutableBooleanBagTest
         ImmutableBooleanBag bag = this.classUnderTest();
         ImmutableBooleanSet expected = BooleanSets.immutable.with(false);
         ImmutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanSingletonBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanSingletonBagTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link ImmutableBooleanSingletonBag}.
@@ -36,7 +37,7 @@ public class ImmutableBooleanSingletonBagTest extends AbstractImmutableBooleanBa
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((argument1, argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertEquals("true1", string);
+        assertEquals("true1", string);
     }
 
     @Override
@@ -55,6 +56,6 @@ public class ImmutableBooleanSingletonBagTest extends AbstractImmutableBooleanBa
         ImmutableBooleanBag bag = this.classUnderTest();
         ImmutableBooleanSet expected = BooleanSets.immutable.with(true);
         ImmutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/HashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/HashBagTest.java
@@ -17,8 +17,11 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class HashBagTest extends MutableBagTestCase
 {
@@ -50,7 +53,7 @@ public class HashBagTest extends MutableBagTestCase
         assertBagsEqual(HashBag.newBagWith("apple", "apple", "hope", "hope", "hope"), bag);
 
         bag.withAll(Collections.nCopies(5, "ubermench"));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(
                         "apple", 2,
                         "hope", 3,
@@ -64,12 +67,12 @@ public class HashBagTest extends MutableBagTestCase
     {
         super.addAll();
         MutableBag<Integer> bag1 = this.newWith();
-        Assert.assertTrue(bag1.addAll(this.newWith(1, 1, 2, 3)));
+        assertTrue(bag1.addAll(this.newWith(1, 1, 2, 3)));
         Verify.assertContainsAll(bag1, 1, 2, 3);
 
-        Assert.assertTrue(bag1.addAll(this.newWith(1, 2, 3)));
+        assertTrue(bag1.addAll(this.newWith(1, 2, 3)));
         Verify.assertSize(7, bag1);
-        Assert.assertFalse(bag1.addAll(this.newWith()));
+        assertFalse(bag1.addAll(this.newWith()));
         Verify.assertContainsAll(bag1, 1, 2, 3);
 
         MutableBag<Integer> bag2 = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
@@ -94,7 +97,7 @@ public class HashBagTest extends MutableBagTestCase
     @Test
     public void newBagFromBag()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 HashBag.newBag(HashBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4)));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsReadUntouchableTest.java
@@ -15,8 +15,10 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class MultiReaderHashBagAsReadUntouchableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {
@@ -47,26 +49,26 @@ public class MultiReaderHashBagAsReadUntouchableTest extends UnmodifiableMutable
     @Test
     public void occurrencesOf()
     {
-        Assert.assertEquals(2, this.getCollection().occurrencesOf(1));
-        Assert.assertEquals(0, this.getCollection().occurrencesOf(0));
+        assertEquals(2, this.getCollection().occurrencesOf(1));
+        assertEquals(0, this.getCollection().occurrencesOf(0));
     }
 
     @Test
     public void sizeDistinct()
     {
-        Assert.assertEquals(1, this.getCollection().sizeDistinct());
+        assertEquals(1, this.getCollection().sizeDistinct());
     }
 
     @Test
     public void toMapOfItemToCount()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), this.getCollection().toMapOfItemToCount());
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), this.getCollection().toMapOfItemToCount());
     }
 
     @Test
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{1=2}", this.getCollection().toStringOfItemToCount());
+        assertEquals("{1=2}", this.getCollection().toStringOfItemToCount());
     }
 
     @Test
@@ -80,7 +82,7 @@ public class MultiReaderHashBagAsReadUntouchableTest extends UnmodifiableMutable
             }
         });
 
-        Assert.assertEquals(2, sum[0]);
+        assertEquals(2, sum[0]);
     }
 
     @Test
@@ -89,12 +91,12 @@ public class MultiReaderHashBagAsReadUntouchableTest extends UnmodifiableMutable
         MutableBag<String> bag = MultiReaderHashBag.newBagWith("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5").asReadUntouchable();
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void distinctView()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().distinctView());
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().distinctView());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class MultiReaderHashBagAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {
@@ -32,6 +33,6 @@ public class MultiReaderHashBagAsUnmodifiableTest extends UnmodifiableMutableCol
         MutableBag<String> bag = MultiReaderHashBag.newBagWith("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5").asUnmodifiable();
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollectionTestCase
 {
@@ -28,23 +30,23 @@ public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollection
     @Override
     public void asSynchronized()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
     }
 
     @Override
     public void asUnmodifiable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
     }
 
     @Test
     public void addOccurrences()
     {
         MutableBag<Integer> bag = this.newWith(1, 1);
-        Assert.assertEquals(4, bag.addOccurrences(1, 2));
+        assertEquals(4, bag.addOccurrences(1, 2));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1), bag);
-        Assert.assertEquals(0, bag.addOccurrences(2, 0));
-        Assert.assertEquals(2, bag.addOccurrences(2, 2));
+        assertEquals(0, bag.addOccurrences(2, 0));
+        assertEquals(2, bag.addOccurrences(2, 2));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2), bag);
     }
 
@@ -52,7 +54,7 @@ public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollection
     @Test
     public void makeString()
     {
-        Assert.assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
+        assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
     }
 
     @Override
@@ -61,14 +63,14 @@ public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollection
     {
         Appendable builder = new StringBuilder();
         MultiReaderHashBag.newBagWith(1, 1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 1, 2, 3", builder.toString());
+        assertEquals("1, 1, 2, 3", builder.toString());
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
+        assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
     }
 
     @Test
@@ -77,12 +79,12 @@ public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollection
         MutableBag<String> bag = this.newWith("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5");
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void distinctView()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().distinctView());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().distinctView());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
@@ -40,8 +40,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link MultiReaderHashBag}.
@@ -72,7 +79,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     @Test
     public void hashBagNewWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith("Alice", "Bob", "Bob", "Bob", "Cooper", "Dio"),
                 HashBag.newBagWith("Alice", "Bob", "Cooper", "Dio", "Bob", "Bob"));
     }
@@ -102,13 +109,13 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void addOccurrences()
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2, 3);
-        Assert.assertEquals(2, bag.addOccurrences(1, 0));
-        Assert.assertEquals(4, bag.addOccurrences(1, 2));
-        Assert.assertEquals(0, bag.addOccurrences(4, 0));
-        Assert.assertEquals(2, bag.addOccurrences(4, 2));
-        Assert.assertEquals(2, bag.addOccurrences(2, 1));
+        assertEquals(2, bag.addOccurrences(1, 0));
+        assertEquals(4, bag.addOccurrences(1, 2));
+        assertEquals(0, bag.addOccurrences(4, 0));
+        assertEquals(2, bag.addOccurrences(4, 2));
+        assertEquals(2, bag.addOccurrences(2, 1));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3, 4, 4), bag);
-        Assert.assertEquals(3, bag.addOccurrences(2, 1));
+        assertEquals(3, bag.addOccurrences(2, 1));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 4, 4), bag);
     }
 
@@ -118,13 +125,13 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2, 3);
         MultiReaderBag<Integer> withOccurrences = bag.withOccurrences(1, 0);
 
-        Assert.assertSame(bag, withOccurrences);
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 2, 3), withOccurrences);
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3), bag.withOccurrences(1, 2));
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3), bag.withOccurrences(4, 0));
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3, 4, 4), bag.withOccurrences(4, 2));
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3, 4, 4), bag.withOccurrences(2, 1));
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 4, 4), bag.withOccurrences(2, 1));
+        assertSame(bag, withOccurrences);
+        assertEquals(HashBag.newBagWith(1, 1, 2, 3), withOccurrences);
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3), bag.withOccurrences(1, 2));
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3), bag.withOccurrences(4, 0));
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 3, 4, 4), bag.withOccurrences(4, 2));
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3, 4, 4), bag.withOccurrences(2, 1));
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 4, 4), bag.withOccurrences(2, 1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -137,7 +144,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void removeOccurrences()
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 1, 1, 2, 2, 3);
-        Assert.assertFalse(bag.removeOccurrences(4, 2));
+        assertFalse(bag.removeOccurrences(4, 2));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3), bag);
 
         bag.removeOccurrences(1, 3);
@@ -151,11 +158,11 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 1, 1, 2, 2, 3);
         MultiReaderBag<Integer> withoutOccurrences = bag.withoutOccurrences(4, 2);
 
-        Assert.assertSame(bag, withoutOccurrences);
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3), withoutOccurrences);
+        assertSame(bag, withoutOccurrences);
+        assertEquals(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 3), withoutOccurrences);
 
         bag.withoutOccurrences(1, 3);
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 2), bag.withoutOccurrences(3, 1));
+        assertEquals(HashBag.newBagWith(1, 2, 2), bag.withoutOccurrences(3, 1));
     }
 
     @Test
@@ -163,10 +170,10 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2);
 
-        Assert.assertFalse(bag.setOccurrences(1, 2));
-        Assert.assertTrue(bag.setOccurrences(3, 3));
+        assertFalse(bag.setOccurrences(1, 2));
+        assertTrue(bag.setOccurrences(3, 3));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 2, 3, 3, 3), bag);
-        Assert.assertTrue(bag.setOccurrences(2, 0));
+        assertTrue(bag.setOccurrences(2, 0));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith(1, 1, 3, 3, 3), bag);
     }
 
@@ -174,15 +181,15 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void occurrencesOf()
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2);
-        Assert.assertEquals(2, bag.occurrencesOf(1));
-        Assert.assertEquals(1, bag.occurrencesOf(2));
+        assertEquals(2, bag.occurrencesOf(1));
+        assertEquals(1, bag.occurrencesOf(2));
     }
 
     @Test
     public void sizeDistinct()
     {
         MultiReaderHashBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 2, 2, 3);
-        Assert.assertEquals(3, bag.sizeDistinct());
+        assertEquals(3, bag.sizeDistinct());
     }
 
     @Override
@@ -191,7 +198,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         MutableBag<Boolean> bag = MultiReaderHashBag.newBagWith(Boolean.TRUE, Boolean.FALSE, null);
         MutableBag<String> newCollection = bag.collect(String::valueOf);
-        Assert.assertEquals(HashBag.newBagWith("true", "false", "null"), newCollection);
+        assertEquals(HashBag.newBagWith("true", "false", "null"), newCollection);
     }
 
     @Override
@@ -210,12 +217,12 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith("1", "1", "2", "3"),
                 MultiReaderHashBag.newBagWith(1, 1, 2, 3).collectIf(
                         Integer.class::isInstance,
                         String::valueOf));
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith("1", "1"),
                 MultiReaderHashBag.newBagWith(1, 1, 2, 3).collectIf(
                         Predicates.lessThan(2),
@@ -310,8 +317,8 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         MutableBag<Integer> integers = MultiReaderHashBag.newBagWith(-3, -2, -1, 0, 1, 2, 2, 2, 3, 3, 4, 5);
         PartitionMutableCollection<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(-2, 0, 2, 2, 2, 4), result.getSelected());
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(-3, -1, 1, 3, 3, 5), result.getRejected());
+        assertEquals(MultiReaderHashBag.newBagWith(-2, 0, 2, 2, 2, 4), result.getSelected());
+        assertEquals(MultiReaderHashBag.newBagWith(-3, -1, 1, 3, 3, 5), result.getRejected());
     }
 
     @Override
@@ -320,8 +327,8 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         MutableBag<Integer> integers = MultiReaderHashBag.newBagWith(-3, -2, -1, 0, 1, 2, 2, 2, 3, 3, 4, 5);
         PartitionMutableCollection<Integer> result = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(-2, 0, 2, 2, 2, 4), result.getSelected());
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(-3, -1, 1, 3, 3, 5), result.getRejected());
+        assertEquals(MultiReaderHashBag.newBagWith(-2, 0, 2, 2, 2, 4), result.getSelected());
+        assertEquals(MultiReaderHashBag.newBagWith(-3, -1, 1, 3, 3, 5), result.getRejected());
     }
 
     @Override
@@ -364,16 +371,16 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void toMapOfItemToCount()
     {
         MutableBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 2, 2, 3, 3, 3);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
     }
 
     @Test
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", MultiReaderHashBag.newBagWith().toStringOfItemToCount());
-        Assert.assertEquals("{1=3}", MultiReaderHashBag.newBagWith(1, 1, 1).toStringOfItemToCount());
+        assertEquals("{}", MultiReaderHashBag.newBagWith().toStringOfItemToCount());
+        assertEquals("{1=3}", MultiReaderHashBag.newBagWith(1, 1, 1).toStringOfItemToCount());
         String actual = MultiReaderHashBag.newBagWith(1, 2, 2).toStringOfItemToCount();
-        Assert.assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
+        assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
     }
 
     @Test
@@ -389,7 +396,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
             }
         });
 
-        Assert.assertEquals(13, sum[0]);
+        assertEquals(13, sum[0]);
     }
 
     @Test
@@ -406,13 +413,13 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         Verify.assertPostSerializedEqualsAndHashCode(integers);
         Verify.assertEqualsAndHashCode(integers, integers2);
         Verify.assertEqualsAndHashCode(integers, randomAccessList);
-        Assert.assertNotEquals(integers, integers3);
-        Assert.assertNotEquals(integers, integers5);
-        Assert.assertNotEquals(integers, randomAccessList2);
-        Assert.assertNotEquals(integers, Sets.fixedSize.of());
+        assertNotEquals(integers, integers3);
+        assertNotEquals(integers, integers5);
+        assertNotEquals(integers, randomAccessList2);
+        assertNotEquals(integers, Sets.fixedSize.of());
         Verify.assertEqualsAndHashCode(integers3, integers4);
-        Assert.assertEquals(integers, integers2);
-        Assert.assertNotEquals(integers, integers3);
+        assertEquals(integers, integers2);
+        assertNotEquals(integers, integers3);
     }
 
     @Override
@@ -421,7 +428,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         super.toSet();
         MutableBag<Integer> bag = MultiReaderHashBag.newBagWith(3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
     }
 
     @Override
@@ -430,7 +437,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         super.toList();
         MutableBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 1);
-        Assert.assertEquals(FastList.newListWith(1, 1, 1), bag.toList());
+        assertEquals(FastList.newListWith(1, 1, 1), bag.toList());
     }
 
     @Override
@@ -438,7 +445,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void injectInto()
     {
         MutableBag<Integer> bag = MultiReaderHashBag.newBagWith(1, 1, 3);
-        Assert.assertEquals(Integer.valueOf(6), bag.injectInto(1, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(6), bag.injectInto(1, AddFunction.INTEGER));
     }
 
     @Override
@@ -448,7 +455,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MutableBag<Integer> result = HashBag.newBag();
         MutableBag<Integer> collection = MultiReaderHashBag.newBagWith(1, 2, 3, 4, 4);
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 4), result);
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 4), result);
     }
 
     @Override
@@ -465,13 +472,13 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MutableBag<Integer> collection = MultiReaderHashBag.newBagWith(1, 1, 3, 4, 5);
         MutableBag<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     private void verifyDelegateIsUnmodifiable(MutableBag<Integer> delegate)
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
     }
 
     @Test
@@ -484,14 +491,14 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
             result[0] = delegate.getFirst();
             this.verifyDelegateIsUnmodifiable(delegate);
         });
-        Assert.assertNotNull(result[0]);
+        assertNotNull(result[0]);
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
+        assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
     }
 
     @Override
@@ -500,14 +507,14 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         Appendable builder = new StringBuilder();
         MultiReaderHashBag.newBagWith(1, 1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 1, 2, 3", builder.toString());
+        assertEquals("1, 1, 2, 3", builder.toString());
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
+        assertEquals("[1, 1, 2, 3]", MultiReaderHashBag.newBagWith(1, 1, 2, 3).toString());
     }
 
     @Override
@@ -515,7 +522,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     public void iterator()
     {
         MultiReaderHashBag<Integer> integers = MultiReaderHashBag.newBagWith(1, 1, 2, 3, 4);
-        Assert.assertThrows(UnsupportedOperationException.class, integers::iterator);
+        assertThrows(UnsupportedOperationException.class, integers::iterator);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -540,11 +547,11 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
             delegateList.set(delegate);
             iterator.set(delegate.iterator());
         });
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 2, 3, 4), bag);
+        assertEquals(HashBag.newBagWith(1, 2, 2, 3, 4), bag);
 
-        Assert.assertThrows(NullPointerException.class, () -> iterator.get().hasNext());
+        assertThrows(NullPointerException.class, () -> iterator.get().hasNext());
 
-        Assert.assertThrows(NullPointerException.class, () -> delegateList.get().iterator());
+        assertThrows(NullPointerException.class, () -> delegateList.get().iterator());
     }
 
     @Test
@@ -557,7 +564,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
             numbers.add(each);
             Verify.assertSize(1, numbers.select(each::equals));
             numbers.add(each);
-            Assert.assertEquals(2, numbers.count(each::equals));
+            assertEquals(2, numbers.count(each::equals));
             numbers.add(each);
             Integer[] removed = new Integer[1];
             numbers.withWriteLockAndDelegate(bag ->
@@ -568,10 +575,10 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
                 bag.add(removed[0]);
             });
             numbers.add(each);
-            Assert.assertEquals(4, numbers.count(each::equals));
+            assertEquals(4, numbers.count(each::equals));
         }, 1);
 
-        interval.forEach(Procedures.cast(each -> Assert.assertEquals(4, numbers.occurrencesOf(each))));
+        interval.forEach(Procedures.cast(each -> assertEquals(4, numbers.occurrencesOf(each))));
     }
 
     @Test
@@ -580,7 +587,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MultiReaderHashBag<String> numbers = this.newWith();
         Interval interval = Interval.oneTo(50000);
         ParallelIterate.collect(interval, String::valueOf, numbers, true);
-        Assert.assertEquals(numbers, interval.collect(String::valueOf).toBag());
+        assertEquals(numbers, interval.collect(String::valueOf).toBag());
     }
 
     @Test
@@ -589,7 +596,7 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
         MutableBag<String> bag = this.newWith("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5");
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -597,12 +604,12 @@ public class MultiReaderHashBagTest extends MultiReaderMutableCollectionTestCase
     {
         MultiReaderHashBag<Integer> numbers = this.newWith(1, 1, 1, 2, 2, 3, 3);
         MutableList<ObjectIntPair<Integer>> pairs = numbers.topOccurrences(1);
-        Assert.assertEquals(Integer.valueOf(1), pairs.getFirst().getOne());
-        Assert.assertEquals(3, pairs.getFirst().getTwo());
+        assertEquals(Integer.valueOf(1), pairs.getFirst().getOne());
+        assertEquals(3, pairs.getFirst().getTwo());
         numbers.withReadLockAndDelegate(bag ->
         {
-            Assert.assertEquals(Integer.valueOf(1), bag.topOccurrences(1).getFirst().getOne());
-            Assert.assertEquals(3, bag.topOccurrences(1).getFirst().getTwo());
+            assertEquals(Integer.valueOf(1), bag.topOccurrences(1).getFirst().getOne());
+            assertEquals(3, bag.topOccurrences(1).getFirst().getTwo());
         });
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
@@ -42,8 +42,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class MutableBagTestCase extends AbstractCollectionTestCase
 {
@@ -57,26 +64,26 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     public void equalsAndHashCode()
     {
         super.equalsAndHashCode();
-        Assert.assertNotEquals(this.newWith(1, 1, 2, 3), this.newWith(1, 2, 2, 3));
+        assertNotEquals(this.newWith(1, 1, 2, 3), this.newWith(1, 2, 2, 3));
         Verify.assertEqualsAndHashCode(this.newWith(null, null, 2, 3), this.newWith(null, 2, null, 3));
-        Assert.assertEquals(this.newWith(1, 1, 2, 3).toMapOfItemToCount().hashCode(), this.newWith(1, 1, 2, 3).hashCode());
-        Assert.assertEquals(this.newWith(null, null, 2, 3).toMapOfItemToCount().hashCode(), this.newWith(null, null, 2, 3).hashCode());
+        assertEquals(this.newWith(1, 1, 2, 3).toMapOfItemToCount().hashCode(), this.newWith(1, 1, 2, 3).hashCode());
+        assertEquals(this.newWith(null, null, 2, 3).toMapOfItemToCount().hashCode(), this.newWith(null, null, 2, 3).hashCode());
     }
 
     @Test
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", this.newWith().toStringOfItemToCount());
-        Assert.assertEquals("{1=3}", this.newWith(1, 1, 1).toStringOfItemToCount());
+        assertEquals("{}", this.newWith().toStringOfItemToCount());
+        assertEquals("{1=3}", this.newWith(1, 1, 1).toStringOfItemToCount());
         String actual = this.newWith(1, 2, 2).toStringOfItemToCount();
-        Assert.assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
+        assertTrue("{1=1, 2=2}".equals(actual) || "{2=2, 1=1}".equals(actual));
     }
 
     @Test
     public void toMapOfItemToCount()
     {
         MutableBagIterable<Integer> bag = this.newWith(1, 2, 2, 3, 3, 3);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
     }
 
     @Test
@@ -100,28 +107,28 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         {
             validate.add(each);
         }
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 2), HashBag.newBag(validate));
+        assertEquals(HashBag.newBagWith(1, 1, 2), HashBag.newBag(validate));
 
         Iterator<Integer> iterator = bag.iterator();
         MutableBagIterable<Integer> expected = this.newWith(1, 1, 2);
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
 
         this.assertIteratorRemove(bag, iterator, expected);
         this.assertIteratorRemove(bag, iterator, expected);
         this.assertIteratorRemove(bag, iterator, expected);
         Verify.assertEmpty(bag);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     private void assertIteratorRemove(MutableBagIterable<Integer> bag, Iterator<Integer> iterator, MutableBagIterable<Integer> expected)
     {
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         Integer first = iterator.next();
         iterator.remove();
         expected.remove(first);
-        Assert.assertEquals(expected, bag);
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertEquals(expected, bag);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
@@ -133,16 +140,16 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         iterator.next();
         Integer value = iterator.next();
         Integer value2 = iterator.next();
-        Assert.assertNotEquals(value, value2);
+        assertNotEquals(value, value2);
         iterator.remove();
         Integer value3 = iterator.next();
-        Assert.assertNotEquals(value, value3);
+        assertNotEquals(value, value3);
         iterator.remove();
         Integer value4 = iterator.next();
-        Assert.assertNotEquals(value, value4);
+        assertNotEquals(value, value4);
         iterator.remove();
         Integer value5 = iterator.next();
-        Assert.assertNotEquals(value, value5);
+        assertNotEquals(value, value5);
     }
 
     @Test
@@ -161,8 +168,8 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         iterator.next();
         iterator.next();
         iterator.remove();
-        Assert.assertEquals(4, bag.sizeDistinct());
-        Assert.assertEquals(8, bag.size());
+        assertEquals(4, bag.sizeDistinct());
+        assertEquals(8, bag.size());
     }
 
     @Override
@@ -172,10 +179,10 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         super.removeIf();
 
         MutableBagIterable<Integer> objects = this.newWith(4, 1, 3, 3, 2);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(2)));
-        Assert.assertEquals(HashBag.newBagWith(1, 3, 3, 4), objects);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(3)));
-        Assert.assertEquals(HashBag.newBagWith(1, 4), objects);
+        assertTrue(objects.removeIf(Predicates.equal(2)));
+        assertEquals(HashBag.newBagWith(1, 3, 3, 4), objects);
+        assertTrue(objects.removeIf(Predicates.equal(3)));
+        assertEquals(HashBag.newBagWith(1, 4), objects);
     }
 
     @Override
@@ -185,7 +192,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<Integer> bag = this.newWith(1, 1, 2);
         MutableList<Integer> validate = Lists.mutable.of();
         bag.forEach(CollectionAddProcedure.on(validate));
-        Assert.assertEquals(HashBag.newBagWith(1, 1, 2), HashBag.newBag(validate));
+        assertEquals(HashBag.newBagWith(1, 1, 2), HashBag.newBag(validate));
     }
 
     @Test
@@ -197,15 +204,15 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         bag.addOccurrences(3, 1);
         IntegerSum sum = new IntegerSum(0);
         bag.forEachWithOccurrences((each, index) -> sum.add(each * index));
-        Assert.assertEquals(10, sum.getIntSum());
+        assertEquals(10, sum.getIntSum());
         bag.removeOccurrences(2, 1);
         IntegerSum sum2 = new IntegerSum(0);
         bag.forEachWithOccurrences((each, index) -> sum2.add(each * index));
-        Assert.assertEquals(8, sum2.getIntSum());
+        assertEquals(8, sum2.getIntSum());
         bag.removeOccurrences(1, 3);
         IntegerSum sum3 = new IntegerSum(0);
         bag.forEachWithOccurrences((each, index) -> sum3.add(each * index));
-        Assert.assertEquals(5, sum3.getIntSum());
+        assertEquals(5, sum3.getIntSum());
     }
 
     @Test
@@ -219,8 +226,8 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected1, actual1);
-        Assert.assertEquals(expected1, bag1.collectWithOccurrences(PrimitiveTuples::pair));
+        assertEquals(expected1, actual1);
+        assertEquals(expected1, bag1.collectWithOccurrences(PrimitiveTuples::pair));
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
@@ -229,10 +236,10 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
 
         Bag<Integer> bag2 = this.newWith(3, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 4, 5, 7);
-        Assert.assertEquals(
+        assertEquals(
                 this.newWith(8, 5, 6, 5, 6, 8),
                 bag2.collectWithOccurrences((each, index) -> each + index));
     }
@@ -244,37 +251,37 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         super.toImmutable();
         Verify.assertInstanceOf(MutableBagIterable.class, this.newWith());
         Verify.assertInstanceOf(ImmutableBagIterable.class, this.newWith().toImmutable());
-        Assert.assertFalse(this.newWith().toImmutable() instanceof MutableBagIterable);
+        assertFalse(this.newWith().toImmutable() instanceof MutableBagIterable);
     }
 
     @Test
     @Override
     public void getLast()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(3).getLast());
+        assertEquals(Integer.valueOf(1), this.newWith(1).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(3).getLast());
     }
 
     @Test
     public void occurrencesOf()
     {
         MutableBagIterable<Integer> bag = this.newWith(1, 1, 2);
-        Assert.assertEquals(2, bag.occurrencesOf(1));
-        Assert.assertEquals(1, bag.occurrencesOf(2));
+        assertEquals(2, bag.occurrencesOf(1));
+        assertEquals(1, bag.occurrencesOf(2));
     }
 
     @Test
     public void addOccurrences()
     {
         MutableBagIterable<String> bag = this.newWith();
-        Assert.assertEquals(0, bag.addOccurrences("0", 0));
-        Assert.assertEquals(1, bag.addOccurrences("1", 1));
-        Assert.assertEquals(1, bag.addOccurrences("1", 0));
-        Assert.assertEquals(2, bag.addOccurrences("2", 2));
+        assertEquals(0, bag.addOccurrences("0", 0));
+        assertEquals(1, bag.addOccurrences("1", 1));
+        assertEquals(1, bag.addOccurrences("1", 0));
+        assertEquals(2, bag.addOccurrences("2", 2));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith("1", "2", "2"), bag);
-        Assert.assertEquals(1, bag.addOccurrences("1", 0));
-        Assert.assertEquals(6, bag.addOccurrences("2", 4));
-        Assert.assertEquals(1, bag.addOccurrences("3", 1));
+        assertEquals(1, bag.addOccurrences("1", 0));
+        assertEquals(6, bag.addOccurrences("2", 4));
+        assertEquals(1, bag.addOccurrences("3", 1));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2", "3"), bag);
     }
 
@@ -284,14 +291,14 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<String> bag = this.newWith();
         MutableBagIterable<String> withOccurrences = bag.withOccurrences("0", 0);
 
-        Assert.assertEquals(HashBag.newBag(), withOccurrences);
-        Assert.assertSame(bag, withOccurrences);
-        Assert.assertEquals(HashBag.newBagWith("1"), bag.withOccurrences("1", 1));
-        Assert.assertEquals(HashBag.newBagWith("1"), bag.withOccurrences("1", 0));
-        Assert.assertEquals(HashBag.newBagWith("1", "2", "2"), bag.withOccurrences("2", 2));
-        Assert.assertEquals(HashBag.newBagWith("1", "2", "2"), bag.withOccurrences("1", 0));
-        Assert.assertEquals(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2"), bag.withOccurrences("2", 4));
-        Assert.assertEquals(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2", "3"), bag.withOccurrences("3", 1));
+        assertEquals(HashBag.newBag(), withOccurrences);
+        assertSame(bag, withOccurrences);
+        assertEquals(HashBag.newBagWith("1"), bag.withOccurrences("1", 1));
+        assertEquals(HashBag.newBagWith("1"), bag.withOccurrences("1", 0));
+        assertEquals(HashBag.newBagWith("1", "2", "2"), bag.withOccurrences("2", 2));
+        assertEquals(HashBag.newBagWith("1", "2", "2"), bag.withOccurrences("1", 0));
+        assertEquals(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2"), bag.withOccurrences("2", 4));
+        assertEquals(HashBag.newBagWith("1", "2", "2", "2", "2", "2", "2", "3"), bag.withOccurrences("3", 1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -312,19 +319,19 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<String> bag = this.newWith("betamax-tape", "betamax-tape");
         MutableBagIterable<String> expected = HashBag.newBag(bag);
 
-        Assert.assertFalse(bag.removeOccurrences("dvd", 2));
+        assertFalse(bag.removeOccurrences("dvd", 2));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertFalse(bag.removeOccurrences("dvd", 0));
+        assertFalse(bag.removeOccurrences("dvd", 0));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertFalse(bag.removeOccurrences("betamax-tape", 0));
+        assertFalse(bag.removeOccurrences("betamax-tape", 0));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertTrue(bag.removeOccurrences("betamax-tape", 1));
+        assertTrue(bag.removeOccurrences("betamax-tape", 1));
         MutableBagTestCase.assertBagsEqual(HashBag.newBagWith("betamax-tape"), bag);
 
-        Assert.assertTrue(bag.removeOccurrences("betamax-tape", 10));
+        assertTrue(bag.removeOccurrences("betamax-tape", 10));
         MutableBagTestCase.assertBagsEqual(HashBag.<String>newBag(), bag);
     }
 
@@ -335,7 +342,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<String> expected = HashBag.newBag(bag);
 
         MutableBagTestCase.assertBagsEqual(expected, bag.withoutOccurrences("dvd", 2));
-        Assert.assertSame(bag, bag.withoutOccurrences("dvd", 2));
+        assertSame(bag, bag.withoutOccurrences("dvd", 2));
 
         MutableBagTestCase.assertBagsEqual(expected, bag.withoutOccurrences("dvd", 0));
 
@@ -364,19 +371,19 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<String> bag = this.newWith();
         MutableBagIterable<String> expected = this.newWith("betamax-tape", "betamax-tape");
 
-        Assert.assertTrue(bag.setOccurrences("betamax-tape", 2));
+        assertTrue(bag.setOccurrences("betamax-tape", 2));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertFalse(bag.setOccurrences("betamax-tape", 2));
+        assertFalse(bag.setOccurrences("betamax-tape", 2));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertFalse(bag.setOccurrences("dvd", 0));
+        assertFalse(bag.setOccurrences("dvd", 0));
         MutableBagTestCase.assertBagsEqual(expected, bag);
 
-        Assert.assertTrue(bag.setOccurrences("betamax-tape", 3));
+        assertTrue(bag.setOccurrences("betamax-tape", 3));
         MutableBagTestCase.assertBagsEqual(expected.with("betamax-tape"), bag);
 
-        Assert.assertTrue(bag.setOccurrences("betamax-tape", 0));
+        assertTrue(bag.setOccurrences("betamax-tape", 0));
         MutableBagTestCase.assertBagsEqual(HashBag.<String>newBag(), bag);
     }
 
@@ -388,16 +395,16 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
 
     protected static void assertBagsEqual(Bag<?> expected, Bag<?> actual)
     {
-        Assert.assertEquals(expected.toMapOfItemToCount(), actual.toMapOfItemToCount());
-        Assert.assertEquals(expected.sizeDistinct(), actual.sizeDistinct());
-        Assert.assertEquals(expected.size(), actual.size());
+        assertEquals(expected.toMapOfItemToCount(), actual.toMapOfItemToCount());
+        assertEquals(expected.sizeDistinct(), actual.sizeDistinct());
+        assertEquals(expected.size(), actual.size());
         Verify.assertEqualsAndHashCode(expected, actual);
     }
 
     @Test
     public void toSortedListWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2, 2, 3, 3, 3),
                 this.newWith(3, 3, 3, 2, 2, 1).toSortedList());
     }
@@ -408,7 +415,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     {
         super.toSet();
         MutableBagIterable<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
     }
 
     @Override
@@ -417,7 +424,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
     {
         super.toList();
         MutableBagIterable<Integer> bag = this.newWith(1, 1, 1);
-        Assert.assertEquals(FastList.newListWith(1, 1, 1), bag.toList());
+        assertEquals(FastList.newListWith(1, 1, 1), bag.toList());
     }
 
     @Override
@@ -427,10 +434,10 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         super.removeObject();
 
         MutableBagIterable<String> bag = this.newWith("dakimakura", "dakimakura");
-        Assert.assertFalse(bag.remove("Mr. T"));
-        Assert.assertTrue(bag.remove("dakimakura"));
-        Assert.assertTrue(bag.remove("dakimakura"));
-        Assert.assertFalse(bag.remove("dakimakura"));
+        assertFalse(bag.remove("Mr. T"));
+        assertTrue(bag.remove("dakimakura"));
+        assertTrue(bag.remove("dakimakura"));
+        assertFalse(bag.remove("dakimakura"));
         MutableBagTestCase.assertBagsEqual(Bags.mutable.of(), bag);
     }
 
@@ -463,8 +470,8 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
 
         MutableBagIterable<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         PartitionMutableCollection<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(Iterables.iBag(2, 2, 4, 4, 4, 4), result.getSelected());
-        Assert.assertEquals(Iterables.iBag(1, 3, 3, 3), result.getRejected());
+        assertEquals(Iterables.iBag(2, 2, 4, 4, 4, 4), result.getSelected());
+        assertEquals(Iterables.iBag(1, 3, 3, 3), result.getRejected());
     }
 
     @Override
@@ -475,22 +482,22 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
 
         MutableBagIterable<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         PartitionMutableCollection<Integer> result = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(Iterables.iBag(2, 2, 4, 4, 4, 4), result.getSelected());
-        Assert.assertEquals(Iterables.iBag(1, 3, 3, 3), result.getRejected());
+        assertEquals(Iterables.iBag(2, 2, 4, 4, 4, 4), result.getSelected());
+        assertEquals(Iterables.iBag(1, 3, 3, 3), result.getRejected());
     }
 
     @Test
     public void selectByOccurrences()
     {
         MutableBagIterable<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(Iterables.iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
+        assertEquals(Iterables.iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
     }
 
     @Test
     public void selectDuplicates()
     {
         MutableBagIterable<Integer> integers = this.newWith(0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5);
-        Assert.assertEquals(Iterables.iBag(1, 1, 1, 1, 2, 2, 2, 3, 3), integers.selectDuplicates());
+        assertEquals(Iterables.iBag(1, 1, 1, 1, 2, 2, 2, 3, 3), integers.selectDuplicates());
     }
 
     @Test
@@ -509,10 +516,10 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
                 PrimitiveTuples.pair("ten", 10));
         MutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertSize(0, this.newWith("one").topOccurrences(0));
         Verify.assertSize(0, this.newWith().topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(5));
@@ -525,58 +532,58 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         Verify.assertSize(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1));
         Verify.assertSize(0, this.newWith().topOccurrences(0));
         Verify.assertSize(0, this.newWith("one").topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
     }
 
     @Test
     public void anySatisfyWithOccurrences()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 2));
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(3)));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 2));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(3)));
 
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 5));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(1) && value == 7));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(10)));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 5));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(1) && value == 7));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(10)));
     }
 
     @Test
     public void noneSatisfyWithOccurrences()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 1));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(30)));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 0));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(2)));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 1));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(30)));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 0));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(2)));
     }
 
     @Test
     public void allSatisfyWithOccurrences()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3);
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3)));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(4) && value == 3));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3)));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(4) && value == 3));
         bag = this.newWith(3, 3, 3, 1);
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 3));
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) || object == 1));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(300) || object == 1));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 3));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object.equals(3) || object == 1));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(300) || object == 1));
     }
 
     @Test
     public void detectWithOccurrences()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        Assert.assertEquals((Integer) 3, bag.detectWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        Assert.assertEquals((Integer) 3, bag.detectWithOccurrences((object, value) -> object.equals(3)));
-        Assert.assertEquals((Integer) 1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 10));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(10) && value == 5));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(100)));
+        assertEquals((Integer) 3, bag.detectWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertEquals((Integer) 3, bag.detectWithOccurrences((object, value) -> object.equals(3)));
+        assertEquals((Integer) 1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 10));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(10) && value == 5));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(100)));
     }
 
     @Test
@@ -595,10 +602,10 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
                 PrimitiveTuples.pair("ten", 10));
         MutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertSize(0, this.newWith("one").bottomOccurrences(0));
         Verify.assertSize(0, this.newWith().bottomOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").bottomOccurrences(5));
@@ -611,7 +618,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         Verify.assertSize(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1));
         Verify.assertSize(0, this.newWith().bottomOccurrences(0));
         Verify.assertSize(0, this.newWith("one").bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
     }
 
     @Test
@@ -620,7 +627,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBag<String> bag = Bags.mutable.with("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5");
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Override
@@ -633,7 +640,7 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
                 Tuples.pair("1", "1"),
                 Tuples.pair("2", "2"),
                 Tuples.pair("3", "3"));
-        Assert.assertEquals(expected, bag.zip(bag::iterator).toBag());
+        assertEquals(expected, bag.zip(bag::iterator).toBag());
     }
 
     @Test
@@ -642,6 +649,6 @@ public abstract class MutableBagTestCase extends AbstractCollectionTestCase
         MutableBagIterable<String> bag = this.newWith("1", "2", "2", "3", "3", "3", "3", "4", "5", "5", "6");
         RichIterable<String> expected = bag.toSet();
         RichIterable<String> actual = bag.distinctView();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
@@ -33,10 +33,12 @@ import org.eclipse.collections.impl.collection.mutable.AbstractSynchronizedColle
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * JUnit test for {@link SynchronizedBag}.
@@ -62,16 +64,16 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     @Test
     public void getFirst()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
@@ -82,8 +84,8 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
         Multimap<Boolean, Integer> multimap =
                 list.groupBy(object -> IntegerPredicates.isOdd().accept(object));
 
-        Assert.assertEquals(Bags.mutable.of(1, 3, 5, 7), multimap.get(Boolean.TRUE));
-        Assert.assertEquals(Bags.mutable.of(2, 4, 6), multimap.get(Boolean.FALSE));
+        assertEquals(Bags.mutable.of(1, 3, 5, 7), multimap.get(Boolean.TRUE));
+        assertEquals(Bags.mutable.of(2, 4, 6), multimap.get(Boolean.FALSE));
     }
 
     @Override
@@ -117,8 +119,8 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
 
         MutableBag<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         PartitionMutableCollection<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iBag(2, 2, 4, 4, 4, 4), result.getSelected());
-        Assert.assertEquals(iBag(1, 3, 3, 3), result.getRejected());
+        assertEquals(iBag(2, 2, 4, 4, 4, 4), result.getSelected());
+        assertEquals(iBag(1, 3, 3, 3), result.getRejected());
     }
 
     @Override
@@ -129,21 +131,21 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
 
         MutableBag<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         PartitionMutableCollection<Integer> result = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iBag(2, 2, 4, 4, 4, 4), result.getSelected());
-        Assert.assertEquals(iBag(1, 3, 3, 3), result.getRejected());
+        assertEquals(iBag(2, 2, 4, 4, 4, 4), result.getSelected());
+        assertEquals(iBag(1, 3, 3, 3), result.getRejected());
     }
 
     @Test
     public void selectByOccurrences()
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
+        assertEquals(iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
     }
 
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iBag(1, 1, 1, 1, 2, 2, 2, 3, 3),
                 this.newWith(0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5).selectDuplicates());
     }
@@ -152,11 +154,11 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     public void addOccurrences()
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(6, integers.addOccurrences(1, 2));
+        assertEquals(6, integers.addOccurrences(1, 2));
         Verify.assertBagsEqual(this.newWith(1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4), integers);
-        Assert.assertEquals(0, integers.addOccurrences(5, 0));
-        Assert.assertEquals(2, integers.addOccurrences(5, 2));
-        Assert.assertEquals(3, integers.addOccurrences(3, 1));
+        assertEquals(0, integers.addOccurrences(5, 0));
+        assertEquals(2, integers.addOccurrences(5, 2));
+        assertEquals(3, integers.addOccurrences(3, 1));
         Verify.assertBagsEqual(this.newWith(1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 5, 5), integers);
     }
 
@@ -164,24 +166,24 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     public void removeOccurrences()
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(1, integers.occurrencesOf(4));
-        Assert.assertEquals(3, integers.occurrencesOf(2));
+        assertEquals(1, integers.occurrencesOf(4));
+        assertEquals(3, integers.occurrencesOf(2));
         integers.removeOccurrences(4, 1);
         integers.removeOccurrences(2, 2);
-        Assert.assertEquals(0, integers.occurrencesOf(4));
-        Assert.assertEquals(1, integers.occurrencesOf(2));
+        assertEquals(0, integers.occurrencesOf(4));
+        assertEquals(1, integers.occurrencesOf(2));
     }
 
     @Test
     public void setOccurrences()
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
-        Assert.assertEquals(0, integers.occurrencesOf(5));
-        Assert.assertEquals(3, integers.occurrencesOf(2));
+        assertEquals(0, integers.occurrencesOf(5));
+        assertEquals(3, integers.occurrencesOf(2));
         integers.setOccurrences(5, 5);
         integers.setOccurrences(2, 2);
-        Assert.assertEquals(5, integers.occurrencesOf(5));
-        Assert.assertEquals(2, integers.occurrencesOf(2));
+        assertEquals(5, integers.occurrencesOf(5));
+        assertEquals(2, integers.occurrencesOf(2));
     }
 
     @Test
@@ -189,7 +191,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
         MapIterable<Integer, Integer> result = integers.toMapOfItemToCount();
-        Assert.assertEquals(Maps.mutable.with(1, 4, 2, 3, 3, 2, 4, 1), result);
+        assertEquals(Maps.mutable.with(1, 4, 2, 3, 3, 2, 4, 1), result);
     }
 
     @Test
@@ -197,7 +199,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
     {
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1);
         String result = integers.toStringOfItemToCount();
-        Assert.assertEquals(Maps.mutable.with(1, 4).toString(), result);
+        assertEquals(Maps.mutable.with(1, 4).toString(), result);
     }
 
     @Test
@@ -206,7 +208,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
         MutableBag<Integer> integers = this.newWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
         MutableBag<Integer> result = HashBag.newBag();
         integers.forEachWithOccurrences(result::setOccurrences);
-        Assert.assertEquals(integers, result);
+        assertEquals(integers, result);
     }
 
     /**
@@ -223,7 +225,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
@@ -232,7 +234,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Test
@@ -251,10 +253,10 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
         strings.addOccurrences("ten", 10);
         MutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertSize(0, this.newWith().topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -281,10 +283,10 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
         strings.addOccurrences("ten", 10);
         MutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertSize(0, this.newWith().bottomOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -301,7 +303,7 @@ public class SynchronizedBagTest extends AbstractSynchronizedCollectionTestCase
         MutableBag<String> bag = Bags.mutable.with("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5").asSynchronized();
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBagTest.java
@@ -41,10 +41,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableBag}.
@@ -111,7 +111,7 @@ public class UnmodifiableBagTest
     {
         MutableList<Pair<Object, Integer>> list = Lists.mutable.of();
         this.getCollection().forEachWithOccurrences((each, index) -> list.add(Tuples.pair(each, index)));
-        Assert.assertEquals(FastList.newListWith(Tuples.pair("", 1)), list);
+        assertEquals(FastList.newListWith(Tuples.pair("", 1)), list);
     }
 
     /**
@@ -128,7 +128,7 @@ public class UnmodifiableBagTest
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
@@ -137,34 +137,34 @@ public class UnmodifiableBagTest
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Test
     public void toMapOfItemToCount()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("", 1), this.getCollection().toMapOfItemToCount());
+        assertEquals(UnifiedMap.newWithKeysValues("", 1), this.getCollection().toMapOfItemToCount());
     }
 
     @Test
     public void selectInstancesOf()
     {
         MutableBag<Number> numbers = UnmodifiableBag.of(HashBag.newBagWith(1, 2.0, 3, 4.0, 5));
-        Assert.assertEquals(iBag(1, 3, 5), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iBag(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
+        assertEquals(iBag(1, 3, 5), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iBag(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
     }
 
     @Test
     public void selectByOccurrences()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 3, 4));
-        Assert.assertEquals(iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
+        assertEquals(iBag(1, 1, 1, 1, 3, 3), integers.selectByOccurrences(IntPredicates.isEven()));
     }
 
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnmodifiableBag.of(HashBag.newBagWith(1, 1, 1, 1, 2, 2, 2, 3, 3)),
                 UnmodifiableBag.of(HashBag.newBagWith(0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5)).selectDuplicates());
     }
@@ -174,7 +174,7 @@ public class UnmodifiableBagTest
     public void collectBoolean()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(0, 1, 2, 2));
-        Assert.assertEquals(
+        assertEquals(
                 BooleanHashBag.newBagWith(false, true, true, true),
                 integers.collectBoolean(PrimitiveFunctions.integerIsPositive()));
     }
@@ -184,7 +184,7 @@ public class UnmodifiableBagTest
     public void collectByte()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 3),
                 integers.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
@@ -194,7 +194,7 @@ public class UnmodifiableBagTest
     public void collectChar()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 CharHashBag.newBagWith('A', 'B', 'B', 'C', 'C', 'C'),
                 integers.collectChar(integer -> (char) (integer.intValue() + 64)));
     }
@@ -204,7 +204,7 @@ public class UnmodifiableBagTest
     public void collectDouble()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashBag.newBagWith(1.0d, 2.0d, 2.0d, 3.0d, 3.0d, 3.0d),
                 integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
@@ -214,7 +214,7 @@ public class UnmodifiableBagTest
     public void collectFloat()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashBag.newBagWith(1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f),
                 integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
@@ -224,7 +224,7 @@ public class UnmodifiableBagTest
     public void collectInt()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 IntHashBag.newBagWith(1, 2, 2, 3, 3, 3),
                 integers.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
@@ -234,7 +234,7 @@ public class UnmodifiableBagTest
     public void collectLong()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 LongHashBag.newBagWith(1L, 2L, 2L, 3L, 3L, 3L),
                 integers.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
@@ -244,7 +244,7 @@ public class UnmodifiableBagTest
     public void collectShort()
     {
         MutableBag<Integer> integers = UnmodifiableBag.of(HashBag.newBagWith(1, 2, 2, 3, 3, 3));
-        Assert.assertEquals(
+        assertEquals(
                 ShortHashBag.newBagWith((short) 1, (short) 2, (short) 2, (short) 3, (short) 3, (short) 3),
                 integers.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
@@ -266,10 +266,10 @@ public class UnmodifiableBagTest
         MutableBag<String> strings = mutable.asUnmodifiable();
         MutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
     }
 
     @Test
@@ -289,10 +289,10 @@ public class UnmodifiableBagTest
         MutableBag<String> strings = mutable.asUnmodifiable();
         MutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
     }
 
     @Test
@@ -301,7 +301,7 @@ public class UnmodifiableBagTest
         MutableBag<String> bag = Bags.mutable.with("0", "1", "1", "1", "1", "2", "2", "2", "3", "3", "4", "5").asUnmodifiable();
         MutableSet<String> expected = Sets.mutable.with("0", "4", "5");
         MutableSet<String> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -310,6 +310,6 @@ public class UnmodifiableBagTest
         MutableBag<String> bag = Bags.mutable.of("1", "2", "2", "3", "3", "3", "3", "4", "5", "5", "6");
         RichIterable<String> expected = bag.toSet();
         RichIterable<String> actual = bag.asUnmodifiable().distinctView();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/AbstractMutableBooleanBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/AbstractMutableBooleanBagTestCase.java
@@ -25,8 +25,14 @@ import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanBag}.
@@ -54,10 +60,10 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     @Test
     public void sizeDistinct()
     {
-        Assert.assertEquals(0L, this.newWith().sizeDistinct());
-        Assert.assertEquals(1L, this.newWith(true).sizeDistinct());
-        Assert.assertEquals(1L, this.newWith(true, true, true).sizeDistinct());
-        Assert.assertEquals(2L, this.newWith(true, false, true, false, true).sizeDistinct());
+        assertEquals(0L, this.newWith().sizeDistinct());
+        assertEquals(1L, this.newWith(true).sizeDistinct());
+        assertEquals(1L, this.newWith(true, true, true).sizeDistinct());
+        assertEquals(2L, this.newWith(true, false, true, false, true).sizeDistinct());
     }
 
     @Override
@@ -66,11 +72,11 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     {
         super.addAllIterable();
         MutableBooleanBag bag = this.newWith();
-        Assert.assertTrue(bag.addAll(BooleanArrayList.newListWith(true, false, true, false, true)));
-        Assert.assertFalse(bag.addAll(new BooleanArrayList()));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), bag);
-        Assert.assertTrue(bag.addAll(BooleanHashBag.newBagWith(true, false, true, false, true)));
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false, false, true, true, true, true, true, true), bag);
+        assertTrue(bag.addAll(BooleanArrayList.newListWith(true, false, true, false, true)));
+        assertFalse(bag.addAll(new BooleanArrayList()));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), bag);
+        assertTrue(bag.addAll(BooleanHashBag.newBagWith(true, false, true, false, true)));
+        assertEquals(BooleanHashBag.newBagWith(false, false, false, false, true, true, true, true, true, true), bag);
     }
 
     @Test
@@ -78,15 +84,15 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     {
         MutableBooleanBag bag = this.newWith();
         bag.addOccurrences(false, 3);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false), bag);
+        assertEquals(BooleanHashBag.newBagWith(false, false, false), bag);
         bag.addOccurrences(false, 2);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
+        assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
         bag.addOccurrences(false, 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
+        assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
         bag.addOccurrences(true, 0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
+        assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false), bag);
         bag.addOccurrences(true, 1);
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false, true), bag);
+        assertEquals(BooleanHashBag.newBagWith(false, false, false, false, false, true), bag);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -99,28 +105,28 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     public void removeOccurrences()
     {
         MutableBooleanBag bag1 = this.newWith();
-        Assert.assertFalse(bag1.removeOccurrences(true, 5));
+        assertFalse(bag1.removeOccurrences(true, 5));
         bag1.addOccurrences(true, 5);
-        Assert.assertTrue(bag1.removeOccurrences(true, 2));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true, true), bag1);
-        Assert.assertFalse(bag1.removeOccurrences(true, 0));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true, true), bag1);
-        Assert.assertTrue(bag1.removeOccurrences(true, 5));
-        Assert.assertEquals(new BooleanHashBag(), bag1);
-        Assert.assertFalse(bag1.removeOccurrences(true, 5));
-        Assert.assertEquals(new BooleanHashBag(), bag1);
+        assertTrue(bag1.removeOccurrences(true, 2));
+        assertEquals(BooleanHashBag.newBagWith(true, true, true), bag1);
+        assertFalse(bag1.removeOccurrences(true, 0));
+        assertEquals(BooleanHashBag.newBagWith(true, true, true), bag1);
+        assertTrue(bag1.removeOccurrences(true, 5));
+        assertEquals(new BooleanHashBag(), bag1);
+        assertFalse(bag1.removeOccurrences(true, 5));
+        assertEquals(new BooleanHashBag(), bag1);
 
         MutableBooleanBag bag2 = this.newWith();
-        Assert.assertFalse(bag2.removeOccurrences(false, 5));
+        assertFalse(bag2.removeOccurrences(false, 5));
         bag2.addOccurrences(false, 5);
-        Assert.assertTrue(bag2.removeOccurrences(false, 2));
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false), bag2);
-        Assert.assertFalse(bag2.removeOccurrences(false, 0));
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, false), bag2);
-        Assert.assertTrue(bag2.removeOccurrences(false, 5));
-        Assert.assertEquals(new BooleanHashBag(), bag2);
-        Assert.assertFalse(bag2.removeOccurrences(false, 5));
-        Assert.assertEquals(new BooleanHashBag(), bag2);
+        assertTrue(bag2.removeOccurrences(false, 2));
+        assertEquals(BooleanHashBag.newBagWith(false, false, false), bag2);
+        assertFalse(bag2.removeOccurrences(false, 0));
+        assertEquals(BooleanHashBag.newBagWith(false, false, false), bag2);
+        assertTrue(bag2.removeOccurrences(false, 5));
+        assertEquals(new BooleanHashBag(), bag2);
+        assertFalse(bag2.removeOccurrences(false, 5));
+        assertEquals(new BooleanHashBag(), bag2);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -135,7 +141,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         StringBuilder stringBuilder = new StringBuilder();
         this.classUnderTest().forEachWithOccurrences((argument1, argument2) -> stringBuilder.append(argument1).append(argument2));
         String string = stringBuilder.toString();
-        Assert.assertTrue("true2false1".equals(string)
+        assertTrue("true2false1".equals(string)
                 || "false1true2".equals(string));
     }
 
@@ -154,12 +160,12 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         super.anySatisfy();
         long[] count = {0};
         MutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertTrue(bag.anySatisfy(value ->
+        assertTrue(bag.anySatisfy(value ->
         {
             count[0]++;
             return value;
         }));
-        Assert.assertEquals(2L, count[0]);
+        assertEquals(2L, count[0]);
     }
 
     @Override
@@ -169,12 +175,12 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         super.allSatisfy();
         int[] count = {0};
         MutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertFalse(bag.allSatisfy(value ->
+        assertFalse(bag.allSatisfy(value ->
         {
             count[0]++;
             return !value;
         }));
-        Assert.assertEquals(2L, count[0]);
+        assertEquals(2L, count[0]);
     }
 
     @Override
@@ -183,7 +189,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     {
         super.noneSatisfy();
         MutableBooleanBag bag = this.newWith(false, true, false);
-        Assert.assertFalse(bag.noneSatisfy(value -> value));
+        assertFalse(bag.noneSatisfy(value -> value));
     }
 
     @Override
@@ -193,11 +199,11 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         super.collect();
         MutableBooleanBag bag = this.newWith(true, false, false, true, true, true);
         BooleanToObjectFunction<String> stringValueOf = parameter -> parameter ? "true" : "false";
-        Assert.assertEquals(HashBag.newBagWith("true", "false", "false", "true", "true", "true"), bag.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("true", "false", "false", "true", "true", "true"), bag.collect(stringValueOf));
         MutableBooleanBag bag1 = this.newWith(false, false);
-        Assert.assertEquals(HashBag.newBagWith("false", "false"), bag1.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("false", "false"), bag1.collect(stringValueOf));
         MutableBooleanBag bag2 = this.newWith(true, true);
-        Assert.assertEquals(HashBag.newBagWith("true", "true"), bag2.collect(stringValueOf));
+        assertEquals(HashBag.newBagWith("true", "true"), bag2.collect(stringValueOf));
     }
 
     @Override
@@ -209,8 +215,8 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         MutableBooleanCollection collection2 = this.newWith(true, false, false, true);
         MutableBooleanCollection collection3 = this.newWith(true, false);
         MutableBooleanCollection collection4 = this.newWith(true, true, false);
-        Assert.assertEquals(collection1, collection2);
-        Assert.assertNotEquals(collection3, collection4);
+        assertEquals(collection1, collection2);
+        assertNotEquals(collection3, collection4);
     }
 
     @Override
@@ -223,7 +229,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         MutableBooleanCollection collection3 = this.newWith(true, false);
         MutableBooleanCollection collection4 = this.newWith(true, true, false);
         Verify.assertEqualsAndHashCode(collection1, collection2);
-        Assert.assertNotEquals(collection3.hashCode(), collection4.hashCode());
+        assertNotEquals(collection3.hashCode(), collection4.hashCode());
     }
 
     @Override
@@ -231,7 +237,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[true, true, true]", BooleanHashBag.newBagWith(true, true, true).toString());
+        assertEquals("[true, true, true]", BooleanHashBag.newBagWith(true, true, true).toString());
     }
 
     @Override
@@ -239,7 +245,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("true, true, true", BooleanHashBag.newBagWith(true, true, true).makeString());
+        assertEquals("true, true, true", BooleanHashBag.newBagWith(true, true, true).makeString());
     }
 
     @Override
@@ -249,12 +255,12 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true, true, true).appendString(appendable1);
-        Assert.assertEquals("true, true, true", appendable1.toString());
+        assertEquals("true, true, true", appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         MutableBooleanBag bag1 = this.newWith(false, false, true);
         bag1.appendString(appendable2);
-        Assert.assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
+        assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
                 || "true, false, false".equals(appendable2.toString())
                 || "false, true, false".equals(appendable2.toString()));
     }
@@ -265,7 +271,7 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     {
         super.toList();
         MutableBooleanList list = this.newWith(false, false, true).toList();
-        Assert.assertTrue(list.equals(BooleanArrayList.newListWith(false, false, true))
+        assertTrue(list.equals(BooleanArrayList.newListWith(false, false, true))
                 || list.equals(BooleanArrayList.newListWith(true, false, false))
                 || list.equals(BooleanArrayList.newListWith(false, true, false)));
     }
@@ -273,29 +279,29 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
-        Assert.assertNotSame(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertNotSame(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(ImmutableBooleanBag.class, this.classUnderTest().toImmutable());
     }
 
     @Test
     public void topOccurrences()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
-        Assert.assertTrue(this.newWith().topOccurrences(1).isEmpty());
-        Assert.assertEquals(
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertTrue(this.newWith().topOccurrences(1).isEmpty());
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 2)),
                 this.newWith(true, true, false).topOccurrences(1));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(false, 2)),
                 this.newWith(false, true, false).topOccurrences(1));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 2), PrimitiveTuples.pair(false, 1)),
                 this.newWith(true, true, false).topOccurrences(2));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 1), PrimitiveTuples.pair(false, 1)).toBag(),
                 this.newWith(true, false).topOccurrences(1).toBag());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(false, 2), PrimitiveTuples.pair(true, 1)).toBag(),
                 this.newWith(true, false, false).topOccurrences(2).toBag());
     }
@@ -303,21 +309,21 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
     @Test
     public void bottomOccurrences()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
-        Assert.assertTrue(this.newWith().bottomOccurrences(1).isEmpty());
-        Assert.assertEquals(
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertTrue(this.newWith().bottomOccurrences(1).isEmpty());
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(false, 1)),
                 this.newWith(true, true, false).bottomOccurrences(1));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 1)),
                 this.newWith(false, true, false).bottomOccurrences(1));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 1), PrimitiveTuples.pair(false, 2)),
                 this.newWith(false, true, false).bottomOccurrences(2));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(true, 1), PrimitiveTuples.pair(false, 1)),
                 this.newWith(true, false).bottomOccurrences(1));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(PrimitiveTuples.pair(false, 1), PrimitiveTuples.pair(true, 2)),
                 this.newWith(true, true, false).bottomOccurrences(2));
     }
@@ -328,11 +334,11 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         MutableBooleanBag bag = BooleanBags.mutable.with(false, false, true);
         MutableBooleanSet expected = BooleanSets.mutable.with(true);
         MutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         MutableBooleanBag bag2 = BooleanBags.mutable.with(false, false, true, true);
         MutableBooleanSet expected2 = BooleanSets.mutable.empty();
         MutableBooleanSet actual2 = bag2.selectUnique();
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBagTest.java
@@ -19,8 +19,13 @@ import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link BooleanHashBag}.
@@ -44,7 +49,7 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
     public void newCollection()
     {
         super.newCollection();
-        Assert.assertEquals(
+        assertEquals(
                 BooleanHashBag.newBagWith(true, false, true, false, true),
                 BooleanHashBag.newBag(BooleanArrayList.newListWith(true, false, true, false, true)));
     }
@@ -70,12 +75,12 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
         BooleanHashBag hashBag1 = new BooleanHashBag().with(true, false, true);
         BooleanHashBag hashBag2 = new BooleanHashBag().with(true).with(false).with(true).with(false);
         BooleanHashBag hashBag3 = new BooleanHashBag().with(true).with(false).with(true).with(false).with(true);
-        Assert.assertSame(emptyBag, hashBag0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), hashBag);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false), hashBag0);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), hashBag1);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false), hashBag2);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), hashBag3);
+        assertSame(emptyBag, hashBag0);
+        assertEquals(BooleanHashBag.newBagWith(true), hashBag);
+        assertEquals(BooleanHashBag.newBagWith(true, false), hashBag0);
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), hashBag1);
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false), hashBag2);
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), hashBag3);
     }
 
     @Override
@@ -85,21 +90,21 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
         super.booleanIterator();
         BooleanHashBag bag = this.newWith(true, false, false, true, true, true);
         BooleanIterator iterator = bag.booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -110,7 +115,7 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
         StringBuilder appendable2 = new StringBuilder();
         BooleanHashBag bag1 = this.newWith(false, false, true);
         bag1.appendString(appendable2);
-        Assert.assertEquals(appendable2.toString(), "false, false, true", appendable2.toString());
+        assertEquals(appendable2.toString(), "false, false, true", appendable2.toString());
     }
 
     @Override
@@ -119,7 +124,7 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
     {
         super.toList();
         MutableBooleanList list = this.newWith(true, true, true, false).toList();
-        Assert.assertEquals(list, BooleanArrayList.newListWith(false, true, true, true));
+        assertEquals(list, BooleanArrayList.newListWith(false, true, true, true));
     }
 
     @Override
@@ -131,6 +136,6 @@ public class BooleanHashBagTest extends AbstractMutableBooleanBagTestCase
         MutableBooleanBag bag = this.classUnderTest();
         MutableBooleanSet expected = BooleanSets.mutable.with(false);
         MutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/SynchronizedBooleanBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/SynchronizedBooleanBagTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.bag.mutable.primitive;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanBag}.
@@ -39,11 +41,11 @@ public class SynchronizedBooleanBagTest extends AbstractMutableBooleanBagTestCas
     {
         super.asSynchronized();
         MutableBooleanBag bagWithLockObject = new SynchronizedBooleanBag(BooleanHashBag.newBagWith(true, false, true), new Object());
-        Assert.assertSame(bagWithLockObject, bagWithLockObject.asSynchronized());
-        Assert.assertEquals(bagWithLockObject, bagWithLockObject.asSynchronized());
+        assertSame(bagWithLockObject, bagWithLockObject.asSynchronized());
+        assertEquals(bagWithLockObject, bagWithLockObject.asSynchronized());
         MutableBooleanBag bag = this.classUnderTest();
-        Assert.assertSame(bag, bag.asSynchronized());
-        Assert.assertEquals(bag, bag.asSynchronized());
+        assertSame(bag, bag.asSynchronized());
+        assertEquals(bag, bag.asSynchronized());
     }
 
     @Override
@@ -54,6 +56,6 @@ public class SynchronizedBooleanBagTest extends AbstractMutableBooleanBagTestCas
         MutableBooleanBag bag = this.classUnderTest();
         MutableBooleanSet expected = BooleanSets.mutable.with(false);
         MutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/UnmodifiableBooleanBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/UnmodifiableBooleanBagTest.java
@@ -15,8 +15,13 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanBag}.
@@ -161,21 +166,21 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
     public void containsAllArray()
     {
         UnmodifiableBooleanBag collection = this.classUnderTest();
-        Assert.assertTrue(collection.containsAll(true));
-        Assert.assertTrue(collection.containsAll(true, false, true));
-        Assert.assertTrue(collection.containsAll(true, false));
-        Assert.assertTrue(collection.containsAll(true, true));
-        Assert.assertTrue(collection.containsAll(false, false));
+        assertTrue(collection.containsAll(true));
+        assertTrue(collection.containsAll(true, false, true));
+        assertTrue(collection.containsAll(true, false));
+        assertTrue(collection.containsAll(true, true));
+        assertTrue(collection.containsAll(false, false));
         UnmodifiableBooleanBag emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
-        Assert.assertFalse(this.newWith(true, true).containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(this.newWith(true, true).containsAll(false, true, false));
 
         UnmodifiableBooleanBag trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(true, false));
+        assertFalse(trueCollection.containsAll(true, false));
         UnmodifiableBooleanBag falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(true, false));
+        assertFalse(falseCollection.containsAll(true, false));
     }
 
     @Override
@@ -183,22 +188,22 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
     public void containsAllIterable()
     {
         UnmodifiableBooleanBag emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
         UnmodifiableBooleanBag collection = this.newWith(true, true, false, false, false);
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
 
         UnmodifiableBooleanBag trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
         UnmodifiableBooleanBag falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
     }
 
     @Override
@@ -206,8 +211,8 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.bag, this.bag.asUnmodifiable());
-        Assert.assertEquals(this.bag, this.bag.asUnmodifiable());
+        assertSame(this.bag, this.bag.asUnmodifiable());
+        assertEquals(this.bag, this.bag.asUnmodifiable());
     }
 
     @Override
@@ -215,9 +220,9 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -225,8 +230,8 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -244,6 +249,6 @@ public class UnmodifiableBooleanBagTest extends AbstractMutableBooleanBagTestCas
         MutableBooleanBag bag = this.classUnderTest();
         MutableBooleanSet expected = BooleanSets.mutable.with(false);
         MutableBooleanSet actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBagTestCase.java
@@ -78,8 +78,18 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutableCollectionTestCase
 {
@@ -116,65 +126,65 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         MutableSortedBag<Integer> mutable = TreeBag.newBag(immutable);
         Verify.assertEqualsAndHashCode(mutable, immutable);
         Verify.assertPostSerializedEqualsAndHashCode(immutable);
-        Assert.assertNotEquals(FastList.newList(mutable), immutable);
+        assertNotEquals(FastList.newList(mutable), immutable);
 
         ImmutableSortedBag<Integer> bag1 = SortedBags.immutable.of(1, 1, 1, 4);
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(1, 1, 1, 3);
-        Assert.assertNotEquals(bag1, bag2);
+        assertNotEquals(bag1, bag2);
     }
 
     @Test
     public void anySatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.newWith(1, 2, 2);
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(1)));
-        Assert.assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 2));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 6));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(20)));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(1)));
+        assertTrue(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 2));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(2) && value == 6));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> object.equals(20)));
     }
 
     @Test
     public void allSatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.newWith(1, 2, 2);
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object > 0));
-        Assert.assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> object > 0));
+        assertFalse(bag.allSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
     }
 
     @Test
     public void noneSatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.newWith(1, 2, 2);
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object > 100));
-        Assert.assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> object > 100));
+        assertFalse(bag.noneSatisfyWithOccurrences((object, value) -> object.equals(1) && value == 1));
     }
 
     @Test
     public void detectWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.newWith(1, 2, 2);
-        Assert.assertEquals((Integer) 1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(100)));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 100));
+        assertEquals((Integer) 1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(100)));
+        assertNull(bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 100));
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(-1, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2, 2)));
-        Assert.assertEquals(0, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
-        Assert.assertEquals(1, SortedBags.immutable.of(1, 1, 2, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
+        assertEquals(-1, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2, 2)));
+        assertEquals(0, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
+        assertEquals(1, SortedBags.immutable.of(1, 1, 2, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
 
-        Assert.assertEquals(-1, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 3, 3)));
-        Assert.assertEquals(1, SortedBags.immutable.of(1, 1, 3, 3).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
+        assertEquals(-1, SortedBags.immutable.of(1, 1, 2, 2).compareTo(SortedBags.immutable.of(1, 1, 3, 3)));
+        assertEquals(1, SortedBags.immutable.of(1, 1, 3, 3).compareTo(SortedBags.immutable.of(1, 1, 2, 2)));
 
-        Assert.assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 2, 2, 1, 1, 1).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 2, 2, 1, 1)));
-        Assert.assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2)));
-        Assert.assertEquals(0, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
-        Assert.assertEquals(-1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 2, 2, 1, 1, 1).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 2, 2, 1, 1)));
+        assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2)));
+        assertEquals(0, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(-1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
 
-        Assert.assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 3, 3)));
-        Assert.assertEquals(-1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 3, 3).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 3, 3)));
+        assertEquals(-1, SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 3, 3).compareTo(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
     }
 
     @Test
@@ -184,13 +194,13 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         Verify.assertAllSatisfy(ints, IntegerPredicates.isEven());
 
         ImmutableSortedBag<Integer> ints2 = this.classUnderTest().selectByOccurrences(IntPredicates.isOdd());
-        Assert.assertEquals(ints2, this.classUnderTest());
+        assertEquals(ints2, this.classUnderTest());
     }
 
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.with(1, 1, 1),
                 this.classUnderTest().selectDuplicates());
     }
@@ -236,13 +246,13 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(1, 1, 1, 2), immutable.newWithout(4));
 
         // removing at the beginning point (not existing element)
-        Assert.assertEquals(immutable, immutable.newWithout(0));
+        assertEquals(immutable, immutable.newWithout(0));
 
         // removing at the middle point (not existing element)
-        Assert.assertEquals(immutable, immutable.newWithout(3));
+        assertEquals(immutable, immutable.newWithout(3));
 
         // removing at the end point (not existing element)
-        Assert.assertEquals(immutable, immutable.newWithout(5));
+        assertEquals(immutable, immutable.newWithout(5));
     }
 
     @Test
@@ -250,20 +260,20 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedBag<Integer> actualBag = bag.newWithAll(HashBag.newBagWith(3, 4));
-        Assert.assertNotEquals(bag, actualBag);
+        assertNotEquals(bag, actualBag);
         TreeBag<Integer> expectedBag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1, 1, 1);
         Verify.assertSortedBagsEqual(
                 expectedBag,
                 actualBag);
-        Assert.assertSame(expectedBag.comparator(), actualBag.comparator());
+        assertSame(expectedBag.comparator(), actualBag.comparator());
     }
 
     @Test
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", SortedBags.immutable.empty().toStringOfItemToCount());
-        Assert.assertEquals("{1=3, 2=1}", this.classUnderTest().toStringOfItemToCount());
-        Assert.assertEquals("{2=1, 1=3}", this.classUnderTest(Comparator.reverseOrder()).toStringOfItemToCount());
+        assertEquals("{}", SortedBags.immutable.empty().toStringOfItemToCount());
+        assertEquals("{1=3, 2=1}", this.classUnderTest().toStringOfItemToCount());
+        assertEquals("{2=1, 1=3}", this.classUnderTest(Comparator.reverseOrder()).toStringOfItemToCount());
     }
 
     @Test
@@ -272,30 +282,30 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
         ImmutableSortedBag<Integer> withoutAll = bag.newWithoutAll(bag);
 
-        Assert.assertEquals(SortedBags.immutable.<Integer>empty(), withoutAll);
-        Assert.assertEquals(Bags.immutable.<Integer>empty(), withoutAll);
+        assertEquals(SortedBags.immutable.<Integer>empty(), withoutAll);
+        assertEquals(Bags.immutable.<Integer>empty(), withoutAll);
 
         ImmutableSortedBag<Integer> largeWithoutAll = bag.newWithoutAll(Interval.fromTo(101, 150));
-        Assert.assertEquals(bag, largeWithoutAll);
+        assertEquals(bag, largeWithoutAll);
 
         ImmutableSortedBag<Integer> largeWithoutAll2 = bag.newWithoutAll(HashBag.newBag(Interval.fromTo(151, 199)));
-        Assert.assertEquals(bag, largeWithoutAll2);
+        assertEquals(bag, largeWithoutAll2);
     }
 
     @Test
     public void size()
     {
         ImmutableSortedBag<Object> empty = SortedBags.immutable.empty();
-        Assert.assertEquals(0, empty.size());
+        assertEquals(0, empty.size());
 
         ImmutableSortedBag<?> empty2 = SortedBags.immutable.empty(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(0, empty2.size());
+        assertEquals(0, empty2.size());
 
         ImmutableSortedBag<Integer> integers = SortedBags.immutable.of(Comparator.reverseOrder(), 1, 2, 3, 4, 4, 4);
-        Assert.assertEquals(6, integers.size());
+        assertEquals(6, integers.size());
 
         ImmutableSortedBag<Integer> integers2 = SortedBags.immutable.of(1, 2, 3, 4, 4, 4);
-        Assert.assertEquals(6, integers2.size());
+        assertEquals(6, integers2.size());
     }
 
     @Test
@@ -313,7 +323,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> bag1 = this.classUnderTest();
 
-        Assert.assertTrue(bag1.containsAllArguments(bag1.toArray()));
+        assertTrue(bag1.containsAllArguments(bag1.toArray()));
     }
 
     @Test
@@ -321,8 +331,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> bag1 = this.classUnderTest();
 
-        Assert.assertTrue(bag1.containsAllIterable(FastList.newListWith(1, 1, 1, 2)));
-        Assert.assertFalse(bag1.containsAllIterable(FastList.newListWith(50, 1, 1, 2)));
+        assertTrue(bag1.containsAllIterable(FastList.newListWith(1, 1, 1, 2)));
+        assertFalse(bag1.containsAllIterable(FastList.newListWith(50, 1, 1, 2)));
     }
 
     @Test
@@ -330,8 +340,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> bag1 = this.classUnderTest();
 
-        Assert.assertTrue(bag1.containsAll(FastList.newListWith(1, 1, 1, 2)));
-        Assert.assertFalse(bag1.containsAll(FastList.newListWith(50, 1, 1, 2)));
+        assertTrue(bag1.containsAll(FastList.newListWith(1, 1, 1, 2)));
+        assertFalse(bag1.containsAll(FastList.newListWith(50, 1, 1, 2)));
     }
 
     @Override
@@ -340,8 +350,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         MutableList<Integer> tapResult = Lists.mutable.empty();
         ImmutableSortedBag<Integer> collection = this.classUnderTest();
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Test
@@ -350,7 +360,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         MutableBag<Integer> result = HashBag.newBag();
         ImmutableSortedBag<Integer> collection = this.classUnderTest();
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Test
@@ -377,7 +387,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         MutableSortedSet<Integer> set = integers.toSortedSet();
-        Assert.assertEquals(SortedSets.immutable.of(1, 2), set);
+        assertEquals(SortedSets.immutable.of(1, 2), set);
     }
 
     @Override
@@ -387,14 +397,14 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
         MutableSortedSet<Integer> set = integers.toSortedSet();
         ImmutableSortedSet<Integer> expected = SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2);
-        Assert.assertEquals(expected, set);
-        Assert.assertNotSame(expected.comparator(), set.comparator());
+        assertEquals(expected, set);
+        assertNotSame(expected.comparator(), set.comparator());
 
         ImmutableSortedBag<Integer> integers2 = this.classUnderTest(Comparators.reverseNaturalOrder());
         MutableSortedSet<Integer> set2 = integers2.toSortedSet(Comparators.reverseNaturalOrder());
         ImmutableSortedSet<Integer> expected2 = SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2);
-        Assert.assertEquals(expected2, set2);
-        Assert.assertSame(expected2.comparator(), set2.comparator());
+        assertEquals(expected2, set2);
+        assertSame(expected2.comparator(), set2.comparator());
     }
 
     @Override
@@ -406,7 +416,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         TreeBag<Integer> expectedBag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2);
         ImmutableSortedBag<Integer> actualBag = integers.select(Predicates.lessThan(integers.size()));
         Verify.assertSortedBagsEqual(expectedBag, actualBag);
-        Assert.assertSame(expectedBag.comparator(), actualBag.comparator());
+        assertSame(expectedBag.comparator(), actualBag.comparator());
     }
 
     @Override
@@ -418,7 +428,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         TreeBag<Integer> expectedBag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2);
         ImmutableSortedBag<Integer> actualBag = integers.selectWith(Predicates2.lessThan(), integers.size());
         Verify.assertSortedBagsEqual(expectedBag, actualBag);
-        Assert.assertSame(expectedBag.comparator(), actualBag.comparator());
+        assertSame(expectedBag.comparator(), actualBag.comparator());
     }
 
     @Test
@@ -455,7 +465,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         Verify.assertSortedBagsEqual(
                 expectedBag,
                 actualBag);
-        Assert.assertSame(expectedBag.comparator(), actualBag.comparator());
+        assertSame(expectedBag.comparator(), actualBag.comparator());
     }
 
     @Test
@@ -469,7 +479,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 integers.reject(Predicates.greaterThan(integers.size()), FastList.newList()));
 
         ImmutableSortedBag<Integer> integers2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith(2),
                 integers2.reject(each -> each == 1, new HashBag<>()));
     }
@@ -479,10 +489,10 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void selectInstancesOf()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(bag, bag.selectInstancesOf(Integer.class));
+        assertEquals(bag, bag.selectInstancesOf(Integer.class));
         Verify.assertIterableEmpty(bag.selectInstancesOf(Double.class));
-        Assert.assertSame(bag.comparator(), bag.selectInstancesOf(Integer.class).comparator());
-        Assert.assertSame(bag.comparator(), bag.selectInstancesOf(Double.class).comparator());
+        assertSame(bag.comparator(), bag.selectInstancesOf(Integer.class).comparator());
+        assertSame(bag.comparator(), bag.selectInstancesOf(Double.class).comparator());
     }
 
     @Override
@@ -492,15 +502,15 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionImmutableSortedBag<Integer> partition1 = integers.partition(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(partition1.getSelected());
-        Assert.assertEquals(integers, partition1.getRejected());
-        Assert.assertSame(integers.comparator(), partition1.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition1.getRejected().comparator());
+        assertEquals(integers, partition1.getRejected());
+        assertSame(integers.comparator(), partition1.getSelected().comparator());
+        assertSame(integers.comparator(), partition1.getRejected().comparator());
 
         PartitionImmutableSortedBag<Integer> partition2 = integers.partition(integer -> integer % 2 == 0);
         Verify.assertSortedBagsEqual(integers.select(integer -> integer % 2 == 0), partition2.getSelected());
         Verify.assertSortedBagsEqual(integers.reject(integer -> integer % 2 == 0), partition2.getRejected());
-        Assert.assertSame(integers.comparator(), partition2.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition2.getRejected().comparator());
+        assertSame(integers.comparator(), partition2.getSelected().comparator());
+        assertSame(integers.comparator(), partition2.getRejected().comparator());
     }
 
     @Override
@@ -510,15 +520,15 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionImmutableSortedBag<Integer> partition1 = integers.partitionWith(Predicates2.greaterThan(), integers.size());
         Verify.assertIterableEmpty(partition1.getSelected());
-        Assert.assertEquals(integers, partition1.getRejected());
-        Assert.assertSame(integers.comparator(), partition1.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition1.getRejected().comparator());
+        assertEquals(integers, partition1.getRejected());
+        assertSame(integers.comparator(), partition1.getSelected().comparator());
+        assertSame(integers.comparator(), partition1.getRejected().comparator());
 
         PartitionImmutableSortedBag<Integer> partition2 = integers.partitionWith((integer, divisor) -> integer % divisor == 0, 2);
         Verify.assertSortedBagsEqual(integers.select(integer -> integer % 2 == 0), partition2.getSelected());
         Verify.assertSortedBagsEqual(integers.reject(integer -> integer % 2 == 0), partition2.getRejected());
-        Assert.assertSame(integers.comparator(), partition2.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition2.getRejected().comparator());
+        assertSame(integers.comparator(), partition2.getSelected().comparator());
+        assertSame(integers.comparator(), partition2.getRejected().comparator());
     }
 
     @Test
@@ -527,15 +537,15 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionSortedBag<Integer> partition1 = integers.partitionWhile(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(partition1.getSelected());
-        Assert.assertEquals(integers, partition1.getRejected());
-        Assert.assertSame(integers.comparator(), partition1.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition1.getRejected().comparator());
+        assertEquals(integers, partition1.getRejected());
+        assertSame(integers.comparator(), partition1.getSelected().comparator());
+        assertSame(integers.comparator(), partition1.getRejected().comparator());
 
         PartitionSortedBag<Integer> partition2 = integers.partitionWhile(Predicates.lessThanOrEqualTo(integers.size()));
-        Assert.assertEquals(integers, partition2.getSelected());
+        assertEquals(integers, partition2.getSelected());
         Verify.assertIterableEmpty(partition2.getRejected());
-        Assert.assertSame(integers.comparator(), partition2.getSelected().comparator());
-        Assert.assertSame(integers.comparator(), partition2.getRejected().comparator());
+        assertSame(integers.comparator(), partition2.getSelected().comparator());
+        assertSame(integers.comparator(), partition2.getRejected().comparator());
     }
 
     @Test
@@ -544,11 +554,11 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedBag<Integer> take1 = integers.takeWhile(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(take1);
-        Assert.assertSame(integers.comparator(), take1.comparator());
+        assertSame(integers.comparator(), take1.comparator());
 
         ImmutableSortedBag<Integer> take2 = integers.takeWhile(Predicates.lessThanOrEqualTo(integers.size()));
-        Assert.assertEquals(integers, take2);
-        Assert.assertSame(integers.comparator(), take2.comparator());
+        assertEquals(integers, take2);
+        assertSame(integers.comparator(), take2.comparator());
     }
 
     @Test
@@ -556,12 +566,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedBag<Integer> drop1 = integers.dropWhile(Predicates.greaterThan(integers.size()));
-        Assert.assertEquals(integers, drop1);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop1.comparator());
+        assertEquals(integers, drop1);
+        assertEquals(Collections.<Integer>reverseOrder(), drop1.comparator());
 
         ImmutableSortedBag<Integer> drop2 = integers.dropWhile(Predicates.lessThanOrEqualTo(integers.size()));
         Verify.assertIterableEmpty(drop2);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop2.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), drop2.comparator());
     }
 
     @Override
@@ -585,7 +595,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair(Integer.valueOf(1), 2),
                 PrimitiveTuples.pair(Integer.valueOf(1), 3));
         ImmutableList<ObjectIntPair<Integer>> actual = integers.collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**
@@ -602,7 +612,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair(Integer.valueOf(1), 3));
         MutableList<ObjectIntPair<Integer>> actual =
                 integers.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Override
@@ -617,7 +627,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectToTarget()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(HashBag.newBag(integers), integers.collect(Functions.getIntegerPassThru(), HashBag.newBag()));
+        assertEquals(HashBag.newBag(integers), integers.collect(Functions.getIntegerPassThru(), HashBag.newBag()));
         Verify.assertListsEqual(
                 integers.toList(),
                 integers.collect(Functions.getIntegerPassThru(), FastList.newList()));
@@ -629,7 +639,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableList<String> actual = this.classUnderTest(Collections.reverseOrder()).flatCollect(integer -> Lists.fixedSize.of(String.valueOf(integer)));
         ImmutableList<String> expected = this.classUnderTest(Collections.reverseOrder()).collect(String::valueOf);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         Verify.assertListsEqual(expected.toList(), actual.toList());
     }
 
@@ -639,7 +649,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         MutableBag<String> actual = this.classUnderTest().flatCollect(integer -> Lists.fixedSize.of(String.valueOf(integer)), HashBag.newBag());
 
         ImmutableList<String> expected = this.classUnderTest().collect(String::valueOf);
-        Assert.assertEquals(expected.toBag(), actual);
+        assertEquals(expected.toBag(), actual);
     }
 
     @Test
@@ -651,31 +661,31 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         List<Object> nullsMinusOne = Collections.nCopies(immutableBag.size() - 1, null);
 
         ImmutableList<Pair<Integer, Object>> pairs = immutableBag.zip(nulls);
-        Assert.assertEquals(immutableBag.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(immutableBag.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
         Verify.assertListsEqual(FastList.newListWith(2, 1, 1, 1), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toList());
-        Assert.assertEquals(FastList.newList(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(FastList.newList(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableList<Pair<Integer, Object>> pairsPlusOne = immutableBag.zip(nullsPlusOne);
-        Assert.assertEquals(immutableBag.toList(), pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(immutableBag.toList(), pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
         Verify.assertListsEqual(
                 FastList.newListWith(2, 1, 1, 1),
                 pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).castToList());
-        Assert.assertEquals(FastList.newList(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(FastList.newList(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableList<Pair<Integer, Object>> pairsMinusOne = immutableBag.zip(nullsMinusOne);
         Verify.assertListsEqual(
                 FastList.newListWith(2, 1, 1),
                 pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).castToList());
-        Assert.assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, FastList.newList()));
-        Assert.assertEquals(immutableBag.zip(nulls).toBag(), immutableBag.zip(nulls, new HashBag<>()));
+        assertEquals(immutableBag.zip(nulls), immutableBag.zip(nulls, FastList.newList()));
+        assertEquals(immutableBag.zip(nulls).toBag(), immutableBag.zip(nulls, new HashBag<>()));
 
         FastList<Holder> holders = FastList.newListWith(new Holder(1), new Holder(2), new Holder(3));
         ImmutableList<Pair<Integer, Holder>> zipped = immutableBag.zip(holders);
         Verify.assertSize(3, zipped.castToList());
         AbstractImmutableSortedBagTestCase.Holder two = new Holder(-1);
         AbstractImmutableSortedBagTestCase.Holder two1 = new Holder(-1);
-        Assert.assertEquals(Tuples.pair(10, two1), zipped.newWith(Tuples.pair(10, two)).getLast());
-        Assert.assertEquals(Tuples.pair(1, new Holder(3)), this.classUnderTest().zip(holders.reverseThis()).getFirst());
+        assertEquals(Tuples.pair(10, two1), zipped.newWith(Tuples.pair(10, two)).getLast());
+        assertEquals(Tuples.pair(1, new Holder(3)), this.classUnderTest().zip(holders.reverseThis()).getFirst());
     }
 
     @Test
@@ -691,7 +701,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 Tuples.pair(2, 5),
                 Tuples.pair(1, 6)).toImmutable();
         ImmutableSortedSet<Pair<Integer, Integer>> actual = integers.zipWithIndex();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         ImmutableSortedBag<Integer> integersNoComparator = SortedBags.immutable.of(1, 3, 5, 5, 5, 2, 4);
         ImmutableSortedSet<Pair<Integer, Integer>> expected2 = TreeSortedSet.newSetWith(
@@ -703,7 +713,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 Tuples.pair(5, 5),
                 Tuples.pair(5, 6)).toImmutable();
         ImmutableSortedSet<Pair<Integer, Integer>> actual2 = integersNoComparator.zipWithIndex();
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 
     @Override
@@ -716,7 +726,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
+        assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
         Verify.assertInstanceOf(ImmutableSortedBag.class, this.classUnderTest().chunk(10).getFirst());
     }
 
@@ -725,8 +735,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void detect()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
-        Assert.assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
+        assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
     }
 
     @Override
@@ -734,8 +744,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void detectWith()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
-        Assert.assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
     }
 
     @Override
@@ -745,8 +755,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         Function0<Integer> function = new PassThruFunction0<>(integers.size() + 1);
         Integer sum = Integer.valueOf(integers.size() + 1);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
-        Assert.assertEquals(Integer.valueOf(integers.size() + 1), integers.detectWithIfNone(Object::equals, sum, function));
+        assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
+        assertEquals(Integer.valueOf(integers.size() + 1), integers.detectWithIfNone(Object::equals, sum, function));
     }
 
     @Override
@@ -755,8 +765,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         Function0<Integer> function = new PassThruFunction0<>(integers.size() + 1);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
-        Assert.assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
+        assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
+        assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
     }
 
     @Override
@@ -764,8 +774,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void allSatisfy()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
+        assertTrue(integers.allSatisfy(Integer.class::isInstance));
+        assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
     }
 
     @Override
@@ -773,8 +783,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void anySatisfy()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfy(String.class::isInstance));
-        Assert.assertTrue(integers.anySatisfy(Integer.class::isInstance));
+        assertFalse(integers.anySatisfy(String.class::isInstance));
+        assertTrue(integers.anySatisfy(Integer.class::isInstance));
     }
 
     @Override
@@ -782,8 +792,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void count()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers.size(), integers.count(Integer.class::isInstance));
-        Assert.assertEquals(0, integers.count(String.class::isInstance));
+        assertEquals(integers.size(), integers.count(Integer.class::isInstance));
+        assertEquals(0, integers.count(String.class::isInstance));
     }
 
     @Override
@@ -800,7 +810,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         HashBag<Integer> actual = integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), HashBag.newBag());
-        Assert.assertEquals(integers.toBag(), actual);
+        assertEquals(integers.toBag(), actual);
     }
 
     @Override
@@ -808,9 +818,9 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void getFirst()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.getFirst());
+        assertEquals(Integer.valueOf(1), integers.getFirst());
         ImmutableSortedBag<Integer> revInt = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(Integer.valueOf(2), revInt.getFirst());
+        assertEquals(Integer.valueOf(2), revInt.getFirst());
     }
 
     @Override
@@ -818,9 +828,9 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void getLast()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(2), integers.getLast());
+        assertEquals(Integer.valueOf(2), integers.getLast());
         ImmutableSortedBag<Integer> revInt = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(Integer.valueOf(1), revInt.getLast());
+        assertEquals(Integer.valueOf(1), revInt.getLast());
     }
 
     @Override
@@ -828,8 +838,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void isEmpty()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertFalse(bag.isEmpty());
-        Assert.assertTrue(bag.notEmpty());
+        assertFalse(bag.isEmpty());
+        assertTrue(bag.notEmpty());
     }
 
     @Override
@@ -841,12 +851,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         for (int i = 0; iterator.hasNext(); i++)
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(i + 1, integer.intValue());
+            assertEquals(i + 1, integer.intValue());
         }
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
         Iterator<Integer> intItr = integers.iterator();
         intItr.next();
-        Assert.assertThrows(UnsupportedOperationException.class, intItr::remove);
+        assertThrows(UnsupportedOperationException.class, intItr::remove);
     }
 
     @Override
@@ -855,7 +865,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         Integer result = integers.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
     }
 
     @Override
@@ -864,24 +874,24 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         MutableList<Integer> copy = FastList.newList(integers);
-        Assert.assertArrayEquals(integers.toArray(), copy.toArray());
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size() - 1]), copy.toArray(new Integer[integers.size() - 1]));
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size() + 1]), copy.toArray(new Integer[integers.size() + 1]));
+        assertArrayEquals(integers.toArray(), copy.toArray());
+        assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
+        assertArrayEquals(integers.toArray(new Integer[integers.size() - 1]), copy.toArray(new Integer[integers.size() - 1]));
+        assertArrayEquals(integers.toArray(new Integer[integers.size() + 1]), copy.toArray(new Integer[integers.size() + 1]));
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).makeString(), this.classUnderTest().makeString());
+        assertEquals(FastList.newList(this.classUnderTest()).makeString(), this.classUnderTest().makeString());
     }
 
     @Override
@@ -890,7 +900,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         Appendable builder = new StringBuilder();
         this.classUnderTest().appendString(builder);
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).makeString(), builder.toString());
+        assertEquals(FastList.newList(this.classUnderTest()).makeString(), builder.toString());
     }
 
     @Test
@@ -908,7 +918,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         MutableList<Integer> copy = FastList.newList(integers);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(copy.sortThis(Collections.reverseOrder()), list);
+        assertEquals(copy.sortThis(Collections.reverseOrder()), list);
         MutableList<Integer> list2 = integers.toSortedList();
         Verify.assertListsEqual(copy.sortThis(), list2);
     }
@@ -918,7 +928,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(integers.toList(), list);
+        assertEquals(integers.toList(), list);
     }
 
     @Test
@@ -934,8 +944,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         MutableSortedBag<Integer> bag = integers.toSortedBag(Collections.reverseOrder());
-        Assert.assertEquals(integers.toBag(), bag);
-        Assert.assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), bag.toList());
+        assertEquals(integers.toBag(), bag);
+        assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), bag.toList());
     }
 
     @Test
@@ -982,7 +992,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
         for (Integer each : bag)
         {
-            Assert.assertNotNull(each);
+            assertNotNull(each);
         }
     }
 
@@ -992,51 +1002,51 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Collections.reverseOrder(), 1, 2, 2, 3, 3, 3);
         MutableSortedMap<Integer, Integer> expected = TreeSortedMap.newMapWith(Collections.reverseOrder(), 1, 1, 2, 2, 3, 3);
         MutableSortedMap<Integer, Integer> actual = bag.toMapOfItemToCount();
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(bag.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertSame(bag.comparator(), actual.comparator());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.classUnderTest().min(Comparators.reverseNaturalOrder()));
+        assertEquals(Integer.valueOf(2), this.classUnderTest().min(Comparators.reverseNaturalOrder()));
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverseNaturalOrder()));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverseNaturalOrder()));
     }
 
     @Override
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.classUnderTest().max());
+        assertEquals(Integer.valueOf(2), this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest(Comparator.reverseOrder()).minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.classUnderTest(Comparator.reverseOrder()).minBy(String::valueOf));
     }
 
     @Override
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.classUnderTest().maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(2), this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Test
@@ -1045,8 +1055,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> undertest = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedBagMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru());
         ImmutableSortedBagMultimap<Integer, Integer> expected = TreeBag.newBag(undertest).groupBy(Functions.getPassThru()).toImmutable();
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(Comparators.reverseNaturalOrder(), actual.comparator());
+        assertEquals(expected, actual);
+        assertSame(Comparators.reverseNaturalOrder(), actual.comparator());
     }
 
     @Test
@@ -1056,8 +1066,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         ImmutableSortedBagMultimap<Integer, Integer> actual = undertest.groupByEach(function);
         ImmutableSortedBagMultimap<Integer, Integer> expected = TreeBag.newBag(undertest).groupByEach(function).toImmutable();
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(Collections.reverseOrder(), actual.comparator());
+        assertEquals(expected, actual);
+        assertSame(Collections.reverseOrder(), actual.comparator());
     }
 
     @Test
@@ -1066,7 +1076,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> undertest = this.classUnderTest(Comparators.reverseNaturalOrder());
         TreeBagMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru(), TreeBagMultimap.newMultimap());
         TreeBagMultimap<Integer, Integer> expected = TreeBag.newBag(undertest).groupBy(Functions.getPassThru());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -1076,48 +1086,48 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         TreeBagMultimap<Integer, Integer> actual = undertest.groupByEach(function, TreeBagMultimap.newMultimap());
         TreeBagMultimap<Integer, Integer> expected = TreeBag.newBag(undertest).groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void groupByUniqueKey()
     {
         ImmutableSortedBag<Integer> bag1 = this.newWith(1, 2, 3);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag1.groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), bag1.groupByUniqueKey(id -> id));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertThrows(IllegalStateException.class, () -> bag2.groupByUniqueKey(id -> id));
+        assertThrows(IllegalStateException.class, () -> bag2.groupByUniqueKey(id -> id));
     }
 
     @Test
     public void groupByUniqueKey_target()
     {
         ImmutableSortedBag<Integer> bag1 = this.newWith(1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3),
                 bag1.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
 
         ImmutableSortedBag<Integer> bag2 = this.newWith(1, 2, 3);
-        Assert.assertThrows(IllegalStateException.class, () -> bag2.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(2, 2)));
+        assertThrows(IllegalStateException.class, () -> bag2.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(2, 2)));
     }
 
     @Test
     public void distinct()
     {
         ImmutableSortedBag<Integer> bag1 = this.classUnderTest();
-        Assert.assertEquals(SortedSets.immutable.of(1, 2), bag1.distinct());
+        assertEquals(SortedSets.immutable.of(1, 2), bag1.distinct());
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedSet<Integer> expected = SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2);
         ImmutableSortedSet<Integer> actual = bag2.distinct();
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertSame(expected.comparator(), actual.comparator());
     }
 
     @Test
     public void toStack()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(ArrayStack.newStackWith(2, 1, 1, 1), bag.toStack());
+        assertEquals(ArrayStack.newStackWith(2, 1, 1, 1), bag.toStack());
     }
 
     @Override
@@ -1125,7 +1135,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectBoolean()
     {
         ImmutableSortedBag<String> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), "true", "nah", "TrUe");
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayList.newListWith(true, false, true),
                 bag.collectBoolean(Boolean::parseBoolean));
     }
@@ -1135,7 +1145,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectByte()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ByteArrayList.newListWith((byte) 3, (byte) 2, (byte) 1, (byte) 1, (byte) 1),
                 bag.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
@@ -1145,7 +1155,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectChar()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 CharArrayList.newListWith((char) 3, (char) 2, (char) 1, (char) 1, (char) 1),
                 bag.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
     }
@@ -1155,7 +1165,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectDouble()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 DoubleArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
@@ -1165,7 +1175,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectFloat()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 FloatArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
@@ -1175,7 +1185,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectInt()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 IntArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
@@ -1185,7 +1195,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectLong()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 LongArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
@@ -1195,7 +1205,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectShort()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ShortArrayList.newListWith((short) 3, (short) 2, (short) 1, (short) 1, (short) 1),
                 bag.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
@@ -1204,12 +1214,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectBoolean_target()
     {
         ImmutableSortedBag<String> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), "true", "nah", "TrUe");
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayList.newListWith(true, false, true),
                 bag.collectBoolean(Boolean::parseBoolean, new BooleanArrayList()));
 
         ImmutableSortedBag<String> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), "true", "nah", "TrUe");
-        Assert.assertEquals(
+        assertEquals(
                 BooleanHashBag.newBagWith(true, false, true),
                 bag2.collectBoolean(Boolean::parseBoolean, new BooleanHashBag()));
     }
@@ -1218,12 +1228,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectByte_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ByteArrayList.newListWith((byte) 3, (byte) 2, (byte) 1, (byte) 1, (byte) 1),
                 bag.collectByte(PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ByteHashBag.newBagWith((byte) 3, (byte) 2, (byte) 1, (byte) 1, (byte) 1),
                 bag2.collectByte(PrimitiveFunctions.unboxIntegerToByte(), new ByteHashBag()));
     }
@@ -1232,12 +1242,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectChar_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 CharArrayList.newListWith((char) 3, (char) 2, (char) 1, (char) 1, (char) 1),
                 bag.collectChar(PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 CharHashBag.newBagWith((char) 3, (char) 2, (char) 1, (char) 1, (char) 1),
                 bag2.collectChar(PrimitiveFunctions.unboxIntegerToChar(), new CharHashBag()));
     }
@@ -1246,12 +1256,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectDouble_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 DoubleArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashBag.newBagWith(3, 2, 1, 1, 1),
                 bag2.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), new DoubleHashBag()));
     }
@@ -1260,12 +1270,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectFloat_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 FloatArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashBag.newBagWith(3, 2, 1, 1, 1),
                 bag2.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), new FloatHashBag()));
     }
@@ -1274,12 +1284,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectInt_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 IntArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectInt(PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 IntHashBag.newBagWith(3, 2, 1, 1, 1),
                 bag2.collectInt(PrimitiveFunctions.unboxIntegerToInt(), new IntHashBag()));
     }
@@ -1288,12 +1298,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectLong_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 LongArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectLong(PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 LongHashBag.newBagWith(3, 2, 1, 1, 1),
                 bag2.collectLong(PrimitiveFunctions.unboxIntegerToLong(), new LongHashBag()));
     }
@@ -1302,12 +1312,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void collectShort_target()
     {
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ShortArrayList.newListWith((short) 3, (short) 2, (short) 1, (short) 1, (short) 1),
                 bag.collectShort(PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ShortHashBag.newBagWith((short) 3, (short) 2, (short) 1, (short) 1, (short) 1),
                 bag2.collectShort(PrimitiveFunctions.unboxIntegerToShort(), new ShortHashBag()));
     }
@@ -1316,9 +1326,9 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void occurrencesOf()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(0, bag.occurrencesOf(5));
-        Assert.assertEquals(3, bag.occurrencesOf(1));
-        Assert.assertEquals(1, bag.occurrencesOf(2));
+        assertEquals(0, bag.occurrencesOf(5));
+        assertEquals(3, bag.occurrencesOf(1));
+        assertEquals(1, bag.occurrencesOf(2));
     }
 
     @Test
@@ -1326,8 +1336,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
         ImmutableSortedBag<Integer> actual = bag.toImmutable();
-        Assert.assertEquals(bag, actual);
-        Assert.assertSame(bag, actual);
+        assertEquals(bag, actual);
+        assertSame(bag, actual);
     }
 
     @Test
@@ -1338,24 +1348,24 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
 
         MutableList<Integer> result = Lists.mutable.empty();
         integers1.forEach(5, 7, result::add);
-        Assert.assertEquals(Lists.immutable.with(3, 3, 2), result);
+        assertEquals(Lists.immutable.with(3, 3, 2), result);
 
         MutableList<Integer> result2 = Lists.mutable.empty();
         integers1.forEach(5, 5, result2::add);
-        Assert.assertEquals(Lists.immutable.with(3), result2);
+        assertEquals(Lists.immutable.with(3), result2);
 
         MutableList<Integer> result3 = Lists.mutable.empty();
         integers1.forEach(0, 9, result3::add);
-        Assert.assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
+        assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEach(-1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEach(0, -1, result::add));
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers1.forEach(7, 5, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEach(0, -1, result::add));
+        assertThrows(IllegalArgumentException.class, () -> integers1.forEach(7, 5, result::add));
 
         ImmutableSortedBag<Integer> integers2 = this.classUnderTest();
         MutableList<Integer> mutableList = Lists.mutable.of();
         integers2.forEach(0, integers2.size() - 1, mutableList::add);
-        Assert.assertEquals(this.classUnderTest().toList(), mutableList);
+        assertEquals(this.classUnderTest().toList(), mutableList);
     }
 
     @Test
@@ -1364,26 +1374,26 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> integers1 = SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         StringBuilder builder = new StringBuilder();
         integers1.forEachWithIndex(5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("353627", builder.toString());
+        assertEquals("353627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         integers1.forEachWithIndex(5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("35", builder2.toString());
+        assertEquals("35", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         integers1.forEachWithIndex(0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("40414243343536272819", builder3.toString());
+        assertEquals("40414243343536272819", builder3.toString());
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEachWithIndex(-1, 0, new AddToList(Lists.mutable.empty())));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEachWithIndex(0, -1, new AddToList(Lists.mutable.empty())));
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers1.forEachWithIndex(7, 5, new AddToList(Lists.mutable.empty())));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEachWithIndex(-1, 0, new AddToList(Lists.mutable.empty())));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers1.forEachWithIndex(0, -1, new AddToList(Lists.mutable.empty())));
+        assertThrows(IllegalArgumentException.class, () -> integers1.forEachWithIndex(7, 5, new AddToList(Lists.mutable.empty())));
 
         ImmutableSortedBag<Integer> integers2 = this.classUnderTest();
         MutableList<Integer> mutableList1 = Lists.mutable.of();
         integers2.forEachWithIndex(0, integers2.size() - 1, (each, index) -> mutableList1.add(each + index));
         MutableList<Integer> result = Lists.mutable.of();
         Lists.mutable.ofAll(integers2).forEachWithIndex(0, integers2.size() - 1, (each, index) -> result.add(each + index));
-        Assert.assertEquals(result, mutableList1);
+        assertEquals(result, mutableList1);
     }
 
     @Test
@@ -1401,21 +1411,21 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair("nine", 9),
                 PrimitiveTuples.pair("ten", 10));
         ListIterable<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
-        Assert.assertEquals(5, top5.size());
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
-        Assert.assertEquals(0, this.newWith().topOccurrences(5).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(5).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(1).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(2).size());
-        Assert.assertEquals(3, this.newWith("one", "one", "two", "three").topOccurrences(2).size());
-        Assert.assertEquals(2, this.newWith("one", "one", "two", "two", "three").topOccurrences(1).size());
-        Assert.assertEquals(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1).size());
-        Assert.assertEquals(0, this.newWith().topOccurrences(0).size());
-        Assert.assertEquals(0, this.newWith("one").topOccurrences(0).size());
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertEquals(5, top5.size());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
+        assertEquals(0, this.newWith().topOccurrences(5).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(5).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(1).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(2).size());
+        assertEquals(3, this.newWith("one", "one", "two", "three").topOccurrences(2).size());
+        assertEquals(2, this.newWith("one", "one", "two", "two", "three").topOccurrences(1).size());
+        assertEquals(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1).size());
+        assertEquals(0, this.newWith().topOccurrences(0).size());
+        assertEquals(0, this.newWith("one").topOccurrences(0).size());
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
     }
 
     @Test
@@ -1433,75 +1443,75 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
                 PrimitiveTuples.pair("nine", 9),
                 PrimitiveTuples.pair("ten", 10));
         ListIterable<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
-        Assert.assertEquals(5, bottom5.size());
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
-        Assert.assertEquals(0, this.newWith().bottomOccurrences(5).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(5).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(1).size());
-        Assert.assertEquals(3, this.newWith("one", "two", "three").topOccurrences(2).size());
-        Assert.assertEquals(3, this.newWith("one", "one", "two", "three").topOccurrences(2).size());
-        Assert.assertEquals(2, this.newWith("one", "one", "two", "two", "three").topOccurrences(1).size());
-        Assert.assertEquals(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1).size());
-        Assert.assertEquals(0, this.newWith().bottomOccurrences(0).size());
-        Assert.assertEquals(0, this.newWith("one").bottomOccurrences(0).size());
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertEquals(5, bottom5.size());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals(0, this.newWith().bottomOccurrences(5).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(5).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(1).size());
+        assertEquals(3, this.newWith("one", "two", "three").topOccurrences(2).size());
+        assertEquals(3, this.newWith("one", "one", "two", "three").topOccurrences(2).size());
+        assertEquals(2, this.newWith("one", "one", "two", "two", "three").topOccurrences(1).size());
+        assertEquals(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1).size());
+        assertEquals(0, this.newWith().bottomOccurrences(0).size());
+        assertEquals(0, this.newWith("one").bottomOccurrences(0).size());
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
     }
 
     @Test
     public void corresponds()
     {
-        Assert.assertFalse(this.newWith(1, 2, 3, 4, 5).corresponds(this.newWith(1, 2, 3, 4), Predicates2.alwaysTrue()));
+        assertFalse(this.newWith(1, 2, 3, 4, 5).corresponds(this.newWith(1, 2, 3, 4), Predicates2.alwaysTrue()));
 
         ImmutableSortedBag<Integer> integers1 = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         MutableList<Integer> integers2 = FastList.newListWith(2, 3, 3, 4, 4, 4, 5, 5, 5, 5);
-        Assert.assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
 
         ImmutableSortedBag<Integer> integers3 = this.newWith(1, 2, 3, 4);
         MutableSortedSet<Integer> integers4 = SortedSets.mutable.of(2, 3, 4, 5);
-        Assert.assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
-        Assert.assertFalse(integers3.corresponds(integers4, Predicates2.greaterThan()));
-        Assert.assertTrue(integers3.corresponds(integers4, Predicates2.lessThan()));
+        assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
+        assertFalse(integers3.corresponds(integers4, Predicates2.greaterThan()));
+        assertTrue(integers3.corresponds(integers4, Predicates2.lessThan()));
     }
 
     @Test
     public void detectIndex()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(0, integers.detectIndex(each -> each == 2));
+        assertEquals(0, integers.detectIndex(each -> each == 2));
 
         ImmutableSortedBag<Integer> integers2 = this.classUnderTest();
-        Assert.assertEquals(-1, integers2.detectIndex(each -> each == 100));
+        assertEquals(-1, integers2.detectIndex(each -> each == 100));
     }
 
     @Test
     public void indexOf()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(1, integers.indexOf(1));
-        Assert.assertEquals(1, integers.indexOf(1));
-        Assert.assertEquals(0, integers.indexOf(2));
-        Assert.assertEquals(-1, integers.indexOf(0));
-        Assert.assertEquals(-1, integers.indexOf(5));
+        assertEquals(1, integers.indexOf(1));
+        assertEquals(1, integers.indexOf(1));
+        assertEquals(0, integers.indexOf(2));
+        assertEquals(-1, integers.indexOf(0));
+        assertEquals(-1, integers.indexOf(5));
     }
 
     @Test
     public void take()
     {
         ImmutableSortedBag<Integer> integers1 = this.classUnderTest();
-        Assert.assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.take(0));
-        Assert.assertSame(integers1.comparator(), integers1.take(0).comparator());
-        Assert.assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(3));
-        Assert.assertSame(integers1.comparator(), integers1.take(3).comparator());
-        Assert.assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(integers1.size() - 1));
+        assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.take(0));
+        assertSame(integers1.comparator(), integers1.take(0).comparator());
+        assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(3));
+        assertSame(integers1.comparator(), integers1.take(3).comparator());
+        assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(integers1.size() - 1));
 
         ImmutableSortedBag<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertSame(integers2, integers2.take(integers2.size()));
-        Assert.assertSame(integers2, integers2.take(10));
-        Assert.assertSame(integers2, integers2.take(Integer.MAX_VALUE));
+        assertSame(integers2, integers2.take(integers2.size()));
+        assertSame(integers2, integers2.take(10));
+        assertSame(integers2, integers2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1514,12 +1524,12 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
     public void drop()
     {
         ImmutableSortedBag<Integer> integers1 = this.classUnderTest();
-        Assert.assertSame(integers1, integers1.drop(0));
-        Assert.assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(3));
-        Assert.assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(integers1.size() - 1));
-        Assert.assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(integers1.size()));
-        Assert.assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(10));
-        Assert.assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(Integer.MAX_VALUE));
+        assertSame(integers1, integers1.drop(0));
+        assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(3));
+        assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(integers1.size() - 1));
+        assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(integers1.size()));
+        assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(10));
+        assertEquals(SortedBags.immutable.empty(integers1.comparator()), integers1.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1535,8 +1545,8 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         ImmutableSortedBag<Integer> bag = SortedBags.immutable.with(comparator, 5, 4, 3, 3, 2, 2, 2, 1, 1, 1, 1, 0);
         ImmutableSortedSet<Integer> expected = SortedSets.immutable.with(comparator, 5, 4, 0);
         ImmutableSortedSet<Integer> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
-        Assert.assertEquals(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertEquals(expected.comparator(), actual.comparator());
     }
 
     @Test
@@ -1547,7 +1557,7 @@ public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutab
         RichIterable<Integer> expected = bag.toSortedSet(comparator);
         RichIterable<Integer> actual = bag.distinctView();
         // test content/type
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         // test sorting
         Verify.assertIterablesEqual(expected, actual);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableEmptySortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableEmptySortedBagTest.java
@@ -63,8 +63,16 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestCase
 {
@@ -104,39 +112,39 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         //Evaluates true for all empty lists and false for all non-empty lists
 
-        Assert.assertTrue(this.classUnderTest().corresponds(Lists.mutable.of(), Predicates2.alwaysFalse()));
+        assertTrue(this.classUnderTest().corresponds(Lists.mutable.of(), Predicates2.alwaysFalse()));
 
         ImmutableSortedBag<Integer> integers = this.classUnderTest().newWith(Integer.valueOf(1));
-        Assert.assertFalse(this.classUnderTest().corresponds(integers, Predicates2.alwaysTrue()));
+        assertFalse(this.classUnderTest().corresponds(integers, Predicates2.alwaysTrue()));
     }
 
     @Override
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(0, this.classUnderTest().compareTo(this.classUnderTest()));
-        Assert.assertEquals(0, this.classUnderTest(Comparator.reverseOrder()).compareTo(this.classUnderTest(Comparator.reverseOrder())));
-        Assert.assertEquals(0, this.classUnderTest(Comparator.naturalOrder()).compareTo(this.classUnderTest(Comparator.reverseOrder())));
-        Assert.assertEquals(-1, this.classUnderTest().compareTo(TreeBag.newBagWith(1)));
-        Assert.assertEquals(-1, this.classUnderTest(Comparator.reverseOrder()).compareTo(TreeBag.newBagWith(Comparator.reverseOrder(), 1)));
-        Assert.assertEquals(-5, this.classUnderTest().compareTo(TreeBag.newBagWith(1, 2, 2, 3, 4)));
-        Assert.assertEquals(0, this.classUnderTest().compareTo(TreeBag.newBag()));
-        Assert.assertEquals(0, this.classUnderTest().compareTo(TreeBag.newBag(Comparator.reverseOrder())));
+        assertEquals(0, this.classUnderTest().compareTo(this.classUnderTest()));
+        assertEquals(0, this.classUnderTest(Comparator.reverseOrder()).compareTo(this.classUnderTest(Comparator.reverseOrder())));
+        assertEquals(0, this.classUnderTest(Comparator.naturalOrder()).compareTo(this.classUnderTest(Comparator.reverseOrder())));
+        assertEquals(-1, this.classUnderTest().compareTo(TreeBag.newBagWith(1)));
+        assertEquals(-1, this.classUnderTest(Comparator.reverseOrder()).compareTo(TreeBag.newBagWith(Comparator.reverseOrder(), 1)));
+        assertEquals(-5, this.classUnderTest().compareTo(TreeBag.newBagWith(1, 2, 2, 3, 4)));
+        assertEquals(0, this.classUnderTest().compareTo(TreeBag.newBag()));
+        assertEquals(0, this.classUnderTest().compareTo(TreeBag.newBag(Comparator.reverseOrder())));
     }
 
     @Override
     @Test
     public void selectDuplicates()
     {
-        Assert.assertEquals(Bags.immutable.empty(), this.classUnderTest().selectDuplicates());
+        assertEquals(Bags.immutable.empty(), this.classUnderTest().selectDuplicates());
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(1));
-        Assert.assertFalse(this.classUnderTest(Comparator.reverseOrder()).contains(1));
+        assertFalse(this.classUnderTest().contains(1));
+        assertFalse(this.classUnderTest(Comparator.reverseOrder()).contains(1));
     }
 
     @Test(expected = NullPointerException.class)
@@ -149,45 +157,45 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Override
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.alwaysFalse(), "false"));
-        Assert.assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).allSatisfyWith(Predicates2.alwaysFalse(), false));
+        assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.alwaysFalse(), "false"));
+        assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).allSatisfyWith(Predicates2.alwaysFalse(), false));
     }
 
     @Override
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.alwaysFalse(), "false"));
-        Assert.assertFalse(this.classUnderTest(Comparators.reverseNaturalOrder()).anySatisfyWith(Predicates2.alwaysFalse(), false));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.alwaysFalse(), "false"));
+        assertFalse(this.classUnderTest(Comparators.reverseNaturalOrder()).anySatisfyWith(Predicates2.alwaysFalse(), false));
     }
 
     @Override
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.alwaysFalse(), "false"));
-        Assert.assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).noneSatisfyWith(Predicates2.alwaysFalse(), false));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.alwaysFalse(), "false"));
+        assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).noneSatisfyWith(Predicates2.alwaysFalse(), false));
     }
 
     @Override
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.alwaysFalse()));
-        Assert.assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).noneSatisfy(Predicates.alwaysFalse()));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.alwaysFalse()));
+        assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).noneSatisfy(Predicates.alwaysFalse()));
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith(1, 2, 3)));
-        Assert.assertFalse(this.classUnderTest(Comparator.reverseOrder()).containsAllIterable(FastList.newListWith(1, 2, 3)));
+        assertFalse(this.classUnderTest().containsAllIterable(FastList.newListWith(1, 2, 3)));
+        assertFalse(this.classUnderTest(Comparator.reverseOrder()).containsAllIterable(FastList.newListWith(1, 2, 3)));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertFalse(this.classUnderTest(Comparator.reverseOrder()).containsAll(FastList.newListWith(1, 2, 3)));
+        assertFalse(this.classUnderTest().containsAll(FastList.newListWith(1, 2, 3)));
+        assertFalse(this.classUnderTest(Comparator.reverseOrder()).containsAll(FastList.newListWith(1, 2, 3)));
     }
 
     @Override
@@ -204,8 +212,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void anySatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> true));
-        Assert.assertFalse(bag.anySatisfyWithOccurrences((object, value) -> false));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> true));
+        assertFalse(bag.anySatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -213,8 +221,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void allSatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> true));
-        Assert.assertTrue(bag.allSatisfyWithOccurrences((object, value) -> false));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> true));
+        assertTrue(bag.allSatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -222,8 +230,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void noneSatisfyWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> true));
-        Assert.assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> false));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> true));
+        assertTrue(bag.noneSatisfyWithOccurrences((object, value) -> false));
     }
 
     @Override
@@ -231,39 +239,39 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void detectWithOccurrences()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> true));
-        Assert.assertNull(bag.detectWithOccurrences((object, value) -> false));
+        assertNull(bag.detectWithOccurrences((object, value) -> true));
+        assertNull(bag.detectWithOccurrences((object, value) -> false));
     }
 
     @Override
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().chunk(10));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().chunk(10));
     }
 
     @Override
     @Test
     public void detect()
     {
-        Assert.assertNull(this.classUnderTest().detect(each -> each % 2 == 0));
-        Assert.assertNull(this.classUnderTest(Comparator.naturalOrder()).detect(each -> each % 2 == 0));
+        assertNull(this.classUnderTest().detect(each -> each % 2 == 0));
+        assertNull(this.classUnderTest(Comparator.naturalOrder()).detect(each -> each % 2 == 0));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(each -> each % 2 == 0));
-        Assert.assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).allSatisfy(each -> each % 2 == 0));
+        assertTrue(this.classUnderTest().allSatisfy(each -> each % 2 == 0));
+        assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).allSatisfy(each -> each % 2 == 0));
     }
 
     @Override
     @Test
     public void detectWith()
     {
-        Assert.assertNull(this.classUnderTest().detectWith(Predicates2.greaterThan(), 3));
-        Assert.assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).detectWith(Predicates2.greaterThan(), 3));
+        assertNull(this.classUnderTest().detectWith(Predicates2.greaterThan(), 3));
+        assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).detectWith(Predicates2.greaterThan(), 3));
     }
 
     @Override
@@ -299,15 +307,15 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Test
     public void toSortedBag()
     {
-        Assert.assertEquals(TreeBag.newBag(), this.classUnderTest().toSortedBag());
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).toSortedBag());
+        assertEquals(TreeBag.newBag(), this.classUnderTest().toSortedBag());
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).toSortedBag());
     }
 
     @Override
     @Test
     public void toSortedMap()
     {
-        Assert.assertEquals(SortedMaps.mutable.empty(), this.classUnderTest().toSortedMap(Functions.getIntegerPassThru(), Functions.getIntegerPassThru()));
+        assertEquals(SortedMaps.mutable.empty(), this.classUnderTest().toSortedMap(Functions.getIntegerPassThru(), Functions.getIntegerPassThru()));
     }
 
     @Override
@@ -318,7 +326,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
                 Functions.getIntegerPassThru(), Functions.getIntegerPassThru());
         Verify.assertEmpty(map);
         Verify.assertInstanceOf(TreeSortedMap.class, map);
-        Assert.assertEquals(Comparators.<String>reverseNaturalOrder(), map.comparator());
+        assertEquals(Comparators.<String>reverseNaturalOrder(), map.comparator());
     }
 
     @Override
@@ -335,16 +343,16 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Test
     public void toStack()
     {
-        Assert.assertEquals(Stacks.immutable.empty(), this.classUnderTest().toStack());
-        Assert.assertEquals(Stacks.immutable.empty(), this.classUnderTest(Comparators.reverseNaturalOrder()).toStack());
+        assertEquals(Stacks.immutable.empty(), this.classUnderTest().toStack());
+        assertEquals(Stacks.immutable.empty(), this.classUnderTest(Comparators.reverseNaturalOrder()).toStack());
     }
 
     @Override
     @Test
     public void toStringOfItemToCount()
     {
-        Assert.assertEquals("{}", this.classUnderTest().toStringOfItemToCount());
-        Assert.assertEquals("{}", this.classUnderTest(Comparator.reverseOrder()).toStringOfItemToCount());
+        assertEquals("{}", this.classUnderTest().toStringOfItemToCount());
+        assertEquals("{}", this.classUnderTest(Comparator.reverseOrder()).toStringOfItemToCount());
     }
 
     @Override
@@ -352,7 +360,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void groupByUniqueKey()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(Maps.mutable.empty(), bag.groupByUniqueKey(integer -> integer));
+        assertEquals(Maps.mutable.empty(), bag.groupByUniqueKey(integer -> integer));
     }
 
     @Override
@@ -360,7 +368,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void groupByUniqueKey_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0),
                 bag.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
@@ -368,23 +376,23 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Test
     public void countByEach()
     {
-        Assert.assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
+        assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
     }
 
     @Test
     public void countByEach_target()
     {
         MutableBag<Integer> target = Bags.mutable.empty();
-        Assert.assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
+        assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
     }
 
     @Override
     @Test
     public void zip()
     {
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().zip(Iterables.iBag()));
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().zip(Iterables.iBag(), FastList.newList()));
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest(Comparators.reverseNaturalOrder()).zip(Iterables.iBag()));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().zip(Iterables.iBag()));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().zip(Iterables.iBag(), FastList.newList()));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest(Comparators.reverseNaturalOrder()).zip(Iterables.iBag()));
     }
 
     @Override
@@ -392,8 +400,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest(Comparator.reverseOrder());
         ImmutableSortedSet<Pair<Integer, Integer>> actual = bag.zipWithIndex();
-        Assert.assertEquals(SortedSets.immutable.empty(), actual);
-        Assert.assertSame(SortedSets.immutable.empty(Comparator.<Integer>reverseOrder()).comparator(), actual.comparator());
+        assertEquals(SortedSets.immutable.empty(), actual);
+        assertSame(SortedSets.immutable.empty(Comparator.<Integer>reverseOrder()).comparator(), actual.comparator());
     }
 
     @Override
@@ -428,24 +436,24 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Test
     public void newWithTest()
     {
-        Assert.assertEquals(SortedBags.immutable.of(1), this.classUnderTest().newWith(1));
-        Assert.assertEquals(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1), this.classUnderTest(Comparators.reverseNaturalOrder()).newWith(1));
+        assertEquals(SortedBags.immutable.of(1), this.classUnderTest().newWith(1));
+        assertEquals(SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1), this.classUnderTest(Comparators.reverseNaturalOrder()).newWith(1));
     }
 
     @Override
     @Test
     public void newWithAll()
     {
-        Assert.assertEquals(SortedBags.immutable.ofAll(FastList.newListWith(1, 2, 3, 3)), this.classUnderTest().newWithAll(FastList.newListWith(1, 2, 3, 3)));
-        Assert.assertEquals(SortedBags.immutable.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 3)), this.classUnderTest(Comparators.reverseNaturalOrder()).newWithAll(FastList.newListWith(1, 2, 3, 3)));
+        assertEquals(SortedBags.immutable.ofAll(FastList.newListWith(1, 2, 3, 3)), this.classUnderTest().newWithAll(FastList.newListWith(1, 2, 3, 3)));
+        assertEquals(SortedBags.immutable.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 3)), this.classUnderTest(Comparators.reverseNaturalOrder()).newWithAll(FastList.newListWith(1, 2, 3, 3)));
     }
 
     @Override
     @Test
     public void newWithout()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().newWithout(1));
-        Assert.assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).newWithout(1));
+        assertEquals(this.classUnderTest(), this.classUnderTest().newWithout(1));
+        assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).newWithout(1));
     }
 
     @Override
@@ -456,8 +464,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         PartitionImmutableSortedBag<Integer> partition = bag.partition(Predicates.lessThan(4));
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertSame(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertSame(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertSame(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertSame(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -468,8 +476,8 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         PartitionSortedBag<Integer> partition = bag.partitionWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertSame(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertSame(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertSame(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertSame(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -480,7 +488,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         TreeSortedMap<Object, Object> expectedMap = TreeSortedMap.newMap(Comparators.reverseNaturalOrder());
         MutableSortedMap<Integer, Integer> actualMap = bag.toMapOfItemToCount();
         Verify.assertSortedMapsEqual(expectedMap, actualMap);
-        Assert.assertSame(expectedMap.comparator(), actualMap.comparator());
+        assertSame(expectedMap.comparator(), actualMap.comparator());
     }
 
     @Override
@@ -491,24 +499,24 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         PartitionImmutableSortedBag<Integer> partition = bag.partitionWith(Predicates2.lessThan(), 4);
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject(each -> each % 2 == 0));
-        Assert.assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).reject(each -> each % 2 == 0));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject(each -> each % 2 == 0));
+        assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).reject(each -> each % 2 == 0));
     }
 
     @Override
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().rejectWith(Predicates2.alwaysFalse(), 2));
-        Assert.assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).rejectWith(Predicates2.alwaysFalse(), 2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().rejectWith(Predicates2.alwaysFalse(), 2));
+        assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).rejectWith(Predicates2.alwaysFalse(), 2));
     }
 
     @Override
@@ -533,7 +541,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
         MutableSortedSet<Integer> set = integers.toSortedSet();
-        Assert.assertEquals(SortedSets.immutable.empty(), set);
+        assertEquals(SortedSets.immutable.empty(), set);
     }
 
     @Override
@@ -542,22 +550,22 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
         MutableSortedSet<Integer> set = integers.toSortedSet();
-        Assert.assertEquals(SortedSets.immutable.of(Comparator.<Integer>reverseOrder()), set);
+        assertEquals(SortedSets.immutable.of(Comparator.<Integer>reverseOrder()), set);
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select(each -> each % 2 == 0));
-        Assert.assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).select(each -> each % 2 == 0));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select(each -> each % 2 == 0));
+        assertEquals(this.classUnderTest(Comparators.reverseNaturalOrder()), this.classUnderTest(Comparators.reverseNaturalOrder()).select(each -> each % 2 == 0));
     }
 
     @Override
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().selectWith(Predicates2.alwaysFalse(), "false"));
+        assertEquals(this.classUnderTest(), this.classUnderTest().selectWith(Predicates2.alwaysFalse(), "false"));
     }
 
     @Override
@@ -567,18 +575,18 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         ImmutableSortedBag<Integer> set = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedBag<Integer> take = set.takeWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(take);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), take.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), take.comparator());
     }
 
     @Override
     @Test
     public void distinct()
     {
-        Assert.assertEquals(SortedSets.immutable.empty(), this.classUnderTest().distinct());
+        assertEquals(SortedSets.immutable.empty(), this.classUnderTest().distinct());
         ImmutableSortedSet<Object> expected = SortedSets.immutable.with(Comparators.reverseNaturalOrder());
         ImmutableSortedSet<Integer> actual = this.classUnderTest(Comparators.reverseNaturalOrder()).distinct();
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertSame(expected.comparator(), actual.comparator());
     }
 
     @Override
@@ -588,7 +596,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         ImmutableSortedBag<Integer> set = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedBag<Integer> drop = set.dropWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(drop);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), drop.comparator());
     }
 
     @Override
@@ -598,7 +606,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         ImmutableSortedBag<Integer> immutable = this.classUnderTest();
         Verify.assertEqualsAndHashCode(HashBag.newBag(), immutable);
         Verify.assertPostSerializedIdentity(immutable);
-        Assert.assertNotEquals(Lists.mutable.empty(), immutable);
+        assertNotEquals(Lists.mutable.empty(), immutable);
 
         ImmutableSortedBag<Integer> bagWithComparator = this.classUnderTest(Comparators.reverseNaturalOrder());
         Verify.assertEqualsAndHashCode(HashBag.newBag(), bagWithComparator);
@@ -609,57 +617,57 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     @Test
     public void getLast()
     {
-        Assert.assertNull(this.classUnderTest().getLast());
-        Assert.assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).getLast());
+        assertNull(this.classUnderTest().getLast());
+        assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).getLast());
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNull(this.classUnderTest().getFirst());
-        Assert.assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).getFirst());
+        assertNull(this.classUnderTest().getFirst());
+        assertNull(this.classUnderTest(Comparators.reverseNaturalOrder()).getFirst());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
     public void detectIndex()
     {
-        Assert.assertEquals(-1, this.classUnderTest().detectIndex(each -> each > 1));
+        assertEquals(-1, this.classUnderTest().detectIndex(each -> each > 1));
     }
 
     @Override
     public void indexOf()
     {
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(1));
+        assertEquals(-1, this.classUnderTest().indexOf(1));
     }
 
     @Override
     @Test
     public void occurrencesOf()
     {
-        Assert.assertEquals(0, this.classUnderTest().occurrencesOf(1));
+        assertEquals(0, this.classUnderTest().occurrencesOf(1));
     }
 
     @Override
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().isEmpty());
-        Assert.assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).isEmpty());
+        assertTrue(this.classUnderTest().isEmpty());
+        assertTrue(this.classUnderTest(Comparators.reverseNaturalOrder()).isEmpty());
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(each -> each * 2 == 4));
-        Assert.assertFalse(this.classUnderTest(Comparators.reverseNaturalOrder()).anySatisfy(each -> each * 2 == 4));
+        assertFalse(this.classUnderTest().anySatisfy(each -> each * 2 == 4));
+        assertFalse(this.classUnderTest(Comparators.reverseNaturalOrder()).anySatisfy(each -> each * 2 == 4));
     }
 
     @Override
@@ -667,21 +675,21 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectIfToTarget()
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers.toBag(), integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), HashBag.newBag()));
+        assertEquals(integers.toBag(), integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), HashBag.newBag()));
     }
 
     @Override
     @Test
     public void topOccurrences()
     {
-        Assert.assertEquals(0, this.classUnderTest().topOccurrences(5).size());
+        assertEquals(0, this.classUnderTest().topOccurrences(5).size());
     }
 
     @Override
     @Test
     public void bottomOccurrences()
     {
-        Assert.assertEquals(0, this.newWith().bottomOccurrences(5).size());
+        assertEquals(0, this.newWith().bottomOccurrences(5).size());
     }
 
     /**
@@ -693,7 +701,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         ImmutableList<ObjectIntPair<Integer>> actual = integers.collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(Lists.mutable.empty(), actual);
+        assertEquals(Lists.mutable.empty(), actual);
     }
 
     /**
@@ -705,7 +713,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         MutableList<ObjectIntPair<Integer>> actual =
                 integers.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(Lists.mutable.empty(), actual);
+        assertEquals(Lists.mutable.empty(), actual);
     }
 
     @Override
@@ -713,7 +721,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectBoolean()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new BooleanArrayList(),
                 bag.collectBoolean(each -> false));
     }
@@ -723,7 +731,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectByte()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ByteArrayList(),
                 bag.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
@@ -733,7 +741,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectChar()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new CharArrayList(),
                 bag.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
     }
@@ -743,7 +751,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectDouble()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new DoubleArrayList(),
                 bag.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
@@ -753,7 +761,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectFloat()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new FloatArrayList(),
                 bag.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
@@ -763,7 +771,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectInt()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new IntArrayList(),
                 bag.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
@@ -773,7 +781,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectLong()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new LongArrayList(),
                 bag.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
@@ -783,7 +791,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectShort()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ShortArrayList(),
                 bag.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
@@ -793,12 +801,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectBoolean_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new BooleanArrayList(),
                 bag.collectBoolean(each -> false, new BooleanArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new BooleanHashBag(),
                 bag2.collectBoolean(each -> false, new BooleanHashBag()));
     }
@@ -808,12 +816,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectByte_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ByteArrayList(),
                 bag.collectByte(PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ByteHashBag(),
                 bag2.collectByte(PrimitiveFunctions.unboxIntegerToByte(), new ByteHashBag()));
     }
@@ -823,12 +831,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectChar_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new CharArrayList(),
                 bag.collectChar(PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new CharHashBag(),
                 bag2.collectChar(PrimitiveFunctions.unboxIntegerToChar(), new CharHashBag()));
     }
@@ -838,12 +846,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectDouble_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new DoubleArrayList(),
                 bag.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new DoubleHashBag(),
                 bag2.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), new DoubleHashBag()));
     }
@@ -853,12 +861,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectFloat_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new FloatArrayList(),
                 bag.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new FloatHashBag(),
                 bag2.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), new FloatHashBag()));
     }
@@ -868,12 +876,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectInt_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new IntArrayList(),
                 bag.collectInt(PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new IntHashBag(),
                 bag2.collectInt(PrimitiveFunctions.unboxIntegerToInt(), new IntHashBag()));
     }
@@ -883,12 +891,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectLong_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new LongArrayList(),
                 bag.collectLong(PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new LongHashBag(),
                 bag2.collectLong(PrimitiveFunctions.unboxIntegerToLong(), new LongHashBag()));
     }
@@ -898,12 +906,12 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     public void collectShort_target()
     {
         ImmutableSortedBag<Integer> bag = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ShortArrayList(),
                 bag.collectShort(PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
 
         ImmutableSortedBag<Integer> bag2 = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 new ShortHashBag(),
                 bag2.collectShort(PrimitiveFunctions.unboxIntegerToShort(), new ShortHashBag()));
     }
@@ -914,22 +922,22 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
     {
         ImmutableSortedBag<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         MutableList<Integer> copy = FastList.newList(integers);
-        Assert.assertArrayEquals(integers.toArray(), copy.toArray());
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
+        assertArrayEquals(integers.toArray(), copy.toArray());
+        assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
     }
 
     @Override
     @Test
     public void take()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
     }
 
     @Override
     @Test
     public void drop()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
     }
 
     @Override
@@ -942,7 +950,7 @@ public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestC
         ImmutableSortedBag<Integer> bag = this.classUnderTest(comparator);
         ImmutableSortedSet<Integer> expected = SortedSets.immutable.empty(comparator);
         ImmutableSortedSet<Integer> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
-        Assert.assertEquals(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertEquals(expected.comparator(), actual.comparator());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagFactoryTest.java
@@ -18,67 +18,69 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableSortedBagFactoryTest
 {
     @Test
     public void empty()
     {
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.immutable.empty());
+        assertEquals(TreeBag.newBag(), SortedBags.immutable.empty());
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.empty());
 
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.empty(Comparators.reverseNaturalOrder()));
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.empty(Comparators.reverseNaturalOrder()));
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.empty(Comparators.reverseNaturalOrder()));
     }
 
     @Test
     public void ofElements()
     {
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.of(1, 1, 2));
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.of(1, 1, 2));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2));
 
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.immutable.of());
+        assertEquals(TreeBag.newBag(), SortedBags.immutable.of());
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.of());
         Comparator<Integer> nullComparator = null;
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.immutable.of(nullComparator));
+        assertEquals(TreeBag.newBag(), SortedBags.immutable.of(nullComparator));
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.of(nullComparator));
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.of(Comparator.reverseOrder()));
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.of(Comparator.reverseOrder()));
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.of(Comparator.reverseOrder()));
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.of(Comparator.reverseOrder(), new Integer[]{}));
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.immutable.of(Comparator.reverseOrder(), new Integer[]{}));
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.of(Comparator.reverseOrder(), new Integer[]{}));
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.immutable.of(new Integer[]{}));
+        assertEquals(TreeBag.newBag(), SortedBags.immutable.of(new Integer[]{}));
         Verify.assertInstanceOf(ImmutableSortedBag.class, SortedBags.immutable.of(new Integer[]{}));
     }
 
     @Test
     public void withElements()
     {
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.with(1, 1, 2)), SortedBags.immutable.with(1, 1, 2));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ImmutableSortedBagImpl<>(SortedBags.mutable.with(Comparators.reverseNaturalOrder(), FastList.newList().toArray())));
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.with(1, 1, 2)), SortedBags.immutable.with(1, 1, 2));
+        assertThrows(IllegalArgumentException.class, () -> new ImmutableSortedBagImpl<>(SortedBags.mutable.with(Comparators.reverseNaturalOrder(), FastList.newList().toArray())));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2));
     }
 
     @Test
     public void ofAll()
     {
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.ofAll(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1, 1, 2))));
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.ofAll(FastList.newListWith(1, 1, 2)));
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 1, 2)));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.ofAll(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1, 1, 2))));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(1, 1, 2)), SortedBags.immutable.ofAll(FastList.newListWith(1, 1, 2)));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2)), SortedBags.immutable.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 1, 2)));
     }
 
     @Test
     public void ofSortedBag()
     {
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1))));
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(TreeBag.newBagWith(1)));
-        Assert.assertEquals(SortedBags.immutable.of(Comparators.reverseNaturalOrder()), SortedBags.immutable.ofSortedBag(TreeBag.newBag(Comparators.reverseNaturalOrder())));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1))));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(TreeBag.newBagWith(1)));
+        assertEquals(SortedBags.immutable.of(Comparators.reverseNaturalOrder()), SortedBags.immutable.ofSortedBag(TreeBag.newBag(Comparators.reverseNaturalOrder())));
     }
 
     @Test
     public void withSortedBag()
     {
-        Assert.assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1))));
+        assertEquals(new ImmutableSortedBagImpl<>(SortedBags.immutable.of(1)), SortedBags.immutable.ofSortedBag(new ImmutableSortedBagImpl<>(TreeBag.newBagWith(1))));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplTest.java
@@ -20,8 +20,10 @@ import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ImmutableSortedBagImplTest extends AbstractImmutableSortedBagTestCase
 {
@@ -65,8 +67,8 @@ public class ImmutableSortedBagImplTest extends AbstractImmutableSortedBagTestCa
         ImmutableSortedBag<Integer> bag = this.classUnderTest(comparator);
         ImmutableSortedSet<Integer> expected = SortedSets.immutable.with(comparator, 2);
         ImmutableSortedSet<Integer> actual = bag.selectUnique();
-        Assert.assertEquals(expected, actual);
-        Assert.assertEquals(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertEquals(expected.comparator(), actual.comparator());
     }
 
     @Override
@@ -78,7 +80,7 @@ public class ImmutableSortedBagImplTest extends AbstractImmutableSortedBagTestCa
         RichIterable<Integer> expected = bag.toSortedSet(comparator);
         RichIterable<Integer> actual = bag.distinctView();
         // this assertion is a reminder to get rid of this test override once distinctView returns a set
-        Assert.assertNotEquals(expected, actual);
+        assertNotEquals(expected, actual);
         // test sorting
         Verify.assertIterablesEqual(expected, actual);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
@@ -72,8 +72,18 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableSortedBag}s.
@@ -106,9 +116,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         Verify.assertInstanceOf(MutableSortedBag.class, this.newWith());
         Verify.assertInstanceOf(ImmutableSortedBag.class, this.newWith().toImmutable());
-        Assert.assertFalse(this.newWith().toImmutable() instanceof MutableSortedBag);
+        assertFalse(this.newWith().toImmutable() instanceof MutableSortedBag);
 
-        Assert.assertEquals(SortedBags.immutable.with(2, 2, 3), this.newWith(2, 2, 3).toImmutable());
+        assertEquals(SortedBags.immutable.with(2, 2, 3), this.newWith(2, 2, 3).toImmutable());
     }
 
     @Test(expected = ClassCastException.class)
@@ -118,7 +128,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         collection.add(collection);
         String simpleName = collection.getClass().getSimpleName();
         String string = collection.toString();
-        Assert.assertTrue(
+        assertTrue(
                 ("[1, (this " + simpleName + ")]").equals(string)
                         || ("[(this " + simpleName + "), 1]").equals(string));
     }
@@ -128,7 +138,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         collection.add(collection);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test(expected = ClassCastException.class)
@@ -138,7 +148,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         collection.add(collection);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -150,7 +160,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         TreeBag<Integer> expected = TreeBag.newBag(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 1, 2, 3));
         MutableSortedBag<Integer> collection = this.newWith(Comparators.reverseNaturalOrder());
 
-        Assert.assertTrue(collection.addAll(FastList.newListWith(3, 2, 1, 1)));
+        assertTrue(collection.addAll(FastList.newListWith(3, 2, 1, 1)));
         Verify.assertSortedBagsEqual(expected, collection);
     }
 
@@ -163,7 +173,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         TreeBag<Integer> expected = TreeBag.newBag(Collections.reverseOrder(), FastList.newListWith(2, 1, 2, 3));
         MutableSortedBag<Integer> collection = this.newWith(Collections.reverseOrder());
 
-        Assert.assertTrue(collection.addAllIterable(FastList.newListWith(3, 2, 1, 2)));
+        assertTrue(collection.addAllIterable(FastList.newListWith(3, 2, 1, 2)));
         Verify.assertSortedBagsEqual(expected, collection);
     }
 
@@ -172,7 +182,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         MutableSortedBag<Integer> set = this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3);
         MutableSortedBag<Integer> clone = set.clone();
-        Assert.assertNotSame(set, clone);
+        assertNotSame(set, clone);
         Verify.assertSortedBagsEqual(set, clone);
     }
 
@@ -182,9 +192,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.testToString();
 
-        Assert.assertEquals("[2, 1, 1]", this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2).toString());
-        Assert.assertEquals("[3, 2, 1, 1]", this.newWith(Collections.reverseOrder(), 3, 1, 1, 2).toString());
-        Assert.assertEquals("[-1, 2, 3]", this.newWith(3, -1, 2).toString());
+        assertEquals("[2, 1, 1]", this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2).toString());
+        assertEquals("[3, 2, 1, 1]", this.newWith(Collections.reverseOrder(), 3, 1, 1, 2).toString());
+        assertEquals("[-1, 2, 3]", this.newWith(3, -1, 2).toString());
     }
 
     @Override
@@ -193,7 +203,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.makeString();
 
-        Assert.assertEquals("3, 3, 2", this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 3).makeString());
+        assertEquals("3, 3, 2", this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 3).makeString());
     }
 
     @Override
@@ -201,7 +211,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.makeStringWithSeparator();
 
-        Assert.assertEquals("3!2!-3", this.newWith(Comparators.reverseNaturalOrder(), 3, 2, -3).makeString("!"));
+        assertEquals("3!2!-3", this.newWith(Comparators.reverseNaturalOrder(), 3, 2, -3).makeString("!"));
     }
 
     @Override
@@ -209,7 +219,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.makeStringWithSeparatorAndStartAndEnd();
 
-        Assert.assertEquals("<1,2,3>", this.newWith(1, 2, 3).makeString("<", ",", ">"));
+        assertEquals("<1,2,3>", this.newWith(1, 2, 3).makeString("<", ",", ">"));
     }
 
     @Override
@@ -221,8 +231,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 5, 5, 1, 2, 3);
         Appendable builder = new StringBuilder();
         bag.appendString(builder);
-        Assert.assertEquals(bag.toString(), "[" + builder + "]");
-        Assert.assertEquals("5, 5, 3, 2, 1", builder.toString());
+        assertEquals(bag.toString(), "[" + builder + "]");
+        assertEquals("5, 5, 3, 2, 1", builder.toString());
     }
 
     @Override
@@ -233,8 +243,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 5, 5, 1, 2, 3);
         Appendable builder = new StringBuilder();
         bag.appendString(builder, ", ");
-        Assert.assertEquals(bag.toString(), "[" + builder + "]");
-        Assert.assertEquals("5, 5, 3, 2, 1", builder.toString());
+        assertEquals(bag.toString(), "[" + builder + "]");
+        assertEquals("5, 5, 3, 2, 1", builder.toString());
     }
 
     @Override
@@ -245,8 +255,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 5, 5, 1, 2, 3);
         Appendable builder = new StringBuilder();
         bag.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(bag.toString(), builder.toString());
-        Assert.assertEquals("[5, 5, 3, 2, 1]", builder.toString());
+        assertEquals(bag.toString(), builder.toString());
+        assertEquals("[5, 5, 3, 2, 1]", builder.toString());
     }
 
     @Override
@@ -256,10 +266,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.removeObject();
 
         MutableSortedBag<String> bag = this.newWith(Collections.reverseOrder(), "5", "1", "2", "2", "3");
-        Assert.assertFalse(bag.remove("7"));
-        Assert.assertTrue(bag.remove("1"));
+        assertFalse(bag.remove("7"));
+        assertTrue(bag.remove("1"));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), "5", "3", "2", "2"), bag);
-        Assert.assertTrue(bag.remove("2"));
+        assertTrue(bag.remove("2"));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), "5", "3", "2"), bag);
     }
 
@@ -270,9 +280,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         // Sorted containers don't support null
 
         MutableSortedBag<Integer> objects = this.newWith(Comparators.reverseNaturalOrder(), 4, 1, 3, 3, 2);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(2)));
+        assertTrue(objects.removeIf(Predicates.equal(2)));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 3, 3, 4), objects);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(3)));
+        assertTrue(objects.removeIf(Predicates.equal(3)));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 4), objects);
     }
 
@@ -283,9 +293,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.removeIfWith();
 
         MutableSortedBag<Integer> objects = this.newWith(Comparators.reverseNaturalOrder(), 4, 1, 3, 3, 2);
-        Assert.assertTrue(objects.removeIfWith(Object::equals, 2));
+        assertTrue(objects.removeIfWith(Object::equals, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 3, 3, 4), objects);
-        Assert.assertTrue(objects.removeIfWith(Object::equals, 3));
+        assertTrue(objects.removeIfWith(Object::equals, 3));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 4), objects);
     }
 
@@ -300,10 +310,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         Verify.assertEqualsAndHashCode(HashBag.newBag(sortedBag), sortedBag);
 
-        Assert.assertNotEquals(HashBag.newBagWith(1, 1, 1, 2, 3, 4), sortedBag);
-        Assert.assertNotEquals(HashBag.newBagWith(1, 1, 2, 3), sortedBag);
-        Assert.assertNotEquals(HashBag.newBagWith(1, 2, 3, 4), sortedBag);
-        Assert.assertNotEquals(HashBag.newBagWith(1, 2, 3, 4, 5), sortedBag);
+        assertNotEquals(HashBag.newBagWith(1, 1, 1, 2, 3, 4), sortedBag);
+        assertNotEquals(HashBag.newBagWith(1, 1, 2, 3), sortedBag);
+        assertNotEquals(HashBag.newBagWith(1, 2, 3, 4), sortedBag);
+        assertNotEquals(HashBag.newBagWith(1, 2, 3, 4, 5), sortedBag);
 
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4), sortedBag);
     }
@@ -409,8 +419,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         PartitionMutableSortedBag<Integer> partition = integers.partitionWhile(Predicates.greaterThan(3));
         Verify.assertSortedBagsEqual(this.newWith(Comparators.reverseNaturalOrder(), 6, 5, 4), partition.getSelected());
         Verify.assertSortedBagsEqual(this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 1), partition.getRejected());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -433,7 +443,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> integers = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 1, 1);
         MutableList<Holder> holders = integers.collect(Holder::new);
-        Assert.assertEquals(FastList.newListWith(new Holder(4), new Holder(3), new Holder(1), new Holder(1)), holders);
+        assertEquals(FastList.newListWith(new Holder(4), new Holder(3), new Holder(1), new Holder(1)), holders);
     }
 
     /**
@@ -477,7 +487,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.flatCollect();
         MutableSortedBag<Integer> integers = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 1, 1);
         MutableList<Holder> holders = integers.flatCollect(Holder.FROM_LIST);
-        Assert.assertEquals(FastList.newListWith(new Holder(4), new Holder(4), new Holder(3), new Holder(3), new Holder(1), new Holder(1), new Holder(1), new Holder(1)), holders);
+        assertEquals(FastList.newListWith(new Holder(4), new Holder(4), new Holder(3), new Holder(3), new Holder(1), new Holder(1), new Holder(1), new Holder(1)), holders);
     }
 
     @Test
@@ -495,7 +505,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Verify.assertSortedBagsEqual(TreeBag.newBag(Comparators.reverseNaturalOrder()), integers.takeWhile(IntegerPredicates.isOdd()));
         MutableSortedBag<Integer> take = integers.takeWhile(Predicates.greaterThan(2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 3, 3), take);
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), take.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), take.comparator());
     }
 
     @Test
@@ -506,7 +516,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 3, 3, 2, 2, 1, 1), integers.dropWhile(IntegerPredicates.isOdd()));
         MutableSortedBag<Integer> drop = integers.dropWhile(Predicates.greaterThan(2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 2, 2, 1, 1), drop);
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), drop.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), drop.comparator());
     }
 
     @Override
@@ -515,7 +525,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.collectIf();
 
-        Assert.assertEquals(
+        assertEquals(
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3, 4, 5, 5).collectIf(
                         Predicates.lessThan(4),
                         Holder::new),
@@ -529,7 +539,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectWith();
         MutableSortedBag<Integer> integers = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 1, 1);
         MutableList<Holder> holders = integers.collectWith(Holder.FROM_INT_INT, 10);
-        Assert.assertEquals(FastList.newListWith(new Holder(14), new Holder(13), new Holder(11), new Holder(11)), holders);
+        assertEquals(FastList.newListWith(new Holder(14), new Holder(13), new Holder(11), new Holder(11)), holders);
     }
 
     @Override
@@ -539,7 +549,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectWith_target();
         MutableSortedBag<Integer> integers = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 1, 1);
         MutableSortedBag<Holder> holders = integers.collectWith(Holder.FROM_INT_INT, 10, TreeBag.newBag(Functions.toIntComparator(Holder.TO_NUMBER)));
-        Assert.assertEquals(TreeBag.newBagWith(Functions.toIntComparator(Holder.TO_NUMBER), new Holder(14), new Holder(13), new Holder(11), new Holder(11)), holders);
+        assertEquals(TreeBag.newBagWith(Functions.toIntComparator(Holder.TO_NUMBER), new Holder(14), new Holder(13), new Holder(11), new Holder(11)), holders);
     }
 
     @Override
@@ -574,10 +584,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         expected.put(-1, 1);
 
         MutableSortedBagMultimap<Integer, Integer> actual = bag.groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBagMultimap<Integer, Integer> actualWithTarget =
                 bag.groupByEach(function, this.<Integer>newWith().groupByEach(function));
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
         for (int i = 1; i < 10; ++i)
         {
             Verify.assertSortedBagsEqual(expected.get(-i), actual.get(-i));
@@ -596,7 +606,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableList<Pair<Integer, Integer>> zip = integers.zip(revInt);
         Verify.assertSize(6, zip);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(
                         Tuples.pair(1, 5), Tuples.pair(2, 4), Tuples.pair(2, 3), Tuples.pair(3, 2), Tuples.pair(4, 2), Tuples.pair(5, 1)),
                 zip);
@@ -604,7 +614,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableList<Pair<Integer, Integer>> revZip = revInt.zip(integers);
         Verify.assertSize(6, revZip);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(
                         Tuples.pair(5, 1), Tuples.pair(4, 2), Tuples.pair(3, 2), Tuples.pair(2, 3), Tuples.pair(2, 4), Tuples.pair(1, 5)),
                 revZip);
@@ -614,11 +624,11 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Person> people = this.newWith(john, johnDoe);
         MutableList<Integer> list = FastList.newListWith(1, 2, 3);
         MutableList<Pair<Person, Integer>> pairs = people.zip(list);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(Tuples.pair(johnDoe, 1), Tuples.pair(john, 2)),
                 pairs);
-        Assert.assertTrue(pairs.add(Tuples.pair(new Person("Jack", "Baker"), 3)));
-        Assert.assertEquals(Tuples.pair(new Person("Jack", "Baker"), 3), pairs.getLast());
+        assertTrue(pairs.add(Tuples.pair(new Person("Jack", "Baker"), 3)));
+        assertEquals(Tuples.pair(new Person("Jack", "Baker"), 3), pairs.getLast());
     }
 
     @Override
@@ -627,7 +637,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.zipWithIndex();
         MutableSortedBag<Integer> integers = this.newWith(Collections.reverseOrder(), 1, 3, 5, 5, 5, 2, 4);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(
                         Tuples.pair(5, 0),
                         Tuples.pair(5, 1),
@@ -653,11 +663,11 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toStringOfItemToCount();
 
-        Assert.assertEquals("{}", this.newWith().toStringOfItemToCount());
-        Assert.assertEquals("{}", this.newWith(Comparators.reverseNaturalOrder()).toStringOfItemToCount());
+        assertEquals("{}", this.newWith().toStringOfItemToCount());
+        assertEquals("{}", this.newWith(Comparators.reverseNaturalOrder()).toStringOfItemToCount());
 
-        Assert.assertEquals("{1=1, 2=2}", this.newWith(1, 2, 2).toStringOfItemToCount());
-        Assert.assertEquals("{2=2, 1=1}", this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 2).toStringOfItemToCount());
+        assertEquals("{1=1, 2=2}", this.newWith(1, 2, 2).toStringOfItemToCount());
+        assertEquals("{2=2, 1=1}", this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 2).toStringOfItemToCount());
     }
 
     @Override
@@ -667,15 +677,15 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.add();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder());
-        Assert.assertTrue(bag.add(1));
+        assertTrue(bag.add(1));
         Verify.assertSortedBagsEqual(this.newWith(1), bag);
-        Assert.assertTrue(bag.add(3));
+        assertTrue(bag.add(3));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 1), bag);
         Verify.assertSize(2, bag);
-        Assert.assertTrue(bag.add(2));
+        assertTrue(bag.add(2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 2, 1), bag);
         Verify.assertSize(3, bag);
-        Assert.assertTrue(bag.add(2));
+        assertTrue(bag.add(2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 2, 2, 1), bag);
         Verify.assertSize(4, bag);
     }
@@ -688,31 +698,31 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> bag = this.newWith(-1, 0, 1, 1, 2);
         Iterator<Integer> iterator = bag.iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(-1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(0), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(2), iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(-1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(0), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(2), iterator.next());
+        assertFalse(iterator.hasNext());
 
         MutableSortedBag<Integer> revBag = this.newWith(Comparators.reverseNaturalOrder(), -1, 0, 1, 1, 2);
         Iterator<Integer> revIterator = revBag.iterator();
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(2), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(0), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(-1), revIterator.next());
-        Assert.assertFalse(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(2), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(1), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(1), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(0), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(-1), revIterator.next());
+        assertFalse(revIterator.hasNext());
 
         MutableSortedBag<Integer> sortedBag = this.newWith(Collections.reverseOrder(), 1, 1, 1, 1, 2);
         MutableList<Integer> validate = Lists.mutable.empty();
@@ -724,7 +734,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         Iterator<Integer> sortedBagIterator = sortedBag.iterator();
         MutableSortedBag<Integer> expected = this.newWith(Collections.reverseOrder(), 1, 1, 1, 1, 2);
-        Assert.assertThrows(IllegalStateException.class, sortedBagIterator::remove);
+        assertThrows(IllegalStateException.class, sortedBagIterator::remove);
 
         this.assertIteratorRemove(sortedBag, sortedBagIterator, expected);
         this.assertIteratorRemove(sortedBag, sortedBagIterator, expected);
@@ -732,18 +742,18 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         this.assertIteratorRemove(sortedBag, sortedBagIterator, expected);
         this.assertIteratorRemove(sortedBag, sortedBagIterator, expected);
         Verify.assertEmpty(sortedBag);
-        Assert.assertFalse(sortedBagIterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, sortedBagIterator::next);
+        assertFalse(sortedBagIterator.hasNext());
+        assertThrows(NoSuchElementException.class, sortedBagIterator::next);
     }
 
     private void assertIteratorRemove(MutableSortedBag<Integer> bag, Iterator<Integer> iterator, MutableSortedBag<Integer> expected)
     {
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         Integer first = iterator.next();
         iterator.remove();
         expected.remove(first);
         Verify.assertSortedBagsEqual(expected, bag);
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Override
@@ -754,17 +764,17 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> revBag = this.newWith(Comparators.reverseNaturalOrder(), -1, 0, 1, 1, 2);
         Iterator<Integer> revIterator = revBag.iterator();
-        Assert.assertTrue(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
         revIterator.next();
-        Assert.assertTrue(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
         revIterator.next();
-        Assert.assertTrue(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
         revIterator.next();
-        Assert.assertTrue(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
         revIterator.next();
-        Assert.assertTrue(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
         revIterator.next();
-        Assert.assertFalse(revIterator.hasNext());
+        assertFalse(revIterator.hasNext());
         revIterator.next();
     }
 
@@ -776,8 +786,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableList<Integer> tapResult = FastList.newList();
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 1, 1, 2);
-        Assert.assertSame(bag, bag.tap(tapResult::add));
-        Assert.assertEquals(bag.toList(), tapResult);
+        assertSame(bag, bag.tap(tapResult::add));
+        assertEquals(bag.toList(), tapResult);
     }
 
     @Override
@@ -789,7 +799,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 1, 1, 2);
         MutableList<Integer> actual = FastList.newList();
         bag.forEach(Procedures.cast(actual::add));
-        Assert.assertEquals(FastList.newListWith(2, 1, 1), actual);
+        assertEquals(FastList.newListWith(2, 1, 1), actual);
     }
 
     @Test
@@ -799,19 +809,19 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableList<Integer> result = Lists.mutable.empty();
         integers.forEach(5, 7, result::add);
-        Assert.assertEquals(Lists.immutable.with(3, 3, 2), result);
+        assertEquals(Lists.immutable.with(3, 3, 2), result);
 
         MutableList<Integer> result2 = Lists.mutable.empty();
         integers.forEach(5, 5, result2::add);
-        Assert.assertEquals(Lists.immutable.with(3), result2);
+        assertEquals(Lists.immutable.with(3), result2);
 
         MutableList<Integer> result3 = Lists.mutable.empty();
         integers.forEach(0, 9, result3::add);
-        Assert.assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
+        assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers.forEach(7, 5, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
+        assertThrows(IllegalArgumentException.class, () -> integers.forEach(7, 5, result::add));
     }
 
     @Test
@@ -820,20 +830,20 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         StringBuilder builder = new StringBuilder();
         integers.forEachWithIndex(5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("353627", builder.toString());
+        assertEquals("353627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         integers.forEachWithIndex(5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("35", builder2.toString());
+        assertEquals("35", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         integers.forEachWithIndex(0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("40414243343536272819", builder3.toString());
+        assertEquals("40414243343536272819", builder3.toString());
 
         MutableList<Integer> result = Lists.mutable.empty();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(7, 5, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
+        assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(7, 5, new AddToList(result)));
     }
 
     @Override
@@ -850,8 +860,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
             actualItems.add(each);
             actualIndexes.add(index);
         });
-        Assert.assertEquals(FastList.newListWith(3, 2, 1), actualItems);
-        Assert.assertEquals(FastList.newListWith(3, 2, 1), actualIndexes);
+        assertEquals(FastList.newListWith(3, 2, 1), actualItems);
+        assertEquals(FastList.newListWith(3, 2, 1), actualIndexes);
 
         MutableSortedBag<Integer> bag2 = this.newWith();
         bag2.addOccurrences(1, 10);
@@ -864,15 +874,15 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
             counter.increment();
             sum.add(each * occurrences * counter.getCount());
         });
-        Assert.assertEquals(140, sum.getIntSum());
+        assertEquals(140, sum.getIntSum());
         bag2.removeOccurrences(2, 1);
         IntegerSum sum2 = new IntegerSum(0);
         bag2.forEachWithOccurrences((each, occurrences) -> sum2.add(each * occurrences));
-        Assert.assertEquals(58, sum2.getIntSum());
+        assertEquals(58, sum2.getIntSum());
         bag2.removeOccurrences(1, 3);
         IntegerSum sum3 = new IntegerSum(0);
         bag2.forEachWithOccurrences((each, occurrences) -> sum3.add(each * occurrences));
-        Assert.assertEquals(55, sum3.getIntSum());
+        assertEquals(55, sum3.getIntSum());
     }
 
     @Test
@@ -881,10 +891,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.getFirst();
 
-        Assert.assertEquals(Integer.valueOf(0), this.newWith(0, 0, 1, 1).getFirst());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 1, 2, 3).getFirst());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(2, 1, 3, 2, 3).getFirst());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(Collections.reverseOrder(), 2, 2, 1, 3).getFirst());
+        assertEquals(Integer.valueOf(0), this.newWith(0, 0, 1, 1).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(2, 1, 3, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(3), this.newWith(Collections.reverseOrder(), 2, 2, 1, 3).getFirst());
     }
 
     @Test
@@ -893,21 +903,21 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.getLast();
 
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(0, 0, 1, 1).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(3, 2, 3, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(Collections.reverseOrder(), 2, 2, 1, 3).getLast());
+        assertEquals(Integer.valueOf(1), this.newWith(0, 0, 1, 1).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(3, 2, 3, 2, 3).getLast());
+        assertEquals(Integer.valueOf(1), this.newWith(Collections.reverseOrder(), 2, 2, 1, 3).getLast());
     }
 
     @Test
     public void indexOf()
     {
         MutableSortedBag<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(0, integers.indexOf(4));
-        Assert.assertEquals(4, integers.indexOf(3));
-        Assert.assertEquals(7, integers.indexOf(2));
-        Assert.assertEquals(9, integers.indexOf(1));
-        Assert.assertEquals(-1, integers.indexOf(0));
+        assertEquals(0, integers.indexOf(4));
+        assertEquals(4, integers.indexOf(3));
+        assertEquals(7, integers.indexOf(2));
+        assertEquals(9, integers.indexOf(1));
+        assertEquals(-1, integers.indexOf(0));
     }
 
     @Override
@@ -917,8 +927,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.occurrencesOf();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 1, 1, 2);
-        Assert.assertEquals(2, bag.occurrencesOf(1));
-        Assert.assertEquals(1, bag.occurrencesOf(2));
+        assertEquals(2, bag.occurrencesOf(1));
+        assertEquals(1, bag.occurrencesOf(2));
     }
 
     @Override
@@ -928,20 +938,20 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.addOccurrences();
 
         MutableSortedBag<Integer> bag = this.newWith();
-        Assert.assertEquals(3, bag.addOccurrences(0, 3));
-        Assert.assertEquals(0, bag.addOccurrences(2, 0));
-        Assert.assertEquals(2, bag.addOccurrences(1, 2));
+        assertEquals(3, bag.addOccurrences(0, 3));
+        assertEquals(0, bag.addOccurrences(2, 0));
+        assertEquals(2, bag.addOccurrences(1, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(0, 0, 0, 1, 1), bag);
-        Assert.assertEquals(6, bag.addOccurrences(0, 3));
-        Assert.assertEquals(4, bag.addOccurrences(1, 2));
+        assertEquals(6, bag.addOccurrences(0, 3));
+        assertEquals(4, bag.addOccurrences(1, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(0, 0, 0, 0, 0, 0, 1, 1, 1, 1), bag);
 
         MutableSortedBag<Integer> revBag = this.newWith(Collections.reverseOrder());
-        Assert.assertEquals(3, revBag.addOccurrences(2, 3));
-        Assert.assertEquals(2, revBag.addOccurrences(3, 2));
+        assertEquals(3, revBag.addOccurrences(2, 3));
+        assertEquals(2, revBag.addOccurrences(3, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 3, 2, 2, 2), revBag);
-        Assert.assertEquals(6, revBag.addOccurrences(2, 3));
-        Assert.assertEquals(4, revBag.addOccurrences(3, 2));
+        assertEquals(6, revBag.addOccurrences(2, 3));
+        assertEquals(4, revBag.addOccurrences(3, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 3, 3, 3, 3, 2, 2, 2, 2, 2, 2), revBag);
     }
 
@@ -954,15 +964,15 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 2, 2, 1);
         MutableSortedBag<Integer> expected = TreeBag.newBag(bag);
 
-        Assert.assertFalse(bag.removeOccurrences(4, 2));
-        Assert.assertFalse(bag.removeOccurrences(4, 0));
-        Assert.assertFalse(bag.removeOccurrences(2, 0));
+        assertFalse(bag.removeOccurrences(4, 2));
+        assertFalse(bag.removeOccurrences(4, 0));
+        assertFalse(bag.removeOccurrences(2, 0));
         Verify.assertSortedBagsEqual(expected, bag);
 
-        Assert.assertTrue(bag.removeOccurrences(2, 2));
+        assertTrue(bag.removeOccurrences(2, 2));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(1), bag);
 
-        Assert.assertTrue(bag.removeOccurrences(1, 100));
+        assertTrue(bag.removeOccurrences(1, 100));
         Verify.assertSortedBagsEqual(TreeBag.<String>newBag(), bag);
     }
 
@@ -973,7 +983,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.toList();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 3, 3, 2);
-        Assert.assertEquals(FastList.newListWith(3, 3, 2, 1), bag.toList());
+        assertEquals(FastList.newListWith(3, 3, 2, 1), bag.toList());
     }
 
     @Override
@@ -983,7 +993,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.toSet();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), bag.toSet());
     }
 
     @Override
@@ -992,7 +1002,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toBag();
 
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("C", "C", "B", "A"),
                 this.newWith(Comparators.reverseNaturalOrder(), "C", "C", "B", "A").toBag());
     }
@@ -1001,7 +1011,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     public void toStack()
     {
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 3, 3, 2);
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3, 3), bag.toStack());
+        assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3, 3), bag.toStack());
     }
 
     @Override
@@ -1010,7 +1020,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toSortedList_natural_ordering();
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2, 3, 4, 4),
                 this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 3, 1, 2).toSortedList());
     }
@@ -1021,7 +1031,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toSortedList_with_comparator();
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(4, 4, 3, 2, 1),
                 this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 3, 1, 2).toSortedList(Comparators.reverseNaturalOrder()));
     }
@@ -1034,7 +1044,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> sortedBag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 10, 2, 3);
         MutableList<Integer> sortedListBy = sortedBag.toSortedListBy(String::valueOf);
-        Assert.assertEquals(FastList.newListWith(1, 1, 1, 10, 2, 3), sortedListBy);
+        assertEquals(FastList.newListWith(1, 1, 1, 10, 2, 3), sortedListBy);
     }
 
     @Override
@@ -1066,10 +1076,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.toSortedSetBy();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 2, 5, 2, 4, 3, 1, 6, 7, 8, 9, 10);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
                 bag.toSortedSetBy(String::valueOf));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 10, 2, 3, 4, 5, 6, 7, 8, 9),
                 bag.toSortedSetBy(String::valueOf).toList());
     }
@@ -1080,7 +1090,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toMap();
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues("4", "4", "3", "3", "2", "2", "1", "1"),
                 this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1).toMap(String::valueOf, String::valueOf));
     }
@@ -1140,7 +1150,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<String> bag = this.newWith(Comparators.reverseNaturalOrder(), "One", "Two", "Two", "Three", "Three", "Three");
         Verify.assertPostSerializedEqualsAndHashCode(bag);
-        Assert.assertNotNull(bag.comparator());
+        assertNotNull(bag.comparator());
     }
 
     @Override
@@ -1174,26 +1184,26 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.toMapOfItemToCount();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 1, 2, 2, 3, 3, 3);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Collections.reverseOrder(), 1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
+        assertEquals(TreeSortedMap.newMapWith(Collections.reverseOrder(), 1, 1, 2, 2, 3, 3), bag.toMapOfItemToCount());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(-1, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 2, 2, 2)));
-        Assert.assertEquals(0, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 2, 2)));
-        Assert.assertEquals(1, this.newWith(1, 1, 2, 2, 2).compareTo(this.newWith(1, 1, 2, 2)));
+        assertEquals(-1, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 2, 2, 2)));
+        assertEquals(0, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 2, 2)));
+        assertEquals(1, this.newWith(1, 1, 2, 2, 2).compareTo(this.newWith(1, 1, 2, 2)));
 
-        Assert.assertEquals(-1, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 3, 3)));
-        Assert.assertEquals(1, this.newWith(1, 1, 3, 3).compareTo(this.newWith(1, 1, 2, 2)));
+        assertEquals(-1, this.newWith(1, 1, 2, 2).compareTo(this.newWith(1, 1, 3, 3)));
+        assertEquals(1, this.newWith(1, 1, 3, 3).compareTo(this.newWith(1, 1, 2, 2)));
 
-        Assert.assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 2, 2, 1, 1, 1).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 2, 2, 1, 1)));
-        Assert.assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2)));
-        Assert.assertEquals(0, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
-        Assert.assertEquals(-1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 2, 2, 1, 1, 1).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 2, 2, 1, 1)));
+        assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2)));
+        assertEquals(0, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(-1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
 
-        Assert.assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 3, 3)));
-        Assert.assertEquals(-1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 3, 3).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
+        assertEquals(1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 3, 3)));
+        assertEquals(-1, this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 3, 3).compareTo(this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 2)));
     }
 
     @Override
@@ -1203,9 +1213,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.containsAllIterable();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4);
-        Assert.assertTrue(bag.containsAllIterable(FastList.newListWith(1, 2)));
-        Assert.assertFalse(bag.containsAllIterable(FastList.newListWith(1, 5)));
-        Assert.assertTrue(bag.containsAllIterable(FastList.newListWith()));
+        assertTrue(bag.containsAllIterable(FastList.newListWith(1, 2)));
+        assertFalse(bag.containsAllIterable(FastList.newListWith(1, 5)));
+        assertTrue(bag.containsAllIterable(FastList.newListWith()));
     }
 
     @Override
@@ -1214,9 +1224,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.containsAllArray();
         MutableSortedBag<Integer> collection = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3, 4);
-        Assert.assertTrue(collection.containsAllArguments(1, 2));
-        Assert.assertFalse(collection.containsAllArguments(1, 5));
-        Assert.assertTrue(collection.containsAllArguments());
+        assertTrue(collection.containsAllArguments(1, 2));
+        assertFalse(collection.containsAllArguments(1, 5));
+        assertTrue(collection.containsAllArguments());
     }
 
     @Override
@@ -1228,7 +1238,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<String> bag = this.newWith(Collections.reverseOrder(), "1", "2", "2", "3", "4");
         StringBuilder builder = new StringBuilder();
         bag.forEachWith((argument1, argument2) -> builder.append(argument1).append(argument2), 0);
-        Assert.assertEquals("4030202010", builder.toString());
+        assertEquals("4030202010", builder.toString());
     }
 
     @Override
@@ -1240,7 +1250,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<String> bag = this.newWith(Collections.reverseOrder(), "1", "2", "2", "3", "4");
         StringBuilder builder = new StringBuilder();
         bag.forEachWithIndex((each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("4031222314", builder.toString());
+        assertEquals("4031222314", builder.toString());
     }
 
     @Override
@@ -1250,7 +1260,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectBoolean();
 
         MutableSortedBag<String> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), "true", "nah", "TrUe");
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayList.newListWith(true, false, true),
                 bag.collectBoolean(Boolean::parseBoolean));
     }
@@ -1261,7 +1271,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.collectByte();
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ByteArrayList.newListWith((byte) 3, (byte) 2, (byte) 1, (byte) 1, (byte) 1),
                 bag.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
@@ -1273,7 +1283,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectChar();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 CharArrayList.newListWith((char) 3, (char) 2, (char) 1, (char) 1, (char) 1),
                 bag.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
     }
@@ -1285,7 +1295,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectDouble();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 DoubleArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
@@ -1297,7 +1307,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectFloat();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 FloatArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
@@ -1309,7 +1319,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectInt();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 IntArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
@@ -1321,7 +1331,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectLong();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 LongArrayList.newListWith(3, 2, 1, 1, 1),
                 bag.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
@@ -1333,7 +1343,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.collectShort();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 ShortArrayList.newListWith((short) 3, (short) 2, (short) 1, (short) 1, (short) 1),
                 bag.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
@@ -1345,8 +1355,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.detect();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(2), bag.detect(Predicates.lessThan(3)));
-        Assert.assertNull(bag.detect(Integer.valueOf(4)::equals));
+        assertEquals(Integer.valueOf(2), bag.detect(Predicates.lessThan(3)));
+        assertNull(bag.detect(Integer.valueOf(4)::equals));
     }
 
     @Override
@@ -1355,10 +1365,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.min();
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4).min());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(4),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 4).min(Comparators.reverseNaturalOrder()));
     }
@@ -1369,10 +1379,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.max();
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4).min());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(4),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3, 4).min(Comparators.reverseNaturalOrder()));
     }
@@ -1383,7 +1393,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.minBy();
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 3).minBy(String::valueOf));
     }
@@ -1394,7 +1404,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.maxBy();
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3).maxBy(String::valueOf));
     }
@@ -1406,9 +1416,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.detectWith();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 4, 5);
-        Assert.assertEquals(Integer.valueOf(5), bag.detectWith(Predicates2.greaterThan(), 3));
-        Assert.assertEquals(Integer.valueOf(2), bag.detectWith(Predicates2.lessThan(), 3));
-        Assert.assertNull(this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
+        assertEquals(Integer.valueOf(5), bag.detectWith(Predicates2.greaterThan(), 3));
+        assertEquals(Integer.valueOf(2), bag.detectWith(Predicates2.lessThan(), 3));
+        assertNull(this.newWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
     }
 
     @Override
@@ -1418,9 +1428,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.detectIfNone();
 
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(Comparators.reverseNaturalOrder(), 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, function));
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(Comparators.reverseNaturalOrder(), 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, null));
-        Assert.assertEquals(Integer.valueOf(6), this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, function));
+        assertEquals(Integer.valueOf(3), this.newWith(Comparators.reverseNaturalOrder(), 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, function));
+        assertEquals(Integer.valueOf(3), this.newWith(Comparators.reverseNaturalOrder(), 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, null));
+        assertEquals(Integer.valueOf(6), this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, function));
     }
 
     @Override
@@ -1430,13 +1440,13 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.detectWithIfNoneBlock();
 
         Function0<Integer> function = new PassThruFunction0<>(-42);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(5),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 1, 2, 3, 4, 5).detectWithIfNone(
                         Predicates2.greaterThan(),
                         4,
                         function));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(-42),
                 this.newWith(Comparators.reverseNaturalOrder(), 1, 2, 2, 2, 3, 4, 5).detectWithIfNone(
                         Predicates2.lessThan(),
@@ -1447,15 +1457,15 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     @Test
     public void corresponds()
     {
-        Assert.assertFalse(this.newWith(1, 2, 3, 4, 5).corresponds(this.newWith(1, 2, 3, 4), Predicates2.alwaysTrue()));
+        assertFalse(this.newWith(1, 2, 3, 4, 5).corresponds(this.newWith(1, 2, 3, 4), Predicates2.alwaysTrue()));
 
         MutableSortedBag<Integer> integers1 = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         MutableSortedBag<Integer> integers2 = this.newWith(2, 3, 3, 4, 4, 4, 5, 5, 5, 5);
-        Assert.assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
 
         MutableSortedBag<Integer> integers3 = this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        Assert.assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
+        assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
     }
 
     @Override
@@ -1465,9 +1475,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.allSatisfy();
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.allSatisfy(Predicates.lessThan(4)));
-        Assert.assertFalse(bag.allSatisfy(Integer.valueOf(2)::equals));
-        Assert.assertFalse(bag.allSatisfy(Predicates.greaterThan(4)));
+        assertTrue(bag.allSatisfy(Predicates.lessThan(4)));
+        assertFalse(bag.allSatisfy(Integer.valueOf(2)::equals));
+        assertFalse(bag.allSatisfy(Predicates.greaterThan(4)));
     }
 
     @Override
@@ -1477,9 +1487,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.allSatisfyWith();
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.allSatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertFalse(bag.allSatisfyWith(Object::equals, 2));
-        Assert.assertFalse(bag.allSatisfyWith(Predicates2.greaterThan(), 4));
+        assertTrue(bag.allSatisfyWith(Predicates2.lessThan(), 4));
+        assertFalse(bag.allSatisfyWith(Object::equals, 2));
+        assertFalse(bag.allSatisfyWith(Predicates2.greaterThan(), 4));
     }
 
     @Override
@@ -1490,9 +1500,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
 
-        Assert.assertFalse(bag.noneSatisfy(Predicates.lessThan(4)));
-        Assert.assertFalse(bag.noneSatisfy(Integer.valueOf(2)::equals));
-        Assert.assertTrue(bag.noneSatisfy(Predicates.greaterThan(4)));
+        assertFalse(bag.noneSatisfy(Predicates.lessThan(4)));
+        assertFalse(bag.noneSatisfy(Integer.valueOf(2)::equals));
+        assertTrue(bag.noneSatisfy(Predicates.greaterThan(4)));
     }
 
     @Override
@@ -1503,9 +1513,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
 
-        Assert.assertFalse(bag.noneSatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertFalse(bag.noneSatisfyWith(Object::equals, 2));
-        Assert.assertTrue(bag.noneSatisfyWith(Predicates2.greaterThan(), 4));
+        assertFalse(bag.noneSatisfyWith(Predicates2.lessThan(), 4));
+        assertFalse(bag.noneSatisfyWith(Object::equals, 2));
+        assertTrue(bag.noneSatisfyWith(Predicates2.greaterThan(), 4));
     }
 
     @Override
@@ -1515,9 +1525,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.anySatisfy();
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.anySatisfy(Predicates.lessThan(4)));
-        Assert.assertTrue(bag.anySatisfy(Integer.valueOf(2)::equals));
-        Assert.assertFalse(bag.anySatisfy(Predicates.greaterThan(4)));
+        assertTrue(bag.anySatisfy(Predicates.lessThan(4)));
+        assertTrue(bag.anySatisfy(Integer.valueOf(2)::equals));
+        assertFalse(bag.anySatisfy(Predicates.greaterThan(4)));
     }
 
     @Override
@@ -1527,9 +1537,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.anySatisfyWith();
 
         MutableSortedBag<Integer> bag = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertTrue(bag.anySatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertTrue(bag.anySatisfyWith(Object::equals, 2));
-        Assert.assertFalse(bag.anySatisfyWith(Predicates2.greaterThan(), 4));
+        assertTrue(bag.anySatisfyWith(Predicates2.lessThan(), 4));
+        assertTrue(bag.anySatisfyWith(Object::equals, 2));
+        assertFalse(bag.anySatisfyWith(Predicates2.greaterThan(), 4));
     }
 
     @Override
@@ -1539,9 +1549,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.count();
 
         MutableSortedBag<Integer> sortedBag = this.newWith(Collections.reverseOrder(), 3, 2, 2, 2, 1);
-        Assert.assertEquals(1, sortedBag.count(Predicates.greaterThan(2)));
-        Assert.assertEquals(4, sortedBag.count(Predicates.greaterThan(1)));
-        Assert.assertEquals(0, sortedBag.count(Predicates.greaterThan(3)));
+        assertEquals(1, sortedBag.count(Predicates.greaterThan(2)));
+        assertEquals(4, sortedBag.count(Predicates.greaterThan(1)));
+        assertEquals(0, sortedBag.count(Predicates.greaterThan(3)));
     }
 
     @Override
@@ -1551,9 +1561,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.countWith();
 
         MutableSortedBag<Integer> sortedBag = this.newWith(Collections.reverseOrder(), 3, 2, 2, 2, 1);
-        Assert.assertEquals(1, sortedBag.countWith(Predicates2.greaterThan(), 2));
-        Assert.assertEquals(4, sortedBag.countWith(Predicates2.greaterThan(), 1));
-        Assert.assertEquals(0, sortedBag.countWith(Predicates2.greaterThan(), 3));
+        assertEquals(1, sortedBag.countWith(Predicates2.greaterThan(), 2));
+        assertEquals(4, sortedBag.countWith(Predicates2.greaterThan(), 1));
+        assertEquals(0, sortedBag.countWith(Predicates2.greaterThan(), 3));
     }
 
     @Override
@@ -1563,8 +1573,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.removeAllIterable();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 5, 5, 3, 2, 2, 2, 1);
-        Assert.assertTrue(bag.removeAllIterable(FastList.newListWith(1, 2, 4)));
-        Assert.assertFalse(bag.removeAllIterable(FastList.newListWith(1, 2, 4)));
+        assertTrue(bag.removeAllIterable(FastList.newListWith(1, 2, 4)));
+        assertFalse(bag.removeAllIterable(FastList.newListWith(1, 2, 4)));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 5, 5, 3), bag);
     }
 
@@ -1575,8 +1585,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.retainAll();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 5, 5, 3, 2, 1, 1, 1);
-        Assert.assertTrue(bag.retainAll(FastList.newListWith(1, 2)));
-        Assert.assertFalse(bag.retainAll(FastList.newListWith(1, 2)));
+        assertTrue(bag.retainAll(FastList.newListWith(1, 2)));
+        assertFalse(bag.retainAll(FastList.newListWith(1, 2)));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 2, 1, 1, 1), bag);
     }
 
@@ -1587,8 +1597,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.retainAllIterable();
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 5, 5, 3, 2, 1, 1, 1);
-        Assert.assertTrue(bag.retainAllIterable(FastList.newListWith(1, 2)));
-        Assert.assertFalse(bag.retainAllIterable(FastList.newListWith(1, 2)));
+        assertTrue(bag.retainAllIterable(FastList.newListWith(1, 2)));
+        assertFalse(bag.retainAllIterable(FastList.newListWith(1, 2)));
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 2, 1, 1, 1), bag);
     }
 
@@ -1598,7 +1608,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.injectInto();
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(11),
                 this.newWith(Collections.reverseOrder(), 1, 1, 2, 3, 4).injectInto(Integer.valueOf(0), AddFunction.INTEGER));
     }
@@ -1611,7 +1621,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<Integer> bag = this.newWith(Collections.reverseOrder(), 1, 1, 2, 3);
         Integer result = bag.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(8), result);
+        assertEquals(Integer.valueOf(8), result);
     }
 
     @Override
@@ -1620,7 +1630,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.injectIntoInt();
 
-        Assert.assertEquals(
+        assertEquals(
                 11,
                 this.newWith(Collections.reverseOrder(), 1, 1, 2, 3, 4).injectInto(0, AddFunction.INTEGER_TO_INT));
     }
@@ -1631,7 +1641,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.injectIntoLong();
 
-        Assert.assertEquals(
+        assertEquals(
                 8,
                 this.newWith(Collections.reverseOrder(), 1, 1, 2, 3).injectInto(1L, AddFunction.INTEGER_TO_LONG));
     }
@@ -1642,7 +1652,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.injectIntoDouble();
 
-        Assert.assertEquals(
+        assertEquals(
                 8.0,
                 this.newWith(Collections.reverseOrder(), 1.0, 1.0, 2.0, 3.0).injectInto(1.0d, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
     }
@@ -1653,7 +1663,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.injectIntoFloat();
 
-        Assert.assertEquals(
+        assertEquals(
                 8.0,
                 this.newWith(Collections.reverseOrder(), 1, 1, 2, 3).injectInto(1.0f, AddFunction.INTEGER_TO_FLOAT), 0.001);
     }
@@ -1665,7 +1675,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.sumFloat();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4, 5);
-        Assert.assertEquals(16.0f, bag.sumOfFloat(Integer::floatValue), 0.001);
+        assertEquals(16.0f, bag.sumOfFloat(Integer::floatValue), 0.001);
     }
 
     @Override
@@ -1675,7 +1685,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.sumDouble();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4, 5);
-        Assert.assertEquals(16.0d, bag.sumOfDouble(Integer::doubleValue), 0.001);
+        assertEquals(16.0d, bag.sumOfDouble(Integer::doubleValue), 0.001);
     }
 
     @Override
@@ -1685,7 +1695,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.sumInteger();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4, 5);
-        Assert.assertEquals(16, bag.sumOfLong(Integer::longValue));
+        assertEquals(16, bag.sumOfLong(Integer::longValue));
     }
 
     @Override
@@ -1695,7 +1705,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         super.sumLong();
 
         MutableSortedBag<Integer> bag = this.newWith(Comparators.reverseNaturalOrder(), 1, 1, 2, 3, 4, 5);
-        Assert.assertEquals(16, bag.sumOfLong(Integer::longValue));
+        assertEquals(16, bag.sumOfLong(Integer::longValue));
     }
 
     @Override
@@ -1704,9 +1714,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     {
         super.toArray();
 
-        Assert.assertArrayEquals(new Object[]{4, 4, 3, 2, 1}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray());
-        Assert.assertArrayEquals(new Integer[]{4, 4, 3, 2, 1}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray(new Integer[0]));
-        Assert.assertArrayEquals(new Integer[]{4, 4, 3, 2, 1, null, null}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray(new Integer[7]));
+        assertArrayEquals(new Object[]{4, 4, 3, 2, 1}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray());
+        assertArrayEquals(new Integer[]{4, 4, 3, 2, 1}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray(new Integer[0]));
+        assertArrayEquals(new Integer[]{4, 4, 3, 2, 1, null, null}, this.newWith(Collections.reverseOrder(), 4, 4, 3, 2, 1).toArray(new Integer[7]));
     }
 
     @Override
@@ -1717,7 +1727,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
 
         MutableSortedBag<String> bag = this.newWith(Comparators.reverseNaturalOrder(), "6", "5", "4", "3", "2", "1", "1");
         RichIterable<RichIterable<String>> groups = bag.chunk(2);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(
                         TreeBag.newBagWith(Comparators.reverseNaturalOrder(), "6", "5"),
                         TreeBag.newBagWith(Comparators.reverseNaturalOrder(), "4", "3"),
@@ -1735,9 +1745,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Function0<AtomicInteger> zeroValueFactory = AtomicInteger::new;
         MutableSortedBag<Integer> sortedBag = this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 2, 1, 1, 1);
         MapIterable<String, AtomicInteger> aggregation = sortedBag.aggregateInPlaceBy(String::valueOf, zeroValueFactory, AtomicInteger::addAndGet);
-        Assert.assertEquals(3, aggregation.get("1").intValue());
-        Assert.assertEquals(4, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(3, aggregation.get("1").intValue());
+        assertEquals(4, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Override
@@ -1750,9 +1760,9 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Function2<Integer, Integer, Integer> sumAggregator = (integer1, integer2) -> integer1 + integer2;
         MutableSortedBag<Integer> sortedBag = this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 2, 1, 1, 1);
         MapIterable<String, Integer> aggregation = sortedBag.aggregateBy(String::valueOf, zeroValueFactory, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("1").intValue());
-        Assert.assertEquals(4, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(3, aggregation.get("1").intValue());
+        assertEquals(4, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Override
@@ -1804,10 +1814,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
                 PrimitiveTuples.pair("ten", 10));
         MutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
         Verify.assertSize(0, this.newWith().topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -1817,7 +1827,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Verify.assertSize(3, this.newWith("one", "one", "two", "two", "three", "three").topOccurrences(1));
         Verify.assertSize(0, this.newWith().topOccurrences(0));
         Verify.assertSize(0, this.newWith("one").topOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().topOccurrences(-1));
     }
 
     @Override
@@ -1839,10 +1849,10 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
                 PrimitiveTuples.pair("ten", 10));
         MutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
         Verify.assertSize(0, this.newWith().bottomOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(5));
         Verify.assertSize(3, this.newWith("one", "two", "three").topOccurrences(1));
@@ -1852,7 +1862,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         Verify.assertSize(3, this.newWith("one", "one", "two", "two", "three", "three").bottomOccurrences(1));
         Verify.assertSize(0, this.newWith().bottomOccurrences(0));
         Verify.assertSize(0, this.newWith("one").bottomOccurrences(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.newWith().bottomOccurrences(-1));
     }
 
     @Override
@@ -1873,33 +1883,33 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     public void detectIndex()
     {
         MutableSortedBag<Integer> integers1 = this.newWith(1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        Assert.assertEquals(2, integers1.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(5, integers1.detectIndex(integer -> integer % 3 == 0));
-        Assert.assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(2, integers1.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(5, integers1.detectIndex(integer -> integer % 3 == 0));
+        assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
 
         MutableSortedBag<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1);
-        Assert.assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(4, integers2.detectIndex(integer -> integer % 3 == 0));
-        Assert.assertEquals(9, integers2.detectIndex(integer -> integer == 1));
-        Assert.assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(4, integers2.detectIndex(integer -> integer % 3 == 0));
+        assertEquals(9, integers2.detectIndex(integer -> integer == 1));
+        assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
     }
 
     @Test
     public void take()
     {
         MutableSortedBag<Integer> integers1 = this.newWith(1, 1, 1, 2);
-        Assert.assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.take(0));
-        Assert.assertSame(integers1.comparator(), integers1.take(0).comparator());
-        Assert.assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(3));
-        Assert.assertSame(integers1.comparator(), integers1.take(3).comparator());
-        Assert.assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(integers1.size() - 1));
+        assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.take(0));
+        assertSame(integers1.comparator(), integers1.take(0).comparator());
+        assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(3));
+        assertSame(integers1.comparator(), integers1.take(3).comparator());
+        assertEquals(this.newWith(integers1.comparator(), 1, 1, 1), integers1.take(integers1.size() - 1));
 
         MutableSortedBag<Integer> expectedBag = this.newWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
         MutableSortedBag<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(expectedBag, integers2.take(integers2.size()));
-        Assert.assertEquals(expectedBag, integers2.take(10));
-        Assert.assertEquals(expectedBag, integers2.take(Integer.MAX_VALUE));
+        assertEquals(expectedBag, integers2.take(integers2.size()));
+        assertEquals(expectedBag, integers2.take(10));
+        assertEquals(expectedBag, integers2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1912,13 +1922,13 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
     public void drop()
     {
         MutableSortedBag<Integer> integers1 = this.newWith(1, 1, 1, 2);
-        Assert.assertEquals(integers1, integers1.drop(0));
-        Assert.assertNotSame(integers1, integers1.drop(0));
-        Assert.assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(3));
-        Assert.assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(integers1.size() - 1));
-        Assert.assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(integers1.size()));
-        Assert.assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(10));
-        Assert.assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(Integer.MAX_VALUE));
+        assertEquals(integers1, integers1.drop(0));
+        assertNotSame(integers1, integers1.drop(0));
+        assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(3));
+        assertEquals(this.newWith(integers1.comparator(), 2), integers1.drop(integers1.size() - 1));
+        assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(integers1.size()));
+        assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(10));
+        assertEquals(SortedBags.mutable.empty(integers1.comparator()), integers1.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1937,8 +1947,8 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         MutableSortedBag<Integer> integers = this.newWith(comparator, 5, 4, 3, 3, 2, 2, 2, 1, 1, 1, 1, 0);
         MutableSortedSet<Integer> expected = SortedSets.mutable.of(comparator, 5, 4, 0);
         MutableSortedSet<Integer> actual = integers.selectUnique();
-        Assert.assertEquals(expected, actual);
-        Assert.assertEquals(expected.comparator(), actual.comparator());
+        assertEquals(expected, actual);
+        assertEquals(expected.comparator(), actual.comparator());
     }
 
     @Override
@@ -1950,7 +1960,7 @@ public abstract class AbstractMutableSortedBagTestCase extends MutableBagTestCas
         RichIterable<String> expected = bag.toSortedSet(comparator);
         RichIterable<String> actual = bag.distinctView();
         // test content/type
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         // test sorting
         Verify.assertIterablesEqual(expected, actual);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/MutableSortedBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/MutableSortedBagFactoryTest.java
@@ -16,71 +16,72 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class MutableSortedBagFactoryTest
 {
     @Test
     public void ofEmpty()
     {
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.mutable.of());
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.mutable.of(Comparators.reverseNaturalOrder()));
+        assertEquals(TreeBag.newBag(), SortedBags.mutable.of());
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.mutable.of(Comparators.reverseNaturalOrder()));
     }
 
     @Test
     public void withEmpty()
     {
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.mutable.with());
-        Assert.assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.mutable.with(Comparators.reverseNaturalOrder()));
+        assertEquals(TreeBag.newBag(), SortedBags.mutable.with());
+        assertEquals(TreeBag.newBag(Comparators.reverseNaturalOrder()), SortedBags.mutable.with(Comparators.reverseNaturalOrder()));
     }
 
     @Test
     public void ofElements()
     {
-        Assert.assertEquals(TreeBag.newBagWith(1, 1, 2), SortedBags.mutable.of(1, 1, 2));
-        Assert.assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 2), SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2));
+        assertEquals(TreeBag.newBagWith(1, 1, 2), SortedBags.mutable.of(1, 1, 2));
+        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 2), SortedBags.mutable.of(Comparators.reverseNaturalOrder(), 1, 1, 2));
     }
 
     @Test
     public void withElements()
     {
-        Assert.assertEquals(TreeBag.newBagWith(1, 1, 2), SortedBags.mutable.with(1, 1, 2));
-        Assert.assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 2), SortedBags.mutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2));
+        assertEquals(TreeBag.newBagWith(1, 1, 2), SortedBags.mutable.with(1, 1, 2));
+        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 1, 2), SortedBags.mutable.with(Comparators.reverseNaturalOrder(), 1, 1, 2));
     }
 
     @Test
     public void ofAll()
     {
         LazyIterable<Integer> list = FastList.newListWith(1, 2, 2).asLazy();
-        Assert.assertEquals(TreeBag.newBagWith(1, 2, 2), SortedBags.mutable.ofAll(list));
+        assertEquals(TreeBag.newBagWith(1, 2, 2), SortedBags.mutable.ofAll(list));
     }
 
     @Test
     public void withAll()
     {
         LazyIterable<Integer> list = FastList.newListWith(1, 2, 2).asLazy();
-        Assert.assertEquals(TreeBag.newBagWith(1, 2, 2), SortedBags.mutable.withAll(list));
+        assertEquals(TreeBag.newBagWith(1, 2, 2), SortedBags.mutable.withAll(list));
     }
 
     @Test
     public void ofAllComparator()
     {
         LazyIterable<Integer> list = FastList.newListWith(1, 2, 2).asLazy();
-        Assert.assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 2, 2), SortedBags.mutable.ofAll(Comparators.reverseNaturalOrder(), list));
+        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 2, 2), SortedBags.mutable.ofAll(Comparators.reverseNaturalOrder(), list));
     }
 
     @Test
     public void withAllComparator()
     {
         LazyIterable<Integer> list = FastList.newListWith(1, 2, 2).asLazy();
-        Assert.assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 2, 2), SortedBags.mutable.withAll(Comparators.reverseNaturalOrder(), list));
+        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 2, 2), SortedBags.mutable.withAll(Comparators.reverseNaturalOrder(), list));
     }
 
     @Test
     public void empty()
     {
-        Assert.assertEquals(TreeBag.newBag(), SortedBags.mutable.empty());
-        Assert.assertEquals(TreeBag.newBag(Comparator.reverseOrder()), SortedBags.mutable.empty(Comparator.reverseOrder()));
+        assertEquals(TreeBag.newBag(), SortedBags.mutable.empty());
+        assertEquals(TreeBag.newBag(Comparator.reverseOrder()), SortedBags.mutable.empty(Comparator.reverseOrder()));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBagTest.java
@@ -25,8 +25,10 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.SynchronizedRichIterable;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedSortedBag}.
@@ -56,7 +58,7 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
     public void asSynchronized()
     {
         MutableSortedBag<Object> synchronizedBag = this.newWith();
-        Assert.assertSame(synchronizedBag, synchronizedBag.asSynchronized());
+        assertSame(synchronizedBag, synchronizedBag.asSynchronized());
     }
 
     @Override
@@ -79,10 +81,10 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
         MutableSortedBag<String> strings = mutable.asSynchronized();
         MutableList<ObjectIntPair<String>> top5 = strings.topOccurrences(5);
         Verify.assertSize(5, top5);
-        Assert.assertEquals("ten", top5.getFirst().getOne());
-        Assert.assertEquals(10, top5.getFirst().getTwo());
-        Assert.assertEquals("six", top5.getLast().getOne());
-        Assert.assertEquals(6, top5.getLast().getTwo());
+        assertEquals("ten", top5.getFirst().getOne());
+        assertEquals(10, top5.getFirst().getTwo());
+        assertEquals("six", top5.getLast().getOne());
+        assertEquals(6, top5.getLast().getTwo());
     }
 
     @Override
@@ -105,10 +107,10 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
         MutableSortedBag<String> strings = mutable.asSynchronized();
         MutableList<ObjectIntPair<String>> bottom5 = strings.bottomOccurrences(5);
         Verify.assertSize(5, bottom5);
-        Assert.assertEquals("one", bottom5.getFirst().getOne());
-        Assert.assertEquals(1, bottom5.getFirst().getTwo());
-        Assert.assertEquals("five", bottom5.getLast().getOne());
-        Assert.assertEquals(5, bottom5.getLast().getTwo());
+        assertEquals("one", bottom5.getFirst().getOne());
+        assertEquals(1, bottom5.getFirst().getTwo());
+        assertEquals("five", bottom5.getLast().getOne());
+        assertEquals(5, bottom5.getLast().getTwo());
     }
 
     @Override
@@ -118,13 +120,13 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
         Bag<Integer> bag1 = this.newWith(3, 3, 3, 2, 2, 1);
         Bag<ObjectIntPair<Integer>> actual1 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1)),
                 actual1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(1), 1),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -133,7 +135,7 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Sets.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -141,7 +143,7 @@ public class SynchronizedSortedBagTest extends AbstractMutableSortedBagTestCase
                 actual2);
 
         Bag<Integer> bag2 = this.newWith(3, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 4, 5, 7);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(6, 5, 8, 5, 6, 8),
                 bag2.collectWithOccurrences((each, index) -> each + index));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBagTest.java
@@ -25,8 +25,10 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link TreeBag}.
@@ -60,7 +62,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
         TreeBag<Integer> sortedBagA = TreeBag.newBag(Collections.reverseOrder());
         TreeBag<Integer> sortedBagB = TreeBag.newBag(sortedBagA.with(1).with(2, 3).with(4, 5, 6).with(1, 1, 1, 1));
         Verify.assertSortedBagsEqual(sortedBagA, sortedBagB);
-        Assert.assertTrue(sortedBagA.getFirst().equals(sortedBagB.getFirst()) && sortedBagB.getFirst() == 6);
+        assertTrue(sortedBagA.getFirst().equals(sortedBagB.getFirst()) && sortedBagB.getFirst() == 6);
         Verify.assertSortedBagsEqual(sortedBagB, TreeBag.newBag(sortedBagB));
     }
 
@@ -78,7 +80,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
         TreeBag<Integer> sortedBagA = TreeBag.newBag(Collections.reverseOrder());
         TreeBag<Integer> sortedBagB = TreeBag.newBag(sortedBagA.with(1).with(2, 3).with(4, 5, 6).with(1, 1, 1, 1));
 
-        Assert.assertEquals(Lists.mutable.of(
+        assertEquals(Lists.mutable.of(
                 PrimitiveTuples.pair((Integer) 6, 0),
                 PrimitiveTuples.pair((Integer) 5, 1),
                 PrimitiveTuples.pair((Integer) 4, 2),
@@ -97,7 +99,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
         TreeBag<String> sortedBagA = TreeBag.newBag(Collections.reverseOrder());
         TreeBag<String> sortedBagB = TreeBag.newBag(sortedBagA.with("1").with("2", "3").with("1"));
         String s = "Alex";
-        Assert.assertEquals(Lists.mutable.of("3", s, "2", s, "1", s, "1", s),
+        assertEquals(Lists.mutable.of("3", s, "2", s, "1", s, "1", s),
                 sortedBagB.flatCollectWith(Lists.mutable::of, s));
     }
 
@@ -132,13 +134,13 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
         Bag<Integer> bag1 = this.newWith(3, 3, 3, 2, 2, 1);
         Bag<ObjectIntPair<Integer>> actual1 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1)),
                 actual1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(1), 1),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -147,7 +149,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Sets.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -155,7 +157,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
                 actual2);
 
         Bag<Integer> bag2 = this.newWith(Comparator.reverseOrder(), 3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -163,7 +165,7 @@ public class TreeBagTest extends AbstractMutableSortedBagTestCase
                 bag2.collectWithOccurrences(PrimitiveTuples::pair));
 
         Bag<Integer> bag3 = this.newWith(3, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 4, 5, 7);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(6, 5, 8, 5, 6, 8),
                 bag3.collectWithOccurrences((each, index) -> each + index));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBagTest.java
@@ -25,8 +25,13 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableSortedBag}.
@@ -78,7 +83,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
         collection.add(collection);
         String simpleName = collection.getClass().getSimpleName();
         String string = collection.toString();
-        Assert.assertTrue(
+        assertTrue(
                 ("[1, (this " + simpleName + ")]").equals(string)
                         || ("[(this " + simpleName + "), 1]").equals(string));
     }
@@ -91,7 +96,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
 
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         collection.add(collection);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Override
@@ -104,7 +109,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
         collection.add(collection);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -127,36 +132,36 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
     {
         MutableSortedBag<Integer> bag = this.newWith(-1, 0, 1, 1, 2);
         Iterator<Integer> iterator = bag.iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(-1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(0), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(2), iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(-1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(0), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(1), iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(Integer.valueOf(2), iterator.next());
+        assertFalse(iterator.hasNext());
 
         MutableSortedBag<Integer> revBag = this.newWith(Comparators.reverseNaturalOrder(), -1, 0, 1, 1, 2);
         Iterator<Integer> revIterator = revBag.iterator();
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(2), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(1), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(0), revIterator.next());
-        Assert.assertTrue(revIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(-1), revIterator.next());
-        Assert.assertFalse(revIterator.hasNext());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(2), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(1), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(1), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(0), revIterator.next());
+        assertTrue(revIterator.hasNext());
+        assertEquals(Integer.valueOf(-1), revIterator.next());
+        assertFalse(revIterator.hasNext());
 
         Iterator<Integer> iterator3 = this.newWith(Comparators.reverseNaturalOrder(), 2, 1, 1, 0, -1).iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator3::remove);
-        Assert.assertEquals(Integer.valueOf(2), iterator3.next());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator3::remove);
+        assertThrows(UnsupportedOperationException.class, iterator3::remove);
+        assertEquals(Integer.valueOf(2), iterator3.next());
+        assertThrows(UnsupportedOperationException.class, iterator3::remove);
     }
 
     @Override
@@ -165,7 +170,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
     {
         MutableSortedBag<Integer> bag = this.newWith(-1, 0, 1, 1, 2);
         Iterator<Integer> iterator = bag.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Override
@@ -179,7 +184,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
     {
         Verify.assertInstanceOf(UnmodifiableSortedBag.class, this.newWith().asUnmodifiable());
         MutableSortedBag<Object> bag = this.newWith();
-        Assert.assertSame(bag, bag.asUnmodifiable());
+        assertSame(bag, bag.asUnmodifiable());
     }
 
     @Override
@@ -370,7 +375,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
     {
         MutableSortedBag<Integer> set = this.newWith(1, 2, 3);
         MutableSortedBag<Integer> clone = set.clone();
-        Assert.assertSame(set, clone);
+        assertSame(set, clone);
         Verify.assertSortedBagsEqual(set, clone);
     }
 
@@ -381,13 +386,13 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
         Bag<Integer> bag1 = this.newWith(3, 3, 3, 2, 2, 1);
         Bag<ObjectIntPair<Integer>> actual1 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Bags.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1)),
                 actual1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(1), 1),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -396,7 +401,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag1.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 Sets.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
@@ -404,7 +409,7 @@ public class UnmodifiableSortedBagTest extends AbstractMutableSortedBagTestCase
                 actual2);
 
         Bag<Integer> bag2 = this.newWith(3, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 4, 5, 7);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(6, 5, 8, 5, 6, 8),
                 bag2.collectWithOccurrences((each, index) -> each + index));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/strategy/mutable/HashBagWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/strategy/mutable/HashBagWithHashingStrategyTest.java
@@ -20,8 +20,14 @@ import org.eclipse.collections.impl.bag.mutable.MutableBagTestCase;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test suite for {@link HashBagWithHashingStrategy}.
@@ -57,11 +63,11 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
     @Test
     public void newBag_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, 1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, Bags.mutable.empty()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, Lists.mutable.empty()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(HashingStrategies.defaultStrategy(), -1));
+        assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null));
+        assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, 1));
+        assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, Bags.mutable.empty()));
+        assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(null, Lists.mutable.empty()));
+        assertThrows(IllegalArgumentException.class, () -> HashBagWithHashingStrategy.newBag(HashingStrategies.defaultStrategy(), -1));
     }
 
     @Override
@@ -70,8 +76,8 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
     {
         super.removeAllIterable();
         MutableBag<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertTrue(objects.removeAllIterable(Bags.mutable.of(1, 2, 4)));
-        Assert.assertEquals(Bags.mutable.of(3), objects.toBag());
+        assertTrue(objects.removeAllIterable(Bags.mutable.of(1, 2, 4)));
+        assertEquals(Bags.mutable.of(3), objects.toBag());
     }
 
     @Override
@@ -80,12 +86,12 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
     {
         super.addAll();
         MutableBag<Integer> bag1 = this.newWith();
-        Assert.assertTrue(bag1.addAll(this.newWith(1, 1, 2, 3)));
+        assertTrue(bag1.addAll(this.newWith(1, 1, 2, 3)));
         Verify.assertContainsAll(bag1, 1, 2, 3);
 
-        Assert.assertTrue(bag1.addAll(this.newWith(1, 2, 3)));
+        assertTrue(bag1.addAll(this.newWith(1, 2, 3)));
         Verify.assertSize(7, bag1);
-        Assert.assertFalse(bag1.addAll(this.newWith()));
+        assertFalse(bag1.addAll(this.newWith()));
         Verify.assertContainsAll(bag1, 1, 2, 3);
 
         MutableBag<Integer> bag2 = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
@@ -103,7 +109,7 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
     public void hashingStrategy()
     {
         HashBagWithHashingStrategy<Integer> map = HashBagWithHashingStrategy.newBagWith(HashingStrategies.defaultStrategy(), 1, 1, 2, 2);
-        Assert.assertSame(HashingStrategies.defaultStrategy(), map.hashingStrategy());
+        assertSame(HashingStrategies.defaultStrategy(), map.hashingStrategy());
     }
 
     @Test
@@ -112,10 +118,10 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
         HashBagWithHashingStrategy<Person> bag = HashBagWithHashingStrategy.newBagWith(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, JANEDOE, JANEDOE, JOHNSMITH, JOHNSMITH, JOHNSMITH, JANESMITH, JANESMITH, JANESMITH, JANESMITH);
         Verify.assertContains(JOHNDOE, bag);
-        Assert.assertEquals(3, bag.occurrencesOf(JOHNDOE));
+        assertEquals(3, bag.occurrencesOf(JOHNDOE));
 
         Verify.assertContains(JOHNSMITH, bag);
-        Assert.assertEquals(7, bag.occurrencesOf(JOHNSMITH));
+        assertEquals(7, bag.occurrencesOf(JOHNSMITH));
 
         Verify.assertContains(JANEDOE, bag);
         Verify.assertContains(JANESMITH, bag);
@@ -127,9 +133,9 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
         HashBagWithHashingStrategy<Person> bag1 = HashBagWithHashingStrategy.newBagWith(LAST_NAME_HASHING_STRATEGY, JOHNDOE, JANEDOE, JOHNSMITH, JANESMITH);
         HashBagWithHashingStrategy<Person> bag2 = HashBagWithHashingStrategy.newBagWith(FIRST_NAME_HASHING_STRATEGY, JOHNDOE, JANEDOE, JOHNSMITH, JANESMITH);
 
-        Assert.assertEquals(bag1, bag2);
-        Assert.assertEquals(bag2, bag1);
-        Assert.assertNotEquals(bag1.hashCode(), bag2.hashCode());
+        assertEquals(bag1, bag2);
+        assertEquals(bag2, bag1);
+        assertNotEquals(bag1.hashCode(), bag2.hashCode());
 
         HashBagWithHashingStrategy<Person> bag3 = HashBagWithHashingStrategy.newBagWith(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, JANEDOE, JANEDOE, JOHNSMITH, JOHNSMITH, JOHNSMITH, JANESMITH, JANESMITH, JANESMITH, JANESMITH);
@@ -137,12 +143,12 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
         MutableBag<Person> hashBag = HashBag.newBag(bag3);
 
         Verify.assertEqualsAndHashCode(bag3, bag4);
-        Assert.assertTrue(bag3.equals(hashBag) && hashBag.equals(bag3) && bag3.hashCode() != hashBag.hashCode());
+        assertTrue(bag3.equals(hashBag) && hashBag.equals(bag3) && bag3.hashCode() != hashBag.hashCode());
 
         HashBag<Person> people = HashBag.newBagWith(
                 JOHNDOE, JANEDOE, JANEDOE, JOHNSMITH, JOHNSMITH, JOHNSMITH, JANESMITH, JANESMITH, JANESMITH, JANESMITH);
         HashBagWithHashingStrategy<Person> bag5 = HashBagWithHashingStrategy.newBag(LAST_NAME_HASHING_STRATEGY, people);
-        Assert.assertNotEquals(bag5, people);
+        assertNotEquals(bag5, people);
     }
 
     @Test
@@ -152,15 +158,15 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
         bag.addOccurrences(null, 5);
 
         //Testing getting values from no chains
-        Assert.assertEquals(1, bag.occurrencesOf("1"));
-        Assert.assertEquals(2, bag.occurrencesOf("2"));
-        Assert.assertEquals(5, bag.occurrencesOf(null));
+        assertEquals(1, bag.occurrencesOf("1"));
+        assertEquals(2, bag.occurrencesOf("2"));
+        assertEquals(5, bag.occurrencesOf(null));
 
         HashBagWithHashingStrategy<Person> bag2 = HashBagWithHashingStrategy.newBag(LAST_NAME_HASHING_STRATEGY);
         bag2.addOccurrences(JOHNSMITH, 1);
-        Assert.assertEquals(1, bag2.occurrencesOf(JOHNSMITH));
+        assertEquals(1, bag2.occurrencesOf(JOHNSMITH));
         bag2.addOccurrences(JANESMITH, 2);
-        Assert.assertEquals(3, bag2.occurrencesOf(JOHNSMITH));
+        assertEquals(3, bag2.occurrencesOf(JOHNSMITH));
     }
 
     @Test
@@ -170,13 +176,13 @@ public class HashBagWithHashingStrategyTest extends MutableBagTestCase
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, JANEDOE, JANEDOE, JOHNSMITH, JOHNSMITH, JOHNSMITH, JANESMITH, JANESMITH, JANESMITH, JANESMITH);
 
         bag.removeOccurrences(JANEDOE, 3);
-        Assert.assertEquals(HashBagWithHashingStrategy.newBagWith(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH), bag);
+        assertEquals(HashBagWithHashingStrategy.newBagWith(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH, JOHNSMITH), bag);
         bag.removeOccurrences(JOHNSMITH, 7);
 
         Verify.assertEmpty(bag);
 
         HashBagWithHashingStrategy<Integer> bag2 = HashBagWithHashingStrategy.newBagWith(HashingStrategies.defaultStrategy(), 1, null, null, 3, 3, 3);
         bag2.removeOccurrences(null, 2);
-        Assert.assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.defaultStrategy(), 1, 3, 3, 3), bag2);
+        assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.defaultStrategy(), 1, 3, 3, 3), bag2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMapTestCase.java
@@ -17,8 +17,11 @@ import org.eclipse.collections.api.bimap.ImmutableBiMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.immutable.ImmutableMapIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableBiMapTestCase extends ImmutableMapIterableTestCase
 {
@@ -43,44 +46,44 @@ public abstract class AbstractImmutableBiMapTestCase extends ImmutableMapIterabl
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
+        assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
     }
 
     @Test
     public void testNewEmpty()
     {
-        Assert.assertTrue(this.newEmpty().isEmpty());
+        assertTrue(this.newEmpty().isEmpty());
     }
 
     @Test
     public void testNewWithMap()
     {
-        Assert.assertEquals(this.classUnderTest(), this.newWithMap());
+        assertEquals(this.classUnderTest(), this.newWithMap());
     }
 
     @Test
     public void testNewWithHashBiMap()
     {
-        Assert.assertEquals(this.classUnderTest(), this.newWithHashBiMap());
+        assertEquals(this.classUnderTest(), this.newWithHashBiMap());
     }
 
     @Test
     public void testNewWithImmutableMap()
     {
-        Assert.assertEquals(this.classUnderTest(), this.newWithImmutableMap());
+        assertEquals(this.classUnderTest(), this.newWithImmutableMap());
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey(1));
-        Assert.assertFalse(this.classUnderTest().containsKey(5));
+        assertTrue(this.classUnderTest().containsKey(1));
+        assertFalse(this.classUnderTest().containsKey(5));
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
     }
 
     @Test
@@ -96,6 +99,6 @@ public abstract class AbstractImmutableBiMapTestCase extends ImmutableMapIterabl
 
         Map<String, String> actualMap = (Map<String, String>) immutableBiMap.toMap(Functions.getPassThru(), Functions.getPassThru(), expectedMap);
 
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMap2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMap2Test.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableHashBiMap2Test extends MapIterableTestCase
 {
@@ -59,7 +60,7 @@ public class ImmutableHashBiMap2Test extends MapIterableTestCase
         ImmutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ImmutableBiMap<String, Integer> result = map.flipUniqueValues();
         ImmutableBiMap<String, Integer> expectedMap = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
-        Assert.assertEquals(expectedMap, result);
+        assertEquals(expectedMap, result);
     }
 
     @Override
@@ -69,7 +70,7 @@ public class ImmutableHashBiMap2Test extends MapIterableTestCase
         ImmutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ImmutableSetMultimap<String, Integer> result = map.flip();
         UnifiedSetMultimap<String, Integer> expected = UnifiedSetMultimap.newMultimap(Tuples.pair("1", 1), Tuples.pair("2", 2), Tuples.pair("3", 3));
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Override
@@ -79,12 +80,12 @@ public class ImmutableHashBiMap2Test extends MapIterableTestCase
         ImmutableBiMap<IntegerWithCast, String> map = this.newMapWithKeysValues(
                 new IntegerWithCast(0), "Test 2",
                 null, "Test 1");
-        Assert.assertEquals(
+        assertEquals(
                 this.newMapWithKeysValues(
                         new IntegerWithCast(0), "Test 2",
                         null, "Test 1"),
                 map);
-        Assert.assertEquals("Test 2", map.get(new IntegerWithCast(0)));
-        Assert.assertEquals("Test 1", map.get(null));
+        assertEquals("Test 2", map.get(new IntegerWithCast(0)));
+        assertEquals("Test 1", map.get(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapInverse2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapInverse2Test.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableHashBiMapInverse2Test extends MapIterableTestCase
 {
@@ -61,7 +62,7 @@ public class ImmutableHashBiMapInverse2Test extends MapIterableTestCase
         ImmutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ImmutableBiMap<String, Integer> result = map.flipUniqueValues();
         ImmutableBiMap<String, Integer> expectedMap = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
-        Assert.assertEquals(expectedMap, result);
+        assertEquals(expectedMap, result);
     }
 
     @Override
@@ -71,7 +72,7 @@ public class ImmutableHashBiMapInverse2Test extends MapIterableTestCase
         ImmutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ImmutableSetMultimap<String, Integer> result = map.flip();
         UnifiedSetMultimap<String, Integer> expected = UnifiedSetMultimap.newMultimap(Tuples.pair("1", 1), Tuples.pair("2", 2), Tuples.pair("3", 3));
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Override
@@ -81,12 +82,12 @@ public class ImmutableHashBiMapInverse2Test extends MapIterableTestCase
         ImmutableBiMap<IntegerWithCast, String> map = this.newMapWithKeysValues(
                 new IntegerWithCast(0), "Test 2",
                 null, "Test 1");
-        Assert.assertEquals(
+        assertEquals(
                 this.newMapWithKeysValues(
                         new IntegerWithCast(0), "Test 2",
                         null, "Test 1"),
                 map);
-        Assert.assertEquals("Test 2", map.get(new IntegerWithCast(0)));
-        Assert.assertEquals("Test 1", map.get(null));
+        assertEquals("Test 2", map.get(new IntegerWithCast(0)));
+        assertEquals("Test 1", map.get(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapTest.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableHashBiMapTest extends AbstractImmutableBiMapTestCase
 {
@@ -56,7 +57,7 @@ public class ImmutableHashBiMapTest extends AbstractImmutableBiMapTestCase
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
+        assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapEntrySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapEntrySetTest.java
@@ -23,8 +23,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMutableBiMapEntrySetTest
 {
@@ -71,8 +77,8 @@ public abstract class AbstractMutableBiMapEntrySetTest
         for (int i = 0; i < objects.length; i++)
         {
             Map.Entry<Integer, String> object = objects[i];
-            Assert.assertEquals(Integer.valueOf(i + 1), object.getKey());
-            Assert.assertEquals(String.valueOf(i + 1), object.getValue());
+            assertEquals(Integer.valueOf(i + 1), object.getKey());
+            assertEquals(String.valueOf(i + 1), object.getValue());
         }
 
         Map.Entry<Integer, String>[] smallArray = biMap.entrySet().toArray(new Map.Entry[2]);
@@ -82,8 +88,8 @@ public abstract class AbstractMutableBiMapEntrySetTest
         for (int i = 0; i < objects.length; i++)
         {
             Map.Entry<Integer, String> object = smallArray[i];
-            Assert.assertEquals(Integer.valueOf(i + 1), object.getKey());
-            Assert.assertEquals(String.valueOf(i + 1), object.getValue());
+            assertEquals(Integer.valueOf(i + 1), object.getKey());
+            assertEquals(String.valueOf(i + 1), object.getValue());
         }
 
         for (int i = 0; i < objects.length; i++)
@@ -91,8 +97,8 @@ public abstract class AbstractMutableBiMapEntrySetTest
             Map.Entry<Integer, String> object = objects[i];
             object.setValue(String.valueOf(i + 4));
         }
-        Assert.assertTrue(Arrays.equals(new Map.Entry[]{ImmutableEntry.of(1, "4"), ImmutableEntry.of(2, "5"), ImmutableEntry.of(3, "6")}, biMap.entrySet().toArray()));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "4", 2, "5", 3, "6"), biMap);
+        assertTrue(Arrays.equals(new Map.Entry[]{ImmutableEntry.of(1, "4"), ImmutableEntry.of(2, "5"), ImmutableEntry.of(3, "6")}, biMap.entrySet().toArray()));
+        assertEquals(HashBiMap.newWithKeysValues(1, "4", 2, "5", 3, "6"), biMap);
     }
 
     @Test
@@ -101,13 +107,13 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, String> biMap = this.newMapWithKeyValue(1, "One");
         Map.Entry<Integer, String> entry = Iterate.getFirst(biMap.entrySet());
         String value = "Ninety-Nine";
-        Assert.assertEquals("One", entry.setValue(value));
-        Assert.assertEquals(value, entry.getValue());
+        assertEquals("One", entry.setValue(value));
+        assertEquals(value, entry.getValue());
         Verify.assertContainsKeyValue(1, value, biMap);
 
         biMap.remove(1);
         Verify.assertEmpty(biMap);
-        Assert.assertNull(entry.setValue("Ignored"));
+        assertNull(entry.setValue("Ignored"));
     }
 
     @Test
@@ -116,7 +122,7 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, Character> biMap = this.newMapWithKeysValues(1, 'a', 2, 'b', 3, 'c');
         Map.Entry<Integer, Character> entry = Iterate.getFirst(biMap.entrySet());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> entry.setValue('b'));
+        assertThrows(IllegalArgumentException.class, () -> entry.setValue('b'));
         Verify.assertContainsKeyValue(2, 'b', biMap);
     }
 
@@ -139,8 +145,8 @@ public abstract class AbstractMutableBiMapEntrySetTest
         Verify.assertSize(2, biMap.inverse());
         Verify.assertSize(2, biMap.entrySet());
 
-        Assert.assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four"), biMap);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four").inverse(), biMap.inverse());
+        assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four"), biMap);
+        assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four").inverse(), biMap.inverse());
 
         MutableBiMap<Integer, String> map1 = this.newMapWithKeysValues(1, null, 3, "Three", 4, "Four");
         Set<Map.Entry<Integer, String>> entries1 = map1.entrySet();
@@ -148,7 +154,7 @@ public abstract class AbstractMutableBiMapEntrySetTest
         Verify.assertSize(2, biMap);
         Verify.assertSize(2, biMap.inverse());
         Verify.assertSize(2, biMap.entrySet());
-        Assert.assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four"), biMap);
+        assertEquals(HashBiMap.newWithKeysValues(3, "Three", 4, "Four"), biMap);
     }
 
     @Test
@@ -167,9 +173,9 @@ public abstract class AbstractMutableBiMapEntrySetTest
         // simple biMap, test for non-existent entries
         MutableBiMap<Integer, String> biMap = this.newMapWithKeysValues(1, "One", 3, "Three");
         Set<Map.Entry<Integer, String>> entries = biMap.entrySet();
-        Assert.assertFalse(entries.containsAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
+        assertFalse(entries.containsAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
 
-        Assert.assertTrue(entries.containsAll(FastList.newListWith(ImmutableEntry.of(1, "One"), ImmutableEntry.of(3, "Three"))));
+        assertTrue(entries.containsAll(FastList.newListWith(ImmutableEntry.of(1, "One"), ImmutableEntry.of(3, "Three"))));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -192,14 +198,14 @@ public abstract class AbstractMutableBiMapEntrySetTest
     public void entrySet_equals()
     {
         MutableBiMap<Integer, String> biMap = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", null, null);
-        Assert.assertNotEquals(UnifiedSet.newSetWith(ImmutableEntry.of(5, "Five")), biMap.entrySet());
+        assertNotEquals(UnifiedSet.newSetWith(ImmutableEntry.of(5, "Five")), biMap.entrySet());
 
         UnifiedSet<ImmutableEntry<Integer, String>> expected = UnifiedSet.newSetWith(
                 ImmutableEntry.of(1, "One"),
                 ImmutableEntry.of(2, "Two"),
                 ImmutableEntry.of(3, "Three"),
                 ImmutableEntry.of(null, null));
-        Assert.assertEquals(expected, biMap.entrySet());
+        assertEquals(expected, biMap.entrySet());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -217,7 +223,7 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, String> biMap = this.newMapWithKeyValue(null, null);
         Map.Entry<Integer, String> entry = Iterate.getFirst(biMap.entrySet());
 
-        Assert.assertEquals(0, entry.hashCode());
+        assertEquals(0, entry.hashCode());
     }
 
     @Test
@@ -226,7 +232,7 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, String> biMap = this.newMapWithKeyValue(1, "a");
         Map.Entry<Integer, String> entry = Iterate.getFirst(biMap.entrySet());
 
-        Assert.assertEquals(entry, ImmutableEntry.of(1, "a"));
+        assertEquals(entry, ImmutableEntry.of(1, "a"));
     }
 
     @Test
@@ -235,7 +241,7 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, String> biMap = this.newMapWithKeyValue(null, null);
         Map.Entry<Integer, String> entry = Iterate.getFirst(biMap.entrySet());
 
-        Assert.assertNotEquals(entry, new Object());
+        assertNotEquals(entry, new Object());
     }
 
     @Test
@@ -244,6 +250,6 @@ public abstract class AbstractMutableBiMapEntrySetTest
         MutableBiMap<Integer, String> biMap = this.newMapWithKeyValue(1, "a");
         Map.Entry<Integer, String> entry = Iterate.getFirst(biMap.entrySet());
 
-        Assert.assertEquals("1=a", entry.toString());
+        assertEquals("1=a", entry.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapKeySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapKeySetTestCase.java
@@ -19,8 +19,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMutableBiMapKeySetTestCase
 {
@@ -45,15 +50,15 @@ public abstract class AbstractMutableBiMapKeySetTestCase
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3, null, 4);
         Set<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.contains("One"));
-        Assert.assertTrue(keySet.contains("Two"));
-        Assert.assertTrue(keySet.contains("Three"));
-        Assert.assertFalse(keySet.contains("Four"));
-        Assert.assertTrue(keySet.contains(null));
+        assertTrue(keySet.contains("One"));
+        assertTrue(keySet.contains("Two"));
+        assertTrue(keySet.contains("Three"));
+        assertFalse(keySet.contains("Four"));
+        assertTrue(keySet.contains(null));
         keySet.remove(null);
-        Assert.assertFalse(keySet.contains(null));
+        assertFalse(keySet.contains(null));
         map.remove("One");
-        Assert.assertFalse(keySet.contains("One"));
+        assertFalse(keySet.contains("One"));
     }
 
     @Test
@@ -61,17 +66,17 @@ public abstract class AbstractMutableBiMapKeySetTestCase
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3, null, 4);
         Set<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
+        assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
         keySet.remove(null);
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
         map.remove("One");
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
     }
 
     @Test
@@ -79,12 +84,12 @@ public abstract class AbstractMutableBiMapKeySetTestCase
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3, null, 4);
         Set<String> keySet = map.keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         HashBiMap<String, Integer> map1 = HashBiMap.newMap();
         Set<String> keySet1 = map1.keySet();
-        Assert.assertTrue(keySet1.isEmpty());
+        assertTrue(keySet1.isEmpty());
         map1.put("One", 1);
-        Assert.assertFalse(keySet1.isEmpty());
+        assertFalse(keySet1.isEmpty());
     }
 
     @Test
@@ -114,29 +119,29 @@ public abstract class AbstractMutableBiMapKeySetTestCase
 
         HashBag<String> expected = HashBag.newBagWith("One", "Two", "Three", null);
         HashBag<String> actual = HashBag.newBag();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
         for (int i = 0; i < 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
 
         Iterator<String> iterator1 = keySet.iterator();
         for (int i = 4; i > 0; i--)
         {
-            Assert.assertTrue(iterator1.hasNext());
+            assertTrue(iterator1.hasNext());
             iterator1.next();
             iterator1.remove();
-            Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+            assertThrows(IllegalStateException.class, iterator1::remove);
             Verify.assertSize(i - 1, keySet);
             Verify.assertSize(i - 1, map);
             Verify.assertSize(i - 1, map.inverse());
         }
 
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
         Verify.assertEmpty(map);
         Verify.assertEmpty(map.inverse());
         Verify.assertEmpty(keySet);
@@ -146,55 +151,55 @@ public abstract class AbstractMutableBiMapKeySetTestCase
     public void removeFromKeySet()
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().remove("Four"));
+        assertFalse(map.keySet().remove("Four"));
 
-        Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().remove("Two"));
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void removeNullFromKeySet()
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().remove(null));
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3).inverse(), map.inverse());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().remove(null));
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3).inverse(), map.inverse());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         map.put(null, 4);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertTrue(map.keySet().remove(null));
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3).inverse(), map.inverse());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
+        assertTrue(map.keySet().remove(null));
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3).inverse(), map.inverse());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
     }
 
     @Test
     public void removeAllFromKeySet()
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void retainAllFromKeySet()
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertEquals(HashBiMap.newWithKeysValues("One", 1, "Three", 3).inverse(), map.inverse());
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
@@ -212,8 +217,8 @@ public abstract class AbstractMutableBiMapKeySetTestCase
     {
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3, null, 0);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
-        Assert.assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
     }
 
     @Test
@@ -222,11 +227,11 @@ public abstract class AbstractMutableBiMapKeySetTestCase
         MutableBiMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
         HashBag<String> expected = HashBag.newBagWith("One", "Two", "Three");
         Set<String> keySet = map.keySet();
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapTestCase.java
@@ -27,8 +27,15 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTestCase
 {
@@ -53,8 +60,8 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
 
     public static void assertBiMapsEqual(BiMap<?, ?> expected, BiMap<?, ?> actual)
     {
-        Assert.assertEquals(expected, actual);
-        Assert.assertEquals(expected.inverse(), actual.inverse());
+        assertEquals(expected, actual);
+        assertEquals(expected.inverse(), actual.inverse());
     }
 
     @Test
@@ -69,7 +76,7 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
         expected.put(3, "Three");
         expected.put(4, "Four");
 
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3, "Four", 4).flip());
     }
@@ -85,20 +92,20 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     public void forcePut()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertNull(biMap.forcePut(4, 'd'));
+        assertNull(biMap.forcePut(4, 'd'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
+        assertEquals(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertNull(biMap.forcePut(1, null));
+        assertNull(biMap.forcePut(1, null));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertNull(biMap.forcePut(1, 'e'));
+        assertNull(biMap.forcePut(1, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'e', null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertNull(biMap.forcePut(5, 'e'));
+        assertNull(biMap.forcePut(5, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(5, 'e', null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
+        assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(4, 'e', null, 'b', 3, 'c'), biMap);
 
         HashBiMap<Integer, Character> actual = HashBiMap.newMap();
@@ -111,20 +118,20 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     public void put()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertNull(biMap.put(4, 'd'));
+        assertNull(biMap.put(4, 'd'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
+        assertEquals(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertNull(biMap.put(1, null));
+        assertNull(biMap.put(1, null));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertNull(biMap.put(1, 'e'));
+        assertNull(biMap.put(1, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'e', null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> biMap.put(5, 'e'));
+        assertThrows(IllegalArgumentException.class, () -> biMap.put(5, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'e', null, 'b', 3, 'c', 4, 'd'), biMap);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> biMap.put(4, 'e'));
+        assertThrows(IllegalArgumentException.class, () -> biMap.put(4, 'e'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'e', null, 'b', 3, 'c', 4, 'd'), biMap);
 
         HashBiMap<Integer, Character> actual = HashBiMap.newMap();
@@ -138,57 +145,57 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     {
         MutableBiMap<Integer, Character> map = this.classUnderTest();
         MutableBiMap<Character, Integer> result = map.flipUniqueValues();
-        Assert.assertEquals(map.inverse(), result);
-        Assert.assertNotSame(map.inverse(), result);
+        assertEquals(map.inverse(), result);
+        assertNotSame(map.inverse(), result);
         result.put('d', 4);
-        Assert.assertEquals(this.classUnderTest(), map);
+        assertEquals(this.classUnderTest(), map);
     }
 
     @Test
     public void get()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertNull(biMap.get(1));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertNull(biMap.get(4));
+        assertNull(biMap.get(1));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertNull(biMap.get(4));
 
-        Assert.assertNull(biMap.put(4, 'd'));
-        Assert.assertNull(biMap.get(1));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertEquals(Character.valueOf('d'), biMap.get(4));
+        assertNull(biMap.put(4, 'd'));
+        assertNull(biMap.get(1));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertEquals(Character.valueOf('d'), biMap.get(4));
 
-        Assert.assertNull(biMap.put(1, null));
-        Assert.assertNull(biMap.get(1));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertEquals(Character.valueOf('d'), biMap.get(4));
+        assertNull(biMap.put(1, null));
+        assertNull(biMap.get(1));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertEquals(Character.valueOf('d'), biMap.get(4));
 
-        Assert.assertNull(biMap.forcePut(1, 'e'));
-        Assert.assertEquals(Character.valueOf('e'), biMap.get(1));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertEquals(Character.valueOf('d'), biMap.get(4));
+        assertNull(biMap.forcePut(1, 'e'));
+        assertEquals(Character.valueOf('e'), biMap.get(1));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertEquals(Character.valueOf('d'), biMap.get(4));
 
-        Assert.assertNull(biMap.forcePut(5, 'e'));
-        Assert.assertNull(biMap.get(1));
-        Assert.assertEquals(Character.valueOf('e'), biMap.get(5));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertEquals(Character.valueOf('d'), biMap.get(4));
+        assertNull(biMap.forcePut(5, 'e'));
+        assertNull(biMap.get(1));
+        assertEquals(Character.valueOf('e'), biMap.get(5));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertEquals(Character.valueOf('d'), biMap.get(4));
 
-        Assert.assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
-        Assert.assertNull(biMap.get(1));
-        Assert.assertNull(biMap.get(5));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertEquals(Character.valueOf('e'), biMap.get(4));
+        assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
+        assertNull(biMap.get(1));
+        assertNull(biMap.get(5));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertEquals(Character.valueOf('e'), biMap.get(4));
 
         HashBiMap<Integer, Character> actual = HashBiMap.newMap();
-        Assert.assertNull(actual.get(1));
+        assertNull(actual.get(1));
         actual.put(1, null);
-        Assert.assertNull(actual.get(1));
+        assertNull(actual.get(1));
     }
 
     @Override
@@ -199,47 +206,47 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
 
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
 
-        Assert.assertTrue(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertFalse(biMap.containsKey(4));
+        assertTrue(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertFalse(biMap.containsKey(4));
 
-        Assert.assertNull(biMap.put(4, 'd'));
-        Assert.assertTrue(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertTrue(biMap.containsKey(4));
+        assertNull(biMap.put(4, 'd'));
+        assertTrue(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertTrue(biMap.containsKey(4));
 
-        Assert.assertNull(biMap.put(1, null));
-        Assert.assertTrue(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertTrue(biMap.containsKey(4));
+        assertNull(biMap.put(1, null));
+        assertTrue(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertTrue(biMap.containsKey(4));
 
-        Assert.assertNull(biMap.forcePut(1, 'e'));
-        Assert.assertTrue(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertTrue(biMap.containsKey(4));
+        assertNull(biMap.forcePut(1, 'e'));
+        assertTrue(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertTrue(biMap.containsKey(4));
 
-        Assert.assertNull(biMap.forcePut(5, 'e'));
-        Assert.assertFalse(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(5));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertTrue(biMap.containsKey(4));
+        assertNull(biMap.forcePut(5, 'e'));
+        assertFalse(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(5));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertTrue(biMap.containsKey(4));
 
-        Assert.assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
-        Assert.assertFalse(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertTrue(biMap.containsKey(4));
-        Assert.assertFalse(biMap.containsKey(5));
+        assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
+        assertFalse(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertTrue(biMap.containsKey(4));
+        assertFalse(biMap.containsKey(5));
 
         HashBiMap<Integer, Character> actual = HashBiMap.newMap();
         actual.put(1, null);
-        Assert.assertTrue(actual.containsKey(1));
-        Assert.assertFalse(actual.containsKey(0));
+        assertTrue(actual.containsKey(1));
+        assertFalse(actual.containsKey(0));
     }
 
     @Override
@@ -250,48 +257,48 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
 
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
 
-        Assert.assertTrue(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertFalse(biMap.containsValue('d'));
+        assertTrue(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertFalse(biMap.containsValue('d'));
 
-        Assert.assertNull(biMap.put(4, 'd'));
-        Assert.assertTrue(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertTrue(biMap.containsValue('d'));
+        assertNull(biMap.put(4, 'd'));
+        assertTrue(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertTrue(biMap.containsValue('d'));
 
-        Assert.assertNull(biMap.put(1, null));
-        Assert.assertTrue(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertTrue(biMap.containsValue('d'));
+        assertNull(biMap.put(1, null));
+        assertTrue(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertTrue(biMap.containsValue('d'));
 
-        Assert.assertNull(biMap.forcePut(1, 'e'));
-        Assert.assertTrue(biMap.containsValue('e'));
-        Assert.assertFalse(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertTrue(biMap.containsValue('d'));
+        assertNull(biMap.forcePut(1, 'e'));
+        assertTrue(biMap.containsValue('e'));
+        assertFalse(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertTrue(biMap.containsValue('d'));
 
-        Assert.assertNull(biMap.forcePut(5, 'e'));
-        Assert.assertFalse(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('e'));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertTrue(biMap.containsValue('d'));
+        assertNull(biMap.forcePut(5, 'e'));
+        assertFalse(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('e'));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertTrue(biMap.containsValue('d'));
 
-        Assert.assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
-        Assert.assertFalse(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('e'));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertFalse(biMap.containsValue('d'));
+        assertEquals(Character.valueOf('d'), biMap.forcePut(4, 'e'));
+        assertFalse(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('e'));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertFalse(biMap.containsValue('d'));
 
         HashBiMap<Integer, Character> actual = HashBiMap.newMap();
         actual.put(1, null);
-        Assert.assertTrue(actual.containsValue(null));
-        Assert.assertFalse(actual.containsValue('\0'));
+        assertTrue(actual.containsValue(null));
+        assertFalse(actual.containsValue('\0'));
     }
 
     @Override
@@ -304,38 +311,38 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
 
         biMap.putAll(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c'));
         HashBiMap<Integer, Character> expected = HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c');
-        Assert.assertEquals(expected, biMap);
+        assertEquals(expected, biMap);
 
         biMap.putAll(UnifiedMap.newWithKeysValues(4, 'd', 5, 'e', 6, 'f'));
         expected.put(4, 'd');
         expected.put(5, 'e');
         expected.put(6, 'f');
-        Assert.assertEquals(expected, biMap);
+        assertEquals(expected, biMap);
     }
 
     @Test
     public void remove()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertNull(biMap.remove(4));
+        assertNull(biMap.remove(4));
         Verify.assertSize(3, biMap);
-        Assert.assertNull(biMap.remove(1));
-        Assert.assertNull(biMap.get(1));
-        Assert.assertNull(biMap.inverse().get(null));
+        assertNull(biMap.remove(1));
+        assertNull(biMap.get(1));
+        assertNull(biMap.inverse().get(null));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(null, 'b', 3, 'c'), biMap);
 
-        Assert.assertEquals(Character.valueOf('b'), biMap.remove(null));
-        Assert.assertNull(biMap.get(null));
-        Assert.assertNull(biMap.inverse().get('b'));
+        assertEquals(Character.valueOf('b'), biMap.remove(null));
+        assertNull(biMap.get(null));
+        assertNull(biMap.inverse().get('b'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(3, 'c'), biMap);
 
-        Assert.assertEquals(Character.valueOf('c'), biMap.remove(3));
-        Assert.assertNull(biMap.get(3));
-        Assert.assertNull(biMap.inverse().get('c'));
+        assertEquals(Character.valueOf('c'), biMap.remove(3));
+        assertNull(biMap.get(3));
+        assertNull(biMap.inverse().get('c'));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newMap(), biMap);
         Verify.assertEmpty(biMap);
 
-        Assert.assertNull(HashBiMap.newMap().remove(1));
+        assertNull(HashBiMap.newMap().remove(1));
     }
 
     @Override
@@ -351,9 +358,9 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.getEmptyMap().toString());
+        assertEquals("{}", this.getEmptyMap().toString());
         String actualString = HashBiMap.newWithKeysValues(1, null, 2, 'b').toString();
-        Assert.assertTrue("{1=null, 2=b}".equals(actualString) || "{2=b, 1=null}".equals(actualString));
+        assertTrue("{1=null, 2=b}".equals(actualString) || "{2=b, 1=null}".equals(actualString));
     }
 
     @Override
@@ -364,10 +371,10 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
 
         MutableBiMap<Integer, Character> emptyMap = this.getEmptyMap();
         Verify.assertEqualsAndHashCode(UnifiedMap.newMap(), emptyMap);
-        Assert.assertEquals(emptyMap, emptyMap);
+        assertEquals(emptyMap, emptyMap);
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues(1, null, null, 'b', 3, 'c'), this.classUnderTest());
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues(null, 'b', 1, null, 3, 'c'), this.classUnderTest());
-        Assert.assertNotEquals(HashBiMap.newWithKeysValues(null, 1, 'b', null, 'c', 3), this.classUnderTest());
+        assertNotEquals(HashBiMap.newWithKeysValues(null, 1, 'b', null, 'c', 3), this.classUnderTest());
         Verify.assertEqualsAndHashCode(HashBiMap.newWithKeysValues(null, 1, 'b', null, 'c', 3), this.classUnderTest().inverse());
     }
 
@@ -379,13 +386,13 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
         mutableMap.put(new IntegerWithCast(0), "Test 2");
         mutableMap.forcePut(new IntegerWithCast(0), "Test 3");
         mutableMap.put(null, "Test 1");
-        Assert.assertEquals(
+        assertEquals(
                 this.newMapWithKeysValues(
                         new IntegerWithCast(0), "Test 3",
                         null, "Test 1"),
                 mutableMap);
-        Assert.assertEquals("Test 3", mutableMap.get(new IntegerWithCast(0)));
-        Assert.assertEquals("Test 1", mutableMap.get(null));
+        assertEquals("Test 3", mutableMap.get(new IntegerWithCast(0)));
+        assertEquals("Test 1", mutableMap.get(null));
     }
 
     @Override
@@ -396,58 +403,58 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
         MutableSet<Character> actual = UnifiedSet.newSet();
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
         Iterator<Character> iterator = biMap.iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(IllegalStateException.class, iterator::remove);
         Verify.assertSize(3, biMap);
         Verify.assertSize(3, biMap.inverse());
         for (int i = 0; i < 3; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
 
         Iterator<Character> iteratorRemove = biMap.iterator();
 
-        Assert.assertTrue(iteratorRemove.hasNext());
+        assertTrue(iteratorRemove.hasNext());
         Character first = iteratorRemove.next();
         iteratorRemove.remove();
         MutableBiMap<Integer, Character> expectedMap = this.classUnderTest();
         expectedMap.inverse().remove(first);
-        Assert.assertEquals(expectedMap, biMap);
-        Assert.assertEquals(expectedMap.inverse(), biMap.inverse());
+        assertEquals(expectedMap, biMap);
+        assertEquals(expectedMap.inverse(), biMap.inverse());
         Verify.assertSize(2, biMap);
         Verify.assertSize(2, biMap.inverse());
 
-        Assert.assertTrue(iteratorRemove.hasNext());
+        assertTrue(iteratorRemove.hasNext());
         Character second = iteratorRemove.next();
         iteratorRemove.remove();
         expectedMap.inverse().remove(second);
-        Assert.assertEquals(expectedMap, biMap);
-        Assert.assertEquals(expectedMap.inverse(), biMap.inverse());
+        assertEquals(expectedMap, biMap);
+        assertEquals(expectedMap.inverse(), biMap.inverse());
         Verify.assertSize(1, biMap);
         Verify.assertSize(1, biMap.inverse());
 
-        Assert.assertTrue(iteratorRemove.hasNext());
+        assertTrue(iteratorRemove.hasNext());
         Character third = iteratorRemove.next();
         iteratorRemove.remove();
         expectedMap.inverse().remove(third);
-        Assert.assertEquals(expectedMap, biMap);
-        Assert.assertEquals(expectedMap.inverse(), biMap.inverse());
+        assertEquals(expectedMap, biMap);
+        assertEquals(expectedMap.inverse(), biMap.inverse());
         Verify.assertEmpty(biMap);
         Verify.assertEmpty(biMap.inverse());
 
-        Assert.assertFalse(iteratorRemove.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iteratorRemove::next);
+        assertFalse(iteratorRemove.hasNext());
+        assertThrows(NoSuchElementException.class, iteratorRemove::next);
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.newMap().withMap(null));
+        assertThrows(NullPointerException.class, () -> this.newMap().withMap(null));
     }
 
     @Override
@@ -458,11 +465,11 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
         Function2<Character, Boolean, Character> toUpperOrLowerCase = (character, parameter) -> parameter
                 ? Character.toUpperCase(character)
                 : Character.toLowerCase(character);
-        Assert.assertEquals(Character.valueOf('D'), biMap.updateValueWith(4, () -> 'd', toUpperOrLowerCase, true));
+        assertEquals(Character.valueOf('D'), biMap.updateValueWith(4, () -> 'd', toUpperOrLowerCase, true));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'D'), biMap);
-        Assert.assertEquals(Character.valueOf('B'), biMap.updateValueWith(null, () -> 'd', toUpperOrLowerCase, true));
+        assertEquals(Character.valueOf('B'), biMap.updateValueWith(null, () -> 'd', toUpperOrLowerCase, true));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'B', 3, 'c', 4, 'D'), biMap);
-        Assert.assertEquals(Character.valueOf('d'), biMap.updateValueWith(4, () -> 'x', toUpperOrLowerCase, false));
+        assertEquals(Character.valueOf('d'), biMap.updateValueWith(4, () -> 'x', toUpperOrLowerCase, false));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'B', 3, 'c', 4, 'd'), biMap);
     }
 
@@ -471,9 +478,9 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     public void updateValue()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertEquals(Character.valueOf('D'), biMap.updateValue(4, () -> 'd', Character::toUpperCase));
+        assertEquals(Character.valueOf('D'), biMap.updateValue(4, () -> 'd', Character::toUpperCase));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'b', 3, 'c', 4, 'D'), biMap);
-        Assert.assertEquals(Character.valueOf('B'), biMap.updateValue(null, () -> 'd', Character::toUpperCase));
+        assertEquals(Character.valueOf('B'), biMap.updateValue(null, () -> 'd', Character::toUpperCase));
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, null, null, 'B', 3, 'c', 4, 'D'), biMap);
     }
 
@@ -496,7 +503,7 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     {
         ImmutableBiMap<Integer, Character> expectedImmutableBiMap = BiMaps.immutable.of(null, 'b', 1, null, 3, 'c');
         ImmutableBiMap<Integer, Character> characters = this.classUnderTest().toImmutable();
-        Assert.assertEquals(expectedImmutableBiMap, characters);
+        assertEquals(expectedImmutableBiMap, characters);
     }
 
     @Test
@@ -504,7 +511,7 @@ public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTes
     {
         MutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
         MutableBiMap<Integer, String> clone = map.clone();
-        Assert.assertNotSame(map, clone);
+        assertNotSame(map, clone);
         Verify.assertEqualsAndHashCode(map, clone);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapValuesTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapValuesTestCase.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMutableBiMapValuesTestCase
 {
@@ -58,14 +62,14 @@ public abstract class AbstractMutableBiMapValuesTestCase
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, null);
         Collection<Integer> values = map.values();
-        Assert.assertTrue(values.contains(1));
-        Assert.assertTrue(values.contains(2));
-        Assert.assertTrue(values.contains(null));
-        Assert.assertFalse(values.contains(4));
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(2));
+        assertTrue(values.contains(null));
+        assertFalse(values.contains(4));
         values.remove(null);
-        Assert.assertFalse(values.contains(null));
+        assertFalse(values.contains(null));
         map.remove(1.0f);
-        Assert.assertFalse(values.contains(1));
+        assertFalse(values.contains(1));
     }
 
     @Test
@@ -73,17 +77,17 @@ public abstract class AbstractMutableBiMapValuesTestCase
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, null);
         Collection<Integer> values = map.values();
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 4)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(5, 4)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(null, null)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 4)));
+        assertFalse(values.containsAll(FastList.newListWith(5, 4)));
         values.remove(null);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2, null)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
         map.remove(1.0f);
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(2)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(2)));
     }
 
     @Test
@@ -91,12 +95,12 @@ public abstract class AbstractMutableBiMapValuesTestCase
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, null, 2.0f, 2, 3.0f, 3);
         Collection<Integer> values = map.values();
-        Assert.assertFalse(values.isEmpty());
+        assertFalse(values.isEmpty());
         HashBiMap<Float, Integer> map1 = HashBiMap.newMap();
         Collection<Integer> values1 = map1.values();
-        Assert.assertTrue(values1.isEmpty());
+        assertTrue(values1.isEmpty());
         map1.put(1.0f, 1);
-        Assert.assertFalse(values1.isEmpty());
+        assertFalse(values1.isEmpty());
     }
 
     @Test
@@ -124,54 +128,54 @@ public abstract class AbstractMutableBiMapValuesTestCase
         MutableSet<String> actual = UnifiedSet.newSet();
 
         Iterator<String> iterator = HashBiMap.newWithKeysValues(0.0f, "zero", 31.0f, "thirtyOne", 32.0f, null).iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
 
         MutableBiMap<Float, String> map1 = this.newMapWithKeysValues(0.0f, "zero", 1.0f, null);
         Iterator<String> iterator1 = map1.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        Assert.assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").equals(map1)
+        assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").equals(map1)
                 || HashBiMap.newWithKeysValues(1.0f, null).equals(map1));
-        Assert.assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").inverse().equals(map1.inverse())
+        assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").inverse().equals(map1.inverse())
                 || HashBiMap.newWithKeysValues(1.0f, null).inverse().equals(map1.inverse()));
         iterator1.next();
         iterator1.remove();
-        Assert.assertEquals(HashBiMap.newMap(), map1);
-        Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+        assertEquals(HashBiMap.newMap(), map1);
+        assertThrows(IllegalStateException.class, iterator1::remove);
 
         MutableBiMap<Float, String> map2 = this.newMapWithKeysValues(0.0f, null, 9.0f, "nine");
         Iterator<String> iterator2 = map2.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator2::remove);
+        assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        Assert.assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).equals(map2)
+        assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).equals(map2)
                 || HashBiMap.newWithKeysValues(9.0f, "nine").equals(map2));
-        Assert.assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).inverse().equals(map2.inverse())
+        assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).inverse().equals(map2.inverse())
                 || HashBiMap.newWithKeysValues(9.0f, "nine").inverse().equals(map2.inverse()));
         iterator2.next();
         iterator2.remove();
-        Assert.assertEquals(HashBiMap.newMap(), map2);
+        assertEquals(HashBiMap.newMap(), map2);
 
         MutableBiMap<Float, String> map3 = this.newMapWithKeysValues(8.0f, "eight", 9.0f, null);
         Iterator<String> iterator3 = map3.iterator();
-        Assert.assertThrows(IllegalStateException.class, iterator3::remove);
+        assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        Assert.assertTrue(map3.toString(), HashBiMap.newWithKeysValues(8.0f, "eight").equals(map3)
+        assertTrue(map3.toString(), HashBiMap.newWithKeysValues(8.0f, "eight").equals(map3)
                 || HashBiMap.newWithKeysValues(9.0f, null).equals(map3));
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(HashBiMap.newMap(), map3);
+        assertEquals(HashBiMap.newMap(), map3);
     }
 
     @Test
@@ -185,46 +189,46 @@ public abstract class AbstractMutableBiMapValuesTestCase
     public void removeFromValues()
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3);
-        Assert.assertFalse(map.values().remove(4));
+        assertFalse(map.values().remove(4));
 
-        Assert.assertTrue(map.values().remove(2));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
+        assertTrue(map.values().remove(2));
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
     }
 
     @Test
     public void removeNullFromValues()
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3);
-        Assert.assertFalse(map.values().remove(null));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3).inverse(), map.inverse());
+        assertFalse(map.values().remove(null));
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3), map);
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3).inverse(), map.inverse());
         map.put(4.0f, null);
-        Assert.assertTrue(map.values().remove(null));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3).inverse(), map.inverse());
+        assertTrue(map.values().remove(null));
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3), map);
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3).inverse(), map.inverse());
     }
 
     @Test
     public void removeAllFromValues()
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3);
-        Assert.assertFalse(map.values().removeAll(FastList.newListWith(4)));
+        assertFalse(map.values().removeAll(FastList.newListWith(4)));
 
-        Assert.assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
+        assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
     }
 
     @Test
     public void retainAllFromValues()
     {
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, 3);
-        Assert.assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
+        assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
 
-        Assert.assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
+        assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3), map);
+        assertEquals(HashBiMap.newWithKeysValues(1.0f, 1, 3.0f, 3).inverse(), map.inverse());
     }
 
     @Test
@@ -233,10 +237,10 @@ public abstract class AbstractMutableBiMapValuesTestCase
         MutableBiMap<Float, Integer> map = this.newMapWithKeysValues(1.0f, 1, 2.0f, 2, 3.0f, null);
         HashBag<Integer> expected = HashBag.newBagWith(1, 2, null);
         Collection<Integer> values = map.values();
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray()));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size()])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(values.toArray(new Integer[values.size() + 1])));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.bimap.MutableBiMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class HashBiMapTest extends AbstractMutableBiMapTestCase
 {
@@ -68,14 +70,14 @@ public class HashBiMapTest extends AbstractMutableBiMapTestCase
     @Test
     public void newMap_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(UnifiedMap.newMap(), null));
+        assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(UnifiedMap.newMap(), null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(null, null));
+        assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(null, UnifiedMap.newMap()));
+        assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(null, UnifiedMap.newMap()));
 
         UnifiedMap<Object, Object> map = UnifiedMap.newMap();
-        Assert.assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(map, map));
+        assertThrows(IllegalArgumentException.class, () -> new HashBiMap<>(map, map));
     }
 
     @Test
@@ -84,25 +86,25 @@ public class HashBiMapTest extends AbstractMutableBiMapTestCase
         HashBiMap<Integer, Character> map = this.getEmptyMap();
         HashBiMap<Integer, Character> map1 = map.withKeysValues(1, 'a');
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a'), map1);
-        Assert.assertSame(map, map1);
+        assertSame(map, map1);
         HashBiMap<Integer, Character> map2 = map1.withKeysValues(2, 'b');
         HashBiMap<Integer, Character> map22 = map.withKeysValues(1, 'a', 2, 'b');
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b'), map2);
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b'), map22);
-        Assert.assertSame(map, map22);
-        Assert.assertSame(map1, map2);
+        assertSame(map, map22);
+        assertSame(map1, map2);
         HashBiMap<Integer, Character> map3 = map2.withKeysValues(3, 'c');
         HashBiMap<Integer, Character> map33 = map.withKeysValues(1, 'a', 2, 'b', 3, 'c');
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b', 3, 'c'), map3);
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b', 3, 'c'), map33);
-        Assert.assertSame(map, map33);
-        Assert.assertSame(map2, map3);
+        assertSame(map, map33);
+        assertSame(map2, map3);
         HashBiMap<Integer, Character> map4 = map3.withKeysValues(4, 'd');
         HashBiMap<Integer, Character> map44 = map.withKeysValues(1, 'a', 2, 'b', 3, 'c', 4, 'd');
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b', 3, 'c', 4, 'd'), map4);
         AbstractMutableBiMapTestCase.assertBiMapsEqual(HashBiMap.newWithKeysValues(1, 'a', 2, 'b', 3, 'c', 4, 'd'), map44);
-        Assert.assertSame(map, map44);
-        Assert.assertSame(map3, map4);
+        assertSame(map, map44);
+        assertSame(map3, map4);
     }
 
     @Test
@@ -112,8 +114,8 @@ public class HashBiMapTest extends AbstractMutableBiMapTestCase
         Key duplicateKey = new Key("key");
 
         MutableBiMap<Key, Integer> biMap = this.newMapWithKeysValues(key, 1, duplicateKey, 2);
-        Assert.assertSame(key, Iterate.getFirst(biMap.entrySet()).getKey());
-        Assert.assertSame(key, Iterate.getFirst(biMap.inverse().entrySet()).getValue());
+        assertSame(key, Iterate.getFirst(biMap.entrySet()).getKey());
+        assertSame(key, Iterate.getFirst(biMap.inverse().entrySet()).getValue());
     }
 
     @Test
@@ -124,8 +126,8 @@ public class HashBiMapTest extends AbstractMutableBiMapTestCase
 
         MutableBiMap<Integer, Key> biMap = this.newMapWithKeyValue(1, value);
         biMap.forcePut(2, duplicateValue);
-        Assert.assertSame(value, Iterate.getFirst(biMap.entrySet()).getValue());
-        Assert.assertSame(value, Iterate.getFirst(biMap.inverse().entrySet()).getKey());
+        assertSame(value, Iterate.getFirst(biMap.entrySet()).getValue());
+        assertSame(value, Iterate.getFirst(biMap.inverse().entrySet()).getKey());
     }
 
     @Test
@@ -141,10 +143,10 @@ public class HashBiMapTest extends AbstractMutableBiMapTestCase
 
         biMap.forcePut(duplicateOfKey1, duplicateOfValue2);
 
-        Assert.assertSame(key1, Iterate.getFirst(biMap.entrySet()).getKey());
-        Assert.assertSame(key1, Iterate.getFirst(biMap.inverse().entrySet()).getValue());
+        assertSame(key1, Iterate.getFirst(biMap.entrySet()).getKey());
+        assertSame(key1, Iterate.getFirst(biMap.inverse().entrySet()).getValue());
 
-        Assert.assertSame(value2, Iterate.getFirst(biMap.entrySet()).getValue());
-        Assert.assertSame(value2, Iterate.getFirst(biMap.inverse().entrySet()).getKey());
+        assertSame(value2, Iterate.getFirst(biMap.entrySet()).getValue());
+        assertSame(value2, Iterate.getFirst(biMap.inverse().entrySet()).getKey());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
@@ -27,8 +27,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
 {
@@ -81,11 +87,11 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     @Test
     public void newMap_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnmodifiableBiMap<>(null));
+        assertThrows(IllegalArgumentException.class, () -> new UnmodifiableBiMap<>(null));
         MutableBiMap<String, String> biMap = null;
-        Assert.assertThrows(IllegalArgumentException.class, () -> UnmodifiableBiMap.of(biMap));
+        assertThrows(IllegalArgumentException.class, () -> UnmodifiableBiMap.of(biMap));
         Map<String, String> map = null;
-        Assert.assertThrows(IllegalArgumentException.class, () -> UnmodifiableBiMap.of(map));
+        assertThrows(IllegalArgumentException.class, () -> UnmodifiableBiMap.of(map));
     }
 
     @Override
@@ -94,10 +100,10 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
 
-        Assert.assertTrue(biMap.containsKey(1));
-        Assert.assertTrue(biMap.containsKey(null));
-        Assert.assertTrue(biMap.containsKey(3));
-        Assert.assertFalse(biMap.containsKey(4));
+        assertTrue(biMap.containsKey(1));
+        assertTrue(biMap.containsKey(null));
+        assertTrue(biMap.containsKey(3));
+        assertFalse(biMap.containsKey(4));
     }
 
     @Override
@@ -106,10 +112,10 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
 
-        Assert.assertTrue(biMap.containsValue(null));
-        Assert.assertTrue(biMap.containsValue('b'));
-        Assert.assertTrue(biMap.containsValue('c'));
-        Assert.assertFalse(biMap.containsValue('d'));
+        assertTrue(biMap.containsValue(null));
+        assertTrue(biMap.containsValue('b'));
+        assertTrue(biMap.containsValue('c'));
+        assertFalse(biMap.containsValue('d'));
     }
 
     @Override
@@ -117,10 +123,10 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void get()
     {
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
-        Assert.assertNull(biMap.get(1));
-        Assert.assertEquals(Character.valueOf('b'), biMap.get(null));
-        Assert.assertEquals(Character.valueOf('c'), biMap.get(3));
-        Assert.assertNull(biMap.get(4));
+        assertNull(biMap.get(1));
+        assertEquals(Character.valueOf('b'), biMap.get(null));
+        assertEquals(Character.valueOf('c'), biMap.get(3));
+        assertNull(biMap.get(4));
     }
 
     @Override
@@ -131,18 +137,18 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
         MutableSet<Character> actual = UnifiedSet.newSet();
         MutableBiMap<Integer, Character> biMap = this.classUnderTest();
         Iterator<Character> iterator = biMap.iterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
         Verify.assertSize(3, biMap);
         Verify.assertSize(3, biMap.inverse());
         for (int i = 0; i < 3; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -151,168 +157,168 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     {
         MutableBiMap<Object, Object> biMap = this.newMap();
         MutableBiMap<Object, Object> clone = biMap.clone();
-        Assert.assertSame(biMap, clone);
+        assertSame(biMap, clone);
     }
 
     @Override
     @Test
     public void withKeyValue()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withKeyValue(1, 'a'));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withKeyValue(1, 'a'));
     }
 
     @Override
     @Test
     public void withMap()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMap(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMap(null));
     }
 
     @Override
     @Test
     public void withMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().withMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
     }
 
     @Override
     @Test
     public void putAllMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void putAllMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.getEmptyMap().putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void putAllMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
     }
 
     @Override
     @Test
     public void withAllKeyValueArguments()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2).withAllKeyValueArguments(Tuples.pair("B", 22), Tuples.pair("C", 3)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2).withAllKeyValueArguments(Tuples.pair("B", 22), Tuples.pair("C", 3)));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue("A", 1).add(Tuples.pair("A", 3)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue("A", 1).add(Tuples.pair("A", 3)));
     }
 
     @Override
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().put(4, 'd'));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().put(4, 'd'));
     }
 
     @Override
     @Test
     public void putPair()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().putPair(Tuples.pair(4, 'd')));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().putPair(Tuples.pair(4, 'd')));
     }
 
     @Override
     @Test
     public void putAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").putAll(UnifiedMap.newMap()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").putAll(UnifiedMap.newMap()));
     }
 
     @Override
     @Test
     public void forcePut()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").forcePut("value2", "key1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").forcePut("value2", "key1"));
     }
 
     @Override
     @Test
     public void updateValue()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").updateValue("key1", () -> "value3", String::toUpperCase));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").updateValue("key1", () -> "value3", String::toUpperCase));
     }
 
     @Override
@@ -323,7 +329,7 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
         Function2<Character, Boolean, Character> toUpperOrLowerCase = (character, parameter) -> parameter
                 ? Character.toUpperCase(character)
                 : Character.toLowerCase(character);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> biMap.updateValueWith(4, () -> 'd', toUpperOrLowerCase, true));
+        assertThrows(UnsupportedOperationException.class, () -> biMap.updateValueWith(4, () -> 'd', toUpperOrLowerCase, true));
     }
 
     @Override
@@ -331,8 +337,8 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void getIfAbsentPut()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, () -> "4"));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, "4"));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, () -> "4"));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, "4"));
     }
 
     @Override
@@ -340,7 +346,7 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void getIfAbsentPutWith()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, object -> "4", null));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, object -> "4", null));
     }
 
     @Override
@@ -348,8 +354,8 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void getIfAbsentPutWithKey()
     {
         MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
-        Assert.assertNull(map.get(4));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWithKey(4, Functions.getIntegerPassThru()));
+        assertNull(map.get(4));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWithKey(4, Functions.getIntegerPassThru()));
     }
 
     @Override
@@ -357,29 +363,29 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void getIfAbsentPutValue()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, "4"));
+        assertNull(map.get(4));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, "4"));
     }
 
     @Override
     @Test
     public void withoutKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2).withoutKey("B"));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2).withoutKey("B"));
     }
 
     @Override
     @Test
     public void withoutAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2, "C", 3).withoutAllKeys(FastList.newListWith("A", "C")));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("A", 1, "B", 2, "C", 3).withoutAllKeys(FastList.newListWith("A", "C")));
     }
 
     @Override
     @Test
     public void withAllKeyValues()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.newMapWithKeysValues("A", 1, "B", 2).withAllKeyValues(
                         FastList.newListWith(Tuples.pair("B", 22), Tuples.pair("C", 3))));
@@ -389,49 +395,49 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().clear());
     }
 
     @Override
     @Test
     public void clearEntrySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).entrySet().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).entrySet().clear());
     }
 
     @Override
     @Test
     public void clearKeySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().clear());
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().clear());
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").remove("key1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").remove("key1"));
     }
 
     @Override
     @Test
     public void removeObject()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).remove("Two"));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).remove("Two"));
     }
 
     @Override
     @Test
     public void removeFromEntrySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).entrySet().remove(ImmutableEntry.of("Two", 2)));
     }
 
     @Override
     @Test
     public void removeFromKeySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().remove("Four"));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().remove("Four"));
     }
 
     @Override
@@ -439,28 +445,28 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void removeNullFromKeySet()
     {
         MutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
     }
 
     @Override
     @Test
     public void removeKey()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeKey(1));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeKey(1));
     }
 
     @Override
     @Test
     public void removeAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(Sets.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(Sets.mutable.empty()));
     }
 
     @Override
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeIf(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeIf(null));
     }
 
     @Override
@@ -468,14 +474,14 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void removeNullFromValues()
     {
         MutableBiMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
     }
 
     @Override
     @Test
     public void removeFromValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().remove(4));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().remove(4));
     }
 
     @Override
@@ -483,7 +489,7 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void retainAllFromEntrySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().retainAll(FastList.newListWith(
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().retainAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Two", 2),
                 ImmutableEntry.of("Three", 3),
@@ -494,14 +500,14 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     @Test
     public void retainAllFromKeySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
     }
 
     @Override
     @Test
     public void retainAllFromValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().retainAll(FastList.newListWith(1, 2, 3, 4)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().retainAll(FastList.newListWith(1, 2, 3, 4)));
     }
 
     @Override
@@ -509,7 +515,7 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void removeAllFromEntrySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().removeAll(FastList.newListWith(
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
     }
@@ -518,14 +524,14 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     @Test
     public void removeAllFromKeySet()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().removeAll(FastList.newListWith("Four")));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).keySet().removeAll(FastList.newListWith("Four")));
     }
 
     @Override
     @Test
     public void removeAllFromValues()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().removeAll(FastList.newListWith(4)));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3).values().removeAll(FastList.newListWith(4)));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/CheckedBlocksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/CheckedBlocksTest.java
@@ -35,11 +35,12 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.eclipse.collections.impl.utility.MapIterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CheckedBlocksTest
 {
@@ -64,7 +65,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedFunction2RuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Function2<String, String, String> block =
                     new CheckedFunction2<String, String, String>()
@@ -99,7 +100,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedCodeBlockRuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Function0<String> function = new CheckedFunction0<String>()
             {
@@ -133,7 +134,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedProcedureRuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Procedure<String> block = new CheckedProcedure<String>()
             {
@@ -167,7 +168,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedObjectIntProcedureRuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             ObjectIntProcedure<String> block = new CheckedObjectIntProcedure<String>()
             {
@@ -202,7 +203,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedFunctionRuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Function<String, String> block =
                     new CheckedFunction<String, String>()
@@ -237,7 +238,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedPredicateRuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Predicate<String> block = new CheckedPredicate<String>()
             {
@@ -272,7 +273,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedPredicate2RuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Predicate2<String, String> block =
                     new CheckedPredicate2<String, String>()
@@ -307,7 +308,7 @@ public class CheckedBlocksTest
     @Test
     public void checkedProcedure2RuntimeException()
     {
-        Assert.assertThrows(LocalException.class, () ->
+        assertThrows(LocalException.class, () ->
         {
             Procedure2<String, String> block = new CheckedProcedure2<String, String>()
             {
@@ -540,7 +541,7 @@ public class CheckedBlocksTest
             }
         };
         ImmutableList<String> list = iList("test");
-        Assert.assertEquals(list, list.select(alwaysTrueBlock));
+        assertEquals(list, list.select(alwaysTrueBlock));
 
         Predicate<String> alwaysFalseBlock = new CheckedPredicate<String>()
         {
@@ -635,7 +636,7 @@ public class CheckedBlocksTest
             }
         };
         MutableList<String> list = mList("test");
-        Assert.assertEquals(list, list.selectWith(alwaysTrueBlock, null));
+        assertEquals(list, list.selectWith(alwaysTrueBlock, null));
 
         Predicate2<String, Object> alwaysFalseBlock = new CheckedPredicate2<String, Object>()
         {
@@ -659,6 +660,6 @@ public class CheckedBlocksTest
                 return argument1 + argument2;
             }
         };
-        Assert.assertEquals(Integer.valueOf(5), checkedFunction2.safeValue(2, 3));
+        assertEquals(Integer.valueOf(5), checkedFunction2.safeValue(2, 3));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/comparator/FunctionComparatorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/comparator/FunctionComparatorTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FunctionComparatorTest
 {
@@ -36,8 +37,8 @@ public class FunctionComparatorTest
                 Band.TO_NAME,
                 String::compareTo);
 
-        Assert.assertEquals(comparator.compare(ACDC, ZZTOP), ACDC.getName().compareTo(ZZTOP.getName()));
-        Assert.assertEquals(comparator.compare(ZZTOP, ACDC), ZZTOP.getName().compareTo(ACDC.getName()));
+        assertEquals(comparator.compare(ACDC, ZZTOP), ACDC.getName().compareTo(ZZTOP.getName()));
+        assertEquals(comparator.compare(ZZTOP, ACDC), ZZTOP.getName().compareTo(ACDC.getName()));
     }
 
     private MutableList<Band> createTestList()
@@ -50,7 +51,7 @@ public class FunctionComparatorTest
     {
         Comparator<Band> byName = (bandA, bandB) -> Band.TO_NAME.valueOf(bandA).compareTo(Band.TO_NAME.valueOf(bandB));
         MutableList<Band> sortedList = this.createTestList().sortThis(byName);
-        Assert.assertEquals(FastList.newListWith(BON_JOVI, METALLICA, SCORPIONS, VAN_HALEN), sortedList);
+        assertEquals(FastList.newListWith(BON_JOVI, METALLICA, SCORPIONS, VAN_HALEN), sortedList);
     }
 
     @Test
@@ -58,7 +59,7 @@ public class FunctionComparatorTest
     {
         Comparator<Band> byName = Comparators.byFunction(Band.TO_NAME, String::compareTo);
         MutableList<Band> sortedList = this.createTestList().sortThis(byName);
-        Assert.assertEquals(FastList.newListWith(BON_JOVI, METALLICA, SCORPIONS, VAN_HALEN), sortedList);
+        assertEquals(FastList.newListWith(BON_JOVI, METALLICA, SCORPIONS, VAN_HALEN), sortedList);
     }
 
     private static final class Band

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
@@ -38,11 +38,14 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ComparatorsTest
 {
@@ -56,27 +59,27 @@ public class ComparatorsTest
     public void naturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "2", "3", "4"),
                 list.sortThis(Comparators.naturalOrder()));
-        Assert.assertThrows(NullPointerException.class, () -> Lists.mutable.with("1", "2", null, "4").sortThis(Comparators.naturalOrder()));
+        assertThrows(NullPointerException.class, () -> Lists.mutable.with("1", "2", null, "4").sortThis(Comparators.naturalOrder()));
     }
 
     @Test
     public void originalNaturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "2", "3", "4"),
                 list.sortThis(Comparators.originalNaturalOrder()));
-        Assert.assertThrows(NullPointerException.class, () -> Lists.mutable.with("1", "2", null, "4").sortThis(Comparators.naturalOrder()));
+        assertThrows(NullPointerException.class, () -> Lists.mutable.with("1", "2", null, "4").sortThis(Comparators.naturalOrder()));
     }
 
     @Test
     public void reverseNaturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("4", "3", "2", "1"),
                 list.sortThis(Comparators.reverseNaturalOrder()));
     }
@@ -85,7 +88,7 @@ public class ComparatorsTest
     public void originalReverseNaturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("4", "3", "2", "1"),
                 list.sortThis(Comparators.originalReverseNaturalOrder()));
     }
@@ -94,20 +97,20 @@ public class ComparatorsTest
     public void reverse()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("4", "3", "2", "1"),
                 list.sortThis(Comparators.reverse(String::compareTo)));
-        Assert.assertThrows(NullPointerException.class, () -> Comparators.reverse(null));
+        assertThrows(NullPointerException.class, () -> Comparators.reverse(null));
     }
 
     @Test
     public void safeNullsLow()
     {
         SerializableComparator<Integer> comparator = Comparators.safeNullsLow(Comparators.byFunction(Functions.getIntegerPassThru()));
-        Assert.assertEquals(-1, comparator.compare(null, 1));
-        Assert.assertEquals(1, comparator.compare(1, null));
-        Assert.assertEquals(0, comparator.compare(null, null));
-        Assert.assertEquals(0, comparator.compare(1, 1));
+        assertEquals(-1, comparator.compare(null, 1));
+        assertEquals(1, comparator.compare(1, null));
+        assertEquals(0, comparator.compare(null, null));
+        assertEquals(0, comparator.compare(1, 1));
     }
 
     @Test
@@ -177,16 +180,16 @@ public class ComparatorsTest
     public void safeNullsHigh()
     {
         SerializableComparator<Integer> comparator = Comparators.safeNullsHigh(Comparators.byFunction(Functions.getIntegerPassThru()));
-        Assert.assertEquals(1, comparator.compare(null, 1));
-        Assert.assertEquals(-1, comparator.compare(1, null));
-        Assert.assertEquals(0, comparator.compare(null, null));
-        Assert.assertEquals(0, comparator.compare(1, 1));
+        assertEquals(1, comparator.compare(null, 1));
+        assertEquals(-1, comparator.compare(1, null));
+        assertEquals(0, comparator.compare(null, null));
+        assertEquals(0, comparator.compare(1, 1));
     }
 
     @Test
     public void chainedComparator()
     {
-        Assert.assertThrows(IllegalArgumentException.class, Comparators::chain);
+        assertThrows(IllegalArgumentException.class, Comparators::chain);
 
         Comparator<Person> byName = Comparators.byFunction(Person.TO_FIRST);
         Comparator<Person> byAge = Comparators.byFunction(Person.TO_AGE);
@@ -244,7 +247,7 @@ public class ComparatorsTest
 
         MutableList<Person> people = Lists.mutable.of(bob, dan, carol, alice);
         people.sortThis(personComparator);
-        Assert.assertEquals(Lists.immutable.of(alice, dan, bob, carol), people);
+        assertEquals(Lists.immutable.of(alice, dan, bob, carol), people);
     }
 
     @Test
@@ -263,7 +266,7 @@ public class ComparatorsTest
 
         MutableList<Person> people = Lists.mutable.of(bob, dan, carol, alice);
         people.sortThis(personComparator);
-        Assert.assertEquals(Lists.immutable.of(bob, carol, alice, dan), people);
+        assertEquals(Lists.immutable.of(bob, carol, alice, dan), people);
     }
 
     @Test
@@ -305,7 +308,7 @@ public class ComparatorsTest
                 Interval.oneTo(3),
                 Interval.oneTo(2));
         list.sortThis(Comparators.descendingCollectionSizeComparator());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.<MutableList<Integer>>with(
                         Lists.mutable.with(1, 2, 3),
                         Lists.mutable.with(1, 2),
@@ -321,7 +324,7 @@ public class ComparatorsTest
                 Interval.oneTo(3),
                 Interval.oneTo(2));
         list.sortThis(Comparators.ascendingCollectionSizeComparator());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.<MutableList<Integer>>with(
                         Lists.mutable.with(1),
                         Lists.mutable.with(1, 2),
@@ -332,25 +335,25 @@ public class ComparatorsTest
     @Test
     public void nullSafeEquals()
     {
-        Assert.assertTrue(Comparators.nullSafeEquals("Fred", "Fred"));
-        Assert.assertTrue(Comparators.nullSafeEquals(null, null));
+        assertTrue(Comparators.nullSafeEquals("Fred", "Fred"));
+        assertTrue(Comparators.nullSafeEquals(null, null));
 
-        Assert.assertFalse(Comparators.nullSafeEquals("Fred", "Jim"));
-        Assert.assertFalse(Comparators.nullSafeEquals("Fred", null));
-        Assert.assertFalse(Comparators.nullSafeEquals(null, "Jim"));
+        assertFalse(Comparators.nullSafeEquals("Fred", "Jim"));
+        assertFalse(Comparators.nullSafeEquals("Fred", null));
+        assertFalse(Comparators.nullSafeEquals(null, "Jim"));
     }
 
     @Test
     public void nullSafeCompare()
     {
-        Assert.assertEquals(0, Comparators.nullSafeCompare(null, null));
-        Assert.assertEquals(0, Comparators.nullSafeCompare("Sheila", "Sheila"));
+        assertEquals(0, Comparators.nullSafeCompare(null, null));
+        assertEquals(0, Comparators.nullSafeCompare("Sheila", "Sheila"));
 
-        Assert.assertTrue(Comparators.nullSafeCompare("Fred", "Jim") < 0);
-        Assert.assertTrue(Comparators.nullSafeCompare("Sheila", "Jim") > 0);
+        assertTrue(Comparators.nullSafeCompare("Fred", "Jim") < 0);
+        assertTrue(Comparators.nullSafeCompare("Sheila", "Jim") > 0);
 
-        Assert.assertEquals(1, Comparators.nullSafeCompare("Fred", null));
-        Assert.assertEquals(-1, Comparators.nullSafeCompare(null, "Jim"));
+        assertEquals(1, Comparators.nullSafeCompare("Fred", null));
+        assertEquals(-1, Comparators.nullSafeCompare(null, "Jim"));
     }
 
     @Test
@@ -391,7 +394,7 @@ public class ComparatorsTest
 
         Comparator<OneOfEach> comparator = Comparators.byFunction(OneOfEach.TO_DATE_VALUE, new FancyDateComparator());
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(april, december, february),
                 iList(february, april, december).toSortedList(comparator));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/FunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/FunctionsTest.java
@@ -35,10 +35,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class FunctionsTest
 {
@@ -90,7 +96,7 @@ public class FunctionsTest
                             },
                             this::throwMyException).valueOf(null);
                 });
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () ->
                 {
@@ -112,95 +118,95 @@ public class FunctionsTest
     public void getPassThru()
     {
         Object object = new Object();
-        Assert.assertSame(object, Functions.getPassThru().valueOf(object));
+        assertSame(object, Functions.getPassThru().valueOf(object));
     }
 
     @Test
     public void getFixedValue()
     {
-        Assert.assertEquals(Integer.valueOf(5), Functions.getFixedValue(5).valueOf(null));
+        assertEquals(Integer.valueOf(5), Functions.getFixedValue(5).valueOf(null));
     }
 
     @Test
     public void getToClass()
     {
-        Assert.assertSame(Integer.class, Functions.getToClass().valueOf(0));
+        assertSame(Integer.class, Functions.getToClass().valueOf(0));
     }
 
     @Test
     public void getMathSinFunction()
     {
         Function<Number, Double> function = Functions.getMathSinFunction();
-        Assert.assertEquals(Math.sin(1.0), function.valueOf(1), 0.0);
+        assertEquals(Math.sin(1.0), function.valueOf(1), 0.0);
     }
 
     @Test
     public void getNumberPassThru()
     {
         Function<Number, Number> function = Functions.getNumberPassThru();
-        Assert.assertEquals(1, function.valueOf(1));
+        assertEquals(1, function.valueOf(1));
     }
 
     @Test
     public void getIntegerPassThru()
     {
         Function<Integer, Integer> function = Functions.getIntegerPassThru();
-        Assert.assertEquals(Integer.valueOf(1), function.valueOf(1));
-        Assert.assertEquals("IntegerPassThruFunction", function.toString());
+        assertEquals(Integer.valueOf(1), function.valueOf(1));
+        assertEquals("IntegerPassThruFunction", function.toString());
     }
 
     @Test
     public void getLongPassThru()
     {
         Function<Long, Long> function = Functions.getLongPassThru();
-        Assert.assertEquals(Long.valueOf(1), function.valueOf(1L));
-        Assert.assertEquals(Long.valueOf(1L), Long.valueOf(((LongFunction<Long>) function).longValueOf(1L)));
-        Assert.assertEquals("LongPassThruFunction", function.toString());
+        assertEquals(Long.valueOf(1), function.valueOf(1L));
+        assertEquals(Long.valueOf(1L), Long.valueOf(((LongFunction<Long>) function).longValueOf(1L)));
+        assertEquals("LongPassThruFunction", function.toString());
     }
 
     @Test
     public void getDoublePassThru()
     {
         Function<Double, Double> function = Functions.getDoublePassThru();
-        Assert.assertEquals(Double.valueOf(1).doubleValue(), function.valueOf(1.0).doubleValue(), 0.0);
-        Assert.assertEquals(Double.valueOf(1).doubleValue(), ((DoubleFunction<Double>) function).doubleValueOf(1.0), 0.0);
-        Assert.assertEquals("DoublePassThruFunction", function.toString());
+        assertEquals(Double.valueOf(1).doubleValue(), function.valueOf(1.0).doubleValue(), 0.0);
+        assertEquals(Double.valueOf(1).doubleValue(), ((DoubleFunction<Double>) function).doubleValueOf(1.0), 0.0);
+        assertEquals("DoublePassThruFunction", function.toString());
     }
 
     @Test
     public void getStringPassThru()
     {
         Function<String, String> function = Functions.getStringPassThru();
-        Assert.assertEquals("hello", function.valueOf("hello"));
+        assertEquals("hello", function.valueOf("hello"));
     }
 
     @Test
     public void getStringTrim()
     {
-        Assert.assertEquals("hello", Functions.getStringTrim().valueOf(" hello  "));
+        assertEquals("hello", Functions.getStringTrim().valueOf(" hello  "));
     }
 
     @Test
     public void getToString()
     {
         Function<Object, String> function = Functions.getToString();
-        Assert.assertEquals("1", function.valueOf(1));
-        Assert.assertEquals("null", function.valueOf(null));
+        assertEquals("1", function.valueOf(1));
+        assertEquals("null", function.valueOf(null));
     }
 
     @Test
     public void getDefaultToString()
     {
         Function<Object, String> function = Functions.getNullSafeToString("N/A");
-        Assert.assertEquals("1", function.valueOf(1));
-        Assert.assertEquals("N/A", function.valueOf(null));
+        assertEquals("1", function.valueOf(1));
+        assertEquals("N/A", function.valueOf(null));
     }
 
     @Test
     public void getStringToInteger()
     {
         Function<String, Integer> function = Functions.getStringToInteger();
-        Assert.assertEquals(Integer.valueOf(1), function.valueOf("1"));
+        assertEquals(Integer.valueOf(1), function.valueOf("1"));
     }
 
     @Test
@@ -208,10 +214,10 @@ public class FunctionsTest
     {
         Function<Object, Integer> function1 =
                 Functions.firstNotNullValue(Functions.getFixedValue(null), Functions.getFixedValue(1), Functions.getFixedValue(2));
-        Assert.assertEquals(Integer.valueOf(1), function1.valueOf(null));
+        assertEquals(Integer.valueOf(1), function1.valueOf(null));
         Function<Object, Integer> function2 =
                 Functions.firstNotNullValue(Functions.getFixedValue(null), Functions.getFixedValue(null));
-        Assert.assertNull(function2.valueOf(null));
+        assertNull(function2.valueOf(null));
     }
 
     @Test
@@ -219,10 +225,10 @@ public class FunctionsTest
     {
         Function<Object, String> function1 =
                 Functions.firstNotEmptyStringValue(Functions.getFixedValue(""), Functions.getFixedValue("hello"), Functions.getFixedValue(""));
-        Assert.assertEquals("hello", function1.valueOf(null));
+        assertEquals("hello", function1.valueOf(null));
         Function<Object, String> function2 =
                 Functions.firstNotEmptyStringValue(Functions.getFixedValue(""), Functions.getFixedValue(""));
-        Assert.assertNull(function2.valueOf(null));
+        assertNull(function2.valueOf(null));
     }
 
     @Test
@@ -232,20 +238,20 @@ public class FunctionsTest
                 Functions.getFixedValue(Lists.immutable.of()),
                 Functions.getFixedValue(Lists.immutable.of("hello")),
                 Functions.getFixedValue(Lists.immutable.of()));
-        Assert.assertEquals(iList("hello"), function1.valueOf(null));
+        assertEquals(iList("hello"), function1.valueOf(null));
 
         Function<Object, ImmutableList<String>> function2 = Functions.firstNotEmptyCollectionValue(
                 Functions.getFixedValue(Lists.immutable.of()),
                 Functions.getFixedValue(Lists.immutable.of()));
-        Assert.assertNull(function2.valueOf(null));
+        assertNull(function2.valueOf(null));
     }
 
     @Test
     public void ifTrue()
     {
         String result = "1";
-        Assert.assertSame(result, Functions.ifTrue(Predicates.alwaysTrue(), Functions.getPassThru()).valueOf(result));
-        Assert.assertNull(result, Functions.ifTrue(Predicates.alwaysFalse(), Functions.getPassThru()).valueOf(result));
+        assertSame(result, Functions.ifTrue(Predicates.alwaysTrue(), Functions.getPassThru()).valueOf(result));
+        assertNull(result, Functions.ifTrue(Predicates.alwaysFalse(), Functions.getPassThru()).valueOf(result));
     }
 
     @Test
@@ -253,8 +259,8 @@ public class FunctionsTest
     {
         String result1 = "1";
         String result2 = "2";
-        Assert.assertSame(result1, Functions.ifElse(Predicates.alwaysTrue(), Functions.getFixedValue(result1), Functions.getFixedValue(result2)).valueOf(null));
-        Assert.assertSame(result2, Functions.ifElse(Predicates.alwaysFalse(), Functions.getFixedValue(result1), Functions.getFixedValue(result2)).valueOf(null));
+        assertSame(result1, Functions.ifElse(Predicates.alwaysTrue(), Functions.getFixedValue(result1), Functions.getFixedValue(result2)).valueOf(null));
+        assertSame(result2, Functions.ifElse(Predicates.alwaysFalse(), Functions.getFixedValue(result1), Functions.getFixedValue(result2)).valueOf(null));
         Verify.assertContains("IfFunction", Functions.ifElse(Predicates.alwaysTrue(), Functions.getFixedValue(result1), Functions.getFixedValue(result2)).toString());
     }
 
@@ -273,39 +279,39 @@ public class FunctionsTest
         Function<String, Integer> toInteger = Functions.getStringToInteger();
         Function<Object, String> toString = String::valueOf;
 
-        Assert.assertEquals("42", Functions.chain(toInteger, toString).valueOf("42"));
-        Assert.assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).valueOf(42));
+        assertEquals("42", Functions.chain(toInteger, toString).valueOf("42"));
+        assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).valueOf(42));
 
         Function<String, Integer> chain = Functions.chain(toInteger, toString).chain(toInteger);
-        Assert.assertEquals(Integer.valueOf(42), chain.valueOf("42"));
-        Assert.assertEquals("42", Functions.chain(toString, toInteger).chain(toString).valueOf(42));
+        assertEquals(Integer.valueOf(42), chain.valueOf("42"));
+        assertEquals("42", Functions.chain(toString, toInteger).chain(toString).valueOf(42));
 
-        Assert.assertEquals("42", Functions.chain(toInteger, toString).chain(toInteger).chain(toString).valueOf("42"));
-        Assert.assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).chain(toString).chain(toInteger).valueOf(42));
+        assertEquals("42", Functions.chain(toInteger, toString).chain(toInteger).chain(toString).valueOf("42"));
+        assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).chain(toString).chain(toInteger).valueOf(42));
 
-        Assert.assertEquals(Integer.valueOf(42), Functions.chain(toInteger, toString).chain(toInteger).chain(toString).chain(toInteger).valueOf("42"));
-        Assert.assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).chain(toString).chain(toInteger).chain(toString).chain(toInteger).valueOf(42));
+        assertEquals(Integer.valueOf(42), Functions.chain(toInteger, toString).chain(toInteger).chain(toString).chain(toInteger).valueOf("42"));
+        assertEquals(Integer.valueOf(42), Functions.chain(toString, toInteger).chain(toString).chain(toInteger).chain(toString).chain(toInteger).valueOf(42));
     }
 
     @Test
     public void chain_two()
     {
         Function<Boolean, Integer> chain = Functions.chain(BOOLEAN_STRING, STRING_LENGTH);
-        Assert.assertEquals(Integer.valueOf(5), chain.valueOf(Boolean.FALSE));
+        assertEquals(Integer.valueOf(5), chain.valueOf(Boolean.FALSE));
     }
 
     @Test
     public void chain_three()
     {
         Function<String, String> chain = Functions.chain(STRING_LENGTH, IS_ODD).chain(BOOLEAN_STRING);
-        Assert.assertEquals("true", chain.valueOf("foo"));
+        assertEquals("true", chain.valueOf("foo"));
     }
 
     @Test
     public void chain_four()
     {
         Function<Integer, Boolean> chain = Functions.chain(IS_ODD, BOOLEAN_STRING).chain(STRING_LENGTH).chain(IS_ODD);
-        Assert.assertEquals(Boolean.TRUE, chain.valueOf(Integer.valueOf(4)));
+        assertEquals(Boolean.TRUE, chain.valueOf(Integer.valueOf(4)));
     }
 
     @Test
@@ -313,8 +319,8 @@ public class FunctionsTest
     {
         Function<String, Integer> toInteger = Functions.getStringToInteger();
         Functions.BooleanFunctionChain<String, Integer> booleanFunctionChain = Functions.chainBoolean(toInteger, integerObject -> integerObject.intValue() >= 0);
-        Assert.assertTrue(booleanFunctionChain.booleanValueOf("45"));
-        Assert.assertFalse(booleanFunctionChain.booleanValueOf("-45"));
+        assertTrue(booleanFunctionChain.booleanValueOf("45"));
+        assertFalse(booleanFunctionChain.booleanValueOf("-45"));
     }
 
     @Test
@@ -322,8 +328,8 @@ public class FunctionsTest
     {
         Function<String, Integer> toInteger = Functions.getStringToInteger();
         Functions.ByteFunctionChain<String, Integer> byteFunctionChain = Functions.chainByte(toInteger, Integer::byteValue);
-        Assert.assertEquals((byte) 45, byteFunctionChain.byteValueOf("45"));
-        Assert.assertEquals((byte) -45, byteFunctionChain.byteValueOf("-45"));
+        assertEquals((byte) 45, byteFunctionChain.byteValueOf("45"));
+        assertEquals((byte) -45, byteFunctionChain.byteValueOf("-45"));
     }
 
     @Test
@@ -331,8 +337,8 @@ public class FunctionsTest
     {
         Function<Object, String> toString = String::valueOf;
         Functions.CharFunctionChain<Object, String> charFunctionChain = Functions.chainChar(toString, stringObject -> stringObject.charAt(0));
-        Assert.assertEquals('e', charFunctionChain.charValueOf("example string"));
-        Assert.assertEquals('-', charFunctionChain.charValueOf("-4"));
+        assertEquals('e', charFunctionChain.charValueOf("example string"));
+        assertEquals('-', charFunctionChain.charValueOf("-4"));
     }
 
     @Test
@@ -340,16 +346,16 @@ public class FunctionsTest
     {
         Function<String, Integer> toInteger = Functions.getStringToInteger();
         Functions.DoubleFunctionChain<String, Integer> doubleFunctionChain = Functions.chainDouble(toInteger, Integer::doubleValue);
-        Assert.assertEquals(146.0, doubleFunctionChain.doubleValueOf("146"), 0.0);
-        Assert.assertEquals(-456.0, doubleFunctionChain.doubleValueOf("-456"), 0.0);
+        assertEquals(146.0, doubleFunctionChain.doubleValueOf("146"), 0.0);
+        assertEquals(-456.0, doubleFunctionChain.doubleValueOf("-456"), 0.0);
     }
 
     @Test
     public void chainFloat()
     {
         Functions.FloatFunctionChain<Integer, String> floatFunctionChain = Functions.chainFloat(String::valueOf, stringObject -> Float.valueOf(stringObject).floatValue());
-        Assert.assertEquals(146.0, floatFunctionChain.floatValueOf(146), 0.0);
-        Assert.assertEquals(-456.0, floatFunctionChain.floatValueOf(-456), 0.0);
+        assertEquals(146.0, floatFunctionChain.floatValueOf(146), 0.0);
+        assertEquals(-456.0, floatFunctionChain.floatValueOf(-456), 0.0);
     }
 
     @Test
@@ -365,8 +371,8 @@ public class FunctionsTest
             }
         };
         Functions.IntFunctionChain<Float, String> intFunctionChain = Functions.chainInt(toString, stringToLength);
-        Assert.assertEquals(5, intFunctionChain.intValueOf(Float.valueOf(145)));
-        Assert.assertEquals(6, intFunctionChain.intValueOf(Float.valueOf(-145)));
+        assertEquals(5, intFunctionChain.intValueOf(Float.valueOf(145)));
+        assertEquals(6, intFunctionChain.intValueOf(Float.valueOf(-145)));
     }
 
     @Test
@@ -376,16 +382,16 @@ public class FunctionsTest
 
         LongFunction<String> stringToLengthLong = stringObject -> Long.valueOf(stringObject.length()).longValue();
         Functions.LongFunctionChain<Float, String> longFunctionChain = Functions.chainLong(toString, stringToLengthLong);
-        Assert.assertEquals(5L, longFunctionChain.longValueOf(Float.valueOf(145)));
-        Assert.assertEquals(6L, longFunctionChain.longValueOf(Float.valueOf(-145)));
+        assertEquals(5L, longFunctionChain.longValueOf(Float.valueOf(145)));
+        assertEquals(6L, longFunctionChain.longValueOf(Float.valueOf(-145)));
     }
 
     @Test
     public void chainShort()
     {
         Functions.ShortFunctionChain<Integer, String> shortFunctionChain = Functions.chainShort(String::valueOf, stringObject -> Short.valueOf(stringObject).shortValue());
-        Assert.assertEquals((short) 145, shortFunctionChain.shortValueOf(145));
-        Assert.assertEquals((short) -145, shortFunctionChain.shortValueOf(-145));
+        assertEquals((short) 145, shortFunctionChain.shortValueOf(145));
+        assertEquals((short) -145, shortFunctionChain.shortValueOf(-145));
     }
 
     @Test
@@ -393,7 +399,7 @@ public class FunctionsTest
     {
         Functions.FunctionChain<Boolean, String, Integer> chain = Functions.chain(String::valueOf, STRING_LENGTH);
         Functions.BooleanFunctionChain<Boolean, Integer> booleanChain = chain.chainBoolean(integerObject -> integerObject.intValue() >= 0);
-        Assert.assertTrue(booleanChain.booleanValueOf(Boolean.TRUE));
+        assertTrue(booleanChain.booleanValueOf(Boolean.TRUE));
     }
 
     @Test
@@ -401,7 +407,7 @@ public class FunctionsTest
     {
         Functions.FunctionChain<Boolean, String, Integer> chain = Functions.chain(String::valueOf, STRING_LENGTH);
         Functions.ByteFunctionChain<Boolean, Integer> byteChain = chain.chainByte(Integer::byteValue);
-        Assert.assertEquals((byte) 5, byteChain.byteValueOf(Boolean.FALSE));
+        assertEquals((byte) 5, byteChain.byteValueOf(Boolean.FALSE));
     }
 
     @Test
@@ -409,7 +415,7 @@ public class FunctionsTest
     {
         Functions.FunctionChain<String, Boolean, String> chain = Functions.chain(STRING_LENGTH, IS_ODD).chain(BOOLEAN_STRING);
         Functions.CharFunctionChain<String, String> charChain = chain.chainChar(stringObject -> stringObject.charAt(0));
-        Assert.assertEquals('t', charChain.charValueOf("foo"));
+        assertEquals('t', charChain.charValueOf("foo"));
     }
 
     @Test
@@ -417,7 +423,7 @@ public class FunctionsTest
     {
         Functions.FunctionChain<Boolean, String, Integer> chain = Functions.chain(String::valueOf, STRING_LENGTH);
         Functions.DoubleFunctionChain<Boolean, Integer> doubleChain = chain.chainDouble(Integer::doubleValue);
-        Assert.assertEquals(4.0, doubleChain.doubleValueOf(Boolean.TRUE), 0.0);
+        assertEquals(4.0, doubleChain.doubleValueOf(Boolean.TRUE), 0.0);
     }
 
     @Test
@@ -425,7 +431,7 @@ public class FunctionsTest
     {
         Functions.FunctionChain<String, Boolean, String> chain = Functions.chain(STRING_LENGTH, IS_ODD).chain(BOOLEAN_STRING);
         Functions.FloatFunctionChain<String, String> floatChain = chain.chainFloat(stringObject -> Integer.valueOf(stringObject.length()).floatValue());
-        Assert.assertEquals(5.0, floatChain.floatValueOf("12.2"), 0);
+        assertEquals(5.0, floatChain.floatValueOf("12.2"), 0);
     }
 
     @Test
@@ -440,8 +446,8 @@ public class FunctionsTest
             }
         };
         Functions.IntFunctionChain<String, String> intChain = chain.chainInt(stringToLength);
-        Assert.assertEquals(4, intChain.intValueOf("abc"));
-        Assert.assertNotEquals(4, intChain.intValueOf("kata"));
+        assertEquals(4, intChain.intValueOf("abc"));
+        assertNotEquals(4, intChain.intValueOf("kata"));
     }
 
     @Test
@@ -450,8 +456,8 @@ public class FunctionsTest
         Functions.FunctionChain<String, Boolean, String> chain = Functions.chain(STRING_LENGTH, IS_ODD).chain(BOOLEAN_STRING);
         LongFunction<String> stringToLengthLong = stringObject -> Long.valueOf(stringObject.length()).longValue();
         Functions.LongFunctionChain<String, String> longChain = chain.chainLong(stringToLengthLong);
-        Assert.assertEquals(4L, longChain.longValueOf("abc"));
-        Assert.assertNotEquals(4L, longChain.longValueOf("kata"));
+        assertEquals(4L, longChain.longValueOf("abc"));
+        assertNotEquals(4L, longChain.longValueOf("kata"));
     }
 
     @Test
@@ -460,8 +466,8 @@ public class FunctionsTest
         Functions.FunctionChain<String, Boolean, String> chain = Functions.chain(STRING_LENGTH, IS_ODD).chain(BOOLEAN_STRING);
         ShortFunction<String> stringToShort = stringObject -> Integer.valueOf(stringObject.length()).shortValue();
         Functions.ShortFunctionChain<String, String> shortChain = chain.chainShort(stringToShort);
-        Assert.assertEquals((short) 4, shortChain.shortValueOf("abc"));
-        Assert.assertNotEquals((short) 4, shortChain.shortValueOf("kata"));
+        assertEquals((short) 4, shortChain.shortValueOf("abc"));
+        assertNotEquals((short) 4, shortChain.shortValueOf("kata"));
     }
 
     @Test
@@ -470,7 +476,7 @@ public class FunctionsTest
         MutableList<Integer> list = Interval.oneTo(100).toList().shuffleThis();
         Function<Integer, Integer> function = Integer::intValue;
         list.sortThis(Comparators.byFunction(function));
-        Assert.assertEquals(Interval.oneTo(100).toList(), list);
+        assertEquals(Interval.oneTo(100).toList(), list);
     }
 
     @Test
@@ -479,7 +485,7 @@ public class FunctionsTest
         MutableList<Double> list = FastList.newListWith(5.0, 4.0, 3.0, 2.0, 1.0).shuffleThis();
         Function<Double, Double> function = Double::doubleValue;
         list.sortThis(Comparators.byFunction(function));
-        Assert.assertEquals(FastList.newListWith(1.0, 2.0, 3.0, 4.0, 5.0), list);
+        assertEquals(FastList.newListWith(1.0, 2.0, 3.0, 4.0, 5.0), list);
     }
 
     @Test
@@ -493,25 +499,25 @@ public class FunctionsTest
                 return each.longValue();
             }
         }));
-        Assert.assertEquals(FastList.newListWith(1L, 2L, 3L, 4L, 5L), list);
+        assertEquals(FastList.newListWith(1L, 2L, 3L, 4L, 5L), list);
     }
 
     @Test
     public void classFunctionToString()
     {
-        Assert.assertEquals("object.getClass()", Functions.getToClass().toString());
+        assertEquals("object.getClass()", Functions.getToClass().toString());
     }
 
     @Test
     public void mathSinToString()
     {
-        Assert.assertEquals("Math.sin()", Functions.getMathSinFunction().toString());
+        assertEquals("Math.sin()", Functions.getMathSinFunction().toString());
     }
 
     @Test
     public void mathStringToIntegerToString()
     {
-        Assert.assertEquals("stringToInteger", Functions.getStringToInteger().toString());
+        assertEquals("stringToInteger", Functions.getStringToInteger().toString());
     }
 
     @Test
@@ -522,7 +528,7 @@ public class FunctionsTest
         Person johnDoe = new Person("John", "Doe");
         MutableList<Person> people = FastList.newListWith(john, jane, johnDoe);
         MutableList<Person> sorted = people.sortThisBy(Functions.pair(Person.TO_LAST, Person.TO_FIRST));
-        Assert.assertEquals(FastList.newListWith(johnDoe, jane, john), sorted);
+        assertEquals(FastList.newListWith(johnDoe, jane, john), sorted);
     }
 
     @Test
@@ -531,7 +537,7 @@ public class FunctionsTest
         MutableMap<String, Integer> map = UnifiedMap.newWithKeysValues("One", 1);
         MutableSet<Map.Entry<String, Integer>> entries = SetAdapter.adapt(map.entrySet());
         MutableSet<String> keys = entries.collect(Functions.getKeyFunction());
-        Assert.assertEquals(UnifiedSet.newSetWith("One"), keys);
+        assertEquals(UnifiedSet.newSetWith("One"), keys);
     }
 
     @Test
@@ -540,7 +546,7 @@ public class FunctionsTest
         MutableMap<String, Integer> map = UnifiedMap.newWithKeysValues("One", 1);
         MutableSet<Map.Entry<String, Integer>> entries = SetAdapter.adapt(map.entrySet());
         MutableSet<Integer> values = entries.collect(Functions.getValueFunction());
-        Assert.assertEquals(UnifiedSet.newSetWith(1), values);
+        assertEquals(UnifiedSet.newSetWith(1), values);
     }
 
     @Test
@@ -548,7 +554,7 @@ public class FunctionsTest
     {
         ImmutableList<ImmutableList<Integer>> list = Lists.immutable.of(Lists.immutable.of(1), Lists.immutable.of(1, 2), Lists.immutable.of(1, 2, 3));
         ImmutableList<Integer> sizes = list.collect(Functions.getSizeOf());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), sizes);
+        assertEquals(FastList.newListWith(1, 2, 3), sizes);
     }
 
     @Test
@@ -562,10 +568,10 @@ public class FunctionsTest
     public void withDefault()
     {
         Object expected = new Object();
-        Assert.assertSame(expected, Functions.withDefault(Functions.getFixedValue(null), expected).valueOf(new Object()));
+        assertSame(expected, Functions.withDefault(Functions.getFixedValue(null), expected).valueOf(new Object()));
 
         Object expected2 = new Object();
-        Assert.assertSame(expected2, Functions.withDefault(Functions.getFixedValue(expected2), expected).valueOf(new Object()));
+        assertSame(expected2, Functions.withDefault(Functions.getFixedValue(expected2), expected).valueOf(new Object()));
     }
 
     @Test
@@ -573,16 +579,16 @@ public class FunctionsTest
     {
         Object expected = new Object();
         Function<Object, Object> throwsFunction = new ThrowsFunction();
-        Assert.assertSame(expected, Functions.nullSafe(throwsFunction, expected).valueOf(null));
-        Assert.assertSame(expected, Functions.nullSafe(Functions.getFixedValue(expected)).valueOf(new Object()));
-        Assert.assertNull(Functions.nullSafe(throwsFunction).valueOf(null));
+        assertSame(expected, Functions.nullSafe(throwsFunction, expected).valueOf(null));
+        assertSame(expected, Functions.nullSafe(Functions.getFixedValue(expected)).valueOf(new Object()));
+        assertNull(Functions.nullSafe(throwsFunction).valueOf(null));
     }
 
     @Test
     public void classForName()
     {
         Class<?> objectClass = Functions.classForName().valueOf("java.lang.Object");
-        Assert.assertSame(Object.class, objectClass);
+        assertSame(Object.class, objectClass);
     }
 
     @Test
@@ -605,19 +611,19 @@ public class FunctionsTest
 
         MutableList<Pair<String, Integer>> expected = FastList.newListWith(Tuples.pair("One", 1), Tuples.pair("Two", 2), Tuples.pair("Three", 3), Tuples.pair("Four", 4));
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void getTrue()
     {
-        Assert.assertTrue(Functions.getTrue().valueOf(false));
+        assertTrue(Functions.getTrue().valueOf(false));
     }
 
     @Test
     public void getFalse()
     {
-        Assert.assertFalse(Functions.getFalse().valueOf(true));
+        assertFalse(Functions.getFalse().valueOf(true));
     }
 
     private static class ThrowsFunction implements Function<Object, Object>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/HashingStrategiesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/HashingStrategiesTest.java
@@ -21,8 +21,12 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HashingStrategiesTest
 {
@@ -30,11 +34,11 @@ public class HashingStrategiesTest
     public void defaultStrategy()
     {
         HashingStrategy<String> stringHashingStrategy = HashingStrategies.defaultStrategy();
-        Assert.assertEquals("TEST".hashCode(), stringHashingStrategy.computeHashCode("TEST"));
-        Assert.assertEquals("1TeSt1".hashCode(), stringHashingStrategy.computeHashCode("1TeSt1"));
-        Assert.assertTrue(stringHashingStrategy.equals("lowercase", "lowercase"));
-        Assert.assertFalse(stringHashingStrategy.equals("lowercase", "LOWERCASE"));
-        Assert.assertFalse(stringHashingStrategy.equals("12321", "abcba"));
+        assertEquals("TEST".hashCode(), stringHashingStrategy.computeHashCode("TEST"));
+        assertEquals("1TeSt1".hashCode(), stringHashingStrategy.computeHashCode("1TeSt1"));
+        assertTrue(stringHashingStrategy.equals("lowercase", "lowercase"));
+        assertFalse(stringHashingStrategy.equals("lowercase", "LOWERCASE"));
+        assertFalse(stringHashingStrategy.equals("12321", "abcba"));
     }
 
     @Test
@@ -43,13 +47,13 @@ public class HashingStrategiesTest
         HashingStrategy<Integer> integerHashingStrategy =
                 HashingStrategies.nullSafeHashingStrategy(HashingStrategies.defaultStrategy());
 
-        Assert.assertEquals(0, integerHashingStrategy.computeHashCode(null));
-        Assert.assertEquals(5, integerHashingStrategy.computeHashCode(5));
+        assertEquals(0, integerHashingStrategy.computeHashCode(null));
+        assertEquals(5, integerHashingStrategy.computeHashCode(5));
 
-        Assert.assertTrue(integerHashingStrategy.equals(null, null));
-        Assert.assertFalse(integerHashingStrategy.equals(null, 1));
-        Assert.assertFalse(integerHashingStrategy.equals(1, null));
-        Assert.assertTrue(integerHashingStrategy.equals(1, 1));
+        assertTrue(integerHashingStrategy.equals(null, null));
+        assertFalse(integerHashingStrategy.equals(null, 1));
+        assertFalse(integerHashingStrategy.equals(1, null));
+        assertTrue(integerHashingStrategy.equals(1, 1));
     }
 
     @Test
@@ -63,23 +67,23 @@ public class HashingStrategiesTest
         HashingStrategy<Person> lastHashingStrategy = HashingStrategies.nullSafeFromFunction(Person.TO_LAST);
         HashingStrategy<Person> firstHashingStrategy = HashingStrategies.nullSafeFromFunction(Person.TO_FIRST);
 
-        Assert.assertEquals("John".hashCode(), firstHashingStrategy.computeHashCode(john));
-        Assert.assertEquals(0, firstHashingStrategy.computeHashCode(nullFirst));
-        Assert.assertEquals("Jane".hashCode(), firstHashingStrategy.computeHashCode(nullLast));
-        Assert.assertEquals(firstHashingStrategy.computeHashCode(jane), firstHashingStrategy.computeHashCode(nullLast));
-        Assert.assertNotEquals(john.hashCode(), firstHashingStrategy.computeHashCode(john));
-        Assert.assertFalse(firstHashingStrategy.equals(john, jane));
+        assertEquals("John".hashCode(), firstHashingStrategy.computeHashCode(john));
+        assertEquals(0, firstHashingStrategy.computeHashCode(nullFirst));
+        assertEquals("Jane".hashCode(), firstHashingStrategy.computeHashCode(nullLast));
+        assertEquals(firstHashingStrategy.computeHashCode(jane), firstHashingStrategy.computeHashCode(nullLast));
+        assertNotEquals(john.hashCode(), firstHashingStrategy.computeHashCode(john));
+        assertFalse(firstHashingStrategy.equals(john, jane));
 
-        Assert.assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(john));
-        Assert.assertEquals(0, lastHashingStrategy.computeHashCode(nullLast));
-        Assert.assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(nullFirst));
-        Assert.assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(nullFirst));
-        Assert.assertNotEquals(john.hashCode(), lastHashingStrategy.computeHashCode(john));
-        Assert.assertTrue(lastHashingStrategy.equals(john, jane));
+        assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(john));
+        assertEquals(0, lastHashingStrategy.computeHashCode(nullLast));
+        assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(nullFirst));
+        assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(nullFirst));
+        assertNotEquals(john.hashCode(), lastHashingStrategy.computeHashCode(john));
+        assertTrue(lastHashingStrategy.equals(john, jane));
 
-        Assert.assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(john));
-        Assert.assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(jane));
-        Assert.assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(jane));
+        assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(john));
+        assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(jane));
+        assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(jane));
     }
 
     @Test
@@ -90,17 +94,17 @@ public class HashingStrategiesTest
         HashingStrategy<Person> lastHashingStrategy = HashingStrategies.fromFunction(Person.TO_LAST);
         HashingStrategy<Person> firstHashingStrategy = HashingStrategies.fromFunction(Person.TO_FIRST);
 
-        Assert.assertEquals("John".hashCode(), firstHashingStrategy.computeHashCode(john));
-        Assert.assertNotEquals(john.hashCode(), firstHashingStrategy.computeHashCode(john));
-        Assert.assertFalse(firstHashingStrategy.equals(john, jane));
+        assertEquals("John".hashCode(), firstHashingStrategy.computeHashCode(john));
+        assertNotEquals(john.hashCode(), firstHashingStrategy.computeHashCode(john));
+        assertFalse(firstHashingStrategy.equals(john, jane));
 
-        Assert.assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(john));
-        Assert.assertNotEquals(john.hashCode(), lastHashingStrategy.computeHashCode(john));
-        Assert.assertTrue(lastHashingStrategy.equals(john, jane));
+        assertEquals("Smith".hashCode(), lastHashingStrategy.computeHashCode(john));
+        assertNotEquals(john.hashCode(), lastHashingStrategy.computeHashCode(john));
+        assertTrue(lastHashingStrategy.equals(john, jane));
 
-        Assert.assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(john));
-        Assert.assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(jane));
-        Assert.assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(jane));
+        assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(john));
+        assertNotEquals(lastHashingStrategy.computeHashCode(john), firstHashingStrategy.computeHashCode(jane));
+        assertEquals(lastHashingStrategy.computeHashCode(john), lastHashingStrategy.computeHashCode(jane));
     }
 
     @Test
@@ -111,9 +115,9 @@ public class HashingStrategiesTest
         Verify.assertEqualsAndHashCode(john1, john2);
 
         HashingStrategy<Object> identityHashingStrategy = HashingStrategies.identityStrategy();
-        Assert.assertNotEquals(identityHashingStrategy.computeHashCode(john1), identityHashingStrategy.computeHashCode(john2));
-        Assert.assertTrue(identityHashingStrategy.equals(john1, john1));
-        Assert.assertFalse(identityHashingStrategy.equals(john1, john2));
+        assertNotEquals(identityHashingStrategy.computeHashCode(john1), identityHashingStrategy.computeHashCode(john2));
+        assertTrue(identityHashingStrategy.equals(john1, john1));
+        assertFalse(identityHashingStrategy.equals(john1, john2));
     }
 
     @Test
@@ -126,12 +130,12 @@ public class HashingStrategiesTest
         HashingStrategy<Person> chainedHashingStrategy = HashingStrategies.chain(
                 HashingStrategies.fromFunction(Person.TO_FIRST),
                 HashingStrategies.fromFunction(Person.TO_LAST));
-        Assert.assertTrue(chainedHashingStrategy.equals(john1, john2));
+        assertTrue(chainedHashingStrategy.equals(john1, john2));
 
         HashingStrategy<Person> chainedHashingStrategy2 = HashingStrategies.chain(
                 HashingStrategies.fromFunction(Person.TO_FIRST));
-        Assert.assertEquals("John".hashCode(), chainedHashingStrategy2.computeHashCode(john1));
-        Assert.assertTrue(chainedHashingStrategy2.equals(john1, john3));
+        assertEquals("John".hashCode(), chainedHashingStrategy2.computeHashCode(john1));
+        assertTrue(chainedHashingStrategy2.equals(john1, john3));
     }
 
     @Test
@@ -142,8 +146,8 @@ public class HashingStrategiesTest
         Person john3 = new Person("John", "Doe");
 
         HashingStrategy<Person> chainedHashingStrategy = HashingStrategies.fromFunctions(Person.TO_FIRST, Person.TO_LAST);
-        Assert.assertTrue(chainedHashingStrategy.equals(john1, john2));
-        Assert.assertFalse(chainedHashingStrategy.equals(john1, john3));
+        assertTrue(chainedHashingStrategy.equals(john1, john2));
+        assertFalse(chainedHashingStrategy.equals(john1, john3));
     }
 
     @Test
@@ -155,10 +159,10 @@ public class HashingStrategiesTest
         Person john4 = new Person("John", "Smith", 10);
 
         HashingStrategy<Person> chainedHashingStrategy = HashingStrategies.fromFunctions(Person.TO_FIRST, Person.TO_LAST, Person.TO_AGE);
-        Assert.assertEquals(john1.hashCode(), chainedHashingStrategy.computeHashCode(john1));
-        Assert.assertTrue(chainedHashingStrategy.equals(john1, john2));
-        Assert.assertFalse(chainedHashingStrategy.equals(john1, john3));
-        Assert.assertFalse(chainedHashingStrategy.equals(john1, john4));
+        assertEquals(john1.hashCode(), chainedHashingStrategy.computeHashCode(john1));
+        assertTrue(chainedHashingStrategy.equals(john1, john2));
+        assertFalse(chainedHashingStrategy.equals(john1, john3));
+        assertFalse(chainedHashingStrategy.equals(john1, john4));
     }
 
     @Test
@@ -166,10 +170,10 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> isEvenHashingStrategy = HashingStrategies.fromBooleanFunction((BooleanFunction<Integer>) anObject -> anObject.intValue() % 2 == 0);
 
-        Assert.assertEquals(Boolean.TRUE.hashCode(), isEvenHashingStrategy.computeHashCode(Integer.valueOf(2)));
-        Assert.assertEquals(Boolean.FALSE.hashCode(), isEvenHashingStrategy.computeHashCode(Integer.valueOf(1)));
-        Assert.assertTrue(isEvenHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(4)));
-        Assert.assertFalse(isEvenHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(Boolean.TRUE.hashCode(), isEvenHashingStrategy.computeHashCode(Integer.valueOf(2)));
+        assertEquals(Boolean.FALSE.hashCode(), isEvenHashingStrategy.computeHashCode(Integer.valueOf(1)));
+        assertTrue(isEvenHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(4)));
+        assertFalse(isEvenHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test
@@ -177,9 +181,9 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> byteFunctionHashingStrategy = HashingStrategies.fromByteFunction((ByteFunction<Integer>) Integer::byteValue);
 
-        Assert.assertEquals(100, byteFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(byteFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(byteFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(100, byteFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(byteFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(byteFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test
@@ -187,9 +191,9 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> charFunctionHashingStrategy = HashingStrategies.fromCharFunction((CharFunction<Integer>) anObject -> (char) anObject.intValue());
 
-        Assert.assertEquals(100, charFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(charFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(charFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(100, charFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(charFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(charFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test
@@ -197,16 +201,16 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> doubleFunctionHashingStrategy = HashingStrategies.fromDoubleFunction((DoubleFunction<Integer>) Integer::doubleValue);
 
-        Assert.assertEquals(Double.valueOf(100).hashCode(), doubleFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(doubleFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(doubleFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(Double.valueOf(100).hashCode(), doubleFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(doubleFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(doubleFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
 
         HashingStrategy<Double> doublePassThruFunction = HashingStrategies.fromDoubleFunction(Double::doubleValue);
-        Assert.assertEquals(Double.valueOf(Double.NaN).hashCode(), doublePassThruFunction.computeHashCode(Double.NaN));
-        Assert.assertNotEquals(Double.valueOf(Double.POSITIVE_INFINITY).hashCode(), doublePassThruFunction.computeHashCode(Double.NaN));
-        Assert.assertEquals(Double.valueOf(Double.POSITIVE_INFINITY).hashCode(), doublePassThruFunction.computeHashCode(Double.POSITIVE_INFINITY));
-        Assert.assertTrue(doublePassThruFunction.equals(Double.NaN, Double.NaN));
-        Assert.assertFalse(doublePassThruFunction.equals(Double.NaN, Double.POSITIVE_INFINITY));
+        assertEquals(Double.valueOf(Double.NaN).hashCode(), doublePassThruFunction.computeHashCode(Double.NaN));
+        assertNotEquals(Double.valueOf(Double.POSITIVE_INFINITY).hashCode(), doublePassThruFunction.computeHashCode(Double.NaN));
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY).hashCode(), doublePassThruFunction.computeHashCode(Double.POSITIVE_INFINITY));
+        assertTrue(doublePassThruFunction.equals(Double.NaN, Double.NaN));
+        assertFalse(doublePassThruFunction.equals(Double.NaN, Double.POSITIVE_INFINITY));
     }
 
     @Test
@@ -214,16 +218,16 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> floatFunctionHashingStrategy = HashingStrategies.fromFloatFunction((FloatFunction<Integer>) Integer::floatValue);
 
-        Assert.assertEquals(Float.valueOf(100).hashCode(), floatFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(floatFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(floatFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(Float.valueOf(100).hashCode(), floatFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(floatFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(floatFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
 
         HashingStrategy<Float> floatPassThruFunction = HashingStrategies.fromFloatFunction(Float::floatValue);
-        Assert.assertEquals(Float.valueOf(Float.NaN).hashCode(), floatPassThruFunction.computeHashCode(Float.NaN));
-        Assert.assertNotEquals(Float.valueOf(Float.POSITIVE_INFINITY).hashCode(), floatPassThruFunction.computeHashCode(Float.NaN));
-        Assert.assertEquals(Float.valueOf(Float.POSITIVE_INFINITY).hashCode(), floatPassThruFunction.computeHashCode(Float.POSITIVE_INFINITY));
-        Assert.assertTrue(floatPassThruFunction.equals(Float.NaN, Float.NaN));
-        Assert.assertFalse(floatPassThruFunction.equals(Float.NaN, Float.POSITIVE_INFINITY));
+        assertEquals(Float.valueOf(Float.NaN).hashCode(), floatPassThruFunction.computeHashCode(Float.NaN));
+        assertNotEquals(Float.valueOf(Float.POSITIVE_INFINITY).hashCode(), floatPassThruFunction.computeHashCode(Float.NaN));
+        assertEquals(Float.valueOf(Float.POSITIVE_INFINITY).hashCode(), floatPassThruFunction.computeHashCode(Float.POSITIVE_INFINITY));
+        assertTrue(floatPassThruFunction.equals(Float.NaN, Float.NaN));
+        assertFalse(floatPassThruFunction.equals(Float.NaN, Float.POSITIVE_INFINITY));
     }
 
     @Test
@@ -231,9 +235,9 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> intFunctionHashingStrategy = HashingStrategies.fromIntFunction((IntFunction<Integer>) Integer::intValue);
 
-        Assert.assertEquals(100, intFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(intFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(intFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(100, intFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(intFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(intFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test
@@ -241,9 +245,9 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> longFunctionHashingStrategy = HashingStrategies.fromLongFunction((LongFunction<Integer>) Integer::longValue);
 
-        Assert.assertEquals(Long.valueOf(100).hashCode(), longFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(longFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(longFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(Long.valueOf(100).hashCode(), longFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(longFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(longFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test
@@ -251,9 +255,9 @@ public class HashingStrategiesTest
     {
         HashingStrategy<Integer> shortFunctionHashingStrategy = HashingStrategies.fromShortFunction((ShortFunction<Integer>) Integer::shortValue);
 
-        Assert.assertEquals(100, shortFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
-        Assert.assertTrue(shortFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
-        Assert.assertFalse(shortFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
+        assertEquals(100, shortFunctionHashingStrategy.computeHashCode(Integer.valueOf(100)));
+        assertTrue(shortFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(2)));
+        assertFalse(shortFunctionHashingStrategy.equals(Integer.valueOf(2), Integer.valueOf(1)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/IntegerPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/IntegerPredicatesTest.java
@@ -12,8 +12,10 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IntegerPredicatesTest
 {
@@ -22,79 +24,79 @@ public class IntegerPredicatesTest
     @Test
     public void isOdd()
     {
-        Assert.assertTrue(IntegerPredicates.isOdd().accept(1));
-        Assert.assertFalse(IntegerPredicates.isOdd().accept(-2));
+        assertTrue(IntegerPredicates.isOdd().accept(1));
+        assertFalse(IntegerPredicates.isOdd().accept(-2));
     }
 
     @Test
     public void isEven()
     {
-        Assert.assertTrue(IntegerPredicates.isEven().accept(-42));
-        Assert.assertTrue(IntegerPredicates.isEven().accept(0));
-        Assert.assertFalse(IntegerPredicates.isEven().accept(1));
+        assertTrue(IntegerPredicates.isEven().accept(-42));
+        assertTrue(IntegerPredicates.isEven().accept(0));
+        assertFalse(IntegerPredicates.isEven().accept(1));
     }
 
     @Test
     public void attributeIsOdd()
     {
-        Assert.assertTrue(IntegerPredicates.attributeIsOdd(INT_VALUE).accept(1));
-        Assert.assertFalse(IntegerPredicates.attributeIsOdd(INT_VALUE).accept(-2));
+        assertTrue(IntegerPredicates.attributeIsOdd(INT_VALUE).accept(1));
+        assertFalse(IntegerPredicates.attributeIsOdd(INT_VALUE).accept(-2));
     }
 
     @Test
     public void attributeIsEven()
     {
-        Assert.assertTrue(IntegerPredicates.attributeIsEven(INT_VALUE).accept(-42));
-        Assert.assertTrue(IntegerPredicates.attributeIsEven(INT_VALUE).accept(0));
-        Assert.assertFalse(IntegerPredicates.attributeIsEven(INT_VALUE).accept(1));
+        assertTrue(IntegerPredicates.attributeIsEven(INT_VALUE).accept(-42));
+        assertTrue(IntegerPredicates.attributeIsEven(INT_VALUE).accept(0));
+        assertFalse(IntegerPredicates.attributeIsEven(INT_VALUE).accept(1));
     }
 
     @Test
     public void attributeIsZero()
     {
-        Assert.assertFalse(IntegerPredicates.attributeIsZero(INT_VALUE).accept(-42));
-        Assert.assertTrue(IntegerPredicates.attributeIsZero(INT_VALUE).accept(0));
-        Assert.assertFalse(IntegerPredicates.attributeIsZero(INT_VALUE).accept(1));
+        assertFalse(IntegerPredicates.attributeIsZero(INT_VALUE).accept(-42));
+        assertTrue(IntegerPredicates.attributeIsZero(INT_VALUE).accept(0));
+        assertFalse(IntegerPredicates.attributeIsZero(INT_VALUE).accept(1));
     }
 
     @Test
     public void attributeIsPositive()
     {
-        Assert.assertFalse(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(-42));
-        Assert.assertFalse(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(0));
-        Assert.assertTrue(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(1));
+        assertFalse(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(-42));
+        assertFalse(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(0));
+        assertTrue(IntegerPredicates.attributeIsPositive(INT_VALUE).accept(1));
     }
 
     @Test
     public void attributeIsNegative()
     {
-        Assert.assertTrue(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(-42));
-        Assert.assertFalse(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(0));
-        Assert.assertFalse(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(1));
+        assertTrue(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(-42));
+        assertFalse(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(0));
+        assertFalse(IntegerPredicates.attributeIsNegative(INT_VALUE).accept(1));
     }
 
     @Test
     public void isZero()
     {
-        Assert.assertTrue(IntegerPredicates.isZero().accept(0));
-        Assert.assertFalse(IntegerPredicates.isZero().accept(1));
-        Assert.assertFalse(IntegerPredicates.isZero().accept(-1));
+        assertTrue(IntegerPredicates.isZero().accept(0));
+        assertFalse(IntegerPredicates.isZero().accept(1));
+        assertFalse(IntegerPredicates.isZero().accept(-1));
     }
 
     @Test
     public void isPositive()
     {
-        Assert.assertFalse(IntegerPredicates.isPositive().accept(0));
-        Assert.assertTrue(IntegerPredicates.isPositive().accept(1));
-        Assert.assertFalse(IntegerPredicates.isPositive().accept(-1));
+        assertFalse(IntegerPredicates.isPositive().accept(0));
+        assertTrue(IntegerPredicates.isPositive().accept(1));
+        assertFalse(IntegerPredicates.isPositive().accept(-1));
     }
 
     @Test
     public void isNegative()
     {
-        Assert.assertFalse(IntegerPredicates.isNegative().accept(0));
-        Assert.assertFalse(IntegerPredicates.isNegative().accept(1));
-        Assert.assertTrue(IntegerPredicates.isNegative().accept(-1));
+        assertFalse(IntegerPredicates.isNegative().accept(0));
+        assertFalse(IntegerPredicates.isNegative().accept(1));
+        assertTrue(IntegerPredicates.isNegative().accept(-1));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/LongPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/LongPredicatesTest.java
@@ -12,8 +12,10 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LongPredicatesTest
 {
@@ -22,78 +24,78 @@ public class LongPredicatesTest
     @Test
     public void isOdd()
     {
-        Assert.assertTrue(LongPredicates.isOdd().accept(1L));
-        Assert.assertFalse(LongPredicates.isOdd().accept(-2L));
+        assertTrue(LongPredicates.isOdd().accept(1L));
+        assertFalse(LongPredicates.isOdd().accept(-2L));
     }
 
     @Test
     public void isEven()
     {
-        Assert.assertTrue(LongPredicates.isEven().accept(-42L));
-        Assert.assertTrue(LongPredicates.isEven().accept(0L));
-        Assert.assertFalse(LongPredicates.isEven().accept(1L));
+        assertTrue(LongPredicates.isEven().accept(-42L));
+        assertTrue(LongPredicates.isEven().accept(0L));
+        assertFalse(LongPredicates.isEven().accept(1L));
     }
 
     @Test
     public void attributeIsOdd()
     {
-        Assert.assertTrue(LongPredicates.attributeIsOdd(LONG_VALUE).accept(1L));
-        Assert.assertFalse(LongPredicates.attributeIsOdd(LONG_VALUE).accept(-2L));
+        assertTrue(LongPredicates.attributeIsOdd(LONG_VALUE).accept(1L));
+        assertFalse(LongPredicates.attributeIsOdd(LONG_VALUE).accept(-2L));
     }
 
     @Test
     public void attributeIsEven()
     {
-        Assert.assertTrue(LongPredicates.attributeIsEven(LONG_VALUE).accept(-42L));
-        Assert.assertTrue(LongPredicates.attributeIsEven(LONG_VALUE).accept(0L));
-        Assert.assertFalse(LongPredicates.attributeIsEven(LONG_VALUE).accept(1L));
+        assertTrue(LongPredicates.attributeIsEven(LONG_VALUE).accept(-42L));
+        assertTrue(LongPredicates.attributeIsEven(LONG_VALUE).accept(0L));
+        assertFalse(LongPredicates.attributeIsEven(LONG_VALUE).accept(1L));
     }
 
     @Test
     public void isZero()
     {
-        Assert.assertTrue(LongPredicates.isZero().accept(0L));
-        Assert.assertFalse(LongPredicates.isZero().accept(1L));
-        Assert.assertFalse(LongPredicates.isZero().accept(-1L));
+        assertTrue(LongPredicates.isZero().accept(0L));
+        assertFalse(LongPredicates.isZero().accept(1L));
+        assertFalse(LongPredicates.isZero().accept(-1L));
     }
 
     @Test
     public void isPositive()
     {
-        Assert.assertFalse(LongPredicates.isPositive().accept(0L));
-        Assert.assertTrue(LongPredicates.isPositive().accept(1L));
-        Assert.assertFalse(LongPredicates.isPositive().accept(-1L));
+        assertFalse(LongPredicates.isPositive().accept(0L));
+        assertTrue(LongPredicates.isPositive().accept(1L));
+        assertFalse(LongPredicates.isPositive().accept(-1L));
     }
 
     @Test
     public void isNegative()
     {
-        Assert.assertFalse(LongPredicates.isNegative().accept(0L));
-        Assert.assertFalse(LongPredicates.isNegative().accept(1L));
-        Assert.assertTrue(LongPredicates.isNegative().accept(-1L));
+        assertFalse(LongPredicates.isNegative().accept(0L));
+        assertFalse(LongPredicates.isNegative().accept(1L));
+        assertTrue(LongPredicates.isNegative().accept(-1L));
     }
 
     @Test
     public void attributeIsZero()
     {
-        Assert.assertTrue(LongPredicates.attributeIsZero(Integer::longValue).accept(0));
-        Assert.assertFalse(LongPredicates.attributeIsZero(Integer::longValue).accept(1));
+        assertTrue(LongPredicates.attributeIsZero(Integer::longValue).accept(0));
+        assertFalse(LongPredicates.attributeIsZero(Integer::longValue).accept(1));
     }
 
     @Test
     public void attributeIsPositive()
     {
-        Assert.assertTrue(LongPredicates.attributeIsPositive(Integer::longValue).accept(1));
-        Assert.assertFalse(LongPredicates.attributeIsPositive(Integer::longValue).accept(0));
-        Assert.assertFalse(LongPredicates.attributeIsPositive(Integer::longValue).accept(-1));
+        assertTrue(LongPredicates.attributeIsPositive(Integer::longValue).accept(1));
+        assertFalse(LongPredicates.attributeIsPositive(Integer::longValue).accept(0));
+        assertFalse(LongPredicates.attributeIsPositive(Integer::longValue).accept(-1));
     }
 
     @Test
     public void attributeIsNegative()
     {
-        Assert.assertTrue(LongPredicates.attributeIsNegative(Integer::longValue).accept(-1));
-        Assert.assertFalse(LongPredicates.attributeIsNegative(Integer::longValue).accept(0));
-        Assert.assertFalse(LongPredicates.attributeIsNegative(Integer::longValue).accept(1));
+        assertTrue(LongPredicates.attributeIsNegative(Integer::longValue).accept(-1));
+        assertFalse(LongPredicates.attributeIsNegative(Integer::longValue).accept(0));
+        assertFalse(LongPredicates.attributeIsNegative(Integer::longValue).accept(1));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/MultimapFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/MultimapFunctionsTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class MultimapFunctionsTest
 {
@@ -31,7 +32,7 @@ public class MultimapFunctionsTest
 
         Function<String, RichIterable<String>> getFunction = MultimapFunctions.get(multimap);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(
                         FastList.newListWith("O", "N", "E"),
                         FastList.newListWith("T", "W", "O"),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/Predicates2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/Predicates2Test.java
@@ -18,8 +18,13 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class Predicates2Test
 {
@@ -66,7 +71,7 @@ public class Predicates2Test
                             },
                             this::throwMyException).accept(null, null);
                 });
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () ->
                 {
@@ -87,218 +92,218 @@ public class Predicates2Test
     @Test
     public void staticOr()
     {
-        Assert.assertTrue(Predicates2.or(TRUE, FALSE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(Predicates2.or(FALSE, FALSE).accept(OBJECT, OBJECT));
-        Assert.assertTrue(Predicates2.or(TRUE, TRUE).accept(OBJECT, OBJECT));
-        Assert.assertNotNull(Predicates2.or(TRUE, TRUE).toString());
+        assertTrue(Predicates2.or(TRUE, FALSE).accept(OBJECT, OBJECT));
+        assertFalse(Predicates2.or(FALSE, FALSE).accept(OBJECT, OBJECT));
+        assertTrue(Predicates2.or(TRUE, TRUE).accept(OBJECT, OBJECT));
+        assertNotNull(Predicates2.or(TRUE, TRUE).toString());
     }
 
     @Test
     public void instanceOr()
     {
-        Assert.assertTrue(TRUE.or(FALSE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(FALSE.or(FALSE).accept(OBJECT, OBJECT));
-        Assert.assertTrue(TRUE.or(TRUE).accept(OBJECT, OBJECT));
-        Assert.assertNotNull(TRUE.or(TRUE).toString());
+        assertTrue(TRUE.or(FALSE).accept(OBJECT, OBJECT));
+        assertFalse(FALSE.or(FALSE).accept(OBJECT, OBJECT));
+        assertTrue(TRUE.or(TRUE).accept(OBJECT, OBJECT));
+        assertNotNull(TRUE.or(TRUE).toString());
     }
 
     @Test
     public void staticAnd()
     {
-        Assert.assertTrue(Predicates2.and(TRUE, TRUE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(Predicates2.and(TRUE, FALSE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(Predicates2.and(FALSE, FALSE).accept(OBJECT, OBJECT));
-        Assert.assertNotNull(Predicates2.and(FALSE, FALSE).toString());
+        assertTrue(Predicates2.and(TRUE, TRUE).accept(OBJECT, OBJECT));
+        assertFalse(Predicates2.and(TRUE, FALSE).accept(OBJECT, OBJECT));
+        assertFalse(Predicates2.and(FALSE, FALSE).accept(OBJECT, OBJECT));
+        assertNotNull(Predicates2.and(FALSE, FALSE).toString());
     }
 
     @Test
     public void instanceAnd()
     {
-        Assert.assertTrue(TRUE.and(TRUE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(TRUE.and(FALSE).accept(OBJECT, OBJECT));
-        Assert.assertFalse(FALSE.and(FALSE).accept(OBJECT, OBJECT));
-        Assert.assertNotNull(FALSE.and(FALSE).toString());
+        assertTrue(TRUE.and(TRUE).accept(OBJECT, OBJECT));
+        assertFalse(TRUE.and(FALSE).accept(OBJECT, OBJECT));
+        assertFalse(FALSE.and(FALSE).accept(OBJECT, OBJECT));
+        assertNotNull(FALSE.and(FALSE).toString());
     }
 
     @Test
     public void equal()
     {
-        Assert.assertTrue(Predicates2.equal().accept(1, 1));
-        Assert.assertFalse(Predicates2.equal().accept(2, 1));
-        Assert.assertFalse(Predicates2.equal().accept(null, 1));
-        Assert.assertNotNull(Predicates2.equal().toString());
+        assertTrue(Predicates2.equal().accept(1, 1));
+        assertFalse(Predicates2.equal().accept(2, 1));
+        assertFalse(Predicates2.equal().accept(null, 1));
+        assertNotNull(Predicates2.equal().toString());
     }
 
     @Test
     public void notEqual()
     {
-        Assert.assertFalse(Predicates2.notEqual().accept(1, 1));
-        Assert.assertTrue(Predicates2.notEqual().accept(2, 1));
-        Assert.assertTrue(Predicates2.notEqual().accept(1, 2));
-        Assert.assertTrue(Predicates2.notEqual().accept(null, 1));
-        Assert.assertTrue(Predicates2.notEqual().accept(1, null));
-        Assert.assertFalse(Predicates2.notEqual().accept(null, null));
-        Assert.assertNotNull(Predicates2.notEqual().toString());
+        assertFalse(Predicates2.notEqual().accept(1, 1));
+        assertTrue(Predicates2.notEqual().accept(2, 1));
+        assertTrue(Predicates2.notEqual().accept(1, 2));
+        assertTrue(Predicates2.notEqual().accept(null, 1));
+        assertTrue(Predicates2.notEqual().accept(1, null));
+        assertFalse(Predicates2.notEqual().accept(null, null));
+        assertNotNull(Predicates2.notEqual().toString());
     }
 
     @Test
     public void not()
     {
-        Assert.assertFalse(Predicates2.not(TRUE).accept(OBJECT, OBJECT));
-        Assert.assertTrue(Predicates2.not(FALSE).accept(OBJECT, OBJECT));
-        Assert.assertNotNull(Predicates2.not(FALSE).toString());
+        assertFalse(Predicates2.not(TRUE).accept(OBJECT, OBJECT));
+        assertTrue(Predicates2.not(FALSE).accept(OBJECT, OBJECT));
+        assertNotNull(Predicates2.not(FALSE).toString());
     }
 
     @Test
     public void testNull()
     {
-        Assert.assertFalse(Predicates2.isNull().accept(OBJECT, null));
-        Assert.assertTrue(Predicates2.isNull().accept(null, null));
-        Assert.assertNotNull(Predicates2.isNull().toString());
+        assertFalse(Predicates2.isNull().accept(OBJECT, null));
+        assertTrue(Predicates2.isNull().accept(null, null));
+        assertNotNull(Predicates2.isNull().toString());
     }
 
     @Test
     public void notNull()
     {
-        Assert.assertTrue(Predicates2.notNull().accept(OBJECT, null));
-        Assert.assertFalse(Predicates2.notNull().accept(null, null));
-        Assert.assertNotNull(Predicates2.notNull().toString());
+        assertTrue(Predicates2.notNull().accept(OBJECT, null));
+        assertFalse(Predicates2.notNull().accept(null, null));
+        assertNotNull(Predicates2.notNull().toString());
     }
 
     @Test
     public void sameAs()
     {
-        Assert.assertTrue(Predicates2.sameAs().accept(OBJECT, OBJECT));
-        Assert.assertFalse(Predicates2.sameAs().accept(OBJECT, new Object()));
-        Assert.assertNotNull(Predicates2.sameAs().toString());
+        assertTrue(Predicates2.sameAs().accept(OBJECT, OBJECT));
+        assertFalse(Predicates2.sameAs().accept(OBJECT, new Object()));
+        assertNotNull(Predicates2.sameAs().toString());
     }
 
     @Test
     public void notSameAs()
     {
-        Assert.assertFalse(Predicates2.notSameAs().accept(OBJECT, OBJECT));
-        Assert.assertTrue(Predicates2.notSameAs().accept(OBJECT, new Object()));
-        Assert.assertNotNull(Predicates2.notSameAs().toString());
+        assertFalse(Predicates2.notSameAs().accept(OBJECT, OBJECT));
+        assertTrue(Predicates2.notSameAs().accept(OBJECT, new Object()));
+        assertNotNull(Predicates2.notSameAs().toString());
     }
 
     @Test
     public void instanceOf()
     {
-        Assert.assertTrue(Predicates2.instanceOf().accept(1, Integer.class));
-        Assert.assertFalse(Predicates2.instanceOf().accept(1.0, Integer.class));
-        Assert.assertNotNull(Predicates2.instanceOf().toString());
+        assertTrue(Predicates2.instanceOf().accept(1, Integer.class));
+        assertFalse(Predicates2.instanceOf().accept(1.0, Integer.class));
+        assertNotNull(Predicates2.instanceOf().toString());
     }
 
     @Test
     public void notInstanceOf()
     {
-        Assert.assertFalse(Predicates2.notInstanceOf().accept(1, Integer.class));
-        Assert.assertTrue(Predicates2.notInstanceOf().accept(1.0, Integer.class));
-        Assert.assertNotNull(Predicates2.notInstanceOf().toString());
+        assertFalse(Predicates2.notInstanceOf().accept(1, Integer.class));
+        assertTrue(Predicates2.notInstanceOf().accept(1.0, Integer.class));
+        assertNotNull(Predicates2.notInstanceOf().toString());
     }
 
     @Test
     public void attributeEqual()
     {
         Integer one = 1;
-        Assert.assertTrue(Predicates2.attributeEqual(Functions.getToString()).accept(one, "1"));
-        Assert.assertFalse(Predicates2.attributeEqual(Functions.getToString()).accept(one, "2"));
-        Assert.assertNotNull(Predicates2.attributeEqual(Functions.getToString()).toString());
+        assertTrue(Predicates2.attributeEqual(Functions.getToString()).accept(one, "1"));
+        assertFalse(Predicates2.attributeEqual(Functions.getToString()).accept(one, "2"));
+        assertNotNull(Predicates2.attributeEqual(Functions.getToString()).toString());
     }
 
     @Test
     public void attributeNotEqual()
     {
         Integer one = 1;
-        Assert.assertFalse(Predicates2.attributeNotEqual(Functions.getToString()).accept(one, "1"));
-        Assert.assertTrue(Predicates2.attributeNotEqual(Functions.getToString()).accept(one, "2"));
-        Assert.assertNotNull(Predicates2.attributeNotEqual(Functions.getToString()).toString());
+        assertFalse(Predicates2.attributeNotEqual(Functions.getToString()).accept(one, "1"));
+        assertTrue(Predicates2.attributeNotEqual(Functions.getToString()).accept(one, "2"));
+        assertNotNull(Predicates2.attributeNotEqual(Functions.getToString()).toString());
     }
 
     @Test
     public void attributeLessThan()
     {
         Integer one = 1;
-        Assert.assertFalse(Predicates2.attributeLessThan(Functions.getToString()).accept(one, "1"));
-        Assert.assertTrue(Predicates2.attributeLessThan(Functions.getToString()).accept(one, "2"));
-        Assert.assertNotNull(Predicates2.attributeLessThan(Functions.getToString()).toString());
+        assertFalse(Predicates2.attributeLessThan(Functions.getToString()).accept(one, "1"));
+        assertTrue(Predicates2.attributeLessThan(Functions.getToString()).accept(one, "2"));
+        assertNotNull(Predicates2.attributeLessThan(Functions.getToString()).toString());
     }
 
     @Test
     public void attributeGreaterThan()
     {
         Integer one = 1;
-        Assert.assertTrue(Predicates2.attributeGreaterThan(Functions.getToString()).accept(one, "0"));
-        Assert.assertFalse(Predicates2.attributeGreaterThan(Functions.getToString()).accept(one, "1"));
-        Assert.assertNotNull(Predicates2.attributeGreaterThan(Functions.getToString()).toString());
+        assertTrue(Predicates2.attributeGreaterThan(Functions.getToString()).accept(one, "0"));
+        assertFalse(Predicates2.attributeGreaterThan(Functions.getToString()).accept(one, "1"));
+        assertNotNull(Predicates2.attributeGreaterThan(Functions.getToString()).toString());
     }
 
     @Test
     public void attributeGreaterThanOrEqualTo()
     {
         Integer one = 1;
-        Assert.assertTrue(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "0"));
-        Assert.assertTrue(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "1"));
-        Assert.assertFalse(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "2"));
-        Assert.assertNotNull(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).toString());
+        assertTrue(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "0"));
+        assertTrue(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "1"));
+        assertFalse(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).accept(one, "2"));
+        assertNotNull(Predicates2.attributeGreaterThanOrEqualTo(Functions.getToString()).toString());
     }
 
     @Test
     public void attributeLessThanOrEqualTo()
     {
-        Assert.assertFalse(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "0"));
-        Assert.assertTrue(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "1"));
-        Assert.assertTrue(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "2"));
-        Assert.assertNotNull(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).toString());
+        assertFalse(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "0"));
+        assertTrue(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "1"));
+        assertTrue(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).accept(1, "2"));
+        assertNotNull(Predicates2.attributeLessThanOrEqualTo(Functions.getToString()).toString());
     }
 
     @Test
     public void in()
     {
         MutableList<String> list1 = Lists.fixedSize.of("1", "3");
-        Assert.assertTrue(Predicates2.in().accept("1", list1));
-        Assert.assertFalse(Predicates2.in().accept("2", list1));
-        Assert.assertNotNull(Predicates2.in().toString());
+        assertTrue(Predicates2.in().accept("1", list1));
+        assertFalse(Predicates2.in().accept("2", list1));
+        assertNotNull(Predicates2.in().toString());
         MutableList<String> list2 = Lists.fixedSize.of("1", "2");
         MutableList<String> newList = ListIterate.selectWith(list2, Predicates2.in(), list1);
-        Assert.assertEquals(FastList.newListWith("1"), newList);
+        assertEquals(FastList.newListWith("1"), newList);
     }
 
     @Test
     public void attributeIn()
     {
         MutableList<String> upperList = Lists.fixedSize.of("A", "B");
-        Assert.assertTrue(Predicates2.attributeIn(StringFunctions.toUpperCase()).accept("a", upperList));
-        Assert.assertFalse(Predicates2.attributeIn(StringFunctions.toUpperCase()).accept("c", upperList));
+        assertTrue(Predicates2.attributeIn(StringFunctions.toUpperCase()).accept("a", upperList));
+        assertFalse(Predicates2.attributeIn(StringFunctions.toUpperCase()).accept("c", upperList));
         MutableList<String> lowerList = Lists.fixedSize.of("a", "c");
         MutableList<String> newList =
                 ListIterate.selectWith(lowerList, Predicates2.attributeIn(StringFunctions.toUpperCase()), upperList);
-        Assert.assertEquals(FastList.newListWith("a"), newList);
+        assertEquals(FastList.newListWith("a"), newList);
     }
 
     @Test
     public void attributeIn_MultiTypes()
     {
         MutableList<String> stringInts = Lists.fixedSize.of("1", "2");
-        Assert.assertTrue(Predicates2.attributeIn(Functions.getToString()).accept(1, stringInts));
-        Assert.assertFalse(Predicates2.attributeIn(Functions.getToString()).accept(3, stringInts));
-        Assert.assertFalse(Predicates2.attributeIn(Functions.getToString()).accept(3, stringInts));
+        assertTrue(Predicates2.attributeIn(Functions.getToString()).accept(1, stringInts));
+        assertFalse(Predicates2.attributeIn(Functions.getToString()).accept(3, stringInts));
+        assertFalse(Predicates2.attributeIn(Functions.getToString()).accept(3, stringInts));
         MutableList<Integer> intList = Lists.fixedSize.of(1, 3);
         MutableList<Integer> newList =
                 ListIterate.selectWith(intList, Predicates2.attributeIn(Functions.getToString()), stringInts);
-        Assert.assertEquals(FastList.newListWith(1), newList);
+        assertEquals(FastList.newListWith(1), newList);
     }
 
     @Test
     public void notIn()
     {
         MutableList<String> odds = Lists.fixedSize.of("1", "3");
-        Assert.assertFalse(Predicates2.notIn().accept("1", odds));
-        Assert.assertTrue(Predicates2.notIn().accept("2", odds));
-        Assert.assertNotNull(Predicates2.notIn().toString());
+        assertFalse(Predicates2.notIn().accept("1", odds));
+        assertTrue(Predicates2.notIn().accept("2", odds));
+        assertNotNull(Predicates2.notIn().toString());
         MutableList<String> list = Lists.fixedSize.of("1", "2");
         MutableList<String> newList = ListIterate.selectWith(list, Predicates2.notIn(), odds);
-        Assert.assertEquals(FastList.newListWith("2"), newList);
+        assertEquals(FastList.newListWith("2"), newList);
     }
 
     @Test
@@ -306,49 +311,49 @@ public class Predicates2Test
     {
         Function<String, String> function = StringFunctions.toLowerCase();
         MutableList<String> lowerList = Lists.fixedSize.of("a", "b");
-        Assert.assertFalse(Predicates2.attributeNotIn(function).accept("A", lowerList));
-        Assert.assertTrue(Predicates2.attributeNotIn(function).accept("C", lowerList));
+        assertFalse(Predicates2.attributeNotIn(function).accept("A", lowerList));
+        assertTrue(Predicates2.attributeNotIn(function).accept("C", lowerList));
         MutableList<String> upperList = Lists.fixedSize.of("A", "C");
         MutableList<String> newList = ListIterate.rejectWith(upperList, Predicates2.attributeNotIn(function), lowerList);
-        Assert.assertEquals(FastList.newListWith("A"), newList);
+        assertEquals(FastList.newListWith("A"), newList);
     }
 
     @Test
     public void lessThanNumber()
     {
-        Assert.assertTrue(Predicates2.<Integer>lessThan().accept(-1, 0));
-        Assert.assertTrue(Predicates2.<Double>lessThan().accept(-1.0, 0.0));
-        Assert.assertFalse(Predicates2.<Double>lessThan().accept(0.0, -1.0));
-        Assert.assertNotNull(Predicates2.<Integer>lessThan().toString());
+        assertTrue(Predicates2.<Integer>lessThan().accept(-1, 0));
+        assertTrue(Predicates2.<Double>lessThan().accept(-1.0, 0.0));
+        assertFalse(Predicates2.<Double>lessThan().accept(0.0, -1.0));
+        assertNotNull(Predicates2.<Integer>lessThan().toString());
     }
 
     @Test
     public void greaterThanNumber()
     {
-        Assert.assertFalse(Predicates2.<Integer>greaterThan().accept(-1, 0));
-        Assert.assertFalse(Predicates2.<Double>greaterThan().accept(-1.0, 0.0));
-        Assert.assertTrue(Predicates2.<Double>greaterThan().accept(0.0, -1.0));
-        Assert.assertNotNull(Predicates2.<Integer>greaterThan().toString());
+        assertFalse(Predicates2.<Integer>greaterThan().accept(-1, 0));
+        assertFalse(Predicates2.<Double>greaterThan().accept(-1.0, 0.0));
+        assertTrue(Predicates2.<Double>greaterThan().accept(0.0, -1.0));
+        assertNotNull(Predicates2.<Integer>greaterThan().toString());
     }
 
     @Test
     public void lessEqualThanNumber()
     {
-        Assert.assertTrue(Predicates2.<Integer>lessThanOrEqualTo().accept(-1, 0));
-        Assert.assertTrue(Predicates2.<Double>lessThanOrEqualTo().accept(-1.0, 0.0));
-        Assert.assertTrue(Predicates2.<Double>lessThanOrEqualTo().accept(-1.0, -1.0));
-        Assert.assertFalse(Predicates2.<Double>lessThanOrEqualTo().accept(0.0, -1.0));
-        Assert.assertNotNull(Predicates2.<Integer>lessThanOrEqualTo().toString());
+        assertTrue(Predicates2.<Integer>lessThanOrEqualTo().accept(-1, 0));
+        assertTrue(Predicates2.<Double>lessThanOrEqualTo().accept(-1.0, 0.0));
+        assertTrue(Predicates2.<Double>lessThanOrEqualTo().accept(-1.0, -1.0));
+        assertFalse(Predicates2.<Double>lessThanOrEqualTo().accept(0.0, -1.0));
+        assertNotNull(Predicates2.<Integer>lessThanOrEqualTo().toString());
     }
 
     @Test
     public void greaterEqualNumber()
     {
-        Assert.assertFalse(Predicates2.<Integer>greaterThanOrEqualTo().accept(-1, 0));
-        Assert.assertFalse(Predicates2.<Double>greaterThanOrEqualTo().accept(-1.0, 0.0));
-        Assert.assertTrue(Predicates2.<Double>greaterThanOrEqualTo().accept(-1.0, -1.0));
-        Assert.assertTrue(Predicates2.<Double>greaterThanOrEqualTo().accept(0.0, -1.0));
-        Assert.assertNotNull(Predicates2.<Integer>greaterThanOrEqualTo().toString());
+        assertFalse(Predicates2.<Integer>greaterThanOrEqualTo().accept(-1, 0));
+        assertFalse(Predicates2.<Double>greaterThanOrEqualTo().accept(-1.0, 0.0));
+        assertTrue(Predicates2.<Double>greaterThanOrEqualTo().accept(-1.0, -1.0));
+        assertTrue(Predicates2.<Double>greaterThanOrEqualTo().accept(0.0, -1.0));
+        assertNotNull(Predicates2.<Integer>greaterThanOrEqualTo().toString());
     }
 
     private static class MyRuntimeException extends RuntimeException

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/PredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/PredicatesTest.java
@@ -29,9 +29,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class PredicatesTest
 {
@@ -81,7 +85,7 @@ public class PredicatesTest
     @Test
     public void throwingNoException()
     {
-        Assert.assertTrue(Predicates.throwing(object -> true).accept(true));
+        assertTrue(Predicates.throwing(object -> true).accept(true));
     }
 
     @Test
@@ -103,7 +107,7 @@ public class PredicatesTest
                             a -> { throw new IOException(); },
                             this::throwMyException).accept(null);
                 });
-        Verify.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () -> {
                     Predicates.throwing(
@@ -381,8 +385,8 @@ public class PredicatesTest
     @Test
     public void instanceOf()
     {
-        Assert.assertTrue(Predicates.instanceOf(Integer.class).accept(1));
-        Assert.assertFalse(Predicates.instanceOf(Integer.class).accept(1.0));
+        assertTrue(Predicates.instanceOf(Integer.class).accept(1));
+        assertFalse(Predicates.instanceOf(Integer.class).accept(1.0));
         PredicatesTest.assertToString(Predicates.instanceOf(Integer.class));
     }
 
@@ -399,8 +403,8 @@ public class PredicatesTest
     @Test
     public void notInstanceOf()
     {
-        Assert.assertFalse(Predicates.notInstanceOf(Integer.class).accept(1));
-        Assert.assertTrue(Predicates.notInstanceOf(Integer.class).accept(1.0));
+        assertFalse(Predicates.notInstanceOf(Integer.class).accept(1));
+        assertTrue(Predicates.notInstanceOf(Integer.class).accept(1.0));
 
         PredicatesTest.assertToString(Predicates.notInstanceOf(Integer.class));
     }
@@ -419,8 +423,8 @@ public class PredicatesTest
 
     private static void assertIf(Predicate<List<Object>> predicate, boolean bool)
     {
-        Assert.assertEquals(bool, predicate.accept(Lists.fixedSize.of()));
-        Assert.assertEquals(!bool, predicate.accept(FastList.newListWith((Object) null)));
+        assertEquals(bool, predicate.accept(Lists.fixedSize.of()));
+        assertEquals(!bool, predicate.accept(FastList.newListWith((Object) null)));
         PredicatesTest.assertToString(predicate);
     }
 
@@ -500,11 +504,11 @@ public class PredicatesTest
         Function<Address, String> stateAbbreviation = address -> address.getState().getAbbreviation();
         Predicates<Address> inArizona = Predicates.attributeEqual(stateAbbreviation, "AZ");
         MutableCollection<Employee> azResidents = this.employees.select(Predicates.attributeAnySatisfy(employee -> employee.addresses, inArizona));
-        Assert.assertEquals(FastList.newListWith(this.alice, this.charlie), azResidents);
+        assertEquals(FastList.newListWith(this.alice, this.charlie), azResidents);
 
         Predicates<Address> inAlaska = Predicates.attributeEqual(stateAbbreviation, "AK");
         MutableCollection<Employee> akResidents = this.employees.select(Predicates.attributeAnySatisfy(employee -> employee.addresses, inAlaska));
-        Assert.assertEquals(FastList.newListWith(this.bob, this.diane), akResidents);
+        assertEquals(FastList.newListWith(this.bob, this.diane), akResidents);
         PredicatesTest.assertToString(inArizona);
     }
 
@@ -512,7 +516,7 @@ public class PredicatesTest
     public void attributeAllSatisfy()
     {
         MutableCollection<Employee> noExtendedDependents = this.employees.select(Predicates.attributeAllSatisfy(Employee.TO_DEPENEDENTS, Dependent.IS_IMMEDIATE));
-        Assert.assertEquals(FastList.newListWith(this.bob, this.charlie), noExtendedDependents);
+        assertEquals(FastList.newListWith(this.bob, this.charlie), noExtendedDependents);
     }
 
     @Test
@@ -521,7 +525,7 @@ public class PredicatesTest
         Function<Address, String> stateAbbreviation = address -> address.getState().getAbbreviation();
         Predicates<Address> inAlabama = Predicates.attributeEqual(stateAbbreviation, "AL");
         MutableCollection<Employee> notAlResidents = this.employees.select(Predicates.attributeNoneSatisfy(employee -> employee.addresses, inAlabama));
-        Assert.assertEquals(FastList.newListWith(this.alice, this.bob, this.charlie, this.diane), notAlResidents);
+        assertEquals(FastList.newListWith(this.alice, this.bob, this.charlie, this.diane), notAlResidents);
     }
 
     @Test
@@ -594,7 +598,7 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(predicate, 1, 2, 3);
         PredicatesTest.assertRejects(predicate, 0, 4, null);
         PredicatesTest.assertToString(predicate);
-        Assert.assertTrue(predicate.toString().contains(set.toString()));
+        assertTrue(predicate.toString().contains(set.toString()));
     }
 
     @Test
@@ -605,7 +609,7 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(predicate, 0, 4, null);
         PredicatesTest.assertRejects(predicate, 1, 2, 3);
         PredicatesTest.assertToString(predicate);
-        Assert.assertTrue(predicate.toString().contains(set.toString()));
+        assertTrue(predicate.toString().contains(set.toString()));
     }
 
     @Test
@@ -638,9 +642,9 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(predicate, "1");
         PredicatesTest.assertRejects(predicate, "0");
 
-        Assert.assertEquals(FastList.newListWith("1"), ListIterate.select(Lists.fixedSize.of("1", "2"), inList));
+        assertEquals(FastList.newListWith("1"), ListIterate.select(Lists.fixedSize.of("1", "2"), inList));
         PredicatesTest.assertToString(inList);
-        Assert.assertTrue(inList.toString().contains(list1.toString()));
+        assertTrue(inList.toString().contains(list1.toString()));
         PredicatesTest.assertToString(predicate);
     }
 
@@ -659,7 +663,7 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(in, "a");
         PredicatesTest.assertRejects(in, "c");
 
-        Assert.assertEquals(FastList.newListWith("a"), ListIterate.select(Lists.fixedSize.of("a", "c"), in));
+        assertEquals(FastList.newListWith("a"), ListIterate.select(Lists.fixedSize.of("a", "c"), in));
         PredicatesTest.assertToString(in);
     }
 
@@ -681,10 +685,10 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(predicate2, "0");
         PredicatesTest.assertRejects(predicate2, "1");
 
-        Assert.assertEquals(FastList.newListWith("2"), ListIterate.select(Lists.fixedSize.of("1", "2"), predicate1));
+        assertEquals(FastList.newListWith("2"), ListIterate.select(Lists.fixedSize.of("1", "2"), predicate1));
         PredicatesTest.assertToString(predicate1);
         PredicatesTest.assertToString(predicate2);
-        Assert.assertTrue(predicate1.toString().contains(odds.toString()));
+        assertTrue(predicate1.toString().contains(odds.toString()));
     }
 
     @Test
@@ -702,7 +706,7 @@ public class PredicatesTest
         PredicatesTest.assertAccepts(out, "C");
         PredicatesTest.assertRejects(out, "A");
 
-        Assert.assertEquals(FastList.newListWith("A"), ListIterate.reject(Lists.fixedSize.of("A", "C"), out));
+        assertEquals(FastList.newListWith("A"), ListIterate.reject(Lists.fixedSize.of("A", "C"), out));
         PredicatesTest.assertToString(out);
     }
 
@@ -774,14 +778,14 @@ public class PredicatesTest
     private static void assertToString(Predicate<?> predicate)
     {
         String toString = predicate.toString();
-        Assert.assertTrue(toString.startsWith("Predicates"));
+        assertTrue(toString.startsWith("Predicates"));
     }
 
     private static <T> void assertAccepts(Predicate<? super T> predicate, T... elements)
     {
         for (T element : elements)
         {
-            Assert.assertTrue(predicate.accept(element));
+            assertTrue(predicate.accept(element));
         }
     }
 
@@ -789,7 +793,7 @@ public class PredicatesTest
     {
         for (T element : elements)
         {
-            Assert.assertFalse(predicate.accept(element));
+            assertFalse(predicate.accept(element));
         }
     }
 
@@ -910,18 +914,18 @@ public class PredicatesTest
     public void subClass()
     {
         Predicates<Class<?>> subClass = Predicates.subClass(Number.class);
-        Assert.assertTrue(subClass.accept(Integer.class));
-        Assert.assertFalse(subClass.accept(Object.class));
-        Assert.assertTrue(subClass.accept(Number.class));
+        assertTrue(subClass.accept(Integer.class));
+        assertFalse(subClass.accept(Object.class));
+        assertTrue(subClass.accept(Number.class));
     }
 
     @Test
     public void superClass()
     {
         Predicates<Class<?>> superClass = Predicates.superClass(Number.class);
-        Assert.assertFalse(superClass.accept(Integer.class));
-        Assert.assertTrue(superClass.accept(Object.class));
-        Assert.assertTrue(superClass.accept(Number.class));
+        assertFalse(superClass.accept(Integer.class));
+        assertTrue(superClass.accept(Object.class));
+        assertTrue(superClass.accept(Number.class));
     }
 
     public static final class Employee

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/SerializableComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/SerializableComparatorsTest.java
@@ -15,8 +15,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SerializableComparatorsTest
 {
@@ -30,10 +32,10 @@ public class SerializableComparatorsTest
     public void naturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "2", "3", "4"),
                 list.sortThis(SerializableComparators.naturalOrder()));
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () -> FastList.newListWith("1", "2", null, "4").sortThis(Comparators.naturalOrder()));
     }
@@ -42,7 +44,7 @@ public class SerializableComparatorsTest
     public void reverseNaturalOrder()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("4", "3", "2", "1"),
                 list.sortThis(SerializableComparators.reverseNaturalOrder()));
     }
@@ -51,9 +53,9 @@ public class SerializableComparatorsTest
     public void reverse()
     {
         MutableList<String> list = Lists.mutable.with("1", "4", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("4", "3", "2", "1"),
                 list.sortThis(SerializableComparators.reverse(String::compareTo)));
-        Assert.assertThrows(NullPointerException.class, () -> SerializableComparators.reverse(null));
+        assertThrows(NullPointerException.class, () -> SerializableComparators.reverse(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicates2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicates2Test.java
@@ -11,81 +11,84 @@
 package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StringPredicates2Test
 {
     @Test
     public void startsWith()
     {
-        Assert.assertFalse(StringPredicates2.startsWith().accept(null, "Hello"));
-        Assert.assertTrue(StringPredicates2.startsWith().accept("HelloWorld", "Hello"));
-        Assert.assertFalse(StringPredicates2.startsWith().accept("HelloWorld", "World"));
-        Assert.assertEquals("StringPredicates2.startsWith()", StringPredicates2.startsWith().toString());
+        assertFalse(StringPredicates2.startsWith().accept(null, "Hello"));
+        assertTrue(StringPredicates2.startsWith().accept("HelloWorld", "Hello"));
+        assertFalse(StringPredicates2.startsWith().accept("HelloWorld", "World"));
+        assertEquals("StringPredicates2.startsWith()", StringPredicates2.startsWith().toString());
     }
 
     @Test
     public void notStartsWith()
     {
-        Assert.assertTrue(StringPredicates2.notStartsWith().accept(null, "Hello"));
-        Assert.assertFalse(StringPredicates2.notStartsWith().accept("HelloWorld", "Hello"));
-        Assert.assertTrue(StringPredicates2.notStartsWith().accept("HelloWorld", "World"));
-        Assert.assertEquals("StringPredicates2.notStartsWith()", StringPredicates2.notStartsWith().toString());
+        assertTrue(StringPredicates2.notStartsWith().accept(null, "Hello"));
+        assertFalse(StringPredicates2.notStartsWith().accept("HelloWorld", "Hello"));
+        assertTrue(StringPredicates2.notStartsWith().accept("HelloWorld", "World"));
+        assertEquals("StringPredicates2.notStartsWith()", StringPredicates2.notStartsWith().toString());
     }
 
     @Test
     public void endsWith()
     {
-        Assert.assertFalse(StringPredicates2.endsWith().accept(null, "Hello"));
-        Assert.assertFalse(StringPredicates2.endsWith().accept("HelloWorld", "Hello"));
-        Assert.assertTrue(StringPredicates2.endsWith().accept("HelloWorld", "World"));
-        Assert.assertEquals("StringPredicates2.endsWith()", StringPredicates2.endsWith().toString());
+        assertFalse(StringPredicates2.endsWith().accept(null, "Hello"));
+        assertFalse(StringPredicates2.endsWith().accept("HelloWorld", "Hello"));
+        assertTrue(StringPredicates2.endsWith().accept("HelloWorld", "World"));
+        assertEquals("StringPredicates2.endsWith()", StringPredicates2.endsWith().toString());
     }
 
     @Test
     public void notEndsWith()
     {
-        Assert.assertTrue(StringPredicates2.notEndsWith().accept(null, "Hello"));
-        Assert.assertTrue(StringPredicates2.notEndsWith().accept("HelloWorld", "Hello"));
-        Assert.assertFalse(StringPredicates2.notEndsWith().accept("HelloWorld", "World"));
-        Assert.assertEquals("StringPredicates2.notEndsWith()", StringPredicates2.notEndsWith().toString());
+        assertTrue(StringPredicates2.notEndsWith().accept(null, "Hello"));
+        assertTrue(StringPredicates2.notEndsWith().accept("HelloWorld", "Hello"));
+        assertFalse(StringPredicates2.notEndsWith().accept("HelloWorld", "World"));
+        assertEquals("StringPredicates2.notEndsWith()", StringPredicates2.notEndsWith().toString());
     }
 
     @Test
     public void equalsIgnoreCase()
     {
-        Assert.assertFalse(StringPredicates2.equalsIgnoreCase().accept(null, "HELLO"));
-        Assert.assertTrue(StringPredicates2.equalsIgnoreCase().accept("hello", "HELLO"));
-        Assert.assertTrue(StringPredicates2.equalsIgnoreCase().accept("WORLD", "world"));
-        Assert.assertFalse(StringPredicates2.equalsIgnoreCase().accept("World", "Hello"));
-        Assert.assertEquals("StringPredicates2.equalsIgnoreCase()", StringPredicates2.equalsIgnoreCase().toString());
+        assertFalse(StringPredicates2.equalsIgnoreCase().accept(null, "HELLO"));
+        assertTrue(StringPredicates2.equalsIgnoreCase().accept("hello", "HELLO"));
+        assertTrue(StringPredicates2.equalsIgnoreCase().accept("WORLD", "world"));
+        assertFalse(StringPredicates2.equalsIgnoreCase().accept("World", "Hello"));
+        assertEquals("StringPredicates2.equalsIgnoreCase()", StringPredicates2.equalsIgnoreCase().toString());
     }
 
     @Test
     public void notEqualsIgnoreCase()
     {
-        Assert.assertTrue(StringPredicates2.notEqualsIgnoreCase().accept(null, "HELLO"));
-        Assert.assertFalse(StringPredicates2.notEqualsIgnoreCase().accept("hello", "HELLO"));
-        Assert.assertFalse(StringPredicates2.notEqualsIgnoreCase().accept("WORLD", "world"));
-        Assert.assertTrue(StringPredicates2.notEqualsIgnoreCase().accept("World", "Hello"));
-        Assert.assertEquals("StringPredicates2.notEqualsIgnoreCase()", StringPredicates2.notEqualsIgnoreCase().toString());
+        assertTrue(StringPredicates2.notEqualsIgnoreCase().accept(null, "HELLO"));
+        assertFalse(StringPredicates2.notEqualsIgnoreCase().accept("hello", "HELLO"));
+        assertFalse(StringPredicates2.notEqualsIgnoreCase().accept("WORLD", "world"));
+        assertTrue(StringPredicates2.notEqualsIgnoreCase().accept("World", "Hello"));
+        assertEquals("StringPredicates2.notEqualsIgnoreCase()", StringPredicates2.notEqualsIgnoreCase().toString());
     }
 
     @Test
     public void containsString()
     {
-        Assert.assertTrue(StringPredicates2.contains().accept("WorldHelloWorld", "Hello"));
-        Assert.assertFalse(StringPredicates2.contains().accept("WorldHelloWorld", "Goodbye"));
-        Assert.assertEquals("StringPredicates2.contains()", StringPredicates2.contains().toString());
+        assertTrue(StringPredicates2.contains().accept("WorldHelloWorld", "Hello"));
+        assertFalse(StringPredicates2.contains().accept("WorldHelloWorld", "Goodbye"));
+        assertEquals("StringPredicates2.contains()", StringPredicates2.contains().toString());
     }
 
     @Test
     public void matches()
     {
-        Assert.assertTrue(StringPredicates2.matches().accept("aaaaabbbbb", "a*b*"));
-        Assert.assertFalse(StringPredicates2.matches().accept("ba", "a*b"));
-        Assert.assertEquals("StringPredicates2.matches()", StringPredicates2.matches().toString());
+        assertTrue(StringPredicates2.matches().accept("aaaaabbbbb", "a*b*"));
+        assertFalse(StringPredicates2.matches().accept("ba", "a*b"));
+        assertEquals("StringPredicates2.matches()", StringPredicates2.matches().toString());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicatesTest.java
@@ -12,238 +12,241 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StringPredicatesTest
 {
     @Test
     public void startsWith()
     {
-        Assert.assertFalse(StringPredicates.startsWith("Hello").accept(null));
-        Assert.assertTrue(StringPredicates.startsWith("Hello").accept("HelloWorld"));
-        Assert.assertFalse(StringPredicates.startsWith("World").accept("HelloWorld"));
-        Assert.assertEquals("StringPredicates.startsWith(\"Hello\")", StringPredicates.startsWith("Hello").toString());
+        assertFalse(StringPredicates.startsWith("Hello").accept(null));
+        assertTrue(StringPredicates.startsWith("Hello").accept("HelloWorld"));
+        assertFalse(StringPredicates.startsWith("World").accept("HelloWorld"));
+        assertEquals("StringPredicates.startsWith(\"Hello\")", StringPredicates.startsWith("Hello").toString());
     }
 
     @Test
     public void endsWith()
     {
-        Assert.assertFalse(StringPredicates.endsWith("Hello").accept(null));
-        Assert.assertFalse(StringPredicates.endsWith("Hello").accept("HelloWorld"));
-        Assert.assertTrue(StringPredicates.endsWith("World").accept("HelloWorld"));
-        Assert.assertEquals("StringPredicates.endsWith(\"Hello\")", StringPredicates.endsWith("Hello").toString());
+        assertFalse(StringPredicates.endsWith("Hello").accept(null));
+        assertFalse(StringPredicates.endsWith("Hello").accept("HelloWorld"));
+        assertTrue(StringPredicates.endsWith("World").accept("HelloWorld"));
+        assertEquals("StringPredicates.endsWith(\"Hello\")", StringPredicates.endsWith("Hello").toString());
     }
 
     @Test
     public void equalsIgnoreCase()
     {
-        Assert.assertFalse(StringPredicates.equalsIgnoreCase("HELLO").accept(null));
-        Assert.assertTrue(StringPredicates.equalsIgnoreCase("HELLO").accept("hello"));
-        Assert.assertTrue(StringPredicates.equalsIgnoreCase("world").accept("WORLD"));
-        Assert.assertFalse(StringPredicates.equalsIgnoreCase("Hello").accept("World"));
-        Assert.assertEquals("StringPredicates.equalsIgnoreCase(\"Hello\")", StringPredicates.equalsIgnoreCase("Hello").toString());
+        assertFalse(StringPredicates.equalsIgnoreCase("HELLO").accept(null));
+        assertTrue(StringPredicates.equalsIgnoreCase("HELLO").accept("hello"));
+        assertTrue(StringPredicates.equalsIgnoreCase("world").accept("WORLD"));
+        assertFalse(StringPredicates.equalsIgnoreCase("Hello").accept("World"));
+        assertEquals("StringPredicates.equalsIgnoreCase(\"Hello\")", StringPredicates.equalsIgnoreCase("Hello").toString());
     }
 
     @Test
     public void containsString()
     {
-        Assert.assertTrue(StringPredicates.contains("Hello").accept("WorldHelloWorld"));
-        Assert.assertTrue(StringPredicates.contains("Hello").and(StringPredicates.contains("World")).accept("WorldHelloWorld"));
-        Assert.assertFalse(StringPredicates.contains("Goodbye").accept("WorldHelloWorld"));
-        Assert.assertEquals("StringPredicates.contains(\"Hello\")", StringPredicates.contains("Hello").toString());
+        assertTrue(StringPredicates.contains("Hello").accept("WorldHelloWorld"));
+        assertTrue(StringPredicates.contains("Hello").and(StringPredicates.contains("World")).accept("WorldHelloWorld"));
+        assertFalse(StringPredicates.contains("Goodbye").accept("WorldHelloWorld"));
+        assertEquals("StringPredicates.contains(\"Hello\")", StringPredicates.contains("Hello").toString());
     }
 
     @Test
     public void containsCharacter()
     {
-        Assert.assertTrue(StringPredicates.contains("H".charAt(0)).accept("WorldHelloWorld"));
-        Assert.assertFalse(StringPredicates.contains("B".charAt(0)).accept("WorldHelloWorld"));
-        Assert.assertEquals("StringPredicates.contains(\"H\")", StringPredicates.contains("H".charAt(0)).toString());
+        assertTrue(StringPredicates.contains("H".charAt(0)).accept("WorldHelloWorld"));
+        assertFalse(StringPredicates.contains("B".charAt(0)).accept("WorldHelloWorld"));
+        assertEquals("StringPredicates.contains(\"H\")", StringPredicates.contains("H".charAt(0)).toString());
     }
 
     @Test
     public void emptyAndNotEmpty()
     {
-        Assert.assertFalse(StringPredicates.empty().accept("WorldHelloWorld"));
-        Assert.assertEquals("StringPredicates.empty()", StringPredicates.empty().toString());
-        Assert.assertTrue(StringPredicates.notEmpty().accept("WorldHelloWorld"));
-        Assert.assertEquals("StringPredicates.notEmpty()", StringPredicates.notEmpty().toString());
-        Assert.assertTrue(StringPredicates.empty().accept(""));
-        Assert.assertFalse(StringPredicates.notEmpty().accept(""));
+        assertFalse(StringPredicates.empty().accept("WorldHelloWorld"));
+        assertEquals("StringPredicates.empty()", StringPredicates.empty().toString());
+        assertTrue(StringPredicates.notEmpty().accept("WorldHelloWorld"));
+        assertEquals("StringPredicates.notEmpty()", StringPredicates.notEmpty().toString());
+        assertTrue(StringPredicates.empty().accept(""));
+        assertFalse(StringPredicates.notEmpty().accept(""));
     }
 
     @Test
     public void lessThan()
     {
-        Assert.assertTrue(StringPredicates.lessThan("b").accept("a"));
-        Assert.assertFalse(StringPredicates.lessThan("b").accept("b"));
-        Assert.assertFalse(StringPredicates.lessThan("b").accept("c"));
-        Assert.assertEquals("StringPredicates.lessThan(\"b\")", StringPredicates.lessThan("b").toString());
+        assertTrue(StringPredicates.lessThan("b").accept("a"));
+        assertFalse(StringPredicates.lessThan("b").accept("b"));
+        assertFalse(StringPredicates.lessThan("b").accept("c"));
+        assertEquals("StringPredicates.lessThan(\"b\")", StringPredicates.lessThan("b").toString());
     }
 
     @Test
     public void lessThanOrEqualTo()
     {
-        Assert.assertTrue(StringPredicates.lessThanOrEqualTo("b").accept("a"));
-        Assert.assertTrue(StringPredicates.lessThanOrEqualTo("b").accept("b"));
-        Assert.assertFalse(StringPredicates.lessThanOrEqualTo("b").accept("c"));
-        Assert.assertEquals("StringPredicates.lessThanOrEqualTo(\"b\")", StringPredicates.lessThanOrEqualTo("b").toString());
+        assertTrue(StringPredicates.lessThanOrEqualTo("b").accept("a"));
+        assertTrue(StringPredicates.lessThanOrEqualTo("b").accept("b"));
+        assertFalse(StringPredicates.lessThanOrEqualTo("b").accept("c"));
+        assertEquals("StringPredicates.lessThanOrEqualTo(\"b\")", StringPredicates.lessThanOrEqualTo("b").toString());
     }
 
     @Test
     public void greaterThan()
     {
-        Assert.assertFalse(StringPredicates.greaterThan("b").accept("a"));
-        Assert.assertFalse(StringPredicates.greaterThan("b").accept("b"));
-        Assert.assertTrue(StringPredicates.greaterThan("b").accept("c"));
-        Assert.assertEquals("StringPredicates.greaterThan(\"b\")", StringPredicates.greaterThan("b").toString());
+        assertFalse(StringPredicates.greaterThan("b").accept("a"));
+        assertFalse(StringPredicates.greaterThan("b").accept("b"));
+        assertTrue(StringPredicates.greaterThan("b").accept("c"));
+        assertEquals("StringPredicates.greaterThan(\"b\")", StringPredicates.greaterThan("b").toString());
     }
 
     @Test
     public void greaterThanOrEqualTo()
     {
-        Assert.assertFalse(StringPredicates.greaterThanOrEqualTo("b").accept("a"));
-        Assert.assertTrue(StringPredicates.greaterThanOrEqualTo("b").accept("b"));
-        Assert.assertTrue(StringPredicates.greaterThanOrEqualTo("b").accept("c"));
-        Assert.assertEquals("StringPredicates.greaterThanOrEqualTo(\"b\")", StringPredicates.greaterThanOrEqualTo("b").toString());
+        assertFalse(StringPredicates.greaterThanOrEqualTo("b").accept("a"));
+        assertTrue(StringPredicates.greaterThanOrEqualTo("b").accept("b"));
+        assertTrue(StringPredicates.greaterThanOrEqualTo("b").accept("c"));
+        assertEquals("StringPredicates.greaterThanOrEqualTo(\"b\")", StringPredicates.greaterThanOrEqualTo("b").toString());
     }
 
     @Test
     public void matches()
     {
-        Assert.assertTrue(StringPredicates.matches("a*b*").accept("aaaaabbbbb"));
-        Assert.assertFalse(StringPredicates.matches("a*b").accept("ba"));
-        Assert.assertEquals("StringPredicates.matches(\"a*b\")", StringPredicates.matches("a*b").toString());
+        assertTrue(StringPredicates.matches("a*b*").accept("aaaaabbbbb"));
+        assertFalse(StringPredicates.matches("a*b").accept("ba"));
+        assertEquals("StringPredicates.matches(\"a*b\")", StringPredicates.matches("a*b").toString());
     }
 
     @Test
     public void size()
     {
-        Assert.assertTrue(StringPredicates.size(1).accept("a"));
-        Assert.assertFalse(StringPredicates.size(0).accept("a"));
-        Assert.assertTrue(StringPredicates.size(2).accept("ab"));
-        Assert.assertEquals("StringPredicates.size(2)", StringPredicates.size(2).toString());
+        assertTrue(StringPredicates.size(1).accept("a"));
+        assertFalse(StringPredicates.size(0).accept("a"));
+        assertTrue(StringPredicates.size(2).accept("ab"));
+        assertEquals("StringPredicates.size(2)", StringPredicates.size(2).toString());
     }
 
     @Test
     public void hasLetters()
     {
-        Assert.assertTrue(StringPredicates.hasLetters().accept("a2a"));
-        Assert.assertFalse(StringPredicates.hasLetters().accept("222"));
-        Assert.assertEquals("StringPredicates.hasLetters()", StringPredicates.hasLetters().toString());
+        assertTrue(StringPredicates.hasLetters().accept("a2a"));
+        assertFalse(StringPredicates.hasLetters().accept("222"));
+        assertEquals("StringPredicates.hasLetters()", StringPredicates.hasLetters().toString());
     }
 
     @Test
     public void hasDigits()
     {
-        Assert.assertFalse(StringPredicates.hasDigits().accept("aaa"));
-        Assert.assertTrue(StringPredicates.hasDigits().accept("a22"));
-        Assert.assertEquals("StringPredicates.hasDigits()", StringPredicates.hasDigits().toString());
+        assertFalse(StringPredicates.hasDigits().accept("aaa"));
+        assertTrue(StringPredicates.hasDigits().accept("a22"));
+        assertEquals("StringPredicates.hasDigits()", StringPredicates.hasDigits().toString());
     }
 
     @Test
     public void hasLettersAndDigits()
     {
         Predicate<String> predicate = StringPredicates.hasLettersAndDigits();
-        Assert.assertTrue(predicate.accept("a2a"));
-        Assert.assertFalse(predicate.accept("aaa"));
-        Assert.assertFalse(predicate.accept("222"));
-        Assert.assertEquals("StringPredicates.hasLettersAndDigits()", predicate.toString());
+        assertTrue(predicate.accept("a2a"));
+        assertFalse(predicate.accept("aaa"));
+        assertFalse(predicate.accept("222"));
+        assertEquals("StringPredicates.hasLettersAndDigits()", predicate.toString());
     }
 
     @Test
     public void hasLettersOrDigits()
     {
         Predicate<String> predicate = StringPredicates.hasLettersOrDigits();
-        Assert.assertTrue(predicate.accept("a2a"));
-        Assert.assertTrue(predicate.accept("aaa"));
-        Assert.assertTrue(predicate.accept("222"));
-        Assert.assertEquals("StringPredicates.hasLettersOrDigits()", predicate.toString());
+        assertTrue(predicate.accept("a2a"));
+        assertTrue(predicate.accept("aaa"));
+        assertTrue(predicate.accept("222"));
+        assertEquals("StringPredicates.hasLettersOrDigits()", predicate.toString());
     }
 
     @Test
     public void isAlpha()
     {
         Predicate<String> predicate = StringPredicates.isAlpha();
-        Assert.assertTrue(predicate.accept("aaa"));
-        Assert.assertFalse(predicate.accept("a2a"));
-        Assert.assertEquals("StringPredicates.isAlpha()", predicate.toString());
+        assertTrue(predicate.accept("aaa"));
+        assertFalse(predicate.accept("a2a"));
+        assertEquals("StringPredicates.isAlpha()", predicate.toString());
     }
 
     @Test
     public void isAlphaNumeric()
     {
         Predicate<String> predicate = StringPredicates.isAlphanumeric();
-        Assert.assertTrue(predicate.accept("aaa"));
-        Assert.assertTrue(predicate.accept("a2a"));
-        Assert.assertEquals("StringPredicates.isAlphanumeric()", predicate.toString());
+        assertTrue(predicate.accept("aaa"));
+        assertTrue(predicate.accept("a2a"));
+        assertEquals("StringPredicates.isAlphanumeric()", predicate.toString());
     }
 
     @Test
     public void isBlank()
     {
         Predicate<String> predicate = StringPredicates.isBlank();
-        Assert.assertTrue(predicate.accept(""));
-        Assert.assertTrue(predicate.accept(" "));
-        Assert.assertFalse(predicate.accept("a2a"));
-        Assert.assertEquals("StringPredicates.isBlank()", predicate.toString());
+        assertTrue(predicate.accept(""));
+        assertTrue(predicate.accept(" "));
+        assertFalse(predicate.accept("a2a"));
+        assertEquals("StringPredicates.isBlank()", predicate.toString());
     }
 
     @Test
     public void notBlank()
     {
         Predicate<String> predicate = StringPredicates.notBlank();
-        Assert.assertFalse(predicate.accept(""));
-        Assert.assertFalse(predicate.accept(" "));
-        Assert.assertTrue(predicate.accept("a2a"));
-        Assert.assertEquals("StringPredicates.notBlank()", predicate.toString());
+        assertFalse(predicate.accept(""));
+        assertFalse(predicate.accept(" "));
+        assertTrue(predicate.accept("a2a"));
+        assertEquals("StringPredicates.notBlank()", predicate.toString());
     }
 
     @Test
     public void isNumeric()
     {
         Predicate<String> predicate = StringPredicates.isNumeric();
-        Assert.assertTrue(predicate.accept("222"));
-        Assert.assertFalse(predicate.accept("a2a2a2"));
-        Assert.assertFalse(predicate.accept("aaa"));
-        Assert.assertEquals("StringPredicates.isNumeric()", predicate.toString());
+        assertTrue(predicate.accept("222"));
+        assertFalse(predicate.accept("a2a2a2"));
+        assertFalse(predicate.accept("aaa"));
+        assertEquals("StringPredicates.isNumeric()", predicate.toString());
     }
 
     @Test
     public void hasLowerCase()
     {
         Predicate<String> predicate = StringPredicates.hasLowerCase();
-        Assert.assertTrue(predicate.accept("aaa"));
-        Assert.assertFalse(predicate.accept("AAA"));
-        Assert.assertEquals("StringPredicates.hasLowerCase()", predicate.toString());
+        assertTrue(predicate.accept("aaa"));
+        assertFalse(predicate.accept("AAA"));
+        assertEquals("StringPredicates.hasLowerCase()", predicate.toString());
     }
 
     @Test
     public void hasUpperCase()
     {
         Predicate<String> predicate = StringPredicates.hasUpperCase();
-        Assert.assertFalse(predicate.accept("aaa"));
-        Assert.assertTrue(predicate.accept("AAA"));
-        Assert.assertEquals("StringPredicates.hasUpperCase()", predicate.toString());
+        assertFalse(predicate.accept("aaa"));
+        assertTrue(predicate.accept("AAA"));
+        assertEquals("StringPredicates.hasUpperCase()", predicate.toString());
     }
 
     @Test
     public void hasUndefined()
     {
         Predicate<String> predicate = StringPredicates.hasUndefined();
-        Assert.assertFalse(predicate.accept("aaa"));
-        Assert.assertEquals("StringPredicates.hasUndefined()", predicate.toString());
+        assertFalse(predicate.accept("aaa"));
+        assertEquals("StringPredicates.hasUndefined()", predicate.toString());
     }
 
     @Test
     public void hasSpaces()
     {
         Predicate<String> predicate = StringPredicates.hasSpaces();
-        Assert.assertTrue(predicate.accept("a a a"));
-        Assert.assertTrue(predicate.accept(" "));
-        Assert.assertFalse(predicate.accept("aaa"));
-        Assert.assertEquals("StringPredicates.hasSpaces()", predicate.toString());
+        assertTrue(predicate.accept("a a a"));
+        assertTrue(predicate.accept(" "));
+        assertFalse(predicate.accept("aaa"));
+        assertEquals("StringPredicates.hasSpaces()", predicate.toString());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/BooleanPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/BooleanPredicatesTest.java
@@ -11,93 +11,95 @@
 package org.eclipse.collections.impl.block.factory.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public final class BooleanPredicatesTest
 {
     @Test
     public void testEqual()
     {
-        Assert.assertTrue(BooleanPredicates.equal(true).accept(true));
-        Assert.assertTrue(BooleanPredicates.equal(false).accept(false));
-        Assert.assertFalse(BooleanPredicates.equal(true).accept(false));
-        Assert.assertFalse(BooleanPredicates.equal(false).accept(true));
+        assertTrue(BooleanPredicates.equal(true).accept(true));
+        assertTrue(BooleanPredicates.equal(false).accept(false));
+        assertFalse(BooleanPredicates.equal(true).accept(false));
+        assertFalse(BooleanPredicates.equal(false).accept(true));
     }
 
     @Test
     public void testIsTrue()
     {
-        Assert.assertTrue(BooleanPredicates.isTrue().accept(true));
-        Assert.assertFalse(BooleanPredicates.isTrue().accept(false));
+        assertTrue(BooleanPredicates.isTrue().accept(true));
+        assertFalse(BooleanPredicates.isTrue().accept(false));
     }
 
     @Test
     public void testIsFalse()
     {
-        Assert.assertTrue(BooleanPredicates.isFalse().accept(false));
-        Assert.assertFalse(BooleanPredicates.isFalse().accept(true));
+        assertTrue(BooleanPredicates.isFalse().accept(false));
+        assertFalse(BooleanPredicates.isFalse().accept(true));
     }
 
     @Test
     public void testAnd()
     {
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(false));
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(false));
-        Assert.assertTrue(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(false));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(false));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(false));
+        assertTrue(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(false));
 
-        Assert.assertTrue(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(true));
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(true));
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(true));
+        assertTrue(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(true));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(true));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(true));
 
-        Assert.assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), value -> !value).accept(true));
-        Assert.assertTrue(BooleanPredicates.and(BooleanPredicates.isFalse(), value -> !value).accept(false));
+        assertFalse(BooleanPredicates.and(BooleanPredicates.isFalse(), value -> !value).accept(true));
+        assertTrue(BooleanPredicates.and(BooleanPredicates.isFalse(), value -> !value).accept(false));
     }
 
     @Test
     public void testOr()
     {
-        Assert.assertFalse(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(false));
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(false));
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(false));
+        assertFalse(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(false));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(false));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(false));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(false));
 
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(true));
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(true));
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(true));
-        Assert.assertFalse(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(true));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(true)).accept(true));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.equal(false)).accept(true));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(true)).accept(true));
+        assertFalse(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.equal(false)).accept(true));
 
-        Assert.assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), value -> !value).accept(false));
-        Assert.assertFalse(BooleanPredicates.or(BooleanPredicates.isFalse(), value -> !value).accept(true));
+        assertTrue(BooleanPredicates.or(BooleanPredicates.isFalse(), value -> !value).accept(false));
+        assertFalse(BooleanPredicates.or(BooleanPredicates.isFalse(), value -> !value).accept(true));
     }
 
     @Test
     public void testNot()
     {
-        Assert.assertTrue(BooleanPredicates.not(BooleanPredicates.isTrue()).accept(false));
-        Assert.assertFalse(BooleanPredicates.not(BooleanPredicates.isTrue()).accept(true));
-        Assert.assertTrue(BooleanPredicates.not(BooleanPredicates.isFalse()).accept(true));
-        Assert.assertFalse(BooleanPredicates.not(BooleanPredicates.isFalse()).accept(false));
-        Assert.assertTrue(BooleanPredicates.not(true).accept(false));
-        Assert.assertFalse(BooleanPredicates.not(true).accept(true));
-        Assert.assertTrue(BooleanPredicates.not(false).accept(true));
-        Assert.assertFalse(BooleanPredicates.not(false).accept(false));
+        assertTrue(BooleanPredicates.not(BooleanPredicates.isTrue()).accept(false));
+        assertFalse(BooleanPredicates.not(BooleanPredicates.isTrue()).accept(true));
+        assertTrue(BooleanPredicates.not(BooleanPredicates.isFalse()).accept(true));
+        assertFalse(BooleanPredicates.not(BooleanPredicates.isFalse()).accept(false));
+        assertTrue(BooleanPredicates.not(true).accept(false));
+        assertFalse(BooleanPredicates.not(true).accept(true));
+        assertTrue(BooleanPredicates.not(false).accept(true));
+        assertFalse(BooleanPredicates.not(false).accept(false));
     }
 
     @Test
     public void testAlwaysTrue()
     {
-        Assert.assertTrue(BooleanPredicates.alwaysTrue().accept(false));
-        Assert.assertTrue(BooleanPredicates.alwaysTrue().accept(true));
+        assertTrue(BooleanPredicates.alwaysTrue().accept(false));
+        assertTrue(BooleanPredicates.alwaysTrue().accept(true));
     }
 
     @Test
     public void testAlwaysFalse()
     {
-        Assert.assertFalse(BooleanPredicates.alwaysFalse().accept(false));
-        Assert.assertFalse(BooleanPredicates.alwaysFalse().accept(true));
+        assertFalse(BooleanPredicates.alwaysFalse().accept(false));
+        assertFalse(BooleanPredicates.alwaysFalse().accept(true));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/AddFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/AddFunctionTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 // This class is not a full test of AddFunction at present, but serves as a
 // holder for the addStringBlockHandlesNulls() test which had been put in the
@@ -24,15 +25,15 @@ public class AddFunctionTest
     public void addStringBlockHandlesNulls()
     {
         Function2<String, String, String> undertest = AddFunction.STRING;
-        Assert.assertEquals("two", undertest.value(null, "two"));
-        Assert.assertEquals("one", undertest.value("one", null));
+        assertEquals("two", undertest.value(null, "two"));
+        assertEquals("one", undertest.value("one", null));
     }
 
     @Test
     public void addLongFunction()
     {
         Function2<Long, Long, Long> longFunction = AddFunction.LONG;
-        Assert.assertEquals(Long.valueOf(3L), longFunction.value(1L, 2L));
+        assertEquals(Long.valueOf(3L), longFunction.value(1L, 2L));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
@@ -16,8 +16,11 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class CaseFunctionTest
 {
@@ -25,7 +28,7 @@ public class CaseFunctionTest
     public void noopCase()
     {
         Function<Integer, Integer> function = new CaseFunction<>();
-        Assert.assertNull(function.valueOf(42));
+        assertNull(function.valueOf(42));
     }
 
     @Test
@@ -34,7 +37,7 @@ public class CaseFunctionTest
         CaseFunction<Integer, Integer> function = new CaseFunction<>();
         function.addCase(ignored -> true, Functions.getIntegerPassThru());
         Integer fortyTwo = 42;
-        Assert.assertEquals(fortyTwo, function.valueOf(fortyTwo));
+        assertEquals(fortyTwo, function.valueOf(fortyTwo));
     }
 
     @Test
@@ -45,13 +48,13 @@ public class CaseFunctionTest
                 Predicates.attributeGreaterThan(Foo.TO_VALUE, 5.0D),
                 Functions.getFixedValue("Patience, grasshopper"));
 
-        Assert.assertEquals("Yow!", function.valueOf(new Foo("", 1.0D)));
+        assertEquals("Yow!", function.valueOf(new Foo("", 1.0D)));
 
         CaseFunction<Foo, String> function1 =
                 function.setDefault(Functions.getFixedValue("Patience, young grasshopper"));
-        Assert.assertSame(function, function1);
-        Assert.assertEquals("Patience, grasshopper", function.valueOf(new Foo("", 6.0D)));
-        Assert.assertEquals("Patience, young grasshopper", function.valueOf(new Foo("", 1.0D)));
+        assertSame(function, function1);
+        assertEquals("Patience, grasshopper", function.valueOf(new Foo("", 6.0D)));
+        assertEquals("Patience, young grasshopper", function.valueOf(new Foo("", 1.0D)));
 
         Verify.assertContains("CaseFunction", function.toString());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions0Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions0Test.java
@@ -22,21 +22,25 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class Functions0Test
 {
     @Test
     public void getTrue()
     {
-        Assert.assertTrue(Functions0.getTrue().value());
+        assertTrue(Functions0.getTrue().value());
     }
 
     @Test
     public void getFalse()
     {
-        Assert.assertFalse(Functions0.getFalse().value());
+        assertFalse(Functions0.getFalse().value());
     }
 
     @Test
@@ -54,7 +58,7 @@ public class Functions0Test
     @Test
     public void throwingWithSuccessfulCompletion()
     {
-        Assert.assertEquals("hello", Functions0.throwing(() -> "hello").value());
+        assertEquals("hello", Functions0.throwing(() -> "hello").value());
     }
 
     @Test
@@ -84,7 +88,7 @@ public class Functions0Test
                             },
                             this::throwMyException).value();
                 });
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () ->
                 {
@@ -105,50 +109,50 @@ public class Functions0Test
     @Test
     public void newFastList()
     {
-        Assert.assertEquals(Lists.mutable.of(), Functions0.newFastList().value());
+        assertEquals(Lists.mutable.of(), Functions0.newFastList().value());
         Verify.assertInstanceOf(FastList.class, Functions0.newFastList().value());
     }
 
     @Test
     public void newUnifiedSet()
     {
-        Assert.assertEquals(UnifiedSet.newSet(), Functions0.newUnifiedSet().value());
+        assertEquals(UnifiedSet.newSet(), Functions0.newUnifiedSet().value());
         Verify.assertInstanceOf(UnifiedSet.class, Functions0.newUnifiedSet().value());
     }
 
     @Test
     public void newHashBag()
     {
-        Assert.assertEquals(Bags.mutable.of(), Functions0.newHashBag().value());
+        assertEquals(Bags.mutable.of(), Functions0.newHashBag().value());
         Verify.assertInstanceOf(HashBag.class, Functions0.newHashBag().value());
     }
 
     @Test
     public void newUnifiedMap()
     {
-        Assert.assertEquals(UnifiedMap.newMap(), Functions0.newUnifiedMap().value());
+        assertEquals(UnifiedMap.newMap(), Functions0.newUnifiedMap().value());
         Verify.assertInstanceOf(UnifiedMap.class, Functions0.newUnifiedMap().value());
     }
 
     @Test
     public void zeroInteger()
     {
-        Assert.assertEquals(Integer.valueOf(0), Functions0.zeroInteger().value());
-        Assert.assertEquals(Integer.valueOf(0), Functions0.value(0).value());
+        assertEquals(Integer.valueOf(0), Functions0.zeroInteger().value());
+        assertEquals(Integer.valueOf(0), Functions0.value(0).value());
     }
 
     @Test
     public void zeroAtomicInteger()
     {
         Verify.assertInstanceOf(AtomicInteger.class, Functions0.zeroAtomicInteger().value());
-        Assert.assertEquals(0, Functions0.zeroAtomicInteger().value().get());
+        assertEquals(0, Functions0.zeroAtomicInteger().value().get());
     }
 
     @Test
     public void zeroAtomicLong()
     {
         Verify.assertInstanceOf(AtomicLong.class, Functions0.zeroAtomicLong().value());
-        Assert.assertEquals(0, Functions0.zeroAtomicLong().value().get());
+        assertEquals(0, Functions0.zeroAtomicLong().value().get());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions2Test.java
@@ -20,8 +20,10 @@ import org.eclipse.collections.impl.block.factory.Functions2;
 import org.eclipse.collections.impl.block.function.checked.ThrowingFunction2;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class Functions2Test
 {
@@ -43,25 +45,25 @@ public class Functions2Test
         ThrowingFunction2<String, String, String> throwingFunction2 =
                 (argument1, argument2) -> argument1.concat(argument2);
 
-        Assert.assertEquals("abcdef", Functions2.throwing(throwingFunction2).value("abc", "def"));
+        assertEquals("abcdef", Functions2.throwing(throwingFunction2).value("abc", "def"));
     }
 
     @Test
     public void min()
     {
         Function2<Integer, Integer, Integer> minFunction = Functions2.min(Comparators.naturalOrder());
-        Assert.assertEquals(Integer.valueOf(1), minFunction.value(5, 1));
-        Assert.assertEquals(Integer.valueOf(1), minFunction.value(1, 5));
-        Assert.assertEquals(Integer.valueOf(2), minFunction.value(2, 2));
+        assertEquals(Integer.valueOf(1), minFunction.value(5, 1));
+        assertEquals(Integer.valueOf(1), minFunction.value(1, 5));
+        assertEquals(Integer.valueOf(2), minFunction.value(2, 2));
     }
 
     @Test
     public void max()
     {
         Function2<Integer, Integer, Integer> maxFunction = Functions2.max(Comparators.naturalOrder());
-        Assert.assertEquals(Integer.valueOf(5), maxFunction.value(5, 1));
-        Assert.assertEquals(Integer.valueOf(5), maxFunction.value(1, 5));
-        Assert.assertEquals(Integer.valueOf(5), maxFunction.value(5, 5));
+        assertEquals(Integer.valueOf(5), maxFunction.value(5, 1));
+        assertEquals(Integer.valueOf(5), maxFunction.value(1, 5));
+        assertEquals(Integer.valueOf(5), maxFunction.value(5, 5));
     }
 
     @Test
@@ -70,9 +72,9 @@ public class Functions2Test
         Function2<Twin<Integer>, Twin<Integer>, Twin<Integer>> minBy = Functions2.minBy(Functions.firstOfPair());
         Twin<Integer> twinOne = Tuples.twin(1, 5);
         Twin<Integer> twinTwo = Tuples.twin(0, 10);
-        Assert.assertEquals(twinTwo, minBy.value(twinOne, twinTwo));
-        Assert.assertEquals(twinTwo, minBy.value(twinTwo, twinOne));
-        Assert.assertEquals(twinOne, minBy.value(twinOne, twinOne));
+        assertEquals(twinTwo, minBy.value(twinOne, twinTwo));
+        assertEquals(twinTwo, minBy.value(twinTwo, twinOne));
+        assertEquals(twinOne, minBy.value(twinOne, twinOne));
     }
 
     @Test
@@ -81,9 +83,9 @@ public class Functions2Test
         Function2<Twin<Integer>, Twin<Integer>, Twin<Integer>> minBy = Functions2.maxBy(Functions.firstOfPair());
         Twin<Integer> twinOne = Tuples.twin(1, 5);
         Twin<Integer> twinTwo = Tuples.twin(0, 10);
-        Assert.assertEquals(twinOne, minBy.value(twinOne, twinTwo));
-        Assert.assertEquals(twinOne, minBy.value(twinTwo, twinOne));
-        Assert.assertEquals(twinOne, minBy.value(twinOne, twinOne));
+        assertEquals(twinOne, minBy.value(twinOne, twinTwo));
+        assertEquals(twinOne, minBy.value(twinTwo, twinOne));
+        assertEquals(twinOne, minBy.value(twinOne, twinOne));
     }
 
     @Test
@@ -113,7 +115,7 @@ public class Functions2Test
                             },
                             this::throwMyException).value(null, null);
                 });
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () ->
                 {
@@ -135,14 +137,14 @@ public class Functions2Test
     public void asFunction2Function()
     {
         Function2<Integer, Object, String> block = Functions2.fromFunction(String::valueOf);
-        Assert.assertEquals("1", block.value(1, null));
+        assertEquals("1", block.value(1, null));
     }
 
     @Test
     public void plusInteger()
     {
         Function2<Integer, Integer, Integer> plusInteger = Functions2.integerAddition();
-        Assert.assertEquals(Integer.valueOf(5), plusInteger.value(2, 3));
+        assertEquals(Integer.valueOf(5), plusInteger.value(2, 3));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/IfFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/IfFunctionTest.java
@@ -16,8 +16,11 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IfFunctionTest
 {
@@ -37,7 +40,7 @@ public class IfFunctionTest
                 (Integer ignored) -> 0);
         MutableList<Integer> result = map.valuesView().collect(function).toList();
 
-        Assert.assertEquals(FastList.newListWith(0, 1, 0, 1, 0), result);
+        assertEquals(FastList.newListWith(0, 1, 0, 1, 0), result);
     }
 
     @Test
@@ -47,7 +50,7 @@ public class IfFunctionTest
                 Predicates.greaterThan(5),
                 (Integer ignored) -> true);
 
-        Assert.assertTrue(function.valueOf(10));
+        assertTrue(function.valueOf(10));
     }
 
     @Test
@@ -58,6 +61,6 @@ public class IfFunctionTest
                 (Integer ignored) -> true,
                 (Integer ignored) -> false);
 
-        Assert.assertFalse(function.valueOf(1));
+        assertFalse(function.valueOf(1));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MaxSizeFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MaxSizeFunctionTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link MaxSizeFunction}.
@@ -23,14 +24,14 @@ public class MaxSizeFunctionTest
     @Test
     public void maxSizeCollection()
     {
-        Assert.assertEquals(Integer.valueOf(3), MaxSizeFunction.COLLECTION.value(2, FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(Integer.valueOf(3), MaxSizeFunction.COLLECTION.value(3, FastList.newListWith(1, 2)));
+        assertEquals(Integer.valueOf(3), MaxSizeFunction.COLLECTION.value(2, FastList.newListWith(1, 2, 3)));
+        assertEquals(Integer.valueOf(3), MaxSizeFunction.COLLECTION.value(3, FastList.newListWith(1, 2)));
     }
 
     @Test
     public void maxSizeMap()
     {
-        Assert.assertEquals(Integer.valueOf(3), MaxSizeFunction.MAP.value(2, Maps.mutable.of(1, 1, 2, 2, 3, 3)));
-        Assert.assertEquals(Integer.valueOf(3), MaxSizeFunction.MAP.value(3, Maps.mutable.of(1, 1, 2, 2)));
+        assertEquals(Integer.valueOf(3), MaxSizeFunction.MAP.value(2, Maps.mutable.of(1, 1, 2, 2, 3, 3)));
+        assertEquals(Integer.valueOf(3), MaxSizeFunction.MAP.value(3, Maps.mutable.of(1, 1, 2, 2)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.collections.impl.block.function;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class MinAndMaxBlocksTest
 {
@@ -22,64 +24,64 @@ public class MinAndMaxBlocksTest
     @Test
     public void minBlocks()
     {
-        Assert.assertEquals(new Double(1.0), MinFunction.DOUBLE.value(1.0, 2.0));
-        Assert.assertEquals(new Double(0.0), MinFunction.DOUBLE.value(0.0, 1.0));
-        Assert.assertEquals(new Double(-1.0), MinFunction.DOUBLE.value(1.0, -1.0));
+        assertEquals(new Double(1.0), MinFunction.DOUBLE.value(1.0, 2.0));
+        assertEquals(new Double(0.0), MinFunction.DOUBLE.value(0.0, 1.0));
+        assertEquals(new Double(-1.0), MinFunction.DOUBLE.value(1.0, -1.0));
 
-        Assert.assertEquals(Integer.valueOf(1), MinFunction.INTEGER.value(1, 2));
-        Assert.assertEquals(Integer.valueOf(0), MinFunction.INTEGER.value(0, 1));
-        Assert.assertEquals(Integer.valueOf(-1), MinFunction.INTEGER.value(1, -1));
+        assertEquals(Integer.valueOf(1), MinFunction.INTEGER.value(1, 2));
+        assertEquals(Integer.valueOf(0), MinFunction.INTEGER.value(0, 1));
+        assertEquals(Integer.valueOf(-1), MinFunction.INTEGER.value(1, -1));
 
-        Assert.assertEquals(Long.valueOf(1L), MinFunction.LONG.value(1L, 2L));
-        Assert.assertEquals(Long.valueOf(0L), MinFunction.LONG.value(0L, 1L));
-        Assert.assertEquals(Long.valueOf(-1L), MinFunction.LONG.value(1L, -1L));
+        assertEquals(Long.valueOf(1L), MinFunction.LONG.value(1L, 2L));
+        assertEquals(Long.valueOf(0L), MinFunction.LONG.value(0L, 1L));
+        assertEquals(Long.valueOf(-1L), MinFunction.LONG.value(1L, -1L));
     }
 
     @Test
     public void minBlocksNull()
     {
-        Assert.assertSame(FORTY_TWO_DOUBLE, MinFunction.DOUBLE.value(null, FORTY_TWO_DOUBLE));
-        Assert.assertSame(FORTY_TWO_DOUBLE, MinFunction.DOUBLE.value(FORTY_TWO_DOUBLE, null));
-        Assert.assertSame(null, MinFunction.DOUBLE.value(null, null));
+        assertSame(FORTY_TWO_DOUBLE, MinFunction.DOUBLE.value(null, FORTY_TWO_DOUBLE));
+        assertSame(FORTY_TWO_DOUBLE, MinFunction.DOUBLE.value(FORTY_TWO_DOUBLE, null));
+        assertSame(null, MinFunction.DOUBLE.value(null, null));
 
-        Assert.assertSame(FORTY_TWO_INTEGER, MinFunction.INTEGER.value(null, FORTY_TWO_INTEGER));
-        Assert.assertSame(FORTY_TWO_INTEGER, MinFunction.INTEGER.value(FORTY_TWO_INTEGER, null));
-        Assert.assertSame(null, MinFunction.INTEGER.value(null, null));
+        assertSame(FORTY_TWO_INTEGER, MinFunction.INTEGER.value(null, FORTY_TWO_INTEGER));
+        assertSame(FORTY_TWO_INTEGER, MinFunction.INTEGER.value(FORTY_TWO_INTEGER, null));
+        assertSame(null, MinFunction.INTEGER.value(null, null));
 
-        Assert.assertSame(FORTY_TWO_LONG, MinFunction.LONG.value(null, FORTY_TWO_LONG));
-        Assert.assertSame(FORTY_TWO_LONG, MinFunction.LONG.value(FORTY_TWO_LONG, null));
-        Assert.assertSame(null, MinFunction.LONG.value(null, null));
+        assertSame(FORTY_TWO_LONG, MinFunction.LONG.value(null, FORTY_TWO_LONG));
+        assertSame(FORTY_TWO_LONG, MinFunction.LONG.value(FORTY_TWO_LONG, null));
+        assertSame(null, MinFunction.LONG.value(null, null));
     }
 
     @Test
     public void maxBlocks()
     {
-        Assert.assertEquals(new Double(2.0), MaxFunction.DOUBLE.value(1.0, 2.0));
-        Assert.assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(0.0, 1.0));
-        Assert.assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(1.0, -1.0));
+        assertEquals(new Double(2.0), MaxFunction.DOUBLE.value(1.0, 2.0));
+        assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(0.0, 1.0));
+        assertEquals(new Double(1.0), MaxFunction.DOUBLE.value(1.0, -1.0));
 
-        Assert.assertEquals(Integer.valueOf(2), MaxFunction.INTEGER.value(1, 2));
-        Assert.assertEquals(Integer.valueOf(1), MaxFunction.INTEGER.value(0, 1));
-        Assert.assertEquals(Integer.valueOf(1), MaxFunction.INTEGER.value(1, -1));
+        assertEquals(Integer.valueOf(2), MaxFunction.INTEGER.value(1, 2));
+        assertEquals(Integer.valueOf(1), MaxFunction.INTEGER.value(0, 1));
+        assertEquals(Integer.valueOf(1), MaxFunction.INTEGER.value(1, -1));
 
-        Assert.assertEquals(Long.valueOf(2L), MaxFunction.LONG.value(1L, 2L));
-        Assert.assertEquals(Long.valueOf(1L), MaxFunction.LONG.value(0L, 1L));
-        Assert.assertEquals(Long.valueOf(1L), MaxFunction.LONG.value(1L, -1L));
+        assertEquals(Long.valueOf(2L), MaxFunction.LONG.value(1L, 2L));
+        assertEquals(Long.valueOf(1L), MaxFunction.LONG.value(0L, 1L));
+        assertEquals(Long.valueOf(1L), MaxFunction.LONG.value(1L, -1L));
     }
 
     @Test
     public void maxBlocksNull()
     {
-        Assert.assertSame(FORTY_TWO_DOUBLE, MaxFunction.DOUBLE.value(null, FORTY_TWO_DOUBLE));
-        Assert.assertSame(FORTY_TWO_DOUBLE, MaxFunction.DOUBLE.value(FORTY_TWO_DOUBLE, null));
-        Assert.assertSame(null, MaxFunction.DOUBLE.value(null, null));
+        assertSame(FORTY_TWO_DOUBLE, MaxFunction.DOUBLE.value(null, FORTY_TWO_DOUBLE));
+        assertSame(FORTY_TWO_DOUBLE, MaxFunction.DOUBLE.value(FORTY_TWO_DOUBLE, null));
+        assertSame(null, MaxFunction.DOUBLE.value(null, null));
 
-        Assert.assertSame(FORTY_TWO_INTEGER, MaxFunction.INTEGER.value(null, FORTY_TWO_INTEGER));
-        Assert.assertSame(FORTY_TWO_INTEGER, MaxFunction.INTEGER.value(FORTY_TWO_INTEGER, null));
-        Assert.assertSame(null, MaxFunction.INTEGER.value(null, null));
+        assertSame(FORTY_TWO_INTEGER, MaxFunction.INTEGER.value(null, FORTY_TWO_INTEGER));
+        assertSame(FORTY_TWO_INTEGER, MaxFunction.INTEGER.value(FORTY_TWO_INTEGER, null));
+        assertSame(null, MaxFunction.INTEGER.value(null, null));
 
-        Assert.assertSame(FORTY_TWO_LONG, MaxFunction.LONG.value(null, FORTY_TWO_LONG));
-        Assert.assertSame(FORTY_TWO_LONG, MaxFunction.LONG.value(FORTY_TWO_LONG, null));
-        Assert.assertSame(null, MaxFunction.LONG.value(null, null));
+        assertSame(FORTY_TWO_LONG, MaxFunction.LONG.value(null, FORTY_TWO_LONG));
+        assertSame(FORTY_TWO_LONG, MaxFunction.LONG.value(FORTY_TWO_LONG, null));
+        assertSame(null, MaxFunction.LONG.value(null, null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinSizeFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinSizeFunctionTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link MinSizeFunction}.
@@ -23,14 +24,14 @@ public class MinSizeFunctionTest
     @Test
     public void minSizeCollection()
     {
-        Assert.assertEquals(Integer.valueOf(2), MinSizeFunction.COLLECTION.value(2, FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(Integer.valueOf(2), MinSizeFunction.COLLECTION.value(3, FastList.newListWith(1, 2)));
+        assertEquals(Integer.valueOf(2), MinSizeFunction.COLLECTION.value(2, FastList.newListWith(1, 2, 3)));
+        assertEquals(Integer.valueOf(2), MinSizeFunction.COLLECTION.value(3, FastList.newListWith(1, 2)));
     }
 
     @Test
     public void minSizeMap()
     {
-        Assert.assertEquals(Integer.valueOf(2), MinSizeFunction.MAP.value(2, Maps.mutable.of(1, 1, 2, 2, 3, 3)));
-        Assert.assertEquals(Integer.valueOf(2), MinSizeFunction.MAP.value(3, Maps.mutable.of(1, 1, 2, 2)));
+        assertEquals(Integer.valueOf(2), MinSizeFunction.MAP.value(2, Maps.mutable.of(1, 1, 2, 2, 3, 3)));
+        assertEquals(Integer.valueOf(2), MinSizeFunction.MAP.value(3, Maps.mutable.of(1, 1, 2, 2)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
@@ -11,27 +11,28 @@
 package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class MultiplyFunctionTest
 {
     @Test
     public void integerBlock()
     {
-        Assert.assertEquals(Integer.valueOf(20), MultiplyFunction.INTEGER.value(2, 10));
+        assertEquals(Integer.valueOf(20), MultiplyFunction.INTEGER.value(2, 10));
     }
 
     @Test
     public void doubleBlock()
     {
-        Assert.assertEquals(new Double(20), MultiplyFunction.DOUBLE.value(2.0, 10.0));
+        assertEquals(new Double(20), MultiplyFunction.DOUBLE.value(2.0, 10.0));
     }
 
     @Test
     public void longBlock()
     {
-        Assert.assertEquals(Long.valueOf(20), MultiplyFunction.LONG.value(2L, 10L));
+        assertEquals(Long.valueOf(20), MultiplyFunction.LONG.value(2L, 10L));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/PrimitiveFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/PrimitiveFunctionsTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.DoubleHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.FloatHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link PrimitiveFunctions}.
@@ -27,11 +28,11 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxNumberToInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 IntHashSet.newSetWith(1, 2, 3),
                 UnifiedSet.newSetWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).collectInt(PrimitiveFunctions.unboxNumberToInt()));
 
-        Assert.assertEquals(
+        assertEquals(
                 IntHashSet.newSetWith(1, 2, 3),
                 UnifiedSet.newSetWith(1.1, 2.2, 3.3).collectInt(PrimitiveFunctions.unboxNumberToInt()));
     }
@@ -39,7 +40,7 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxNumberToFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashSet.newSetWith(1.0f, 2.0f, 3.0f),
                 UnifiedSet.newSetWith(1, 2, 3).collectFloat(PrimitiveFunctions.unboxNumberToFloat()));
     }
@@ -47,7 +48,7 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxNumberToLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LongHashSet.newSetWith(1L, 2L, 3L),
                 UnifiedSet.newSetWith(1, 2, 3).collectLong(PrimitiveFunctions.unboxNumberToLong()));
     }
@@ -55,7 +56,7 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxNumberToDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashSet.newSetWith(1.0, 2.0, 3.0),
                 UnifiedSet.newSetWith(1, 2, 3).collectDouble(PrimitiveFunctions.unboxNumberToDouble()));
     }
@@ -63,7 +64,7 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxDoubleToDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 DoubleHashSet.newSetWith(1.0, 2.0, 3.0),
                 UnifiedSet.newSetWith(Double.valueOf(1.0), Double.valueOf(2.0), Double.valueOf(3.0)).collectDouble(PrimitiveFunctions.unboxDoubleToDouble()));
     }
@@ -71,7 +72,7 @@ public class PrimitiveFunctionsTest
     @Test
     public void unboxFloatToFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FloatHashSet.newSetWith(1.0f, 2.0f, 3.0f),
                 UnifiedSet.newSetWith(Float.valueOf(1.0f), Float.valueOf(2.0f), Float.valueOf(3.0f)).collectFloat(PrimitiveFunctions.unboxFloatToFloat()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/StringFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/StringFunctionsTest.java
@@ -14,8 +14,14 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.block.factory.StringFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public final class StringFunctionsTest
 {
@@ -23,26 +29,26 @@ public final class StringFunctionsTest
     public void toUpperCase()
     {
         Function<String, String> function = StringFunctions.toUpperCase();
-        Assert.assertEquals("UPPER", function.valueOf("upper"));
-        Assert.assertEquals("UPPER", function.valueOf("Upper"));
-        Assert.assertEquals("UPPER", function.valueOf("UPPER"));
-        Assert.assertSame("UPPER", function.valueOf("UPPER"));
+        assertEquals("UPPER", function.valueOf("upper"));
+        assertEquals("UPPER", function.valueOf("Upper"));
+        assertEquals("UPPER", function.valueOf("UPPER"));
+        assertSame("UPPER", function.valueOf("UPPER"));
     }
 
     @Test
     public void toLowerCase()
     {
         Function<String, String> function = StringFunctions.toLowerCase();
-        Assert.assertEquals("lower", function.valueOf("LOWER"));
-        Assert.assertEquals("lower", function.valueOf("Lower"));
-        Assert.assertEquals("lower", function.valueOf("lower"));
-        Assert.assertSame("lower", function.valueOf("lower"));
+        assertEquals("lower", function.valueOf("LOWER"));
+        assertEquals("lower", function.valueOf("Lower"));
+        assertEquals("lower", function.valueOf("lower"));
+        assertSame("lower", function.valueOf("lower"));
     }
 
     @Test
     public void toInteger()
     {
-        Assert.assertEquals(-42L, StringFunctions.toInteger().valueOf("-42").longValue());
+        assertEquals(-42L, StringFunctions.toInteger().valueOf("-42").longValue());
         Verify.assertInstanceOf(Integer.class, StringFunctions.toInteger().valueOf("10"));
     }
 
@@ -50,30 +56,30 @@ public final class StringFunctionsTest
     public void length()
     {
         Function<String, Integer> function = StringFunctions.length();
-        Assert.assertEquals(Integer.valueOf(6), function.valueOf("string"));
-        Assert.assertEquals(Integer.valueOf(0), function.valueOf(""));
-        Assert.assertEquals("string.length()", function.toString());
+        assertEquals(Integer.valueOf(6), function.valueOf("string"));
+        assertEquals(Integer.valueOf(0), function.valueOf(""));
+        assertEquals("string.length()", function.toString());
     }
 
     @Test
     public void trim()
     {
         Function<String, String> function = StringFunctions.trim();
-        Assert.assertEquals("trim", function.valueOf("trim "));
-        Assert.assertEquals("trim", function.valueOf(" trim"));
-        Assert.assertEquals("trim", function.valueOf("  trim  "));
-        Assert.assertEquals("trim", function.valueOf("trim"));
-        Assert.assertSame("trim", function.valueOf("trim"));
-        Assert.assertEquals("string.trim()", function.toString());
+        assertEquals("trim", function.valueOf("trim "));
+        assertEquals("trim", function.valueOf(" trim"));
+        assertEquals("trim", function.valueOf("  trim  "));
+        assertEquals("trim", function.valueOf("trim"));
+        assertSame("trim", function.valueOf("trim"));
+        assertEquals("string.trim()", function.toString());
     }
 
     @Test
     public void firstLetter()
     {
         Function<String, Character> function = StringFunctions.firstLetter();
-        Assert.assertNull(function.valueOf(null));
-        Assert.assertNull(function.valueOf(""));
-        Assert.assertEquals('A', function.valueOf("Autocthonic").charValue());
+        assertNull(function.valueOf(null));
+        assertNull(function.valueOf(""));
+        assertEquals('A', function.valueOf("Autocthonic").charValue());
     }
 
     @Test
@@ -81,17 +87,17 @@ public final class StringFunctionsTest
     {
         Function<String, String> function1 = StringFunctions.subString(2, 5);
         String testString = "habits";
-        Assert.assertEquals("bit", function1.valueOf(testString));
+        assertEquals("bit", function1.valueOf(testString));
         Verify.assertContains("string.subString", function1.toString());
 
         Function<String, String> function2 = StringFunctions.subString(0, testString.length());
-        Assert.assertEquals(testString, function2.valueOf(testString));
+        assertEquals(testString, function2.valueOf(testString));
 
         Function<String, String> function3 = StringFunctions.subString(0, testString.length() + 1);
-        Assert.assertThrows(StringIndexOutOfBoundsException.class, () -> function3.valueOf(testString));
+        assertThrows(StringIndexOutOfBoundsException.class, () -> function3.valueOf(testString));
 
         Function<String, String> function4 = StringFunctions.subString(-1, 1);
-        Assert.assertThrows(StringIndexOutOfBoundsException.class, () -> function4.valueOf(testString));
+        assertThrows(StringIndexOutOfBoundsException.class, () -> function4.valueOf(testString));
     }
 
     @Test(expected = StringIndexOutOfBoundsException.class)
@@ -109,26 +115,26 @@ public final class StringFunctionsTest
     @Test
     public void toPrimitiveBoolean()
     {
-        Assert.assertTrue(StringFunctions.toPrimitiveBoolean().booleanValueOf("true"));
-        Assert.assertFalse(StringFunctions.toPrimitiveBoolean().booleanValueOf("nah"));
+        assertTrue(StringFunctions.toPrimitiveBoolean().booleanValueOf("true"));
+        assertFalse(StringFunctions.toPrimitiveBoolean().booleanValueOf("nah"));
     }
 
     @Test
     public void toPrimitiveByte()
     {
-        Assert.assertEquals((byte) 16, StringFunctions.toPrimitiveByte().byteValueOf("16"));
+        assertEquals((byte) 16, StringFunctions.toPrimitiveByte().byteValueOf("16"));
     }
 
     @Test
     public void toFirstChar()
     {
-        Assert.assertEquals('X', StringFunctions.toFirstChar().charValueOf("X-ray"));
+        assertEquals('X', StringFunctions.toFirstChar().charValueOf("X-ray"));
     }
 
     @Test
     public void toPrimitiveChar()
     {
-        Assert.assertEquals('A', StringFunctions.toPrimitiveChar().charValueOf("65"));
+        assertEquals('A', StringFunctions.toPrimitiveChar().charValueOf("65"));
     }
 
     @Test(expected = StringIndexOutOfBoundsException.class)
@@ -140,31 +146,31 @@ public final class StringFunctionsTest
     @Test
     public void toPrimitiveDouble()
     {
-        Assert.assertEquals(3.14159265359d, StringFunctions.toPrimitiveDouble().doubleValueOf("3.14159265359"), 0.0);
+        assertEquals(3.14159265359d, StringFunctions.toPrimitiveDouble().doubleValueOf("3.14159265359"), 0.0);
     }
 
     @Test
     public void toPrimitiveFloat()
     {
-        Assert.assertEquals(3.1415d, StringFunctions.toPrimitiveFloat().floatValueOf("3.1415"), 0.00001);
+        assertEquals(3.1415d, StringFunctions.toPrimitiveFloat().floatValueOf("3.1415"), 0.00001);
     }
 
     @Test
     public void toPrimitiveInt()
     {
-        Assert.assertEquals(256, StringFunctions.toPrimitiveInt().intValueOf("256"));
+        assertEquals(256, StringFunctions.toPrimitiveInt().intValueOf("256"));
     }
 
     @Test
     public void toPrimitiveLong()
     {
-        Assert.assertEquals(0x7fffffffffffffffL, StringFunctions.toPrimitiveLong().longValueOf("9223372036854775807"));
+        assertEquals(0x7fffffffffffffffL, StringFunctions.toPrimitiveLong().longValueOf("9223372036854775807"));
     }
 
     @Test
     public void toPrimitiveShort()
     {
-        Assert.assertEquals(-32768, StringFunctions.toPrimitiveShort().shortValueOf("-32768"));
+        assertEquals(-32768, StringFunctions.toPrimitiveShort().shortValueOf("-32768"));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/SubtractFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/SubtractFunctionTest.java
@@ -10,8 +10,9 @@
 
 package org.eclipse.collections.impl.block.function;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link SubtractFunction}.
@@ -21,24 +22,24 @@ public class SubtractFunctionTest
     @Test
     public void subtractIntegerFunction()
     {
-        Assert.assertEquals(Integer.valueOf(1), SubtractFunction.INTEGER.value(2, 1));
-        Assert.assertEquals(Integer.valueOf(0), SubtractFunction.INTEGER.value(1, 1));
-        Assert.assertEquals(Integer.valueOf(-1), SubtractFunction.INTEGER.value(1, 2));
+        assertEquals(Integer.valueOf(1), SubtractFunction.INTEGER.value(2, 1));
+        assertEquals(Integer.valueOf(0), SubtractFunction.INTEGER.value(1, 1));
+        assertEquals(Integer.valueOf(-1), SubtractFunction.INTEGER.value(1, 2));
     }
 
     @Test
     public void subtractDoubleFunction()
     {
-        Assert.assertEquals(Double.valueOf(0.5), SubtractFunction.DOUBLE.value(2.0, 1.5));
-        Assert.assertEquals(Double.valueOf(0), SubtractFunction.DOUBLE.value(2.0, 2.0));
-        Assert.assertEquals(Double.valueOf(-0.5), SubtractFunction.DOUBLE.value(1.5, 2.0));
+        assertEquals(Double.valueOf(0.5), SubtractFunction.DOUBLE.value(2.0, 1.5));
+        assertEquals(Double.valueOf(0), SubtractFunction.DOUBLE.value(2.0, 2.0));
+        assertEquals(Double.valueOf(-0.5), SubtractFunction.DOUBLE.value(1.5, 2.0));
     }
 
     @Test
     public void subtractLongFunction()
     {
-        Assert.assertEquals(Long.valueOf(1L), SubtractFunction.LONG.value(2L, 1L));
-        Assert.assertEquals(Long.valueOf(0L), SubtractFunction.LONG.value(1L, 1L));
-        Assert.assertEquals(Long.valueOf(-1L), SubtractFunction.LONG.value(1L, 2L));
+        assertEquals(Long.valueOf(1L), SubtractFunction.LONG.value(2L, 1L));
+        assertEquals(Long.valueOf(0L), SubtractFunction.LONG.value(1L, 1L));
+        assertEquals(Long.valueOf(-1L), SubtractFunction.LONG.value(1L, 2L));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/checked/CheckedFunction2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/checked/CheckedFunction2Test.java
@@ -10,15 +10,17 @@
 
 package org.eclipse.collections.impl.block.function.checked;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CheckedFunction2Test
 {
     @Test
     public void value()
     {
-        Assert.assertEquals((Integer) 50, new CheckedFunction2<Integer, Integer, Integer>()
+        assertEquals((Integer) 50, new CheckedFunction2<Integer, Integer, Integer>()
         {
             @Override
             public Integer safeValue(Integer argument1, Integer argument2)
@@ -31,7 +33,7 @@ public class CheckedFunction2Test
     @Test
     public void exceptionHandling()
     {
-        Assert.assertThrows(RuntimeException.class, () -> new CheckedFunction2<Integer, Integer, Integer>()
+        assertThrows(RuntimeException.class, () -> new CheckedFunction2<Integer, Integer, Integer>()
         {
             @Override
             public Integer safeValue(Integer argument1, Integer argument2) throws Exception

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/BooleanCaseFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/BooleanCaseFunctionTest.java
@@ -12,8 +12,11 @@ package org.eclipse.collections.impl.block.function.primitive;
 
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class BooleanCaseFunctionTest
 {
@@ -21,7 +24,7 @@ public class BooleanCaseFunctionTest
     public void noopCase()
     {
         BooleanToObjectFunction<Boolean> function = new BooleanCaseFunction<>();
-        Assert.assertNull(function.valueOf(true));
+        assertNull(function.valueOf(true));
     }
 
     @Test
@@ -29,7 +32,7 @@ public class BooleanCaseFunctionTest
     {
         BooleanCaseFunction<Boolean> function = new BooleanCaseFunction<>();
         function.addCase(value -> value, Boolean::valueOf);
-        Assert.assertEquals(Boolean.valueOf(true), function.valueOf(true));
+        assertEquals(Boolean.valueOf(true), function.valueOf(true));
     }
 
     @Test
@@ -38,12 +41,12 @@ public class BooleanCaseFunctionTest
         BooleanCaseFunction<String> function = new BooleanCaseFunction<>(e -> "Yow!")
                 .addCase(e -> e, e -> "Patience, grasshopper");
 
-        Assert.assertEquals("Yow!", function.valueOf(false));
+        assertEquals("Yow!", function.valueOf(false));
 
         BooleanCaseFunction<String> function1 = function.setDefault(i -> "Patience, young grasshopper");
-        Assert.assertSame(function, function1);
-        Assert.assertEquals("Patience, grasshopper", function.valueOf(true));
-        Assert.assertEquals("Patience, young grasshopper", function.valueOf(false));
+        assertSame(function, function1);
+        assertEquals("Patience, grasshopper", function.valueOf(true));
+        assertEquals("Patience, young grasshopper", function.valueOf(false));
 
         Verify.assertContains("BooleanCaseFunction", function.toString());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/CharFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/CharFunctionTest.java
@@ -10,8 +10,9 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link CharFunction}.
@@ -24,16 +25,16 @@ public class CharFunctionTest
     @Test
     public void toUppercase()
     {
-        Assert.assertEquals('A', CharFunction.TO_UPPERCASE.valueOf('a'));
-        Assert.assertEquals('A', CharFunction.TO_UPPERCASE.valueOf('A'));
-        Assert.assertEquals('1', CharFunction.TO_UPPERCASE.valueOf('1'));
+        assertEquals('A', CharFunction.TO_UPPERCASE.valueOf('a'));
+        assertEquals('A', CharFunction.TO_UPPERCASE.valueOf('A'));
+        assertEquals('1', CharFunction.TO_UPPERCASE.valueOf('1'));
     }
 
     @Test
     public void toLowercase()
     {
-        Assert.assertEquals('a', CharFunction.TO_LOWERCASE.valueOf('a'));
-        Assert.assertEquals('a', CharFunction.TO_LOWERCASE.valueOf('A'));
-        Assert.assertEquals('1', CharFunction.TO_LOWERCASE.valueOf('1'));
+        assertEquals('a', CharFunction.TO_LOWERCASE.valueOf('a'));
+        assertEquals('a', CharFunction.TO_LOWERCASE.valueOf('A'));
+        assertEquals('1', CharFunction.TO_LOWERCASE.valueOf('1'));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/DoubleFunctionImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/DoubleFunctionImplTest.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class DoubleFunctionImplTest
 {
@@ -20,8 +22,8 @@ public final class DoubleFunctionImplTest
     @Test
     public void testValueOf()
     {
-        Assert.assertSame(new TestDoubleFunctionImpl(0.0d).valueOf(JUNK), new TestDoubleFunctionImpl(0.0d).valueOf(JUNK));
-        Assert.assertEquals(Double.valueOf(1.0d), new TestDoubleFunctionImpl(1.0d).valueOf(JUNK));
+        assertSame(new TestDoubleFunctionImpl(0.0d).valueOf(JUNK), new TestDoubleFunctionImpl(0.0d).valueOf(JUNK));
+        assertEquals(Double.valueOf(1.0d), new TestDoubleFunctionImpl(1.0d).valueOf(JUNK));
     }
 
     private static final class TestDoubleFunctionImpl extends DoubleFunctionImpl<Object>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/LongFunctionImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/LongFunctionImplTest.java
@@ -10,8 +10,9 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Junit test for {@link LongFunctionImpl}.
@@ -29,7 +30,7 @@ public class LongFunctionImplTest
             }
         };
 
-        Assert.assertEquals(1L, longFunction.longValueOf(1L));
-        Assert.assertEquals(1L, longFunction.valueOf(1L).longValue());
+        assertEquals(1L, longFunction.longValueOf(1L));
+        assertEquals(1L, longFunction.valueOf(1L).longValue());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicateTest.java
@@ -12,8 +12,10 @@ package org.eclipse.collections.impl.block.predicate;
 
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MapEntryPredicateTest
 {
@@ -49,7 +51,7 @@ public class MapEntryPredicateTest
                 return String.valueOf(argument2).equals(argument1);
             }
         };
-        Assert.assertTrue(mapEntryPredicate.accept(this.entry));
+        assertTrue(mapEntryPredicate.accept(this.entry));
     }
 
     @Test
@@ -63,9 +65,9 @@ public class MapEntryPredicateTest
                 return String.valueOf(argument2).equals(argument1);
             }
         };
-        Assert.assertFalse(mapEntryPredicate.negate().accept(this.entry));
-        Assert.assertFalse(mapEntryPredicate.negate().accept("1", 1));
-        Assert.assertTrue(mapEntryPredicate.negate().accept(new Map.Entry<String, Integer>()
+        assertFalse(mapEntryPredicate.negate().accept(this.entry));
+        assertFalse(mapEntryPredicate.negate().accept("1", 1));
+        assertTrue(mapEntryPredicate.negate().accept(new Map.Entry<String, Integer>()
         {
             @Override
             public String getKey()
@@ -85,6 +87,6 @@ public class MapEntryPredicateTest
                 return null;
             }
         }));
-        Assert.assertTrue(mapEntryPredicate.negate().accept("1", 2));
+        assertTrue(mapEntryPredicate.negate().accept("1", 2));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/PairPredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/PairPredicateTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.impl.block.predicate;
 
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PairPredicateTest
 {
@@ -28,8 +30,8 @@ public class PairPredicateTest
             }
         };
 
-        Assert.assertTrue(pairPredicate.accept(Tuples.pair("1", 1)));
-        Assert.assertFalse(pairPredicate.accept(Tuples.pair("2", 1)));
+        assertTrue(pairPredicate.accept(Tuples.pair("1", 1)));
+        assertFalse(pairPredicate.accept(Tuples.pair("2", 1)));
     }
 
     @Test
@@ -45,9 +47,9 @@ public class PairPredicateTest
         };
 
         PairPredicate<String, String> negatedPredicate = pairPredicate.negate();
-        Assert.assertFalse(negatedPredicate.accept(Tuples.pair("1", "1")));
-        Assert.assertFalse(negatedPredicate.accept("1", "1"));
-        Assert.assertTrue(negatedPredicate.accept(Tuples.pair("2", "1")));
-        Assert.assertTrue(negatedPredicate.accept("2", "1"));
+        assertFalse(negatedPredicate.accept(Tuples.pair("1", "1")));
+        assertFalse(negatedPredicate.accept("1", "1"));
+        assertTrue(negatedPredicate.accept(Tuples.pair("2", "1")));
+        assertTrue(negatedPredicate.accept("2", "1"));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AdaptObjectIntProcedureToProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AdaptObjectIntProcedureToProcedureTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class AdaptObjectIntProcedureToProcedureTest
 {
@@ -24,16 +25,16 @@ public class AdaptObjectIntProcedureToProcedureTest
         Procedure<Integer> procedure =
                 new AdaptObjectIntProcedureToProcedure<>(mockObjectIntProcedure);
         procedure.value(1);
-        Assert.assertEquals(1, mockObjectIntProcedure.getEachValue());
-        Assert.assertEquals(0, mockObjectIntProcedure.getParameterValue());
+        assertEquals(1, mockObjectIntProcedure.getEachValue());
+        assertEquals(0, mockObjectIntProcedure.getParameterValue());
 
         procedure.value(2);
-        Assert.assertEquals(2, mockObjectIntProcedure.getEachValue());
-        Assert.assertEquals(1, mockObjectIntProcedure.getParameterValue());
+        assertEquals(2, mockObjectIntProcedure.getEachValue());
+        assertEquals(1, mockObjectIntProcedure.getParameterValue());
 
         procedure.value(3);
-        Assert.assertEquals(3, mockObjectIntProcedure.getEachValue());
-        Assert.assertEquals(2, mockObjectIntProcedure.getParameterValue());
+        assertEquals(3, mockObjectIntProcedure.getEachValue());
+        assertEquals(2, mockObjectIntProcedure.getParameterValue());
     }
 
     private static class MockObjectIntProcedure

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/BagAddOccurrencesProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/BagAddOccurrencesProcedureTest.java
@@ -13,8 +13,11 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class BagAddOccurrencesProcedureTest
 {
@@ -28,9 +31,9 @@ public class BagAddOccurrencesProcedureTest
         procedure.value("fred", 1);
         procedure.value("mary", 3);
 
-        Assert.assertEquals(2, procedure.getResult().occurrencesOf("fred"));
-        Assert.assertEquals(3, procedure.getResult().occurrencesOf("mary"));
-        Assert.assertEquals(0, procedure.getResult().occurrencesOf("other"));
+        assertEquals(2, procedure.getResult().occurrencesOf("fred"));
+        assertEquals(3, procedure.getResult().occurrencesOf("mary"));
+        assertEquals(0, procedure.getResult().occurrencesOf("other"));
     }
 
     @Test
@@ -43,9 +46,9 @@ public class BagAddOccurrencesProcedureTest
         procedure.value("fred", 1);
         procedure.value("mary", 3);
 
-        Assert.assertEquals(2, procedure.getResult().occurrencesOf("fred"));
-        Assert.assertEquals(3, procedure.getResult().occurrencesOf("mary"));
-        Assert.assertEquals(0, procedure.getResult().occurrencesOf("other"));
+        assertEquals(2, procedure.getResult().occurrencesOf("fred"));
+        assertEquals(3, procedure.getResult().occurrencesOf("mary"));
+        assertEquals(0, procedure.getResult().occurrencesOf("other"));
     }
 
     @Test
@@ -54,7 +57,7 @@ public class BagAddOccurrencesProcedureTest
         MutableBag<String> targetCollection = Bags.mutable.empty();
         BagAddOccurrencesProcedure<String> procedure = BagAddOccurrencesProcedure.on(targetCollection);
         String toString = procedure.toString();
-        Assert.assertNotNull(toString);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(toString));
+        assertNotNull(toString);
+        assertTrue(StringIterate.notEmptyOrWhitespace(toString));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CaseProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CaseProcedureTest.java
@@ -16,8 +16,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class CaseProcedureTest
 {
@@ -29,9 +31,9 @@ public class CaseProcedureTest
         CaseProcedure<String> procedure = new CaseProcedure<>();
         strings.each(procedure);
         Verify.assertEmpty(result);
-        Verify.assertSame(procedure, procedure.setDefault(result::add));
+        assertSame(procedure, procedure.setDefault(result::add));
         strings.each(procedure);
-        Assert.assertEquals(result, strings);
+        assertEquals(result, strings);
         Verify.assertContains("CaseProcedure", procedure.toString());
     }
 
@@ -45,8 +47,8 @@ public class CaseProcedureTest
                 new CaseProcedure<String>(defaultList::add)
                         .addCase("1"::equals, ifOneList::add);
         list.each(procedure);
-        Assert.assertEquals(FastList.newListWith("1"), ifOneList);
-        Assert.assertEquals(FastList.newListWith("2"), defaultList);
+        assertEquals(FastList.newListWith("1"), ifOneList);
+        assertEquals(FastList.newListWith("2"), defaultList);
         Verify.assertContains("CaseProcedure", procedure.toString());
     }
 
@@ -61,8 +63,8 @@ public class CaseProcedureTest
                         .addCase("1"::equals, ifOneList::add)
                         .addCase("2"::equals, ifTwoList::add);
         list.each(procedure);
-        Assert.assertEquals(FastList.newListWith("1"), ifOneList);
-        Assert.assertEquals(FastList.newListWith("2"), ifTwoList);
+        assertEquals(FastList.newListWith("1"), ifOneList);
+        assertEquals(FastList.newListWith("2"), ifTwoList);
         Verify.assertContains("CaseProcedure", procedure.toString());
     }
 
@@ -78,9 +80,9 @@ public class CaseProcedureTest
                         .addCase("1"::equals, ifOneList::add)
                         .addCase("2"::equals, ifTwoList::add);
         list.each(procedure);
-        Assert.assertEquals(FastList.newListWith("1"), ifOneList);
-        Assert.assertEquals(FastList.newListWith("2"), ifTwoList);
-        Assert.assertEquals(FastList.newListWith("3", "4"), defaultList);
+        assertEquals(FastList.newListWith("1"), ifOneList);
+        assertEquals(FastList.newListWith("2"), ifTwoList);
+        assertEquals(FastList.newListWith("3", "4"), defaultList);
         Verify.assertContains("CaseProcedure", procedure.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ChainedProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ChainedProcedureTest.java
@@ -17,8 +17,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ChainedProcedureTest
 {
@@ -34,8 +37,8 @@ public class ChainedProcedureTest
         MutableList<String> list = FastList.newListWith("1", "2");
         Iterate.forEach(list, chainedProcedure);
 
-        Assert.assertEquals(list, list1);
-        Assert.assertEquals(list, list2);
+        assertEquals(list, list1);
+        assertEquals(list, list2);
     }
 
     @Test
@@ -43,8 +46,8 @@ public class ChainedProcedureTest
     {
         Procedure<String> procedure = new CollectionAddProcedure<>(Lists.mutable.of());
         String s = procedure.toString();
-        Assert.assertNotNull(s);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(s));
+        assertNotNull(s);
+        assertTrue(StringIterate.notEmptyOrWhitespace(s));
         Verify.assertContains("ChainedProcedure.with", new ChainedProcedure<>().toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectIfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectIfProcedureTest.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CollectIfProcedureTest
 {
@@ -24,7 +26,7 @@ public class CollectIfProcedureTest
         CollectIfProcedure<Integer, String> underTestFalse = new CollectIfProcedure<>(10, String::valueOf, ignored -> false);
         underTestTrue.value(THE_ANSWER);
         underTestFalse.value(THE_ANSWER);
-        Assert.assertTrue(underTestTrue.getCollection().contains("42"));
-        Assert.assertFalse(underTestFalse.getCollection().contains("42"));
+        assertTrue(underTestTrue.getCollection().contains("42"));
+        assertFalse(underTestFalse.getCollection().contains("42"));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionAddProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionAddProcedureTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CollectionAddProcedureTest
 {
@@ -23,8 +25,8 @@ public class CollectionAddProcedureTest
     {
         CollectionAddProcedure<Integer> procedure = new CollectionAddProcedure<>(Lists.mutable.empty());
         String s = procedure.toString();
-        Assert.assertNotNull(s);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(s));
+        assertNotNull(s);
+        assertTrue(StringIterate.notEmptyOrWhitespace(s));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
@@ -13,8 +13,11 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CollectionRemoveProcedureTest
 {
@@ -34,8 +37,8 @@ public class CollectionRemoveProcedureTest
     {
         CollectionRemoveProcedure<Integer> procedure = CollectionRemoveProcedure.on(Lists.mutable.with(1, 2));
         String s = procedure.toString();
-        Assert.assertNotNull(s);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(s));
-        Assert.assertEquals("Collection.remove()", s);
+        assertNotNull(s);
+        assertTrue(StringIterate.notEmptyOrWhitespace(s));
+        assertEquals("Collection.remove()", s);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CounterProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CounterProcedureTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class CounterProcedureTest
 {
@@ -22,15 +26,15 @@ public class CounterProcedureTest
     {
         MockProcedure mockProcedure = new MockProcedure();
         CounterProcedure<Integer> procedure = new CounterProcedure<>(mockProcedure);
-        Assert.assertNull(mockProcedure.getValue());
-        Assert.assertEquals(0, procedure.getCount());
+        assertNull(mockProcedure.getValue());
+        assertEquals(0, procedure.getCount());
         procedure.value(1);
-        Assert.assertEquals(1, (int) mockProcedure.getValue());
-        Assert.assertEquals(1, procedure.getCount());
+        assertEquals(1, (int) mockProcedure.getValue());
+        assertEquals(1, procedure.getCount());
 
         procedure.value(2);
-        Assert.assertEquals(2, (int) mockProcedure.getValue());
-        Assert.assertEquals(2, procedure.getCount());
+        assertEquals(2, (int) mockProcedure.getValue());
+        assertEquals(2, procedure.getCount());
     }
 
     @Test
@@ -39,8 +43,8 @@ public class CounterProcedureTest
         MockProcedure mockProcedure = new MockProcedure();
         CounterProcedure<Integer> procedure = new CounterProcedure<>(mockProcedure);
         String s = procedure.toString();
-        Assert.assertNotNull(s);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(s));
+        assertNotNull(s);
+        assertTrue(StringIterate.notEmptyOrWhitespace(s));
     }
 
     private static class MockProcedure implements Procedure<Integer>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectIfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectIfProcedureTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FastListCollectIfProcedureTest
 {
@@ -37,6 +38,6 @@ public class FastListCollectIfProcedureTest
 
         String twelve = "twelve";
         procedure.value(Tuples.pair(12, twelve));
-        Assert.assertEquals(Lists.mutable.of(eleven, twelve), procedure.getFastList());
+        assertEquals(Lists.mutable.of(eleven, twelve), procedure.getFastList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectProcedureTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FastListCollectProcedureTest
 {
@@ -30,6 +31,6 @@ public class FastListCollectProcedureTest
         procedure.value(Tuples.pair(2, "two"));
         procedure.value(Tuples.pair(3, "three"));
 
-        Assert.assertEquals(Lists.mutable.of(1, 2, 3), procedure.getFastList());
+        assertEquals(Lists.mutable.of(1, 2, 3), procedure.getFastList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListRejectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListRejectProcedureTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FastListRejectProcedureTest
 {
@@ -28,6 +29,6 @@ public class FastListRejectProcedureTest
         procedure.value(10);
         procedure.value(20);
 
-        Assert.assertEquals(Lists.mutable.of(0, 1), procedure.getFastList());
+        assertEquals(Lists.mutable.of(0, 1), procedure.getFastList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListSelectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListSelectProcedureTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FastListSelectProcedureTest
 {
@@ -28,6 +29,6 @@ public class FastListSelectProcedureTest
         procedure.value(10);
         procedure.value(20);
 
-        Assert.assertEquals(Lists.mutable.of(10, 20), procedure.getFastList());
+        assertEquals(Lists.mutable.of(10, 20), procedure.getFastList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FlatCollectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FlatCollectProcedureTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FlatCollectProcedureTest
 {
@@ -27,6 +28,6 @@ public class FlatCollectProcedureTest
         procedure.value(1);
         procedure.value(2);
         procedure.value(3);
-        Assert.assertEquals(Lists.mutable.of(0, 1, 0, 1, 2, 0, 1, 2, 3), procedure.getCollection());
+        assertEquals(Lists.mutable.of(0, 1, 0, 1, 2, 0, 1, 2, 3), procedure.getCollection());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/IfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/IfProcedureTest.java
@@ -17,10 +17,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class IfProcedureTest
 {
@@ -35,9 +38,9 @@ public class IfProcedureTest
         LOGGER.info("{}", ifProcedure);
         MutableList<String> list = FastList.newListWith("1", "2");
         Iterate.forEach(list, ifProcedure);
-        Assert.assertEquals(1, list1.size());
+        assertEquals(1, list1.size());
         Verify.assertContains("1", list1);
-        Assert.assertEquals(1, list2.size());
+        assertEquals(1, list2.size());
         Verify.assertContains("2", list2);
     }
 
@@ -48,7 +51,7 @@ public class IfProcedureTest
         MutableList<String> list2 = Lists.mutable.of();
         Procedure<String> ifProcedure = new IfProcedure<>("1"::equals, list1::add, list2::add);
         String s = ifProcedure.toString();
-        Assert.assertNotNull(s);
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(s));
+        assertNotNull(s);
+        assertTrue(StringIterate.notEmptyOrWhitespace(s));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxByProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxByProcedureTest.java
@@ -13,8 +13,12 @@ package org.eclipse.collections.impl.block.procedure;
 import java.util.Optional;
 
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MaxByProcedureTest
 {
@@ -22,27 +26,27 @@ public class MaxByProcedureTest
     public void visitedAtLeastOnce()
     {
         MaxByProcedure<Integer, Integer> procedure = new MaxByProcedure<>(Functions.getPassThru());
-        Assert.assertFalse(procedure.isVisitedAtLeastOnce());
+        assertFalse(procedure.isVisitedAtLeastOnce());
         procedure.value(1);
-        Assert.assertTrue(procedure.isVisitedAtLeastOnce());
+        assertTrue(procedure.isVisitedAtLeastOnce());
         procedure.value(2);
-        Assert.assertTrue(procedure.isVisitedAtLeastOnce());
+        assertTrue(procedure.isVisitedAtLeastOnce());
     }
 
     @Test
     public void getResultOptional()
     {
         MaxByProcedure<Integer, Integer> procedure = new MaxByProcedure<>(Functions.getPassThru());
-        Assert.assertFalse(procedure.getResultOptional().isPresent());
+        assertFalse(procedure.getResultOptional().isPresent());
         procedure.value(2);
         Optional<Integer> resultOptional = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 2, resultOptional.get());
 
         procedure.value(1);
         Optional<Integer> resultOptional2 = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional2.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional2.get());
+        assertTrue(resultOptional2.isPresent());
+        assertEquals((Integer) 2, resultOptional2.get());
     }
 
     @Test
@@ -51,15 +55,15 @@ public class MaxByProcedureTest
         MaxByProcedure<Integer, Integer> procedure = new MaxByProcedure<>(Functions.getPassThru());
         Integer first = new Integer(1);
         procedure.value(first);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer second = new Integer(1);
         procedure.value(second);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer third = new Integer(3);
         procedure.value(third);
-        Assert.assertSame(third, procedure.getResult());
+        assertSame(third, procedure.getResult());
         Integer fourth = new Integer(0);
         procedure.value(fourth);
-        Assert.assertSame(third, procedure.getResult());
+        assertSame(third, procedure.getResult());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxProcedureTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import java.util.Optional;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MaxProcedureTest
 {
@@ -21,16 +25,16 @@ public class MaxProcedureTest
     public void getResultOptional()
     {
         MaxProcedure<Integer> procedure = new MaxProcedure<>();
-        Assert.assertFalse(procedure.getResultOptional().isPresent());
+        assertFalse(procedure.getResultOptional().isPresent());
         procedure.value(2);
         Optional<Integer> resultOptional = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 2, resultOptional.get());
 
         procedure.value(1);
         Optional<Integer> resultOptional2 = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional2.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional2.get());
+        assertTrue(resultOptional2.isPresent());
+        assertEquals((Integer) 2, resultOptional2.get());
     }
 
     @Test
@@ -39,15 +43,15 @@ public class MaxProcedureTest
         MaxProcedure<Integer> procedure = new MaxProcedure<>();
         Integer first = new Integer(1);
         procedure.value(first);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer second = new Integer(1);
         procedure.value(second);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer third = new Integer(3);
         procedure.value(third);
-        Assert.assertSame(third, procedure.getResult());
+        assertSame(third, procedure.getResult());
         Integer fourth = new Integer(0);
         procedure.value(fourth);
-        Assert.assertSame(third, procedure.getResult());
+        assertSame(third, procedure.getResult());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinByProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinByProcedureTest.java
@@ -13,8 +13,12 @@ package org.eclipse.collections.impl.block.procedure;
 import java.util.Optional;
 
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MinByProcedureTest
 {
@@ -22,27 +26,27 @@ public class MinByProcedureTest
     public void visitedAtLeastOnce()
     {
         MinByProcedure<Integer, Integer> procedure = new MinByProcedure<>(Functions.getPassThru());
-        Assert.assertFalse(procedure.isVisitedAtLeastOnce());
+        assertFalse(procedure.isVisitedAtLeastOnce());
         procedure.value(1);
-        Assert.assertTrue(procedure.isVisitedAtLeastOnce());
+        assertTrue(procedure.isVisitedAtLeastOnce());
         procedure.value(2);
-        Assert.assertTrue(procedure.isVisitedAtLeastOnce());
+        assertTrue(procedure.isVisitedAtLeastOnce());
     }
 
     @Test
     public void getResultOptional()
     {
         MinByProcedure<Integer, Integer> procedure = new MinByProcedure<>(Functions.getPassThru());
-        Assert.assertFalse(procedure.getResultOptional().isPresent());
+        assertFalse(procedure.getResultOptional().isPresent());
         procedure.value(2);
         Optional<Integer> resultOptional = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 2, resultOptional.get());
 
         procedure.value(1);
         Optional<Integer> resultOptional2 = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional2.isPresent());
-        Assert.assertEquals((Integer) 1, resultOptional2.get());
+        assertTrue(resultOptional2.isPresent());
+        assertEquals((Integer) 1, resultOptional2.get());
     }
 
     @Test
@@ -51,15 +55,15 @@ public class MinByProcedureTest
         MinByProcedure<Integer, Integer> procedure = new MinByProcedure<>(Functions.getPassThru());
         Integer first = new Integer(1);
         procedure.value(first);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer second = new Integer(1);
         procedure.value(second);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer third = new Integer(3);
         procedure.value(third);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer fourth = new Integer(0);
         procedure.value(fourth);
-        Assert.assertSame(fourth, procedure.getResult());
+        assertSame(fourth, procedure.getResult());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinComparatorProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinComparatorProcedureTest.java
@@ -11,8 +11,9 @@
 package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
 
 public class MinComparatorProcedureTest
 {
@@ -26,12 +27,12 @@ public class MinComparatorProcedureTest
         Integer fourth = new Integer(0);
 
         procedure.value(first);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         procedure.value(second);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         procedure.value(third);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         procedure.value(fourth);
-        Assert.assertSame(fourth, procedure.getResult());
+        assertSame(fourth, procedure.getResult());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinProcedureTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import java.util.Optional;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MinProcedureTest
 {
@@ -21,16 +25,16 @@ public class MinProcedureTest
     public void getResultOptional()
     {
         MinProcedure<Integer> procedure = new MinProcedure<>();
-        Assert.assertFalse(procedure.getResultOptional().isPresent());
+        assertFalse(procedure.getResultOptional().isPresent());
         procedure.value(2);
         Optional<Integer> resultOptional = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 2, resultOptional.get());
 
         procedure.value(1);
         Optional<Integer> resultOptional2 = procedure.getResultOptional();
-        Assert.assertTrue(resultOptional2.isPresent());
-        Assert.assertEquals((Integer) 1, resultOptional2.get());
+        assertTrue(resultOptional2.isPresent());
+        assertEquals((Integer) 1, resultOptional2.get());
     }
 
     @Test
@@ -39,15 +43,15 @@ public class MinProcedureTest
         MinProcedure<Integer> procedure = new MinProcedure<>();
         Integer first = new Integer(1);
         procedure.value(first);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer second = new Integer(1);
         procedure.value(second);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer third = new Integer(3);
         procedure.value(third);
-        Assert.assertSame(first, procedure.getResult());
+        assertSame(first, procedure.getResult());
         Integer fourth = new Integer(0);
         procedure.value(fourth);
-        Assert.assertSame(fourth, procedure.getResult());
+        assertSame(fourth, procedure.getResult());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ObjectIntProceduresTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ObjectIntProceduresTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.ObjectIntProcedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ObjectIntProceduresTest
 {
@@ -26,7 +27,7 @@ public class ObjectIntProceduresTest
         MutableList<Integer> result = FastList.newList();
         ObjectIntProcedure<Integer> objectIntProcedure = ObjectIntProcedures.fromProcedure(result::add);
         objectIntProcedure.value(1, 0);
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/Procedures2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/Procedures2Test.java
@@ -25,8 +25,10 @@ import org.eclipse.collections.impl.block.procedure.checked.ThrowingProcedure2;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class Procedures2Test
 {
@@ -50,7 +52,7 @@ public class Procedures2Test
                 PrimitiveTuples.pair(object.intValue(), parameter.intValue()));
 
         Procedures2.throwing(throwingProcedure2).value(2, 3);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(2, 3)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(2, 3)), list);
     }
 
     @Test
@@ -74,7 +76,7 @@ public class Procedures2Test
                             throw new IOException();
                         },
                         this::throwMyException).value(null, null));
-        Assert.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () -> Procedures2.throwing(
                         (one, two) ->
@@ -95,7 +97,7 @@ public class Procedures2Test
         CollectionAddProcedure<Integer> procedure = CollectionAddProcedure.on(FastList.newList());
         Procedure2<Integer, Object> procedure2 = Procedures2.fromProcedure(procedure);
         procedure2.value(1, null);
-        Assert.assertEquals(FastList.newListWith(1), procedure.getResult());
+        assertEquals(FastList.newListWith(1), procedure.getResult());
     }
 
     @Test
@@ -124,8 +126,8 @@ public class Procedures2Test
                 DoubleSummaryStatistics::new,
                 Procedures2.summarizeDouble(Double::doubleValue));
         Verify.assertSize(2, map);
-        Assert.assertEquals(6.0, map.get("2.0").getSum(), 0.0);
-        Assert.assertEquals(9.0, map.get("3.0").getSum(), 0.0);
+        assertEquals(6.0, map.get("2.0").getSum(), 0.0);
+        assertEquals(9.0, map.get("3.0").getSum(), 0.0);
     }
 
     /**
@@ -140,8 +142,8 @@ public class Procedures2Test
                 DoubleSummaryStatistics::new,
                 Procedures2.summarizeFloat(Float::floatValue));
         Verify.assertSize(2, map);
-        Assert.assertEquals(6.0, map.get("2.0").getSum(), 0.0);
-        Assert.assertEquals(9.0, map.get("3.0").getSum(), 0.0);
+        assertEquals(6.0, map.get("2.0").getSum(), 0.0);
+        assertEquals(9.0, map.get("3.0").getSum(), 0.0);
     }
 
     /**
@@ -156,8 +158,8 @@ public class Procedures2Test
                 LongSummaryStatistics::new,
                 Procedures2.summarizeLong(Long::longValue));
         Verify.assertSize(2, map);
-        Assert.assertEquals(6, map.get("2").getSum());
-        Assert.assertEquals(9, map.get("3").getSum());
+        assertEquals(6, map.get("2").getSum());
+        assertEquals(9, map.get("3").getSum());
     }
 
     /**
@@ -172,7 +174,7 @@ public class Procedures2Test
                 IntSummaryStatistics::new,
                 Procedures2.summarizeInt(Integer::intValue));
         Verify.assertSize(2, map);
-        Assert.assertEquals(6, map.get("2").getSum());
-        Assert.assertEquals(9, map.get("3").getSum());
+        assertEquals(6, map.get("2").getSum());
+        assertEquals(9, map.get("3").getSum());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ProceduresTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ProceduresTest.java
@@ -30,8 +30,12 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 public class ProceduresTest
 {
@@ -50,7 +54,7 @@ public class ProceduresTest
         StringBuilder builder = new StringBuilder("a");
         ThrowingProcedure<StringBuilder> throwingProcedure = stringBuilder -> stringBuilder.append("Visited");
         Procedures.throwing(throwingProcedure).value(builder);
-        Assert.assertEquals("aVisited", builder.toString());
+        assertEquals("aVisited", builder.toString());
     }
 
     @Test
@@ -70,7 +74,7 @@ public class ProceduresTest
                         a -> { throw new IOException(); },
                         this::throwMyException)
                         .value(null));
-        Verify.assertThrows(
+        assertThrows(
                 NullPointerException.class,
                 () -> Procedures.throwing(
                         a -> { throw new NullPointerException(); },
@@ -104,8 +108,8 @@ public class ProceduresTest
         appender.value(1);
         appender.value(2);
         appender.value(3);
-        Assert.assertEquals("init123", appendable.toString());
-        Assert.assertEquals("init123", appender.toString());
+        assertEquals("init123", appendable.toString());
+        assertEquals("init123", appender.toString());
     }
 
     @Test(expected = RuntimeException.class)
@@ -145,7 +149,7 @@ public class ProceduresTest
         Procedure<String> procedure = Procedures.fromObjectIntProcedure(objectIntProcedure);
         numberStrings.forEach(procedure);
 
-        Assert.assertEquals(expectedResults, actualResults);
+        assertEquals(expectedResults, actualResults);
     }
 
     @Test
@@ -156,7 +160,7 @@ public class ProceduresTest
                 Procedures.fromObjectIntProcedure((each, parameter) -> list.add(PrimitiveTuples.pair(each, parameter)));
         procedure.value("strOne");
         procedure.value("strTwo");
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair("strOne", 0),
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair("strOne", 0),
                 PrimitiveTuples.pair("strTwo", 1)), list);
     }
 
@@ -165,7 +169,7 @@ public class ProceduresTest
     {
         Procedure<Object> noop = Procedures.noop();
         noop.value("abc");
-        Assert.assertNotNull(noop);
+        assertNotNull(noop);
     }
 
     @Test
@@ -175,7 +179,7 @@ public class ProceduresTest
         integers.add(null);
         MutableList<Integer> result = Lists.mutable.of();
         integers.forEach(Procedures.synchronizedEach(CollectionAddProcedure.on(result)));
-        Assert.assertEquals(result, integers);
+        assertEquals(result, integers);
     }
 
     @Test
@@ -197,7 +201,7 @@ public class ProceduresTest
     {
         Procedure<Object> defaultBlock = each -> { throw new BlockCalledException(); };
         CaseProcedure<Object> undertest = Procedures.caseDefault(defaultBlock);
-        Verify.assertThrows(BlockCalledException.class, () -> undertest.value(1));
+        assertThrows(BlockCalledException.class, () -> undertest.value(1));
     }
 
     @Test
@@ -205,7 +209,7 @@ public class ProceduresTest
     {
         Procedure<Object> caseBlock = each -> { throw new BlockCalledException(); };
         CaseProcedure<Object> undertest = Procedures.caseDefault(DoNothingProcedure.DO_NOTHING, ignored -> true, caseBlock);
-        Verify.assertThrows(BlockCalledException.class, () -> undertest.value(1));
+        assertThrows(BlockCalledException.class, () -> undertest.value(1));
     }
 
     private static final class TestPrintStream
@@ -227,7 +231,7 @@ public class ProceduresTest
             }
             catch (IOException ex)
             {
-                Assert.fail("Failed to marshal an object: " + ex.getMessage());
+                fail("Failed to marshal an object: " + ex.getMessage());
             }
             return null;
         }
@@ -236,7 +240,7 @@ public class ProceduresTest
         public void println(Object x)
         {
             super.println(x);
-            Assert.assertEquals(this.assertValues.remove(0), x);
+            assertEquals(this.assertValues.remove(0), x);
         }
 
         private void shutdown()

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/CheckedProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/CheckedProcedureTest.java
@@ -20,8 +20,11 @@ import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CheckedProcedureTest
 {
@@ -33,7 +36,7 @@ public class CheckedProcedureTest
             @Override
             public void safeValue(Date date)
             {
-                Assert.assertNotNull(date.toString());
+                assertNotNull(date.toString());
             }
         };
         procedure.value(new Date());
@@ -87,7 +90,7 @@ public class CheckedProcedureTest
         {
             success = true;
         }
-        Assert.assertTrue(success);
+        assertTrue(success);
     }
 
     @Test
@@ -98,7 +101,7 @@ public class CheckedProcedureTest
             @Override
             public void safeValue(Integer integer)
             {
-                Assert.assertEquals(Integer.valueOf(1), integer);
+                assertEquals(Integer.valueOf(1), integer);
             }
         };
         procedure.value(1);
@@ -112,7 +115,7 @@ public class CheckedProcedureTest
             @Override
             public void safeValue(Timestamp timestamp)
             {
-                Assert.assertNotNull(timestamp.toString());
+                assertNotNull(timestamp.toString());
             }
         };
         procedure.value(new Timestamp(0));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/MultimapKeyValuesSerializingProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/MultimapKeyValuesSerializingProcedureTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class MultimapKeyValuesSerializingProcedureTest
 {
@@ -47,13 +48,13 @@ public class MultimapKeyValuesSerializingProcedureTest
         @Override
         public void writeObject(Object obj)
         {
-            Assert.assertEquals(this.iterator.next(), obj);
+            assertEquals(this.iterator.next(), obj);
         }
 
         @Override
         public void writeInt(int v)
         {
-            Assert.assertEquals(this.iterator.next(), v);
+            assertEquals(this.iterator.next(), v);
         }
 
         @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/primitive/CheckedBooleanIntProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/primitive/CheckedBooleanIntProcedureTest.java
@@ -17,8 +17,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.primitive.BooleanIntPair;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class CheckedBooleanIntProcedureTest
 {
@@ -36,7 +38,7 @@ public class CheckedBooleanIntProcedureTest
         };
         procedure.value(true, 1);
         procedure.value(false, 10);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(true, 1),
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(true, 1),
                 PrimitiveTuples.pair(false, 10)), list);
     }
 
@@ -54,12 +56,12 @@ public class CheckedBooleanIntProcedureTest
                     throw ioException;
                 }
             }.value(true, 10);
-            Assert.fail("Exception should have been thrown");
+            fail("Exception should have been thrown");
         }
         catch (Exception e)
         {
-            Assert.assertEquals("Checked exception caught in BooleanIntProcedure", e.getMessage());
-            Assert.assertEquals(ioException, e.getCause());
+            assertEquals("Checked exception caught in BooleanIntProcedure", e.getMessage());
+            assertEquals(ioException, e.getCause());
         }
     }
 
@@ -77,11 +79,11 @@ public class CheckedBooleanIntProcedureTest
                     throw exception;
                 }
             }.value(true, 10);
-            Assert.fail("Exception should have been thrown");
+            fail("Exception should have been thrown");
         }
         catch (Exception e)
         {
-            Assert.assertEquals(exception, e);
+            assertEquals(exception, e);
         }
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/BooleanCaseProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/BooleanCaseProcedureTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class BooleanCaseProcedureTest
 {
@@ -29,7 +30,7 @@ public class BooleanCaseProcedureTest
         Verify.assertEmpty(result);
         procedure.setDefault(result::add);
         source.each(procedure);
-        Assert.assertEquals(result, source);
+        assertEquals(result, source);
         Verify.assertContains("BooleanCaseProcedure", procedure.toString());
     }
 
@@ -43,8 +44,8 @@ public class BooleanCaseProcedureTest
                 new BooleanCaseProcedure(defaultList::add)
                         .addCase(value -> value, ifOneList::add);
         list.each(procedure);
-        Assert.assertEquals(BooleanLists.mutable.with(true), ifOneList);
-        Assert.assertEquals(BooleanLists.mutable.with(false), defaultList);
+        assertEquals(BooleanLists.mutable.with(true), ifOneList);
+        assertEquals(BooleanLists.mutable.with(false), defaultList);
     }
 
     @Test
@@ -58,8 +59,8 @@ public class BooleanCaseProcedureTest
                         .addCase(value -> value, ifTrueList::add)
                         .addCase(value -> !value, ifFalseList::add);
         list.each(procedure);
-        Assert.assertEquals(BooleanLists.mutable.with(true), ifTrueList);
-        Assert.assertEquals(BooleanLists.mutable.with(false), ifFalseList);
+        assertEquals(BooleanLists.mutable.with(true), ifTrueList);
+        assertEquals(BooleanLists.mutable.with(false), ifFalseList);
         Verify.assertContains("BooleanCaseProcedure", procedure.toString());
     }
 
@@ -75,8 +76,8 @@ public class BooleanCaseProcedureTest
                         .addCase(value -> value, ifOneList::add)
                         .addCase(value -> !value, ifTwoList::add);
         list.each(procedure);
-        Assert.assertEquals(BooleanLists.mutable.with(true, true), ifOneList);
-        Assert.assertEquals(BooleanLists.mutable.with(false, false), ifTwoList);
-        Assert.assertEquals(BooleanLists.mutable.empty(), defaultList);
+        assertEquals(BooleanLists.mutable.with(true, true), ifOneList);
+        assertEquals(BooleanLists.mutable.with(false, false), ifTwoList);
+        assertEquals(BooleanLists.mutable.empty(), defaultList);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class CollectBooleanProcedureTest
 {
@@ -31,6 +32,6 @@ public class CollectBooleanProcedureTest
         procedure.value("00");
 
         ImmutableBooleanList expected = BooleanLists.immutable.with(true, false, false);
-        Assert.assertEquals(expected, targetList);
+        assertEquals(expected, targetList);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollectionTestCase.java
@@ -59,10 +59,17 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableCollectionTestCase
 {
@@ -88,28 +95,28 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void stream()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().stream().collect(Collectors2.toBag()),
                 this.classUnderTest().reduceInPlace(Collectors2.toBag()));
         Supplier<MutableBag<Integer>> supplier = Bags.mutable::empty;
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().stream().collect(supplier, MutableBag::add, MutableBag::withAll),
                 this.classUnderTest().reduceInPlace(supplier, MutableBag::add));
         Optional<Integer> expectedReduce = this.classUnderTest().reduce(Integer::sum);
         if (expectedReduce.isPresent())
         {
-            Assert.assertEquals(
+            assertEquals(
                     this.classUnderTest().stream().reduce(Integer::sum).get(),
                     expectedReduce.get());
         }
         long count = this.classUnderTest().stream().filter(integer -> integer % 2 == 0).count();
         if (count > 0)
         {
-            Assert.assertTrue(this.classUnderTest().stream().anyMatch(integer -> integer % 2 == 0));
+            assertTrue(this.classUnderTest().stream().anyMatch(integer -> integer % 2 == 0));
         }
         else
         {
-            Assert.assertTrue(this.classUnderTest().stream().noneMatch(integer -> integer % 2 == 0));
+            assertTrue(this.classUnderTest().stream().noneMatch(integer -> integer % 2 == 0));
         }
     }
 
@@ -119,28 +126,28 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void parallelStream()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().parallelStream().collect(Collectors2.toBag()),
                 this.classUnderTest().reduceInPlace(Collectors2.toBag()));
         Supplier<MutableBag<Integer>> supplier = Bags.mutable::empty;
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().parallelStream().collect(supplier, MutableBag::add, MutableBag::withAll),
                 this.classUnderTest().reduceInPlace(supplier, MutableBag::add));
         Optional<Integer> expectedReduce = this.classUnderTest().reduce(Integer::sum);
         if (expectedReduce.isPresent())
         {
-            Assert.assertEquals(
+            assertEquals(
                     this.classUnderTest().parallelStream().reduce(Integer::sum).get(),
                     expectedReduce.get());
         }
         long count = this.classUnderTest().parallelStream().filter(integer -> integer % 2 == 0).count();
         if (count > 0)
         {
-            Assert.assertTrue(this.classUnderTest().parallelStream().anyMatch(integer -> integer % 2 == 0));
+            assertTrue(this.classUnderTest().parallelStream().anyMatch(integer -> integer % 2 == 0));
         }
         else
         {
-            Assert.assertTrue(this.classUnderTest().parallelStream().noneMatch(integer -> integer % 2 == 0));
+            assertTrue(this.classUnderTest().parallelStream().noneMatch(integer -> integer % 2 == 0));
         }
     }
 
@@ -196,7 +203,7 @@ public abstract class AbstractImmutableCollectionTestCase
     public void selectWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 this.<Integer>newMutable().withAll(integers).select(IntegerPredicates.isOdd()),
                 integers.selectWith(Predicates2.in(), iList(1, 3, 5, 7, 9)));
     }
@@ -205,7 +212,7 @@ public abstract class AbstractImmutableCollectionTestCase
     public void selectWith_target()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 this.<Integer>newMutable().with(101).withAll(integers).select(IntegerPredicates.isOdd()),
                 integers.selectWith(Predicates2.in(), iList(1, 3, 5, 7, 9), this.<Integer>newMutable().with(101)));
     }
@@ -214,7 +221,7 @@ public abstract class AbstractImmutableCollectionTestCase
     public void rejectWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 this.<Integer>newMutable().withAll(integers).reject(IntegerPredicates.isOdd()),
                 integers.rejectWith(Predicates2.in(), iList(1, 3, 5, 7, 9)));
     }
@@ -223,7 +230,7 @@ public abstract class AbstractImmutableCollectionTestCase
     public void rejectWith_target()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 this.<Integer>newMutable().with(100).withAll(integers).reject(IntegerPredicates.isOdd()),
                 integers.rejectWith(Predicates2.in(), iList(1, 3, 5, 7, 9), this.<Integer>newMutable().with(100)));
     }
@@ -233,8 +240,8 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         PartitionImmutableCollection<Integer> partition = integers.partition(IntegerPredicates.isOdd());
-        Assert.assertEquals(integers.select(IntegerPredicates.isOdd()), partition.getSelected());
-        Assert.assertEquals(integers.select(IntegerPredicates.isEven()), partition.getRejected());
+        assertEquals(integers.select(IntegerPredicates.isOdd()), partition.getSelected());
+        assertEquals(integers.select(IntegerPredicates.isEven()), partition.getRejected());
     }
 
     @Test
@@ -242,8 +249,8 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         PartitionImmutableCollection<Integer> partition = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isOdd()));
-        Assert.assertEquals(integers.select(IntegerPredicates.isOdd()), partition.getSelected());
-        Assert.assertEquals(integers.select(IntegerPredicates.isEven()), partition.getRejected());
+        assertEquals(integers.select(IntegerPredicates.isOdd()), partition.getSelected());
+        assertEquals(integers.select(IntegerPredicates.isEven()), partition.getRejected());
     }
 
     @Test
@@ -253,7 +260,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<String> expected = integers.collect(Functions.chain(String::valueOf, string -> string + "!"));
         ImmutableCollection<String> actual = integers.collectWith((argument1, argument2) -> argument1 + argument2, "!");
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -264,8 +271,8 @@ public abstract class AbstractImmutableCollectionTestCase
         integers.forEach(Procedures.cast(each -> strings.add(each.toString())));
         MutableCollection<String> target = this.newMutable();
         MutableCollection<String> actual = integers.collect(String::valueOf, target);
-        Assert.assertEquals(strings, actual);
-        Assert.assertSame(target, actual);
+        assertEquals(strings, actual);
+        assertSame(target, actual);
     }
 
     @Test
@@ -276,8 +283,8 @@ public abstract class AbstractImmutableCollectionTestCase
         MutableCollection<String> targetCollection = this.<String>newMutable().with("?");
         MutableCollection<String> actual = integers.collectWith((argument1, argument2) -> argument1 + argument2, "!", targetCollection);
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(expected, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Test
@@ -285,13 +292,13 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Integer result = integers.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
     }
 
     @Test
     public void injectIntoInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER).longValue(),
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_INT));
     }
@@ -299,7 +306,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void injectIntoLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER).longValue(),
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_LONG));
     }
@@ -307,7 +314,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void injectIntoDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER).doubleValue(),
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_DOUBLE),
                 0.0);
@@ -316,7 +323,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void injectIntoFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER).floatValue(),
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_FLOAT),
                 0.0);
@@ -325,7 +332,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void sumFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_FLOAT),
                 this.classUnderTest().sumOfFloat(Integer::floatValue),
                 0.0);
@@ -334,7 +341,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void sumDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_DOUBLE),
                 this.classUnderTest().sumOfDouble(Integer::doubleValue),
                 0.0);
@@ -343,7 +350,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void sumInteger()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_INT),
                 this.classUnderTest().sumOfInt(integer -> integer));
     }
@@ -351,7 +358,7 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void sumLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().injectInto(0, AddFunction.INTEGER_TO_LONG),
                 this.classUnderTest().sumOfLong(Integer::longValue));
     }
@@ -363,8 +370,8 @@ public abstract class AbstractImmutableCollectionTestCase
         integers.addAllIterable(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         ImmutableCollection<Integer> values = integers.toImmutable();
         ImmutableObjectLongMap<Integer> result = values.sumByInt(i -> i % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -374,8 +381,8 @@ public abstract class AbstractImmutableCollectionTestCase
         integers.addAllIterable(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         ImmutableCollection<Integer> values = integers.toImmutable();
         ImmutableObjectDoubleMap<Integer> result = values.sumByFloat(f -> f % 2, e -> e);
-        Assert.assertEquals(25.0f, result.get(1), 0.0);
-        Assert.assertEquals(30.0f, result.get(0), 0.0);
+        assertEquals(25.0f, result.get(1), 0.0);
+        assertEquals(30.0f, result.get(0), 0.0);
     }
 
     @Test
@@ -396,11 +403,11 @@ public abstract class AbstractImmutableCollectionTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(1),
                 1.0e-15);
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(2),
                 1.0e-15);
@@ -413,8 +420,8 @@ public abstract class AbstractImmutableCollectionTestCase
         integers.addAllIterable(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         ImmutableCollection<Integer> values = integers.toImmutable();
         ImmutableObjectLongMap<Integer> result = values.sumByLong(l -> l % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -424,8 +431,8 @@ public abstract class AbstractImmutableCollectionTestCase
         integers.addAllIterable(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         ImmutableCollection<Integer> values = integers.toImmutable();
         ImmutableObjectDoubleMap<Integer> result = values.sumByDouble(d -> d % 2, e -> e);
-        Assert.assertEquals(25.0d, result.get(1), 0.0);
-        Assert.assertEquals(30.0d, result.get(0), 0.0);
+        assertEquals(25.0d, result.get(1), 0.0);
+        assertEquals(30.0d, result.get(0), 0.0);
     }
 
     @Test
@@ -443,11 +450,11 @@ public abstract class AbstractImmutableCollectionTestCase
                     return 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue());
                 });
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(1),
                 1.0e-15);
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(2),
                 1.0e-15);
@@ -456,9 +463,9 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void makeString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + this.classUnderTest().makeString() + ']');
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + this.classUnderTest().makeString(", ") + ']');
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + this.classUnderTest().makeString() + ']');
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + this.classUnderTest().makeString(", ") + ']');
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Test
@@ -466,28 +473,28 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         Appendable builder1 = new StringBuilder();
         this.classUnderTest().appendString(builder1);
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + builder1.toString() + ']');
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + builder1.toString() + ']');
 
         Appendable builder2 = new StringBuilder();
         this.classUnderTest().appendString(builder2, ", ");
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + builder2.toString() + ']');
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), '[' + builder2.toString() + ']');
 
         Appendable builder3 = new StringBuilder();
         this.classUnderTest().appendString(builder3, "[", ", ", "]");
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), builder3.toString());
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), builder3.toString());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
     }
 
     @Test
     public void select()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1)));
+        assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1)));
         Verify.assertIterableEmpty(integers.select(Predicates.greaterThan(integers.size())));
     }
 
@@ -496,7 +503,7 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableCollection<Integer> result = integers.selectInstancesOf(Integer.class);
-        Assert.assertEquals(integers, result);
+        assertEquals(integers, result);
     }
 
     @Test
@@ -504,14 +511,14 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Verify.assertIterableEmpty(integers.reject(Predicates.lessThan(integers.size() + 1)));
-        Assert.assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size())));
+        assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size())));
     }
 
     @Test
     public void collect()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.collect(Functions.getIntegerPassThru()));
+        assertEquals(integers, integers.collect(Functions.getIntegerPassThru()));
     }
 
     @Test
@@ -528,7 +535,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableByteCollection immutableCollection = integers.collectByte(PrimitiveFunctions.unboxIntegerToByte());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(Integer::valueOf));
+        assertEquals(integers, immutableCollection.collect(Integer::valueOf));
     }
 
     @Test
@@ -537,7 +544,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableCharCollection immutableCollection = integers.collectChar(PrimitiveFunctions.unboxIntegerToChar());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(Integer::valueOf));
+        assertEquals(integers, immutableCollection.collect(Integer::valueOf));
     }
 
     @Test
@@ -546,7 +553,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableDoubleCollection immutableCollection = integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(doubleParameter -> Integer.valueOf((int) doubleParameter)));
+        assertEquals(integers, immutableCollection.collect(doubleParameter -> Integer.valueOf((int) doubleParameter)));
     }
 
     @Test
@@ -555,7 +562,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableFloatCollection immutableCollection = integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(floatParameter -> Integer.valueOf((int) floatParameter)));
+        assertEquals(integers, immutableCollection.collect(floatParameter -> Integer.valueOf((int) floatParameter)));
     }
 
     @Test
@@ -564,7 +571,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableIntCollection immutableCollection = integers.collectInt(PrimitiveFunctions.unboxIntegerToInt());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(Integer::valueOf));
+        assertEquals(integers, immutableCollection.collect(Integer::valueOf));
     }
 
     @Test
@@ -573,7 +580,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableLongCollection immutableCollection = integers.collectLong(PrimitiveFunctions.unboxIntegerToLong());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(longParameter -> Integer.valueOf((int) longParameter)));
+        assertEquals(integers, immutableCollection.collect(longParameter -> Integer.valueOf((int) longParameter)));
     }
 
     @Test
@@ -582,7 +589,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         ImmutableShortCollection immutableCollection = integers.collectShort(PrimitiveFunctions.unboxIntegerToShort());
         Verify.assertSize(integers.size(), immutableCollection);
-        Assert.assertEquals(integers, immutableCollection.collect(Integer::valueOf));
+        assertEquals(integers, immutableCollection.collect(Integer::valueOf));
     }
 
     @Test
@@ -592,7 +599,7 @@ public abstract class AbstractImmutableCollectionTestCase
 
         ImmutableCollection<String> expected = this.classUnderTest().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -602,7 +609,7 @@ public abstract class AbstractImmutableCollectionTestCase
 
         ImmutableCollection<String> expected = this.classUnderTest().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -615,19 +622,19 @@ public abstract class AbstractImmutableCollectionTestCase
     public void detect()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
-        Assert.assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
+        assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
     }
 
     @Test
     public void detectWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
-        Assert.assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
 
         FastList<String> strings = FastList.newListWith("1", "2", "3");
-        Assert.assertEquals("1", strings.detectWith(Object::equals, "1"));
+        assertEquals("1", strings.detectWith(Object::equals, "1"));
     }
 
     @Test
@@ -635,8 +642,8 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Function0<Integer> function = new PassThruFunction0<>(integers.size() + 1);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
-        Assert.assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
+        assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
+        assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
     }
 
     @Test
@@ -645,101 +652,101 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Integer sum = Integer.valueOf(integers.size() + 1);
         Function0<Integer> function = new PassThruFunction0<>(sum);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
-        Assert.assertEquals(sum, integers.detectWithIfNone(Object::equals, sum, function));
+        assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
+        assertEquals(sum, integers.detectWithIfNone(Object::equals, sum, function));
     }
 
     @Test
     public void allSatisfy()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
+        assertTrue(integers.allSatisfy(Integer.class::isInstance));
+        assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(integers.allSatisfyWith(Object::equals, 0));
+        assertTrue(integers.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(integers.allSatisfyWith(Object::equals, 0));
     }
 
     @Test
     public void noneSatisfy()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfy(String.class::isInstance));
-        Assert.assertFalse(integers.noneSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(integers.noneSatisfy(String.class::isInstance));
+        assertFalse(integers.noneSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(integers.noneSatisfyWith(Object::equals, 1));
+        assertTrue(integers.noneSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(integers.noneSatisfyWith(Object::equals, 1));
     }
 
     @Test
     public void anySatisfy()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfy(String.class::isInstance));
-        Assert.assertTrue(integers.anySatisfy(Integer.class::isInstance));
+        assertFalse(integers.anySatisfy(String.class::isInstance));
+        assertTrue(integers.anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void anySatisfyWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertTrue(integers.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(integers.anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(integers.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void count()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers.size(), integers.count(Integer.class::isInstance));
-        Assert.assertEquals(0, integers.count(String.class::isInstance));
+        assertEquals(integers.size(), integers.count(Integer.class::isInstance));
+        assertEquals(0, integers.count(String.class::isInstance));
     }
 
     @Test
     public void countWith()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers.size(), integers.countWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, integers.countWith(Predicates2.instanceOf(), String.class));
+        assertEquals(integers.size(), integers.countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, integers.countWith(Predicates2.instanceOf(), String.class));
     }
 
     @Test
     public void collectIf()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru()));
+        assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru()));
     }
 
     @Test
     public void getFirst()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.getFirst());
+        assertEquals(Integer.valueOf(1), integers.getFirst());
     }
 
     @Test
     public void getLast()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(integers.size()), integers.getLast());
+        assertEquals(Integer.valueOf(integers.size()), integers.getLast());
     }
 
     @Test
     public void isEmpty()
     {
         ImmutableCollection<Integer> immutableCollection = this.classUnderTest();
-        Assert.assertFalse(immutableCollection.isEmpty());
-        Assert.assertTrue(immutableCollection.notEmpty());
+        assertFalse(immutableCollection.isEmpty());
+        assertTrue(immutableCollection.notEmpty());
     }
 
     @Test
@@ -750,9 +757,9 @@ public abstract class AbstractImmutableCollectionTestCase
         for (int i = 0; iterator.hasNext(); i++)
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(i + 1, integer.intValue());
+            assertEquals(i + 1, integer.intValue());
         }
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -760,8 +767,8 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         MutableList<Integer> copy = FastList.newList(integers);
-        Assert.assertArrayEquals(integers.toArray(), copy.toArray());
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
+        assertArrayEquals(integers.toArray(), copy.toArray());
+        assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
     }
 
     @Test
@@ -770,9 +777,9 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> integers = this.classUnderTest();
         MutableList<Integer> copy = FastList.newList(integers);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(copy.sortThis(Collections.reverseOrder()), list);
+        assertEquals(copy.sortThis(Collections.reverseOrder()), list);
         MutableList<Integer> list2 = integers.toSortedList();
-        Assert.assertEquals(copy.sortThis(), list2);
+        assertEquals(copy.sortThis(), list2);
     }
 
     @Test
@@ -788,8 +795,8 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         MutableSortedSet<Integer> set = integers.toSortedSet(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(integers.toSet(), set);
-        Assert.assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), set.toList());
+        assertEquals(integers.toSet(), set);
+        assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), set.toList());
     }
 
     @Test
@@ -806,7 +813,7 @@ public abstract class AbstractImmutableCollectionTestCase
         ImmutableCollection<Integer> immutableCollection = this.classUnderTest();
         for (Integer each : immutableCollection)
         {
-            Assert.assertNotNull(each);
+            assertNotNull(each);
         }
     }
 
@@ -830,13 +837,13 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverse(Integer::compareTo)));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverse(Integer::compareTo)));
     }
 
     @Test(expected = NullPointerException.class)
@@ -854,67 +861,67 @@ public abstract class AbstractImmutableCollectionTestCase
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
+        assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(Functions.getIntegerPassThru()));
     }
 
     @Test
     public void iteratorRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().iterator().remove());
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().iterator().remove());
     }
 
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).add(1));
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).add(1));
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).remove(Integer.valueOf(1)));
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).remove(Integer.valueOf(1)));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).clear());
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).clear());
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).removeAll(Lists.fixedSize.of()));
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).removeAll(Lists.fixedSize.of()));
     }
 
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).retainAll(Lists.fixedSize.of()));
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).retainAll(Lists.fixedSize.of()));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).addAll(Lists.fixedSize.of()));
+        assertThrows(UnsupportedOperationException.class, () -> ((Collection<Integer>) this.classUnderTest()).addAll(Lists.fixedSize.of()));
     }
 
     @Test
@@ -923,7 +930,7 @@ public abstract class AbstractImmutableCollectionTestCase
         Procedure2<Counter, Integer> sumAggregator = Counter::add;
         MapIterable<String, Counter> actual = this.classUnderTest().aggregateInPlaceBy(String::valueOf, Counter::new, sumAggregator);
         MapIterable<String, Counter> expected = this.classUnderTest().toBag().aggregateInPlaceBy(String::valueOf, Counter::new, sumAggregator);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -932,7 +939,7 @@ public abstract class AbstractImmutableCollectionTestCase
         Function2<Integer, Integer, Integer> sumAggregator = (integer1, integer2) -> integer1 + integer2;
         MapIterable<String, Integer> actual = this.classUnderTest().aggregateBy(String::valueOf, () -> 0, sumAggregator);
         MapIterable<String, Integer> expected = this.classUnderTest().toBag().aggregateBy(String::valueOf, () -> 0, sumAggregator);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -940,7 +947,7 @@ public abstract class AbstractImmutableCollectionTestCase
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
         ImmutableCollection<Integer> collection = this.classUnderTest();
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/primitive/AbstractImmutableBooleanCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/primitive/AbstractImmutableBooleanCollectionTestCase.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.collection.immutable.primitive;
 import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBooleanIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanCollection}s.
@@ -45,8 +46,8 @@ public abstract class AbstractImmutableBooleanCollectionTestCase extends Abstrac
                 falseCount++;
             }
         }
-        Assert.assertEquals(expectedTrueCount, trueCount);
-        Assert.assertEquals(expectedFalseCount, falseCount);
+        assertEquals(expectedTrueCount, trueCount);
+        assertEquals(expectedFalseCount, falseCount);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
@@ -28,11 +28,15 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableCollection}s.
@@ -45,7 +49,7 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
         MutableCollection<Object> collection = this.newWith().newEmpty();
         Verify.assertEmpty(collection);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.notEmpty());
+        assertFalse(collection.notEmpty());
     }
 
     @Test
@@ -98,18 +102,18 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     public void addAll()
     {
         MutableCollection<Integer> collection = this.newWith();
-        Assert.assertTrue(collection.addAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertFalse(collection.addAll(Collections.emptyList()));
+        assertTrue(collection.addAll(FastList.newListWith(1, 2, 3)));
+        assertFalse(collection.addAll(Collections.emptyList()));
         Verify.assertContainsAll(collection, 1, 2, 3);
 
         boolean result = collection.addAll(FastList.newListWith(1, 2, 3));
         if (collection.size() == 3)
         {
-            Assert.assertFalse("addAll did not modify the collection", result);
+            assertFalse("addAll did not modify the collection", result);
         }
         else
         {
-            Assert.assertTrue("addAll modified the collection", result);
+            assertTrue("addAll modified the collection", result);
         }
         Verify.assertContainsAll(collection, 1, 2, 3);
     }
@@ -118,32 +122,32 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     public void addAllIterable()
     {
         MutableCollection<Integer> collection1 = this.newWith();
-        Assert.assertTrue(collection1.addAllIterable(FastList.newListWith(1, 2, 3)));
+        assertTrue(collection1.addAllIterable(FastList.newListWith(1, 2, 3)));
         Verify.assertContainsAll(collection1, 1, 2, 3);
 
         boolean result1 = collection1.addAllIterable(FastList.newListWith(1, 2, 3));
         if (collection1.size() == 3)
         {
-            Assert.assertFalse("addAllIterable did not modify the collection", result1);
+            assertFalse("addAllIterable did not modify the collection", result1);
         }
         else
         {
-            Assert.assertTrue("addAllIterable modified the collection", result1);
+            assertTrue("addAllIterable modified the collection", result1);
         }
         Verify.assertContainsAll(collection1, 1, 2, 3);
 
         MutableCollection<Integer> collection2 = this.newWith();
-        Assert.assertTrue(collection2.addAllIterable(UnifiedSet.newSetWith(1, 2, 3)));
+        assertTrue(collection2.addAllIterable(UnifiedSet.newSetWith(1, 2, 3)));
         Verify.assertContainsAll(collection2, 1, 2, 3);
 
         boolean result2 = collection2.addAllIterable(UnifiedSet.newSetWith(1, 2, 3));
         if (collection1.size() == 3)
         {
-            Assert.assertFalse("addAllIterable did not modify the collection", result2);
+            assertFalse("addAllIterable did not modify the collection", result2);
         }
         else
         {
-            Assert.assertTrue("addAllIterable modified the collection", result2);
+            assertTrue("addAllIterable modified the collection", result2);
         }
         Verify.assertContainsAll(collection2, 1, 2, 3);
     }
@@ -152,56 +156,56 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     public void removeAll()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertTrue(objects.removeAll(FastList.newListWith(1, 2, 4)));
-        Assert.assertEquals(Bags.mutable.of(3), objects.toBag());
+        assertTrue(objects.removeAll(FastList.newListWith(1, 2, 4)));
+        assertEquals(Bags.mutable.of(3), objects.toBag());
 
         MutableCollection<Integer> objects2 = this.newWith(1, 2, 3);
-        Assert.assertFalse(objects2.removeAll(FastList.newListWith(4, 5)));
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3), objects2.toBag());
+        assertFalse(objects2.removeAll(FastList.newListWith(4, 5)));
+        assertEquals(Bags.mutable.of(1, 2, 3), objects2.toBag());
     }
 
     @Test
     public void removeAllIterable()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertTrue(objects.removeAllIterable(FastList.newListWith(1, 2, 4)));
-        Assert.assertEquals(Bags.mutable.of(3), objects.toBag());
+        assertTrue(objects.removeAllIterable(FastList.newListWith(1, 2, 4)));
+        assertEquals(Bags.mutable.of(3), objects.toBag());
 
         MutableCollection<Integer> objects2 = this.newWith(1, 2, 3);
-        Assert.assertFalse(objects2.removeAllIterable(FastList.newListWith(4, 5)));
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3), objects2.toBag());
+        assertFalse(objects2.removeAllIterable(FastList.newListWith(4, 5)));
+        assertEquals(Bags.mutable.of(1, 2, 3), objects2.toBag());
     }
 
     @Test
     public void retainAll()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertTrue(objects.retainAll(mSet(1, 2)));
+        assertTrue(objects.retainAll(mSet(1, 2)));
         Verify.assertSize(2, objects);
         Verify.assertContainsAll(objects, 1, 2);
 
         MutableCollection<Integer> integers1 = this.newWith(0);
-        Assert.assertFalse(integers1.retainAll(FastList.newListWith(1, 0)));
-        Assert.assertEquals(Bags.mutable.of(0), integers1.toBag());
+        assertFalse(integers1.retainAll(FastList.newListWith(1, 0)));
+        assertEquals(Bags.mutable.of(0), integers1.toBag());
 
         MutableCollection<Integer> integers2 = this.newWith(1, 2, 3);
         Integer copy = new Integer(1);
-        Assert.assertTrue(integers2.retainAll(FastList.newListWith(copy)));
-        Assert.assertEquals(Bags.mutable.of(1), integers2.toBag());
-        Assert.assertNotSame(copy, integers2.getFirst());
+        assertTrue(integers2.retainAll(FastList.newListWith(copy)));
+        assertEquals(Bags.mutable.of(1), integers2.toBag());
+        assertNotSame(copy, integers2.getFirst());
     }
 
     @Test
     public void retainAllIterable()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertTrue(objects.retainAllIterable(iList(1, 2)));
+        assertTrue(objects.retainAllIterable(iList(1, 2)));
         Verify.assertSize(2, objects);
         Verify.assertContainsAll(objects, 1, 2);
 
         MutableCollection<Integer> integers = this.newWith(0);
-        Assert.assertFalse(integers.retainAllIterable(FastList.newListWith(1, 0)));
-        Assert.assertEquals(Bags.mutable.of(0), integers.toBag());
+        assertFalse(integers.retainAllIterable(FastList.newListWith(1, 0)));
+        assertEquals(Bags.mutable.of(0), integers.toBag());
     }
 
     @Test
@@ -220,7 +224,7 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3);
         Integer result = objects.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Test
@@ -245,31 +249,31 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> objects1 = this.newWith(1, 2, 3);
         objects1.add(null);
-        Assert.assertTrue(objects1.removeIf(Predicates.isNull()));
+        assertTrue(objects1.removeIf(Predicates.isNull()));
         Verify.assertSize(3, objects1);
         Verify.assertContainsAll(objects1, 1, 2, 3);
 
         MutableCollection<Integer> objects2 = this.newWith(3, 4, 5);
-        Assert.assertTrue(objects2.removeIf(Predicates.equal(3)));
-        Assert.assertFalse(objects2.removeIf(Predicates.equal(6)));
+        assertTrue(objects2.removeIf(Predicates.equal(3)));
+        assertFalse(objects2.removeIf(Predicates.equal(6)));
 
         MutableCollection<Integer> objects3 = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertTrue(objects3.removeIf(Predicates.greaterThan(0)));
-        Assert.assertFalse(objects3.removeIf(Predicates.equal(5)));
+        assertTrue(objects3.removeIf(Predicates.greaterThan(0)));
+        assertFalse(objects3.removeIf(Predicates.equal(5)));
     }
 
     @Test
     public void removeIfWith()
     {
         MutableCollection<Integer> objects1 = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(objects1.removeIfWith(Predicates2.lessThan(), 3));
+        assertTrue(objects1.removeIfWith(Predicates2.lessThan(), 3));
         Verify.assertSize(2, objects1);
         Verify.assertContainsAll(objects1, 3, 4);
-        Assert.assertFalse(objects1.removeIfWith(Predicates2.greaterThan(), 6));
+        assertFalse(objects1.removeIfWith(Predicates2.greaterThan(), 6));
 
         MutableCollection<Integer> objects2 = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertTrue(objects2.removeIfWith(Predicates2.greaterThan(), 0));
-        Assert.assertFalse(objects2.removeIfWith(Predicates2.greaterThan(), 3));
+        assertTrue(objects2.removeIfWith(Predicates2.greaterThan(), 0));
+        assertFalse(objects2.removeIfWith(Predicates2.greaterThan(), 3));
     }
 
     @Test
@@ -277,8 +281,8 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.with(4);
-        Assert.assertSame(coll, collWith);
-        Assert.assertEquals(this.newWith(1, 2, 3, 4), collWith);
+        assertSame(coll, collWith);
+        assertEquals(this.newWith(1, 2, 3, 4), collWith);
     }
 
     @Test
@@ -286,8 +290,8 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.withAll(FastList.newListWith(4, 5));
-        Assert.assertSame(coll, collWith);
-        Assert.assertEquals(this.newWith(1, 2, 3, 4, 5), collWith);
+        assertSame(coll, collWith);
+        assertEquals(this.newWith(1, 2, 3, 4, 5), collWith);
     }
 
     @Test
@@ -295,8 +299,8 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWithout = coll.without(2);
-        Assert.assertSame(coll, collWithout);
-        Assert.assertEquals(this.newWith(1, 3), collWithout);
+        assertSame(coll, collWithout);
+        assertEquals(this.newWith(1, 3), collWithout);
     }
 
     @Test
@@ -304,8 +308,8 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3, 4, 5);
         MutableCollection<Integer> collWithout = coll.withoutAll(FastList.newListWith(2, 4));
-        Assert.assertSame(coll, collWithout);
-        Assert.assertEquals(this.newWith(1, 3, 5), collWithout);
+        assertSame(coll, collWithout);
+        assertEquals(this.newWith(1, 3, 5), collWithout);
     }
 
     @Test
@@ -313,8 +317,8 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
     {
         MutableCollection<Integer> collection = this.newWith(Interval.oneTo(100000).toArray());
         MutableBagMultimap<Integer, Integer> expected = collection.groupBy(each -> each % 100, Multimaps.mutable.bag.empty());
-        Assert.assertEquals(expected, collection.stream().collect(Collectors2.toBagMultimap(each -> each % 100)));
-        Assert.assertEquals(expected, collection.parallelStream().collect(Collectors2.toBagMultimap(each -> each % 100)));
+        assertEquals(expected, collection.stream().collect(Collectors2.toBagMultimap(each -> each % 100)));
+        assertEquals(expected, collection.parallelStream().collect(Collectors2.toBagMultimap(each -> each % 100)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedCollectionTestCase.java
@@ -11,8 +11,11 @@
 package org.eclipse.collections.impl.collection.mutable;
 
 import org.eclipse.collections.api.collection.MutableCollection;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCollectionTestCase
 {
@@ -22,7 +25,7 @@ public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCol
     {
         MutableCollection<Object> collection = this.newWith(1, 2);
         String string = collection.toString();
-        Assert.assertTrue("[1, 2]".equals(string) || "[2, 1]".equals(string));
+        assertTrue("[1, 2]".equals(string) || "[2, 1]".equals(string));
     }
 
     @Override
@@ -30,7 +33,7 @@ public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCol
     public void makeString()
     {
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Override
@@ -40,7 +43,7 @@ public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCol
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -48,6 +51,6 @@ public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCol
     public void asSynchronized()
     {
         MutableCollection<Object> collection = this.newWith();
-        Assert.assertSame(collection, collection.asSynchronized());
+        assertSame(collection, collection.asSynchronized());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterAsUnmodifiableTest.java
@@ -17,8 +17,10 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Functions2;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class CollectionAdapterAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {
@@ -34,32 +36,32 @@ public class CollectionAdapterAsUnmodifiableTest extends UnmodifiableMutableColl
     @Test
     public void select()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().select(ignored -> true));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().select(ignored -> false));
+        assertEquals(this.getCollection().toList(), this.getCollection().select(ignored -> true));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().select(ignored -> false));
     }
 
     @Override
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().selectWith((ignored1, ignored2) -> true, null));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().selectWith((ignored1, ignored2) -> false, null));
+        assertEquals(this.getCollection().toList(), this.getCollection().selectWith((ignored1, ignored2) -> true, null));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().selectWith((ignored1, ignored2) -> false, null));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().reject(ignored1 -> false));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().reject(ignored -> true));
+        assertEquals(this.getCollection().toList(), this.getCollection().reject(ignored1 -> false));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().reject(ignored -> true));
     }
 
     @Override
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().rejectWith((ignored11, ignored21) -> false, null));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().rejectWith((ignored1, ignored2) -> true, null));
+        assertEquals(this.getCollection().toList(), this.getCollection().rejectWith((ignored11, ignored21) -> false, null));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().rejectWith((ignored1, ignored2) -> true, null));
     }
 
     @Override
@@ -67,8 +69,8 @@ public class CollectionAdapterAsUnmodifiableTest extends UnmodifiableMutableColl
     public void partition()
     {
         PartitionMutableCollection<?> partition = this.getCollection().partition(ignored -> true);
-        Assert.assertEquals(this.getCollection().toList(), partition.getSelected());
-        Assert.assertNotEquals(this.getCollection().toList(), partition.getRejected());
+        assertEquals(this.getCollection().toList(), partition.getSelected());
+        assertNotEquals(this.getCollection().toList(), partition.getRejected());
     }
 
     @Override
@@ -76,31 +78,31 @@ public class CollectionAdapterAsUnmodifiableTest extends UnmodifiableMutableColl
     public void partitionWith()
     {
         PartitionMutableCollection<?> partition = this.getCollection().partitionWith((ignored1, ignored2) -> true, null);
-        Assert.assertEquals(this.getCollection().toList(), partition.getSelected());
-        Assert.assertNotEquals(this.getCollection().toList(), partition.getRejected());
+        assertEquals(this.getCollection().toList(), partition.getSelected());
+        assertNotEquals(this.getCollection().toList(), partition.getRejected());
     }
 
     @Override
     @Test
     public void collect()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().collect(Functions.getPassThru()));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().collect(Object::getClass));
+        assertEquals(this.getCollection().toList(), this.getCollection().collect(Functions.getPassThru()));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().collect(Object::getClass));
     }
 
     @Override
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().collectWith(Functions2.fromFunction(Functions.getPassThru()), null));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().collectWith(Functions2.fromFunction(Object::getClass), null));
+        assertEquals(this.getCollection().toList(), this.getCollection().collectWith(Functions2.fromFunction(Functions.getPassThru()), null));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().collectWith(Functions2.fromFunction(Object::getClass), null));
     }
 
     @Override
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(this.getCollection().toList(), this.getCollection().collectIf(ignored -> true, Functions.getPassThru()));
-        Assert.assertNotEquals(this.getCollection().toList(), this.getCollection().collectIf(ignored -> false, Object::getClass));
+        assertEquals(this.getCollection().toList(), this.getCollection().collectIf(ignored -> true, Functions.getPassThru()));
+        assertNotEquals(this.getCollection().toList(), this.getCollection().collectIf(ignored -> false, Object::getClass));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterTest.java
@@ -42,10 +42,11 @@ import org.eclipse.collections.impl.set.mutable.SetAdapter;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * JUnit test for {@link CollectionAdapter}.
@@ -135,7 +136,7 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
 
         MutableCollection<Number> numbers = this.<Number>newSet().with(1, 2.0, 3, 4.0, 5);
         MutableCollection<Integer> integers = numbers.selectInstancesOf(Integer.class);
-        Assert.assertEquals(HashBag.newBagWith(1, 3, 5), integers.toBag());
+        assertEquals(HashBag.newBagWith(1, 3, 5), integers.toBag());
     }
 
     @Override
@@ -144,10 +145,10 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
     {
         super.collect();
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("1", "2", "3", "4"),
                 this.newSet().with(1, 2, 3, 4).collect(String::valueOf));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("1", "2", "3", "4"),
                 this.newSet().with(1, 2, 3, 4).collect(
                         String::valueOf,
@@ -161,10 +162,10 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
         super.flatCollect();
 
         Function<Integer, Iterable<Integer>> function = Interval::oneTo;
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 1, 2, 1, 2, 3, 1, 2, 3, 4),
                 this.<Integer>newList().with(1, 2, 3, 4).flatCollect(function));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 1, 2, 1, 2, 3, 1, 2, 3, 4),
                 this.<Integer>newList().with(1, 2, 3, 4).flatCollect(function));
     }
@@ -178,8 +179,8 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
         MutableCollection<Integer> list2 = this.<Integer>newList().with(1, 2, 3);
         MutableCollection<Integer> list3 = this.<Integer>newList().with(2, 3, 4);
         Verify.assertEqualsAndHashCode(list1, list2);
-        Assert.assertNotEquals(list1, null);
-        Assert.assertNotEquals(list2, list3);
+        assertNotEquals(list1, null);
+        assertNotEquals(list2, list3);
     }
 
     @Test
@@ -196,7 +197,7 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
         MutableCollection<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
         Verify.assertContainsAll(deserializedCollection, 1, 2, 3, 4, 5);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     @Test
@@ -223,7 +224,7 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
                         Boolean.TRUE, FastList.newListWith(1, 3, 5, 7),
                         Boolean.FALSE, FastList.newListWith(2, 4, 6));
 
-        Assert.assertEquals(expected, multimap.toMap());
+        assertEquals(expected, multimap.toMap());
     }
 
     @Override
@@ -241,11 +242,11 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
 
         Multimap<Integer, Integer> actual =
                 underTest.groupByEach(intervalFunction);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 underTest.groupByEach(intervalFunction, this.<Integer>newWith().groupByEach(intervalFunction));
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
@@ -266,10 +267,10 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
     @Test
     public void testEquals()
     {
-        Assert.assertEquals(new CollectionAdapter<>(FastList.newList()), new CollectionAdapter<>(FastList.newList()));
-        Assert.assertNotEquals(new CollectionAdapter<>(FastList.newList()), new CollectionAdapter<>(FastList.newListWith(1)));
-        Assert.assertEquals(new CollectionAdapter<>(FastList.newListWith(1)), new CollectionAdapter<>(FastList.newListWith(1)));
-        Assert.assertNotEquals(new CollectionAdapter<>(FastList.newListWith(1)), new CollectionAdapter<>(FastList.newListWith(2)));
+        assertEquals(new CollectionAdapter<>(FastList.newList()), new CollectionAdapter<>(FastList.newList()));
+        assertNotEquals(new CollectionAdapter<>(FastList.newList()), new CollectionAdapter<>(FastList.newListWith(1)));
+        assertEquals(new CollectionAdapter<>(FastList.newListWith(1)), new CollectionAdapter<>(FastList.newListWith(1)));
+        assertNotEquals(new CollectionAdapter<>(FastList.newListWith(1)), new CollectionAdapter<>(FastList.newListWith(2)));
     }
 
     @Test
@@ -284,7 +285,7 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
     public void chunk_large_size()
     {
         MutableCollection<String> collection = this.newWith("1", "2", "3", "4", "5", "6", "7");
-        Assert.assertEquals(collection.toList(), collection.chunk(10).getOnly());
+        assertEquals(collection.toList(), collection.chunk(10).getOnly());
     }
 
     @Override
@@ -293,8 +294,8 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
     {
         MutableCollection<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionMutableCollection<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Override
@@ -303,7 +304,7 @@ public class CollectionAdapterTest extends AbstractCollectionTestCase
     {
         MutableCollection<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionMutableCollection<Integer> result = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/SynchronizedMutableCollectionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/SynchronizedMutableCollectionTest.java
@@ -23,10 +23,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.SynchronizedMutableList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedMutableCollection}.
@@ -51,7 +53,7 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     @Override
     public void equalsAndHashCode()
     {
-        Assert.assertNotEquals(this.newWith(), this.newWith());
+        assertNotEquals(this.newWith(), this.newWith());
     }
 
     @Override
@@ -61,8 +63,8 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
         RichIterable<Integer> list = this.newWith(1, 2, 3, 4, 5, 6, 7);
         Multimap<Boolean, Integer> multimap = list.groupBy(object -> IntegerPredicates.isOdd().accept(object));
 
-        Assert.assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
-        Assert.assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
+        assertEquals(FastList.newListWith(1, 3, 5, 7), multimap.get(Boolean.TRUE));
+        assertEquals(FastList.newListWith(2, 4, 6), multimap.get(Boolean.FALSE));
     }
 
     @Override
@@ -78,11 +80,11 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
 
         Multimap<Integer, Integer> actual =
                 underTest.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 underTest.groupByEach(new NegativeIntervalFunction(), FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Override
@@ -105,8 +107,8 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionMutableCollection<Integer> result = integers.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Override
@@ -115,8 +117,8 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> integers = this.newWith(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         PartitionMutableCollection<Integer> result = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
-        Assert.assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
+        assertEquals(iList(-2, 0, 2, 4, 6, 8), result.getSelected());
+        assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
     @Override
@@ -125,8 +127,8 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.with(4);
-        Assert.assertSame(coll, collWith);
-        Assert.assertEquals(this.newWith(1, 2, 3, 4).toList(), collWith.toList());
+        assertSame(coll, collWith);
+        assertEquals(this.newWith(1, 2, 3, 4).toList(), collWith.toList());
     }
 
     @Override
@@ -135,8 +137,8 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.withAll(FastList.newListWith(4, 5));
-        Assert.assertSame(coll, collWith);
-        Assert.assertEquals(this.newWith(1, 2, 3, 4, 5).toList(), collWith.toList());
+        assertSame(coll, collWith);
+        assertEquals(this.newWith(1, 2, 3, 4, 5).toList(), collWith.toList());
     }
 
     @Override
@@ -145,10 +147,10 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWithout = coll.without(2);
-        Assert.assertSame(coll, collWithout);
+        assertSame(coll, collWithout);
         MutableCollection<Integer> expectedSet = this.newWith(1, 3);
-        Assert.assertEquals(expectedSet.toList(), collWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), collWithout.without(4).toList());
+        assertEquals(expectedSet.toList(), collWithout.toList());
+        assertEquals(expectedSet.toList(), collWithout.without(4).toList());
     }
 
     @Override
@@ -157,9 +159,9 @@ public class SynchronizedMutableCollectionTest extends AbstractSynchronizedColle
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3, 4, 5);
         MutableCollection<Integer> collWithout = coll.withoutAll(FastList.newListWith(2, 4));
-        Assert.assertSame(coll, collWithout);
+        assertSame(coll, collWithout);
         MutableCollection<Integer> expectedSet = this.newWith(1, 3, 5);
-        Assert.assertEquals(expectedSet.toList(), collWithout.toList());
-        Assert.assertEquals(expectedSet.toList(), collWithout.withoutAll(FastList.newListWith(2, 4)).toList());
+        assertEquals(expectedSet.toList(), collWithout.toList());
+        assertEquals(expectedSet.toList(), collWithout.withoutAll(FastList.newListWith(2, 4)).toList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTest.java
@@ -55,11 +55,13 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableCollection}.
@@ -81,12 +83,12 @@ public class UnmodifiableMutableCollectionTest
     @Test
     public void delegatingMethods()
     {
-        Assert.assertEquals(this.mutableCollection.notEmpty(), this.unmodifiableCollection.notEmpty());
-        Assert.assertEquals(this.mutableCollection.isEmpty(), this.unmodifiableCollection.isEmpty());
-        Assert.assertEquals(this.mutableCollection.size(), this.unmodifiableCollection.size());
-        Assert.assertEquals(this.mutableCollection.getFirst(), this.unmodifiableCollection.getFirst());
-        Assert.assertEquals(this.mutableCollection.getLast(), this.unmodifiableCollection.getLast());
-        Assert.assertEquals(
+        assertEquals(this.mutableCollection.notEmpty(), this.unmodifiableCollection.notEmpty());
+        assertEquals(this.mutableCollection.isEmpty(), this.unmodifiableCollection.isEmpty());
+        assertEquals(this.mutableCollection.size(), this.unmodifiableCollection.size());
+        assertEquals(this.mutableCollection.getFirst(), this.unmodifiableCollection.getFirst());
+        assertEquals(this.mutableCollection.getLast(), this.unmodifiableCollection.getLast());
+        assertEquals(
                 this.mutableCollection.count(ignored6 -> true),
                 this.unmodifiableCollection.count(ignored5 -> true));
         Verify.assertSize(4, this.unmodifiableCollection.select(ignored4 -> true));
@@ -127,22 +129,22 @@ public class UnmodifiableMutableCollectionTest
                         ignored1 -> true,
                         Functions.getStringPassThru(),
                         FastList.newList()));
-        Assert.assertEquals(METALLICA, this.unmodifiableCollection.detect(StringPredicates.contains("allic")));
-        Assert.assertEquals(
+        assertEquals(METALLICA, this.unmodifiableCollection.detect(StringPredicates.contains("allic")));
+        assertEquals(
                 "Not found",
                 this.unmodifiableCollection.detectIfNone(
                         StringPredicates.contains("donna"),
                         new PassThruFunction0<>("Not found")));
-        Assert.assertEquals(METALLICA, this.unmodifiableCollection.detectWith(Object::equals, METALLICA));
-        Assert.assertEquals("Not found", this.unmodifiableCollection.detectWithIfNone(Object::equals, "Madonna",
+        assertEquals(METALLICA, this.unmodifiableCollection.detectWith(Object::equals, METALLICA));
+        assertEquals("Not found", this.unmodifiableCollection.detectWithIfNone(Object::equals, "Madonna",
                 new PassThruFunction0<>("Not found")));
-        Assert.assertEquals(4, this.unmodifiableCollection.count(ignored -> true));
-        Assert.assertEquals(1, this.unmodifiableCollection.countWith(Object::equals, METALLICA));
-        Assert.assertTrue(this.unmodifiableCollection.anySatisfy(StringPredicates.contains("allic")));
-        Assert.assertTrue(this.unmodifiableCollection.anySatisfyWith(Object::equals, METALLICA));
-        Assert.assertTrue(this.unmodifiableCollection.allSatisfy(Predicates.notNull()));
-        Assert.assertTrue(this.unmodifiableCollection.allSatisfyWith((ignored1, ignored2) -> true, ""));
-        Assert.assertEquals(this.mutableCollection, this.unmodifiableCollection.toList());
+        assertEquals(4, this.unmodifiableCollection.count(ignored -> true));
+        assertEquals(1, this.unmodifiableCollection.countWith(Object::equals, METALLICA));
+        assertTrue(this.unmodifiableCollection.anySatisfy(StringPredicates.contains("allic")));
+        assertTrue(this.unmodifiableCollection.anySatisfyWith(Object::equals, METALLICA));
+        assertTrue(this.unmodifiableCollection.allSatisfy(Predicates.notNull()));
+        assertTrue(this.unmodifiableCollection.allSatisfyWith((ignored1, ignored2) -> true, ""));
+        assertEquals(this.mutableCollection, this.unmodifiableCollection.toList());
         Verify.assertListsEqual(
                 Lists.mutable.of("Bon Jovi", "Europe", METALLICA, "Scorpions"),
                 this.unmodifiableCollection.toSortedList());
@@ -160,78 +162,78 @@ public class UnmodifiableMutableCollectionTest
         MutableCollection<Integer> unmodifiable = new UnmodifiableMutableCollection<>(mutable);
 
         MutableBooleanCollection expectedBooleans = mutable.collectBoolean(PrimitiveFunctions.integerIsPositive());
-        Assert.assertEquals(expectedBooleans, unmodifiable.collectBoolean(PrimitiveFunctions.integerIsPositive()));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, true, true), expectedBooleans);
+        assertEquals(expectedBooleans, unmodifiable.collectBoolean(PrimitiveFunctions.integerIsPositive()));
+        assertEquals(BooleanArrayList.newListWith(true, true, true, true), expectedBooleans);
 
         MutableByteCollection expectedBytes = mutable.collectByte(PrimitiveFunctions.unboxIntegerToByte());
-        Assert.assertEquals(expectedBytes, unmodifiable.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), expectedBytes);
+        assertEquals(expectedBytes, unmodifiable.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
+        assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), expectedBytes);
 
         MutableCharCollection expectedChars = mutable.collectChar(PrimitiveFunctions.unboxIntegerToChar());
-        Assert.assertEquals(expectedChars, unmodifiable.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
-        Assert.assertEquals(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4), expectedChars);
+        assertEquals(expectedChars, unmodifiable.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
+        assertEquals(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4), expectedChars);
 
         MutableDoubleCollection expectedDoubles = mutable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble());
-        Assert.assertEquals(expectedDoubles, unmodifiable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
-        Assert.assertEquals(DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d), expectedDoubles);
+        assertEquals(expectedDoubles, unmodifiable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
+        assertEquals(DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d), expectedDoubles);
 
         MutableFloatCollection expectedFloats = mutable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat());
-        Assert.assertEquals(expectedFloats, unmodifiable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
-        Assert.assertEquals(FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 4.0f), expectedFloats);
+        assertEquals(expectedFloats, unmodifiable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
+        assertEquals(FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 4.0f), expectedFloats);
 
         MutableIntCollection expectedInts = mutable.collectInt(PrimitiveFunctions.unboxIntegerToInt());
-        Assert.assertEquals(expectedInts, unmodifiable.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
-        Assert.assertEquals(IntArrayList.newListWith(1, 2, 3, 4), expectedInts);
+        assertEquals(expectedInts, unmodifiable.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
+        assertEquals(IntArrayList.newListWith(1, 2, 3, 4), expectedInts);
 
         MutableLongCollection expectedLongs = mutable.collectLong(PrimitiveFunctions.unboxIntegerToLong());
-        Assert.assertEquals(expectedLongs, unmodifiable.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
-        Assert.assertEquals(LongArrayList.newListWith(1L, 2L, 3L, 4L), expectedLongs);
+        assertEquals(expectedLongs, unmodifiable.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
+        assertEquals(LongArrayList.newListWith(1L, 2L, 3L, 4L), expectedLongs);
 
         MutableShortCollection expectedShorts = mutable.collectShort(PrimitiveFunctions.unboxIntegerToShort());
-        Assert.assertEquals(expectedShorts, unmodifiable.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
-        Assert.assertEquals(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4), expectedShorts);
+        assertEquals(expectedShorts, unmodifiable.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
+        assertEquals(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4), expectedShorts);
     }
 
     @Test
     public void nullCollection()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new UnmodifiableMutableCollection<>(null));
+        assertThrows(NullPointerException.class, () -> new UnmodifiableMutableCollection<>(null));
     }
 
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.add("Madonna"));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.add("Madonna"));
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.remove(METALLICA));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.remove(METALLICA));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.addAll(FastList.<String>newList().with("Madonna")));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.addAll(FastList.<String>newList().with("Madonna")));
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeAll(FastList.<String>newList().with(METALLICA)));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeAll(FastList.<String>newList().with(METALLICA)));
     }
 
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.retainAll(FastList.<String>newList().with(METALLICA)));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.retainAll(FastList.<String>newList().with(METALLICA)));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, this.unmodifiableCollection::clear);
+        assertThrows(UnsupportedOperationException.class, this.unmodifiableCollection::clear);
     }
 
     @Test
@@ -245,17 +247,17 @@ public class UnmodifiableMutableCollectionTest
     public void collectWith()
     {
         Function2<String, String, String> function = (band, parameter) -> parameter + band.charAt(0);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(">M", ">B", ">E", ">S"),
                 this.unmodifiableCollection.collectWith(function, ">"));
-        Assert.assertEquals(FastList.newListWith("*M", "*B", "*E", "*S"), this.unmodifiableCollection.collectWith(function, "*", FastList.newList()));
+        assertEquals(FastList.newListWith("*M", "*B", "*E", "*S"), this.unmodifiableCollection.collectWith(function, "*", FastList.newList()));
     }
 
     @Test
     public void injectInto()
     {
         Function2<String, String, String> function = (injectValue, band) -> injectValue + band.charAt(0);
-        Assert.assertEquals(">MBES", this.unmodifiableCollection.injectInto(">", function));
+        assertEquals(">MBES", this.unmodifiableCollection.injectInto(">", function));
     }
 
     @Test
@@ -263,19 +265,19 @@ public class UnmodifiableMutableCollectionTest
     {
         Function3<String, String, String, String> function =
                 (injectValue, band, parameter) -> injectValue + band.charAt(0) + parameter;
-        Assert.assertEquals(">M*B*E*S*", this.unmodifiableCollection.injectIntoWith(">", function, "*"));
+        assertEquals(">M*B*E*S*", this.unmodifiableCollection.injectIntoWith(">", function, "*"));
     }
 
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeIf(Predicates.notNull()));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeIf(Predicates.notNull()));
     }
 
     @Test
     public void removeIfWith()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeIfWith((ignored1, ignored2) -> true, METALLICA));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableCollection.removeIfWith((ignored1, ignored2) -> true, METALLICA));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -311,7 +313,7 @@ public class UnmodifiableMutableCollectionTest
             iterator.next();
             counter.increment();
         }
-        Assert.assertEquals(4, counter.getCount());
+        assertEquals(4, counter.getCount());
     }
 
     @Test
@@ -319,7 +321,7 @@ public class UnmodifiableMutableCollectionTest
     {
         Counter counter = new Counter();
         this.unmodifiableCollection.forEach(Procedures.cast(band -> counter.increment()));
-        Assert.assertEquals(4, counter.getCount());
+        assertEquals(4, counter.getCount());
     }
 
     @Test
@@ -327,7 +329,7 @@ public class UnmodifiableMutableCollectionTest
     {
         StringBuilder buf = new StringBuilder();
         this.unmodifiableCollection.forEachWith((band, param) -> buf.append(param).append('<').append(band).append('>'), "GreatBand");
-        Assert.assertEquals("GreatBand<Metallica>GreatBand<Bon Jovi>GreatBand<Europe>GreatBand<Scorpions>", buf.toString());
+        assertEquals("GreatBand<Metallica>GreatBand<Bon Jovi>GreatBand<Europe>GreatBand<Scorpions>", buf.toString());
     }
 
     @Test
@@ -335,7 +337,7 @@ public class UnmodifiableMutableCollectionTest
     {
         Counter counter = new Counter();
         this.unmodifiableCollection.forEachWithIndex((band, index) -> counter.add(index));
-        Assert.assertEquals(6, counter.getCount());
+        assertEquals(6, counter.getCount());
     }
 
     @Test
@@ -359,10 +361,10 @@ public class UnmodifiableMutableCollectionTest
                         Boolean.FALSE, FastList.newListWith(2, 4, 6));
 
         Multimap<Boolean, Integer> multimap = list.groupBy(isOddFunction);
-        Assert.assertEquals(expected, multimap.toMap());
+        assertEquals(expected, multimap.toMap());
 
         Multimap<Boolean, Integer> multimap2 = list.groupBy(isOddFunction, FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, multimap2.toMap());
+        assertEquals(expected, multimap2.toMap());
     }
 
     private <T> UnmodifiableMutableCollection<T> newWith(T... elements)
@@ -398,7 +400,7 @@ public class UnmodifiableMutableCollectionTest
     public void selectInstancesOf()
     {
         MutableCollection<Number> numbers = UnmodifiableMutableCollection.of(FastList.newListWith(1, 2.0, 3, 4.0, 5));
-        Assert.assertEquals(iList(1, 3, 5), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iList(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
+        assertEquals(iList(1, 3, 5), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iList(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTestCase.java
@@ -36,8 +36,12 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMutableCollection}.
@@ -124,7 +128,7 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     @Test
     public void testMakeString()
     {
-        Assert.assertEquals(this.getCollection().toString(), '[' + this.getCollection().makeString() + ']');
+        assertEquals(this.getCollection().toString(), '[' + this.getCollection().makeString() + ']');
     }
 
     @Test
@@ -132,58 +136,58 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     {
         Appendable builder = new StringBuilder();
         this.getCollection().appendString(builder);
-        Assert.assertEquals(this.getCollection().toString(), '[' + builder.toString() + ']');
+        assertEquals(this.getCollection().toString(), '[' + builder.toString() + ']');
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().select(ignored -> true));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().select(ignored -> false));
+        assertEquals(this.getCollection(), this.getCollection().select(ignored -> true));
+        assertNotEquals(this.getCollection(), this.getCollection().select(ignored -> false));
     }
 
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().selectWith((ignored1, ignored2) -> true, null));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().selectWith((ignored1, ignored2) -> false, null));
+        assertEquals(this.getCollection(), this.getCollection().selectWith((ignored1, ignored2) -> true, null));
+        assertNotEquals(this.getCollection(), this.getCollection().selectWith((ignored1, ignored2) -> false, null));
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().reject(ignored1 -> false));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().reject(ignored -> true));
+        assertEquals(this.getCollection(), this.getCollection().reject(ignored1 -> false));
+        assertNotEquals(this.getCollection(), this.getCollection().reject(ignored -> true));
     }
 
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().rejectWith((ignored11, ignored21) -> false, null));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().rejectWith((ignored1, ignored2) -> true, null));
+        assertEquals(this.getCollection(), this.getCollection().rejectWith((ignored11, ignored21) -> false, null));
+        assertNotEquals(this.getCollection(), this.getCollection().rejectWith((ignored1, ignored2) -> true, null));
     }
 
     @Test
     public void partition()
     {
         PartitionMutableCollection<?> partition = this.getCollection().partition(ignored -> true);
-        Assert.assertEquals(this.getCollection(), partition.getSelected());
-        Assert.assertNotEquals(this.getCollection(), partition.getRejected());
+        assertEquals(this.getCollection(), partition.getSelected());
+        assertNotEquals(this.getCollection(), partition.getRejected());
     }
 
     @Test
     public void partitionWith()
     {
         PartitionMutableCollection<?> partition = this.getCollection().partitionWith((ignored1, ignored2) -> true, null);
-        Assert.assertEquals(this.getCollection(), partition.getSelected());
-        Assert.assertNotEquals(this.getCollection(), partition.getRejected());
+        assertEquals(this.getCollection(), partition.getSelected());
+        assertNotEquals(this.getCollection(), partition.getRejected());
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().collect(Functions.getPassThru()));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().collect(Object::getClass));
+        assertEquals(this.getCollection(), this.getCollection().collect(Functions.getPassThru()));
+        assertNotEquals(this.getCollection(), this.getCollection().collect(Object::getClass));
     }
 
     @Test
@@ -245,15 +249,15 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().collectWith(Functions2.fromFunction(Functions.getPassThru()), null));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().collectWith(Functions2.fromFunction(Object::getClass), null));
+        assertEquals(this.getCollection(), this.getCollection().collectWith(Functions2.fromFunction(Functions.getPassThru()), null));
+        assertNotEquals(this.getCollection(), this.getCollection().collectWith(Functions2.fromFunction(Object::getClass), null));
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().collectIf(ignored -> true, Functions.getPassThru()));
-        Assert.assertNotEquals(this.getCollection(), this.getCollection().collectIf(ignored -> false, Object::getClass));
+        assertEquals(this.getCollection(), this.getCollection().collectIf(ignored -> true, Functions.getPassThru()));
+        assertNotEquals(this.getCollection(), this.getCollection().collectIf(ignored -> false, Object::getClass));
     }
 
     @Test
@@ -268,7 +272,7 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     @Test
     public void groupBy()
     {
-        Assert.assertEquals(this.getCollection().size(), this.getCollection().groupBy(Functions.getPassThru()).size());
+        assertEquals(this.getCollection().size(), this.getCollection().groupBy(Functions.getPassThru()).size());
     }
 
     @Test
@@ -280,24 +284,24 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
         List<Object> nullsMinusOne = Collections.nCopies(collection.size() - 1, null);
 
         MutableCollection<Pair<Object, Object>> pairs = collection.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairs.collect((Function<Pair<Object, ?>, Object>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableCollection<Pair<Object, Object>> pairsPlusOne = collection.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairsPlusOne.collect((Function<Pair<Object, ?>, Object>) Pair::getOne).toSet());
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableCollection<Pair<Object, Object>> pairsMinusOne = collection.zip(nullsMinusOne);
-        Assert.assertEquals(collection.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(collection.containsAll(pairsMinusOne.collect((Function<Pair<Object, ?>, Object>) Pair::getOne)));
+        assertEquals(collection.size() - 1, pairsMinusOne.size());
+        assertTrue(collection.containsAll(pairsMinusOne.collect((Function<Pair<Object, ?>, Object>) Pair::getOne)));
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.zip(nulls).toSet(),
                 collection.zip(nulls, new UnifiedSet<>()));
     }
@@ -308,14 +312,14 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
         MutableCollection<Object> collection = (MutableCollection<Object>) this.getCollection();
         MutableCollection<Pair<Object, Integer>> pairs = collection.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.toSet(),
                 pairs.collect((Function<Pair<Object, ?>, Object>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(collection.size() - 1).toSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
 
-        Assert.assertEquals(
+        assertEquals(
                 collection.zipWithIndex().toSet(),
                 collection.zipWithIndex(new UnifiedSet<>()));
     }
@@ -324,7 +328,7 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     public void flatCollect()
     {
         MutableCollection<Object> collection = (MutableCollection<Object>) this.getCollection();
-        Assert.assertEquals(
+        assertEquals(
                 this.getCollection().toBag(),
                 collection.flatCollect((Function<Object, Iterable<Object>>) Lists.fixedSize::of).toBag());
     }
@@ -358,7 +362,7 @@ public abstract class UnmodifiableMutableCollectionTestCase<T>
     {
         MutableList<T> tapResult = Lists.mutable.of();
         MutableCollection<T> collection = this.getCollection();
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
@@ -26,8 +26,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link BooleanIterable}s.
@@ -47,23 +51,23 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable iterable = this.newWith(true, false, true);
         Verify.assertSize(3, iterable);
-        Assert.assertTrue(iterable.containsAll(true, false, true));
+        assertTrue(iterable.containsAll(true, false, true));
 
         BooleanIterable iterable1 = this.newWith();
         Verify.assertEmpty(iterable1);
-        Assert.assertFalse(iterable1.containsAll(true, false, true));
+        assertFalse(iterable1.containsAll(true, false, true));
 
         BooleanIterable iterable2 = this.newWith(true);
         Verify.assertSize(1, iterable2);
-        Assert.assertFalse(iterable2.containsAll(true, false, true));
-        Assert.assertTrue(iterable2.containsAll(true, true));
+        assertFalse(iterable2.containsAll(true, false, true));
+        assertTrue(iterable2.containsAll(true, true));
     }
 
     @Test
     public void newCollection()
     {
-        Assert.assertEquals(this.newMutableCollectionWith(), this.newWith());
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true), this.newWith(true, false, true));
+        assertEquals(this.newMutableCollectionWith(), this.newWith());
+        assertEquals(this.newMutableCollectionWith(true, false, true), this.newWith(true, false, true));
     }
 
     @Test
@@ -78,24 +82,24 @@ public abstract class AbstractBooleanIterableTestCase
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.newWith().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
-        Assert.assertTrue(this.newWith(false).notEmpty());
-        Assert.assertTrue(this.newWith(true).notEmpty());
+        assertFalse(this.newWith().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.newWith(false).notEmpty());
+        assertTrue(this.newWith(true).notEmpty());
     }
 
     @Test
     public void contains()
     {
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.contains(true));
-        Assert.assertFalse(emptyCollection.contains(false));
+        assertFalse(emptyCollection.contains(true));
+        assertFalse(emptyCollection.contains(false));
         BooleanIterable booleanIterable = this.classUnderTest();
         int size = booleanIterable.size();
-        Assert.assertEquals(size >= 1, booleanIterable.contains(true));
-        Assert.assertEquals(size >= 2, booleanIterable.contains(false));
-        Assert.assertFalse(this.newWith(true, true, true).contains(false));
-        Assert.assertFalse(this.newWith(false, false, false).contains(true));
+        assertEquals(size >= 1, booleanIterable.contains(true));
+        assertEquals(size >= 2, booleanIterable.contains(false));
+        assertFalse(this.newWith(true, true, true).contains(false));
+        assertFalse(this.newWith(false, false, false).contains(true));
     }
 
     @Test
@@ -103,138 +107,138 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size >= 1, iterable.containsAll(true));
-        Assert.assertEquals(size >= 2, iterable.containsAll(true, false, true));
-        Assert.assertEquals(size >= 2, iterable.containsAll(true, false));
-        Assert.assertEquals(size >= 1, iterable.containsAll(true, true));
-        Assert.assertEquals(size >= 2, iterable.containsAll(false, false));
+        assertEquals(size >= 1, iterable.containsAll(true));
+        assertEquals(size >= 2, iterable.containsAll(true, false, true));
+        assertEquals(size >= 2, iterable.containsAll(true, false));
+        assertEquals(size >= 1, iterable.containsAll(true, true));
+        assertEquals(size >= 2, iterable.containsAll(false, false));
 
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
-        Assert.assertFalse(this.newWith(true, true).containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(this.newWith(true, true).containsAll(false, true, false));
 
         BooleanIterable trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(true, false));
+        assertFalse(trueCollection.containsAll(true, false));
         BooleanIterable falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(true, false));
+        assertFalse(falseCollection.containsAll(true, false));
     }
 
     @Test
     public void containsAllIterable()
     {
         BooleanIterable emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
         BooleanIterable booleanIterable = this.classUnderTest();
         int size = booleanIterable.size();
-        Assert.assertTrue(booleanIterable.containsAll(new BooleanArrayList()));
-        Assert.assertEquals(size >= 1, booleanIterable.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(size >= 2, booleanIterable.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertEquals(size >= 2, booleanIterable.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(booleanIterable.containsAll(new BooleanArrayList()));
+        assertEquals(size >= 1, booleanIterable.containsAll(BooleanArrayList.newListWith(true)));
+        assertEquals(size >= 2, booleanIterable.containsAll(BooleanArrayList.newListWith(false)));
+        assertEquals(size >= 2, booleanIterable.containsAll(BooleanArrayList.newListWith(true, false)));
         BooleanIterable iterable = this.newWith(true, true, false, false, false);
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(iterable.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
 
         BooleanIterable trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
         BooleanIterable falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
     }
 
     @Test
     public void containsAnyArray()
     {
         BooleanIterable iterable = this.newWith(true);
-        Assert.assertTrue(iterable.containsAny(true, false));
-        Assert.assertFalse(iterable.containsAny());
-        Assert.assertTrue(iterable.containsAny(true));
-        Assert.assertFalse(iterable.containsAny(false, false, false));
+        assertTrue(iterable.containsAny(true, false));
+        assertFalse(iterable.containsAny());
+        assertTrue(iterable.containsAny(true));
+        assertFalse(iterable.containsAny(false, false, false));
 
         BooleanIterable iterable2 = this.newWith(true, false);
-        Assert.assertTrue(iterable2.containsAny(true));
-        Assert.assertFalse(iterable2.containsAny());
-        Assert.assertTrue(iterable2.containsAny(false, false));
-        Assert.assertTrue(iterable2.containsAny(true, false, true, false));
+        assertTrue(iterable2.containsAny(true));
+        assertFalse(iterable2.containsAny());
+        assertTrue(iterable2.containsAny(false, false));
+        assertTrue(iterable2.containsAny(true, false, true, false));
 
         BooleanIterable emptyIterable = this.newWith();
-        Assert.assertFalse(emptyIterable.containsAny(true, true));
-        Assert.assertFalse(emptyIterable.containsAny());
-        Assert.assertFalse(emptyIterable.containsAny(false, true, true));
-        Assert.assertFalse(emptyIterable.containsAny(false));
+        assertFalse(emptyIterable.containsAny(true, true));
+        assertFalse(emptyIterable.containsAny());
+        assertFalse(emptyIterable.containsAny(false, true, true));
+        assertFalse(emptyIterable.containsAny(false));
     }
 
     @Test
     public void containsAnyIterable()
     {
         BooleanIterable iterable = this.newWith(true);
-        Assert.assertTrue(iterable.containsAny(BooleanLists.immutable.with(true, false)));
-        Assert.assertFalse(iterable.containsAny(BooleanLists.mutable.empty()));
-        Assert.assertTrue(iterable.containsAny(BooleanLists.immutable.with(true)));
-        Assert.assertFalse(iterable.containsAny(BooleanLists.immutable.with(false, false, false)));
+        assertTrue(iterable.containsAny(BooleanLists.immutable.with(true, false)));
+        assertFalse(iterable.containsAny(BooleanLists.mutable.empty()));
+        assertTrue(iterable.containsAny(BooleanLists.immutable.with(true)));
+        assertFalse(iterable.containsAny(BooleanLists.immutable.with(false, false, false)));
 
         BooleanIterable iterable2 = this.newWith(true, false);
-        Assert.assertTrue(iterable2.containsAny(BooleanSets.immutable.with(true)));
-        Assert.assertFalse(iterable2.containsAny(BooleanSets.mutable.empty()));
-        Assert.assertTrue(iterable2.containsAny(BooleanSets.immutable.with(false, false)));
-        Assert.assertTrue(iterable2.containsAny(BooleanSets.mutable.with(true, false, true, false)));
+        assertTrue(iterable2.containsAny(BooleanSets.immutable.with(true)));
+        assertFalse(iterable2.containsAny(BooleanSets.mutable.empty()));
+        assertTrue(iterable2.containsAny(BooleanSets.immutable.with(false, false)));
+        assertTrue(iterable2.containsAny(BooleanSets.mutable.with(true, false, true, false)));
 
         BooleanIterable emptyIterable = this.newWith();
-        Assert.assertFalse(emptyIterable.containsAny(BooleanLists.immutable.with(true, true)));
-        Assert.assertFalse(emptyIterable.containsAny(BooleanLists.mutable.empty()));
-        Assert.assertFalse(emptyIterable.containsAny(BooleanLists.immutable.with(false, true, true)));
-        Assert.assertFalse(emptyIterable.containsAny(BooleanLists.mutable.with(false)));
+        assertFalse(emptyIterable.containsAny(BooleanLists.immutable.with(true, true)));
+        assertFalse(emptyIterable.containsAny(BooleanLists.mutable.empty()));
+        assertFalse(emptyIterable.containsAny(BooleanLists.immutable.with(false, true, true)));
+        assertFalse(emptyIterable.containsAny(BooleanLists.mutable.with(false)));
     }
 
     @Test
     public void containsNoneArray()
     {
         BooleanIterable iterable = this.newWith(false);
-        Assert.assertTrue(iterable.containsNone(true, true));
-        Assert.assertTrue(iterable.containsNone());
-        Assert.assertFalse(iterable.containsNone(true, false));
-        Assert.assertFalse(iterable.containsNone(false));
+        assertTrue(iterable.containsNone(true, true));
+        assertTrue(iterable.containsNone());
+        assertFalse(iterable.containsNone(true, false));
+        assertFalse(iterable.containsNone(false));
 
         BooleanIterable iterable2 = this.newWith(true, false, false);
-        Assert.assertFalse(iterable2.containsNone(true, false));
-        Assert.assertTrue(iterable2.containsNone());
-        Assert.assertFalse(iterable2.containsNone(false, false, false));
-        Assert.assertFalse(iterable2.containsNone(false));
+        assertFalse(iterable2.containsNone(true, false));
+        assertTrue(iterable2.containsNone());
+        assertFalse(iterable2.containsNone(false, false, false));
+        assertFalse(iterable2.containsNone(false));
 
         BooleanIterable emptyIterable = this.newWith();
-        Assert.assertTrue(emptyIterable.containsNone(true, true));
-        Assert.assertTrue(emptyIterable.containsNone());
-        Assert.assertTrue(emptyIterable.containsNone(true, false));
-        Assert.assertTrue(emptyIterable.containsNone(false));
+        assertTrue(emptyIterable.containsNone(true, true));
+        assertTrue(emptyIterable.containsNone());
+        assertTrue(emptyIterable.containsNone(true, false));
+        assertTrue(emptyIterable.containsNone(false));
     }
 
     @Test
     public void containsNoneIterable()
     {
         BooleanIterable iterable = this.newWith(false);
-        Assert.assertTrue(iterable.containsNone(BooleanLists.immutable.with(true, true)));
-        Assert.assertTrue(iterable.containsNone(BooleanLists.mutable.empty()));
-        Assert.assertFalse(iterable.containsNone(BooleanLists.immutable.with(true, false)));
-        Assert.assertFalse(iterable.containsNone(BooleanLists.mutable.with(false)));
+        assertTrue(iterable.containsNone(BooleanLists.immutable.with(true, true)));
+        assertTrue(iterable.containsNone(BooleanLists.mutable.empty()));
+        assertFalse(iterable.containsNone(BooleanLists.immutable.with(true, false)));
+        assertFalse(iterable.containsNone(BooleanLists.mutable.with(false)));
 
         BooleanIterable iterable2 = this.newWith(true, false, false);
-        Assert.assertFalse(iterable2.containsNone(BooleanSets.immutable.with(true, false)));
-        Assert.assertTrue(iterable2.containsNone(BooleanSets.mutable.empty()));
-        Assert.assertFalse(iterable2.containsNone(BooleanSets.immutable.with(false, false, false)));
-        Assert.assertFalse(iterable2.containsNone(BooleanSets.mutable.with(false)));
+        assertFalse(iterable2.containsNone(BooleanSets.immutable.with(true, false)));
+        assertTrue(iterable2.containsNone(BooleanSets.mutable.empty()));
+        assertFalse(iterable2.containsNone(BooleanSets.immutable.with(false, false, false)));
+        assertFalse(iterable2.containsNone(BooleanSets.mutable.with(false)));
 
         BooleanIterable emptyIterable = this.newWith();
-        Assert.assertTrue(emptyIterable.containsNone(BooleanLists.immutable.with(true, true)));
-        Assert.assertTrue(emptyIterable.containsNone(BooleanLists.mutable.empty()));
-        Assert.assertTrue(emptyIterable.containsNone(BooleanLists.immutable.with(true, false)));
-        Assert.assertTrue(emptyIterable.containsNone(BooleanLists.mutable.with(false)));
+        assertTrue(emptyIterable.containsNone(BooleanLists.immutable.with(true, true)));
+        assertTrue(emptyIterable.containsNone(BooleanLists.mutable.empty()));
+        assertTrue(emptyIterable.containsNone(BooleanLists.immutable.with(true, false)));
+        assertTrue(emptyIterable.containsNone(BooleanLists.mutable.with(false)));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -256,7 +260,7 @@ public abstract class AbstractBooleanIterableTestCase
         BooleanIterator iterator = iterable.booleanIterator();
         while (iterator.hasNext())
         {
-            Assert.assertTrue(iterator.next());
+            assertTrue(iterator.next());
         }
         iterator.next();
     }
@@ -274,11 +278,11 @@ public abstract class AbstractBooleanIterableTestCase
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
         for (int i = 0; i < 3; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -289,12 +293,12 @@ public abstract class AbstractBooleanIterableTestCase
 
         int size = this.classUnderTest().size();
         int halfSize = size / 2;
-        Assert.assertEquals((size & 1) == 0 ? halfSize : halfSize + 1, sum[0]);
+        assertEquals((size & 1) == 0 ? halfSize : halfSize + 1, sum[0]);
 
         long[] sum1 = new long[1];
         this.newWith(true, false, false, true, true, true).forEach(each -> sum1[0] += each ? 1 : 2);
 
-        Assert.assertEquals(8L, sum1[0]);
+        assertEquals(8L, sum1[0]);
     }
 
     @Test
@@ -309,19 +313,19 @@ public abstract class AbstractBooleanIterableTestCase
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, this.newWith(true, false, true).count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.newWith().count(BooleanPredicates.isFalse()));
+        assertEquals(2L, this.newWith(true, false, true).count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.newWith().count(BooleanPredicates.isFalse()));
 
         BooleanIterable iterable = this.newWith(true, false, false, true, true, true);
-        Assert.assertEquals(4L, iterable.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(2L, iterable.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(6L, iterable.count(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertEquals(4L, iterable.count(BooleanPredicates.isTrue()));
+        assertEquals(2L, iterable.count(BooleanPredicates.isFalse()));
+        assertEquals(6L, iterable.count(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
 
         BooleanIterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
         int halfSize = size / 2;
-        Assert.assertEquals((size & 1) == 1 ? halfSize + 1 : halfSize, iterable1.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(halfSize, iterable1.count(BooleanPredicates.isFalse()));
+        assertEquals((size & 1) == 1 ? halfSize + 1 : halfSize, iterable1.count(BooleanPredicates.isTrue()));
+        assertEquals(halfSize, iterable1.count(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -329,14 +333,14 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable booleanIterable = this.classUnderTest();
         int size = booleanIterable.size();
-        Assert.assertEquals(size >= 1, booleanIterable.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertEquals(size >= 2, booleanIterable.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWith(true, true).anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWith().anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWith().anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(true).anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.newWith(false).anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(false, false, false).anySatisfy(BooleanPredicates.isFalse()));
+        assertEquals(size >= 1, booleanIterable.anySatisfy(BooleanPredicates.isTrue()));
+        assertEquals(size >= 2, booleanIterable.anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWith(true, true).anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWith().anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWith().anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(true).anySatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.newWith(false).anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(false, false, false).anySatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -344,14 +348,14 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable booleanIterable = this.classUnderTest();
         int size = booleanIterable.size();
-        Assert.assertEquals(size <= 1, booleanIterable.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertEquals(size == 0, booleanIterable.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.newWith().allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith().allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.newWith(false, false).allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWith(true, false).allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(true, true, true).allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(false, false, false).allSatisfy(BooleanPredicates.isFalse()));
+        assertEquals(size <= 1, booleanIterable.allSatisfy(BooleanPredicates.isTrue()));
+        assertEquals(size == 0, booleanIterable.allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.newWith().allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith().allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.newWith(false, false).allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWith(true, false).allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(true, true, true).allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(false, false, false).allSatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -359,14 +363,14 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable booleanIterable = this.classUnderTest();
         int size = booleanIterable.size();
-        Assert.assertEquals(size == 0, booleanIterable.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertEquals(size <= 1, booleanIterable.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.newWith().noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith().noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.newWith(false, false).noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(true, true).noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.newWith(true, true).noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.newWith(false, false, false).noneSatisfy(BooleanPredicates.isTrue()));
+        assertEquals(size == 0, booleanIterable.noneSatisfy(BooleanPredicates.isTrue()));
+        assertEquals(size <= 1, booleanIterable.noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.newWith().noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith().noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.newWith(false, false).noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(true, true).noneSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.newWith(true, true).noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.newWith(false, false, false).noneSatisfy(BooleanPredicates.isTrue()));
     }
 
     @Test
@@ -379,8 +383,8 @@ public abstract class AbstractBooleanIterableTestCase
         Verify.assertSize(halfSize, iterable.select(BooleanPredicates.isFalse()));
 
         BooleanIterable iterable1 = this.newWith(false, true, false, false, true, true, true);
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true, true), iterable1.select(BooleanPredicates.isTrue()));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false, false), iterable1.select(BooleanPredicates.isFalse()));
+        assertEquals(this.newMutableCollectionWith(true, true, true, true), iterable1.select(BooleanPredicates.isTrue()));
+        assertEquals(this.newMutableCollectionWith(false, false, false), iterable1.select(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -393,8 +397,8 @@ public abstract class AbstractBooleanIterableTestCase
         Verify.assertSize((size & 1) == 1 ? halfSize + 1 : halfSize, iterable.reject(BooleanPredicates.isFalse()));
 
         BooleanIterable iterable1 = this.newWith(false, true, false, false, true, true, true);
-        Assert.assertEquals(this.newMutableCollectionWith(false, false, false), iterable1.reject(BooleanPredicates.isTrue()));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true, true), iterable1.reject(BooleanPredicates.isFalse()));
+        assertEquals(this.newMutableCollectionWith(false, false, false), iterable1.reject(BooleanPredicates.isTrue()));
+        assertEquals(this.newMutableCollectionWith(true, true, true, true), iterable1.reject(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -402,20 +406,20 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable iterable = this.classUnderTest();
         int size = iterable.size();
-        Assert.assertEquals(size < 2, iterable.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertTrue(iterable.detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
+        assertEquals(size < 2, iterable.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertTrue(iterable.detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
 
         BooleanIterable iterable1 = this.newWith(true, true, true);
-        Assert.assertFalse(iterable1.detectIfNone(BooleanPredicates.isFalse(), false));
-        Assert.assertTrue(iterable1.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertTrue(iterable1.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertTrue(iterable1.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertFalse(iterable1.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(iterable1.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertTrue(iterable1.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertTrue(iterable1.detectIfNone(BooleanPredicates.isTrue(), true));
 
         BooleanIterable iterable2 = this.newWith(false, false, false);
-        Assert.assertTrue(iterable2.detectIfNone(BooleanPredicates.isTrue(), true));
-        Assert.assertFalse(iterable2.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(iterable2.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(iterable2.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(iterable2.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertFalse(iterable2.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(iterable2.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(iterable2.detectIfNone(BooleanPredicates.isFalse(), false));
     }
 
     @Test
@@ -427,11 +431,11 @@ public abstract class AbstractBooleanIterableTestCase
             objects.add((i & 1) == 0 ? 1 : 0);
         }
         RichIterable<Object> expected = this.newObjectCollectionWith(objects.toArray());
-        Assert.assertEquals(expected, this.classUnderTest().collect(value -> Integer.valueOf(value ? 1 : 0)));
+        assertEquals(expected, this.classUnderTest().collect(value -> Integer.valueOf(value ? 1 : 0)));
 
-        Assert.assertEquals(this.newObjectCollectionWith(false, true, false), this.newWith(true, false, true).collect(parameter -> !parameter));
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(parameter -> !parameter));
-        Assert.assertEquals(this.newObjectCollectionWith(true), this.newWith(false).collect(parameter -> !parameter));
+        assertEquals(this.newObjectCollectionWith(false, true, false), this.newWith(true, false, true).collect(parameter -> !parameter));
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(parameter -> !parameter));
+        assertEquals(this.newObjectCollectionWith(true), this.newWith(false).collect(parameter -> !parameter));
     }
 
     @Test
@@ -439,7 +443,7 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable iterable = this.newWith(true, false, true);
         MutableInteger result = iterable.injectInto(new MutableInteger(0), (object, value) -> object.add(value ? 1 : 0));
-        Assert.assertEquals(new MutableInteger(2), result);
+        assertEquals(new MutableInteger(2), result);
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -453,50 +457,50 @@ public abstract class AbstractBooleanIterableTestCase
     {
         BooleanIterable iterable1 = this.newWith(true, false, true);
         boolean and = iterable1.reduce((boolean result, boolean value) -> result && value);
-        Assert.assertFalse(and);
+        assertFalse(and);
 
         BooleanIterable iterable2 = this.newWith(true, true, true);
         boolean and2 = iterable2.reduce((boolean result, boolean value) -> result && value);
-        Assert.assertTrue(and2);
+        assertTrue(and2);
 
         BooleanIterable iterable3 = this.newWith(true, false, true);
         boolean or = iterable3.reduce((boolean result, boolean value) -> result || value);
-        Assert.assertTrue(or);
+        assertTrue(or);
 
         BooleanIterable iterable4 = this.newWith(false, false, false);
         boolean or2 = iterable4.reduce((boolean result, boolean value) -> result || value);
-        Assert.assertFalse(or2);
+        assertFalse(or2);
     }
 
     @Test
     public void reduceIfEmpty()
     {
-        Assert.assertTrue(this.newWith().reduceIfEmpty((boolean result, boolean value) -> result && value, true));
-        Assert.assertFalse(this.newWith().reduceIfEmpty((boolean result, boolean value) -> result && value, false));
+        assertTrue(this.newWith().reduceIfEmpty((boolean result, boolean value) -> result && value, true));
+        assertFalse(this.newWith().reduceIfEmpty((boolean result, boolean value) -> result && value, false));
 
         BooleanIterable iterable1 = this.newWith(true, false, true);
         boolean and = iterable1.reduceIfEmpty((boolean result, boolean value) -> result && value, true);
-        Assert.assertFalse(and);
+        assertFalse(and);
 
         BooleanIterable iterable2 = this.newWith(true, true, true);
         boolean and2 = iterable2.reduceIfEmpty((boolean result, boolean value) -> result && value, false);
-        Assert.assertTrue(and2);
+        assertTrue(and2);
 
         BooleanIterable iterable3 = this.newWith(true, false, true);
         boolean or = iterable3.reduceIfEmpty((boolean result, boolean value) -> result || value, false);
-        Assert.assertTrue(or);
+        assertTrue(or);
 
         BooleanIterable iterable4 = this.newWith(false, false, false);
         boolean or2 = iterable4.reduceIfEmpty((boolean result, boolean value) -> result || value, true);
-        Assert.assertFalse(or2);
+        assertFalse(or2);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertEquals(0L, this.newWith().toArray().length);
-        Assert.assertTrue(Arrays.equals(new boolean[]{true}, this.newWith(true).toArray()));
-        Assert.assertTrue(Arrays.equals(new boolean[]{false, true}, this.newWith(true, false).toArray())
+        assertEquals(0L, this.newWith().toArray().length);
+        assertTrue(Arrays.equals(new boolean[]{true}, this.newWith(true).toArray()));
+        assertTrue(Arrays.equals(new boolean[]{false, true}, this.newWith(true, false).toArray())
                 || Arrays.equals(new boolean[]{true, false}, this.newWith(true, false).toArray()));
     }
 
@@ -515,23 +519,23 @@ public abstract class AbstractBooleanIterableTestCase
         Verify.assertPostSerializedEqualsAndHashCode(iterable6);
         Verify.assertPostSerializedEqualsAndHashCode(iterable1);
         Verify.assertPostSerializedEqualsAndHashCode(iterable5);
-        Assert.assertNotEquals(iterable1, iterable3);
-        Assert.assertNotEquals(iterable1, iterable4);
-        Assert.assertNotEquals(this.newWith(), this.newWith(true));
-        Assert.assertNotEquals(iterable6, this.newWith(true, false));
+        assertNotEquals(iterable1, iterable3);
+        assertNotEquals(iterable1, iterable4);
+        assertNotEquals(this.newWith(), this.newWith(true));
+        assertNotEquals(iterable6, this.newWith(true, false));
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
-        Assert.assertEquals(
+        assertEquals(this.newObjectCollectionWith().hashCode(), this.newWith().hashCode());
+        assertEquals(
                 this.newObjectCollectionWith(true, false, true).hashCode(),
                 this.newWith(true, false, true).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 this.newObjectCollectionWith(true).hashCode(),
                 this.newWith(true).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 this.newObjectCollectionWith(false).hashCode(),
                 this.newWith(false).hashCode());
     }
@@ -539,26 +543,26 @@ public abstract class AbstractBooleanIterableTestCase
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[]", this.newWith().toString());
-        Assert.assertEquals("[true]", this.newWith(true).toString());
+        assertEquals("[]", this.newWith().toString());
+        assertEquals("[true]", this.newWith(true).toString());
         BooleanIterable iterable = this.newWith(true, false);
-        Assert.assertTrue("[true, false]".equals(iterable.toString())
+        assertTrue("[true, false]".equals(iterable.toString())
                 || "[false, true]".equals(iterable.toString()));
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("true", this.newWith(true).makeString("/"));
-        Assert.assertEquals("", this.newWith().makeString());
-        Assert.assertEquals("", this.newWith().makeString("/"));
-        Assert.assertEquals("[]", this.newWith().makeString("[", "/", "]"));
+        assertEquals("true", this.newWith(true).makeString("/"));
+        assertEquals("", this.newWith().makeString());
+        assertEquals("", this.newWith().makeString("/"));
+        assertEquals("[]", this.newWith().makeString("[", "/", "]"));
         BooleanIterable iterable = this.newWith(true, false);
-        Assert.assertTrue("true, false".equals(iterable.makeString())
+        assertTrue("true, false".equals(iterable.makeString())
                 || "false, true".equals(iterable.makeString()));
-        Assert.assertTrue(iterable.makeString("/"), "true/false".equals(iterable.makeString("/"))
+        assertTrue(iterable.makeString("/"), "true/false".equals(iterable.makeString("/"))
                 || "false/true".equals(iterable.makeString("/")));
-        Assert.assertTrue(iterable.makeString("[", "/", "]"), "[true/false]".equals(iterable.makeString("[", "/", "]"))
+        assertTrue(iterable.makeString("[", "/", "]"), "[true/false]".equals(iterable.makeString("[", "/", "]"))
                 || "[false/true]".equals(iterable.makeString("[", "/", "]")));
     }
 
@@ -567,62 +571,62 @@ public abstract class AbstractBooleanIterableTestCase
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", "/", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true).appendString(appendable1);
-        Assert.assertEquals("true", appendable1.toString());
+        assertEquals("true", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
         BooleanIterable iterable = this.newWith(true, false);
         iterable.appendString(appendable2);
-        Assert.assertTrue("true, false".equals(appendable2.toString())
+        assertTrue("true, false".equals(appendable2.toString())
                 || "false, true".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("true/false".equals(appendable3.toString())
+        assertTrue("true/false".equals(appendable3.toString())
                 || "false/true".equals(appendable3.toString()));
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
     }
 
     @Test
     public void toList()
     {
         BooleanIterable iterable = this.newWith(true, false);
-        Assert.assertTrue(BooleanArrayList.newListWith(false, true).equals(iterable.toList())
+        assertTrue(BooleanArrayList.newListWith(false, true).equals(iterable.toList())
                 || BooleanArrayList.newListWith(true, false).equals(iterable.toList()));
         BooleanIterable iterable1 = this.newWith(true);
-        Assert.assertEquals(BooleanArrayList.newListWith(true), iterable1.toList());
+        assertEquals(BooleanArrayList.newListWith(true), iterable1.toList());
         BooleanIterable iterable0 = this.newWith();
-        Assert.assertEquals(BooleanArrayList.newListWith(), iterable0.toList());
+        assertEquals(BooleanArrayList.newListWith(), iterable0.toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.newWith().toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.newWith(true).toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.newWith(true, false, false, true, true, true).toSet());
+        assertEquals(BooleanHashSet.newSetWith(), this.newWith().toSet());
+        assertEquals(BooleanHashSet.newSetWith(true), this.newWith(true).toSet());
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.newWith(true, false, false, true, true, true).toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(), this.newWith().toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.newWith(true).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), this.newWith(true, false, true).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, true, true, true, true), this.newWith(true, false, false, true, true, true).toBag());
+        assertEquals(BooleanHashBag.newBagWith(), this.newWith().toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.newWith(true).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), this.newWith(true, false, true).toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, false, true, true, true, true), this.newWith(true, false, false, true, true, true).toBag());
     }
 
     @Test
     public void asLazy()
     {
         BooleanIterable iterable = this.classUnderTest();
-        Assert.assertEquals(iterable.toBag(), iterable.asLazy().toBag());
+        assertEquals(iterable.toBag(), iterable.asLazy().toBag());
         Verify.assertInstanceOf(LazyBooleanIterable.class, iterable.asLazy());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanCollectionTestCase.java
@@ -19,8 +19,13 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanCollection}s.
@@ -43,8 +48,8 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         collection.clear();
         Verify.assertSize(0, collection);
         Verify.assertEmpty(collection);
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
 
         MutableBooleanCollection collection0 = this.newWith();
         MutableBooleanCollection collection1 = this.newWith(false);
@@ -66,16 +71,16 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         Verify.assertSize(0, collection2);
         Verify.assertSize(0, collection3);
         Verify.assertSize(0, collection4);
-        Assert.assertFalse(collection1.contains(false));
-        Assert.assertFalse(collection2.contains(true));
-        Assert.assertFalse(collection3.contains(true));
-        Assert.assertFalse(collection3.contains(false));
-        Assert.assertFalse(collection4.contains(false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection0);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection3);
-        Assert.assertEquals(this.newMutableCollectionWith(), collection4);
+        assertFalse(collection1.contains(false));
+        assertFalse(collection2.contains(true));
+        assertFalse(collection3.contains(true));
+        assertFalse(collection3.contains(false));
+        assertFalse(collection4.contains(false));
+        assertEquals(this.newMutableCollectionWith(), collection0);
+        assertEquals(this.newMutableCollectionWith(), collection1);
+        assertEquals(this.newMutableCollectionWith(), collection2);
+        assertEquals(this.newMutableCollectionWith(), collection3);
+        assertEquals(this.newMutableCollectionWith(), collection4);
     }
 
     @Override
@@ -92,12 +97,12 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
     {
         super.containsAllArray();
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
         emptyCollection.add(false);
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertTrue(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertTrue(emptyCollection.containsAll(false));
     }
 
     @Override
@@ -106,246 +111,246 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
     {
         super.containsAllIterable();
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
         emptyCollection.add(false);
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
     }
 
     @Test
     public void add()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.add(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true), emptyCollection);
-        Assert.assertTrue(emptyCollection.add(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false), emptyCollection);
-        Assert.assertTrue(emptyCollection.add(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true), emptyCollection);
-        Assert.assertTrue(emptyCollection.add(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false), emptyCollection);
+        assertTrue(emptyCollection.add(true));
+        assertEquals(this.newMutableCollectionWith(true), emptyCollection);
+        assertTrue(emptyCollection.add(false));
+        assertEquals(this.newMutableCollectionWith(true, false), emptyCollection);
+        assertTrue(emptyCollection.add(true));
+        assertEquals(this.newMutableCollectionWith(true, false, true), emptyCollection);
+        assertTrue(emptyCollection.add(false));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false), emptyCollection);
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertTrue(collection.add(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false), collection);
+        assertTrue(collection.add(false));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false), collection);
     }
 
     @Test
     public void addAllArray()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.addAll());
-        Assert.assertTrue(collection.addAll(false, true, false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false), collection);
-        Assert.assertTrue(collection.addAll(this.newMutableCollectionWith(true, false, true, false, true)));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false, true, false, true, false, true), collection);
+        assertFalse(collection.addAll());
+        assertTrue(collection.addAll(false, true, false));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false), collection);
+        assertTrue(collection.addAll(this.newMutableCollectionWith(true, false, true, false, true)));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false, true, false, true, false, true), collection);
     }
 
     @Test
     public void addAllIterable()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.addAll(this.newMutableCollectionWith()));
-        Assert.assertTrue(collection.addAll(this.newMutableCollectionWith(false, true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false), collection);
-        Assert.assertTrue(collection.addAll(this.newMutableCollectionWith(true, false, true, false, true)));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false, true, false, true, false, true), collection);
+        assertFalse(collection.addAll(this.newMutableCollectionWith()));
+        assertTrue(collection.addAll(this.newMutableCollectionWith(false, true, false)));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false), collection);
+        assertTrue(collection.addAll(this.newMutableCollectionWith(true, false, true, false, true)));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true, false, true, false, true, false, true), collection);
 
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.addAll(BooleanArrayList.newListWith(true, false, true, false, true)));
-        Assert.assertFalse(emptyCollection.addAll(new BooleanArrayList()));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true), emptyCollection);
+        assertTrue(emptyCollection.addAll(BooleanArrayList.newListWith(true, false, true, false, true)));
+        assertFalse(emptyCollection.addAll(new BooleanArrayList()));
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true), emptyCollection);
     }
 
     @Test
     public void remove()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection);
-        Assert.assertFalse(collection.remove(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection);
-        Assert.assertTrue(collection.remove(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection);
+        assertTrue(collection.remove(false));
+        assertEquals(this.newMutableCollectionWith(true, true), collection);
+        assertFalse(collection.remove(false));
+        assertEquals(this.newMutableCollectionWith(true, true), collection);
+        assertTrue(collection.remove(true));
+        assertEquals(this.newMutableCollectionWith(true), collection);
 
         MutableBooleanCollection collection1 = this.newWith();
-        Assert.assertFalse(collection1.remove(false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection1);
-        Assert.assertTrue(collection1.add(false));
-        Assert.assertTrue(collection1.add(false));
-        Assert.assertTrue(collection1.remove(false));
-        Assert.assertEquals(this.newMutableCollectionWith(false), collection1);
-        Assert.assertTrue(collection1.remove(false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection1);
+        assertFalse(collection1.remove(false));
+        assertEquals(this.newMutableCollectionWith(), collection1);
+        assertTrue(collection1.add(false));
+        assertTrue(collection1.add(false));
+        assertTrue(collection1.remove(false));
+        assertEquals(this.newMutableCollectionWith(false), collection1);
+        assertTrue(collection1.remove(false));
+        assertEquals(this.newMutableCollectionWith(), collection1);
 
         MutableBooleanCollection collection2 = this.newWith();
-        Assert.assertFalse(collection2.remove(true));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection2);
-        Assert.assertTrue(collection2.add(true));
-        Assert.assertTrue(collection2.add(true));
-        Assert.assertTrue(collection2.remove(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection2);
-        Assert.assertTrue(collection2.remove(true));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection2);
+        assertFalse(collection2.remove(true));
+        assertEquals(this.newMutableCollectionWith(), collection2);
+        assertTrue(collection2.add(true));
+        assertTrue(collection2.add(true));
+        assertTrue(collection2.remove(true));
+        assertEquals(this.newMutableCollectionWith(true), collection2);
+        assertTrue(collection2.remove(true));
+        assertEquals(this.newMutableCollectionWith(), collection2);
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll(true));
+        assertFalse(this.newWith().removeAll(true));
 
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeAll());
-        Assert.assertTrue(collection.removeAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), collection);
-        Assert.assertFalse(collection.removeAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), collection);
-        Assert.assertTrue(collection.removeAll(false, true));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertFalse(collection.removeAll());
+        assertTrue(collection.removeAll(true));
+        assertEquals(this.newMutableCollectionWith(false), collection);
+        assertFalse(collection.removeAll(true));
+        assertEquals(this.newMutableCollectionWith(false), collection);
+        assertTrue(collection.removeAll(false, true));
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         MutableBooleanCollection booleanArrayCollection = this.newWith(false, false);
-        Assert.assertFalse(booleanArrayCollection.removeAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), booleanArrayCollection);
-        Assert.assertTrue(booleanArrayCollection.removeAll(false));
-        Assert.assertEquals(this.newMutableCollectionWith(), booleanArrayCollection);
+        assertFalse(booleanArrayCollection.removeAll(true));
+        assertEquals(this.newMutableCollectionWith(false, false), booleanArrayCollection);
+        assertTrue(booleanArrayCollection.removeAll(false));
+        assertEquals(this.newMutableCollectionWith(), booleanArrayCollection);
         MutableBooleanCollection collection1 = this.classUnderTest();
-        Assert.assertFalse(collection1.removeAll());
-        Assert.assertTrue(collection1.removeAll(true, false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection1);
+        assertFalse(collection1.removeAll());
+        assertTrue(collection1.removeAll(true, false));
+        assertEquals(this.newMutableCollectionWith(), collection1);
 
         MutableBooleanCollection trueFalseList = this.newWith(true, false);
-        Assert.assertTrue(trueFalseList.removeAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), trueFalseList);
+        assertTrue(trueFalseList.removeAll(true));
+        assertEquals(this.newMutableCollectionWith(false), trueFalseList);
 
         MutableBooleanCollection collection2 = this.newWith(true, false, true, false, true);
-        Assert.assertFalse(collection2.removeAll());
-        Assert.assertTrue(collection2.removeAll(true, true));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), collection2);
+        assertFalse(collection2.removeAll());
+        assertTrue(collection2.removeAll(true, true));
+        assertEquals(this.newMutableCollectionWith(false, false), collection2);
 
         MutableBooleanCollection collection3 = this.newWith(true, false, true, false, true);
-        Assert.assertFalse(collection3.removeAll());
-        Assert.assertTrue(collection3.removeAll(true, false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection3);
+        assertFalse(collection3.removeAll());
+        assertTrue(collection3.removeAll(true, false));
+        assertEquals(this.newMutableCollectionWith(), collection3);
 
         MutableBooleanCollection collection4 = this.newWith(true, false, true, false, true);
-        Assert.assertFalse(collection4.removeAll());
-        Assert.assertTrue(collection4.removeAll(false, false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true), collection4);
+        assertFalse(collection4.removeAll());
+        assertTrue(collection4.removeAll(false, false));
+        assertEquals(this.newMutableCollectionWith(true, true, true), collection4);
     }
 
     @Test
     public void removeAll_iterable()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.removeAll(this.newMutableCollectionWith()));
-        Assert.assertTrue(collection.removeAll(this.newMutableCollectionWith(false)));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection);
-        Assert.assertTrue(collection.removeAll(this.newMutableCollectionWith(true, true)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertFalse(collection.removeAll(this.newMutableCollectionWith()));
+        assertTrue(collection.removeAll(this.newMutableCollectionWith(false)));
+        assertEquals(this.newMutableCollectionWith(true, true), collection);
+        assertTrue(collection.removeAll(this.newMutableCollectionWith(true, true)));
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         MutableBooleanCollection list = this.classUnderTest();
-        Assert.assertFalse(list.removeAll(new BooleanArrayList()));
+        assertFalse(list.removeAll(new BooleanArrayList()));
         MutableBooleanCollection booleanArrayList = this.newWith(false, false);
-        Assert.assertFalse(booleanArrayList.removeAll(new BooleanArrayList(true)));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
-        Assert.assertTrue(booleanArrayList.removeAll(new BooleanArrayList(false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), booleanArrayList);
-        Assert.assertTrue(list.removeAll(new BooleanArrayList(true)));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list);
-        Assert.assertTrue(list.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
-        Assert.assertFalse(list.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(booleanArrayList.removeAll(new BooleanArrayList(true)));
+        assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
+        assertTrue(booleanArrayList.removeAll(new BooleanArrayList(false)));
+        assertEquals(this.newMutableCollectionWith(), booleanArrayList);
+        assertTrue(list.removeAll(new BooleanArrayList(true)));
+        assertEquals(this.newMutableCollectionWith(false), list);
+        assertTrue(list.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(list.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(), list);
 
         MutableBooleanCollection list1 = this.newWith(true, false, true, true);
-        Assert.assertFalse(list1.removeAll(new BooleanArrayList()));
-        Assert.assertTrue(list1.removeAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(list1.removeAll(new BooleanArrayList()));
+        assertTrue(list1.removeAll(BooleanArrayList.newListWith(true, true)));
         Verify.assertSize(1, list1);
-        Assert.assertFalse(list1.contains(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list1);
-        Assert.assertTrue(list1.removeAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list1);
+        assertFalse(list1.contains(true));
+        assertEquals(this.newMutableCollectionWith(false), list1);
+        assertTrue(list1.removeAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(this.newMutableCollectionWith(), list1);
 
         MutableBooleanCollection list2 = this.newWith(true, false, true, false, true);
-        Assert.assertTrue(list2.removeAll(BooleanHashBag.newBagWith(true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list2);
+        assertTrue(list2.removeAll(BooleanHashBag.newBagWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(), list2);
     }
 
     @Test
     public void retainAll_iterable()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.retainAll(true, false));
-        Assert.assertTrue(collection.retainAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection);
-        Assert.assertTrue(collection.retainAll(false, false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertFalse(collection.retainAll(true, false));
+        assertTrue(collection.retainAll(true));
+        assertEquals(this.newMutableCollectionWith(true, true), collection);
+        assertTrue(collection.retainAll(false, false));
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         MutableBooleanCollection list = this.classUnderTest();
-        Assert.assertFalse(list.retainAll(false, false, true));
+        assertFalse(list.retainAll(false, false, true));
         MutableBooleanCollection booleanArrayList = this.newWith(false, false);
-        Assert.assertFalse(booleanArrayList.retainAll(false));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
-        Assert.assertTrue(booleanArrayList.retainAll(true));
-        Assert.assertEquals(this.newMutableCollectionWith(), booleanArrayList);
-        Assert.assertTrue(list.retainAll(false));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list);
-        Assert.assertTrue(list.retainAll());
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
-        Assert.assertFalse(list.retainAll(true, false));
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(booleanArrayList.retainAll(false));
+        assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
+        assertTrue(booleanArrayList.retainAll(true));
+        assertEquals(this.newMutableCollectionWith(), booleanArrayList);
+        assertTrue(list.retainAll(false));
+        assertEquals(this.newMutableCollectionWith(false), list);
+        assertTrue(list.retainAll());
+        assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(list.retainAll(true, false));
+        assertEquals(this.newMutableCollectionWith(), list);
 
         MutableBooleanCollection list1 = this.newWith(true, false, true, true);
-        Assert.assertFalse(list1.retainAll(false, false, true));
-        Assert.assertTrue(list1.retainAll(false, false));
+        assertFalse(list1.retainAll(false, false, true));
+        assertTrue(list1.retainAll(false, false));
         Verify.assertSize(1, list1);
-        Assert.assertFalse(list1.contains(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list1);
-        Assert.assertTrue(list1.retainAll(true, true));
-        Assert.assertEquals(this.newMutableCollectionWith(), list1);
+        assertFalse(list1.contains(true));
+        assertEquals(this.newMutableCollectionWith(false), list1);
+        assertTrue(list1.retainAll(true, true));
+        assertEquals(this.newMutableCollectionWith(), list1);
 
         MutableBooleanCollection list2 = this.newWith(true, false, true, false, true);
-        Assert.assertTrue(list2.retainAll());
-        Assert.assertEquals(this.newMutableCollectionWith(), list2);
+        assertTrue(list2.retainAll());
+        assertEquals(this.newMutableCollectionWith(), list2);
     }
 
     @Test
     public void retainAll()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertFalse(collection.retainAll(this.newMutableCollectionWith(true, false)));
-        Assert.assertTrue(collection.retainAll(this.newMutableCollectionWith(true)));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection);
-        Assert.assertTrue(collection.retainAll(this.newMutableCollectionWith(false, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection);
+        assertFalse(collection.retainAll(this.newMutableCollectionWith(true, false)));
+        assertTrue(collection.retainAll(this.newMutableCollectionWith(true)));
+        assertEquals(this.newMutableCollectionWith(true, true), collection);
+        assertTrue(collection.retainAll(this.newMutableCollectionWith(false, false)));
+        assertEquals(this.newMutableCollectionWith(), collection);
 
         MutableBooleanCollection list = this.classUnderTest();
-        Assert.assertFalse(list.retainAll(BooleanArrayList.newListWith(false, false, true)));
+        assertFalse(list.retainAll(BooleanArrayList.newListWith(false, false, true)));
         MutableBooleanCollection booleanArrayList = this.newWith(false, false);
-        Assert.assertFalse(booleanArrayList.retainAll(new BooleanArrayList(false)));
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
-        Assert.assertTrue(booleanArrayList.retainAll(new BooleanArrayList(true)));
-        Assert.assertEquals(this.newMutableCollectionWith(), booleanArrayList);
-        Assert.assertTrue(list.retainAll(new BooleanArrayList(false)));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list);
-        Assert.assertTrue(list.retainAll(new BooleanArrayList()));
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
-        Assert.assertFalse(list.retainAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(booleanArrayList.retainAll(new BooleanArrayList(false)));
+        assertEquals(this.newMutableCollectionWith(false, false), booleanArrayList);
+        assertTrue(booleanArrayList.retainAll(new BooleanArrayList(true)));
+        assertEquals(this.newMutableCollectionWith(), booleanArrayList);
+        assertTrue(list.retainAll(new BooleanArrayList(false)));
+        assertEquals(this.newMutableCollectionWith(false), list);
+        assertTrue(list.retainAll(new BooleanArrayList()));
+        assertEquals(this.newMutableCollectionWith(), list);
+        assertFalse(list.retainAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(), list);
 
         MutableBooleanCollection list1 = this.newWith(true, false, true, true);
-        Assert.assertFalse(list1.retainAll(BooleanArrayList.newListWith(false, false, true)));
-        Assert.assertTrue(list1.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(list1.retainAll(BooleanArrayList.newListWith(false, false, true)));
+        assertTrue(list1.retainAll(BooleanArrayList.newListWith(false, false)));
         Verify.assertSize(1, list1);
-        Assert.assertFalse(list1.contains(true));
-        Assert.assertEquals(this.newMutableCollectionWith(false), list1);
-        Assert.assertTrue(list1.retainAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(this.newMutableCollectionWith(), list1);
+        assertFalse(list1.contains(true));
+        assertEquals(this.newMutableCollectionWith(false), list1);
+        assertTrue(list1.retainAll(BooleanArrayList.newListWith(true, true)));
+        assertEquals(this.newMutableCollectionWith(), list1);
 
         MutableBooleanCollection list2 = this.newWith(true, false, true, false, true);
-        Assert.assertTrue(list2.retainAll(new BooleanHashBag()));
-        Assert.assertEquals(this.newMutableCollectionWith(), list2);
+        assertTrue(list2.retainAll(new BooleanHashBag()));
+        assertEquals(this.newMutableCollectionWith(), list2);
     }
 
     @Test
@@ -357,12 +362,12 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         MutableBooleanCollection collection1 = this.newWith().with(true).with(false).with(true);
         MutableBooleanCollection collection2 = this.newWith().with(true).with(false).with(true).with(false);
         MutableBooleanCollection collection3 = this.newWith().with(true).with(false).with(true).with(false).with(true);
-        Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false), collection0);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true), collection3);
+        assertSame(emptyCollection, collection);
+        assertEquals(this.newMutableCollectionWith(true), collection);
+        assertEquals(this.newMutableCollectionWith(true, false), collection0);
+        assertEquals(this.newMutableCollectionWith(true, false, true), collection1);
+        assertEquals(this.newMutableCollectionWith(true, false, true, false), collection2);
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true), collection3);
     }
 
     @Test
@@ -374,47 +379,47 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         MutableBooleanCollection collection1 = this.newWith().withAll(this.newMutableCollectionWith(true, false, true));
         MutableBooleanCollection collection2 = this.newWith().withAll(this.newMutableCollectionWith(true, false, true, false));
         MutableBooleanCollection collection3 = this.newWith().withAll(this.newMutableCollectionWith(true, false, true, false, true));
-        Assert.assertSame(emptyCollection, collection);
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false), collection0);
-        Assert.assertEquals(this.classUnderTest(), collection1);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false), collection2);
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true, false, true), collection3);
+        assertSame(emptyCollection, collection);
+        assertEquals(this.newMutableCollectionWith(true), collection);
+        assertEquals(this.newMutableCollectionWith(true, false), collection0);
+        assertEquals(this.classUnderTest(), collection1);
+        assertEquals(this.newMutableCollectionWith(true, false, true, false), collection2);
+        assertEquals(this.newMutableCollectionWith(true, false, true, false, true), collection3);
     }
 
     @Test
     public void without()
     {
         MutableBooleanCollection collection = this.newWith(true, false, true, false, true);
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, false, true), collection.without(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, false, true), collection.without(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true), collection.without(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection.without(true));
-        Assert.assertEquals(this.newMutableCollectionWith(true), collection.without(false));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(true));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.without(false));
+        assertEquals(this.newMutableCollectionWith(true, true, false, true), collection.without(false));
+        assertEquals(this.newMutableCollectionWith(true, false, true), collection.without(true));
+        assertEquals(this.newMutableCollectionWith(true, true), collection.without(false));
+        assertEquals(this.newMutableCollectionWith(true), collection.without(true));
+        assertEquals(this.newMutableCollectionWith(true), collection.without(false));
+        assertEquals(this.newMutableCollectionWith(), collection.without(true));
+        assertEquals(this.newMutableCollectionWith(), collection.without(false));
 
         MutableBooleanCollection collection1 = this.newWith(true, false, true, false, true);
-        Assert.assertSame(collection1, collection1.without(false));
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, false, true), collection1);
+        assertSame(collection1, collection1.without(false));
+        assertEquals(this.newMutableCollectionWith(true, true, false, true), collection1);
     }
 
     @Test
     public void withoutAll()
     {
         MutableBooleanCollection mainCollection = this.newWith(true, false, true, false, true);
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true), mainCollection.withoutAll(this.newMutableCollectionWith(false, false)));
+        assertEquals(this.newMutableCollectionWith(true, true, true), mainCollection.withoutAll(this.newMutableCollectionWith(false, false)));
 
         MutableBooleanCollection collection = this.newWith(true, false, true, false, true);
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true), collection.withoutAll(BooleanHashBag.newBagWith(false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(BooleanHashBag.newBagWith(true, false)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.withoutAll(BooleanHashBag.newBagWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(true, true, true), collection.withoutAll(BooleanHashBag.newBagWith(false)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(BooleanHashBag.newBagWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(), collection.withoutAll(BooleanHashBag.newBagWith(true, false)));
 
         MutableBooleanCollection trueCollection = this.newWith(true, true, true);
-        Assert.assertEquals(this.newMutableCollectionWith(true, true, true), trueCollection.withoutAll(BooleanArrayList.newListWith(false)));
+        assertEquals(this.newMutableCollectionWith(true, true, true), trueCollection.withoutAll(BooleanArrayList.newListWith(false)));
         MutableBooleanCollection mutableBooleanCollection = trueCollection.withoutAll(BooleanArrayList.newListWith(true));
-        Assert.assertEquals(this.newMutableCollectionWith(), mutableBooleanCollection);
-        Assert.assertSame(trueCollection, mutableBooleanCollection);
+        assertEquals(this.newMutableCollectionWith(), mutableBooleanCollection);
+        assertSame(trueCollection, mutableBooleanCollection);
     }
 
     @Test
@@ -422,16 +427,16 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
     {
         MutableBooleanCollection collection = this.classUnderTest();
         Verify.assertInstanceOf(this.newWith(true, false, true).asSynchronized().getClass(), collection.asSynchronized());
-        Assert.assertEquals(this.newWith(true, false, true).asSynchronized(), collection.asSynchronized());
-        Assert.assertEquals(collection, collection.asSynchronized());
+        assertEquals(this.newWith(true, false, true).asSynchronized(), collection.asSynchronized());
+        assertEquals(collection, collection.asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(this.newWith(true, false, true).asUnmodifiable().getClass(), this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.newWith(true, false, true).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.newWith(true, false, true).asUnmodifiable(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
     }
 
     @Test
@@ -444,14 +449,14 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         for (int i = 0; i < iterationCount; i++)
         {
             Verify.assertSize(iterableSize--, booleanIterable);
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
             iterator.remove();
             Verify.assertSize(iterableSize, booleanIterable);
         }
         Verify.assertEmpty(booleanIterable);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -459,8 +464,8 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
     {
         MutableBooleanCollection booleanIterable = this.newWith(true, false);
         MutableBooleanIterator iterator = booleanIterable.booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
@@ -470,7 +475,7 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
         MutableBooleanIterator iterator = booleanIterable.booleanIterator();
         iterator.next();
         iterator.remove();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
     }
 
     @Test
@@ -498,7 +503,7 @@ public abstract class AbstractMutableBooleanCollectionTestCase extends AbstractB
                 Lists.mutable.with(this.newMutableCollectionWith(false, true)),
                 iterable3.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
@@ -19,8 +19,11 @@ import org.eclipse.collections.impl.stack.mutable.primitive.SynchronizedBooleanS
 import org.eclipse.collections.impl.stack.mutable.primitive.UnmodifiableBooleanStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanStack}.
@@ -49,7 +52,7 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
         super.peekAtIndex();
         MutableBooleanStack stack = this.classUnderTest();
         stack.pop(2);
-        Assert.assertEquals((this.classUnderTest().size() & 1) != 0, stack.peekAt(0));
+        assertEquals((this.classUnderTest().size() & 1) != 0, stack.peekAt(0));
     }
 
     @Override
@@ -61,7 +64,7 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
         int size = this.classUnderTest().size();
         for (int i = 0; i < size; i++)
         {
-            Assert.assertEquals((i & 1) != 0, stack.peek());
+            assertEquals((i & 1) != 0, stack.peek());
             stack.pop();
         }
     }
@@ -70,9 +73,9 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
     public void peekWithCount()
     {
         MutableBooleanStack stack = this.classUnderTest();
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), stack.peek(2));
+        assertEquals(BooleanArrayList.newListWith(false, true), stack.peek(2));
         stack.pop(2);
-        Assert.assertEquals(BooleanArrayList.newListWith(false), stack.peek(1));
+        assertEquals(BooleanArrayList.newListWith(false), stack.peek(1));
     }
 
     @Test(expected = EmptyStackException.class)
@@ -85,38 +88,38 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
     public void testNewStackWithOrder()
     {
         MutableBooleanStack stack = this.newWith(true, false, true, true);
-        Assert.assertTrue(stack.pop());
-        Assert.assertTrue(stack.pop());
-        Assert.assertFalse(stack.pop());
-        Assert.assertTrue(stack.pop());
+        assertTrue(stack.pop());
+        assertTrue(stack.pop());
+        assertFalse(stack.pop());
+        assertTrue(stack.pop());
     }
 
     @Test
     public void testNewStackIterableOrder()
     {
         MutableBooleanStack stack = this.newWithIterable(BooleanArrayList.newListWith(true, false, true, true));
-        Assert.assertTrue(stack.pop());
-        Assert.assertTrue(stack.pop());
-        Assert.assertFalse(stack.pop());
-        Assert.assertTrue(stack.pop());
+        assertTrue(stack.pop());
+        assertTrue(stack.pop());
+        assertFalse(stack.pop());
+        assertTrue(stack.pop());
     }
 
     @Test
     public void testNewStackFromTopToBottomOrder()
     {
         MutableBooleanStack stack = this.newWithTopToBottom(false, true, true);
-        Assert.assertFalse(stack.pop());
-        Assert.assertTrue(stack.pop());
-        Assert.assertTrue(stack.pop());
+        assertFalse(stack.pop());
+        assertTrue(stack.pop());
+        assertTrue(stack.pop());
     }
 
     @Test
     public void testNewStackFromTopToBottomIterableOrder()
     {
         MutableBooleanStack stack = this.newWithIterableTopToBottom(BooleanArrayList.newListWith(false, true, true));
-        Assert.assertFalse(stack.pop());
-        Assert.assertTrue(stack.pop());
-        Assert.assertTrue(stack.pop());
+        assertFalse(stack.pop());
+        assertTrue(stack.pop());
+        assertTrue(stack.pop());
     }
 
     @Test
@@ -128,7 +131,7 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
         Verify.assertSize(size + 1, stack);
         stack.pop();
         Verify.assertSize(size, stack);
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), stack.peek(2));
+        assertEquals(BooleanArrayList.newListWith(false, true), stack.peek(2));
     }
 
     @Test
@@ -138,7 +141,7 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
         int size = stack.size();
         for (int i = 0; i < size; i++)
         {
-            Assert.assertEquals((i & 1) != 0, stack.pop());
+            assertEquals((i & 1) != 0, stack.pop());
             Verify.assertSize(size - i - 1, stack);
         }
     }
@@ -148,7 +151,7 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
     {
         MutableBooleanStack stack = this.classUnderTest();
         int size = this.classUnderTest().size();
-        Assert.assertEquals(BooleanArrayList.newListWith((size & 1) != 0, (size & 1) == 0), stack.pop(2));
+        assertEquals(BooleanArrayList.newListWith((size & 1) != 0, (size & 1) == 0), stack.pop(2));
         Verify.assertSize(size - 2, stack);
     }
 
@@ -186,13 +189,13 @@ public abstract class AbstractMutableBooleanStackTestCase extends AbstractBoolea
     public void asSynchronized()
     {
         Verify.assertInstanceOf(SynchronizedBooleanStack.class, this.classUnderTest().asSynchronized());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().asSynchronized());
+        assertEquals(this.classUnderTest(), this.classUnderTest().asSynchronized());
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(UnmodifiableBooleanStack.class, this.classUnderTest().asUnmodifiable());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().asUnmodifiable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigDecimalSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigDecimalSummaryStatisticsTest.java
@@ -16,8 +16,11 @@ import java.util.List;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class BigDecimalSummaryStatisticsTest
 {
@@ -27,13 +30,13 @@ public class BigDecimalSummaryStatisticsTest
         BigDecimalSummaryStatistics statistics = new BigDecimalSummaryStatistics();
         List<BigDecimal> integers = Interval.oneTo(5).collect(i -> BigDecimal.valueOf((long) i)).toList();
         integers.forEach(statistics);
-        Assert.assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
@@ -42,13 +45,13 @@ public class BigDecimalSummaryStatisticsTest
         BigDecimalSummaryStatistics statistics = new BigDecimalSummaryStatistics();
         MutableList<BigDecimal> integers = Interval.oneTo(5).collect(i -> BigDecimal.valueOf((long) i)).toList();
         integers.each(statistics);
-        Assert.assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
@@ -60,25 +63,25 @@ public class BigDecimalSummaryStatisticsTest
         BigDecimalSummaryStatistics statistics2 = new BigDecimalSummaryStatistics();
         MutableList<BigDecimal> integers2 = Interval.fromTo(3, 5).collect(i -> BigDecimal.valueOf((long) i)).toList();
         integers2.each(statistics2);
-        Assert.assertSame(statistics1, statistics1.merge(statistics2));
-        Assert.assertEquals(BigDecimal.valueOf(15L), statistics1.getSum());
-        Assert.assertEquals(5L, statistics1.getCount());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics1.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics1.getMinOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics1.getMax());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics1.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics1.getAverage());
+        assertSame(statistics1, statistics1.merge(statistics2));
+        assertEquals(BigDecimal.valueOf(15L), statistics1.getSum());
+        assertEquals(5L, statistics1.getCount());
+        assertEquals(BigDecimal.valueOf(1L), statistics1.getMin());
+        assertEquals(BigDecimal.valueOf(1L), statistics1.getMinOptional().get());
+        assertEquals(BigDecimal.valueOf(5L), statistics1.getMax());
+        assertEquals(BigDecimal.valueOf(5L), statistics1.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics1.getAverage());
     }
 
     @Test
     public void empty()
     {
         BigDecimalSummaryStatistics statistics = new BigDecimalSummaryStatistics();
-        Assert.assertEquals(0L, statistics.getCount());
-        Assert.assertEquals(BigDecimal.ZERO, statistics.getSum());
-        Assert.assertEquals(BigDecimal.ZERO, statistics.getAverage());
-        Assert.assertNull(statistics.getMin());
-        Assert.assertNull(statistics.getMax());
+        assertEquals(0L, statistics.getCount());
+        assertEquals(BigDecimal.ZERO, statistics.getSum());
+        assertEquals(BigDecimal.ZERO, statistics.getAverage());
+        assertNull(statistics.getMin());
+        assertNull(statistics.getMax());
     }
 
     @Test
@@ -86,19 +89,19 @@ public class BigDecimalSummaryStatisticsTest
     {
         BigDecimalSummaryStatistics statistics =
                 Interval.oneTo(5).stream().collect(Collectors2.summarizingBigDecimal(BigDecimal::new));
-        Assert.assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigDecimal.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMin());
+        assertEquals(BigDecimal.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMax());
+        assertEquals(BigDecimal.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.333333333333333333333333333333333"),
                 IntLists.mutable.with(2, 2, 6)
                         .collect(Long::valueOf)
@@ -106,7 +109,7 @@ public class BigDecimalSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigDecimal(BigDecimal::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.666666666666666666666666666666667"),
                 IntLists.mutable.with(2, 3, 6)
                         .collect(Long::valueOf)
@@ -114,7 +117,7 @@ public class BigDecimalSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigDecimal(BigDecimal::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("1"),
                 IntLists.mutable.with(1, 1, 1)
                         .collect(Long::valueOf)
@@ -122,7 +125,7 @@ public class BigDecimalSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigDecimal(BigDecimal::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("4"),
                 IntLists.mutable.with(2, 3, 4, 5, 6)
                         .collect(Long::valueOf)
@@ -130,7 +133,7 @@ public class BigDecimalSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigDecimal(BigDecimal::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.8"),
                 IntLists.mutable.with(2, 3, 4, 5, 5)
                         .collect(Long::valueOf)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigIntegerSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigIntegerSummaryStatisticsTest.java
@@ -17,8 +17,11 @@ import java.util.List;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class BigIntegerSummaryStatisticsTest
 {
@@ -28,13 +31,13 @@ public class BigIntegerSummaryStatisticsTest
         BigIntegerSummaryStatistics statistics = new BigIntegerSummaryStatistics();
         List<BigInteger> integers = Interval.oneTo(5).collect(i -> BigInteger.valueOf((long) i)).toList();
         integers.forEach(statistics);
-        Assert.assertEquals(BigInteger.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigInteger.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMin());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMax());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
@@ -43,13 +46,13 @@ public class BigIntegerSummaryStatisticsTest
         BigIntegerSummaryStatistics statistics = new BigIntegerSummaryStatistics();
         MutableList<BigInteger> integers = Interval.oneTo(5).collect(i -> BigInteger.valueOf((long) i)).toList();
         integers.each(statistics);
-        Assert.assertEquals(BigInteger.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigInteger.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMin());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMax());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
@@ -61,25 +64,25 @@ public class BigIntegerSummaryStatisticsTest
         BigIntegerSummaryStatistics statistics2 = new BigIntegerSummaryStatistics();
         MutableList<BigInteger> integers2 = Interval.fromTo(3, 5).collect(i -> BigInteger.valueOf((long) i)).toList();
         integers2.each(statistics2);
-        Assert.assertSame(statistics1, statistics1.merge(statistics2));
-        Assert.assertEquals(BigInteger.valueOf(15L), statistics1.getSum());
-        Assert.assertEquals(5L, statistics1.getCount());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics1.getMin());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics1.getMinOptional().get());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics1.getMax());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics1.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics1.getAverage());
+        assertSame(statistics1, statistics1.merge(statistics2));
+        assertEquals(BigInteger.valueOf(15L), statistics1.getSum());
+        assertEquals(5L, statistics1.getCount());
+        assertEquals(BigInteger.valueOf(1L), statistics1.getMin());
+        assertEquals(BigInteger.valueOf(1L), statistics1.getMinOptional().get());
+        assertEquals(BigInteger.valueOf(5L), statistics1.getMax());
+        assertEquals(BigInteger.valueOf(5L), statistics1.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics1.getAverage());
     }
 
     @Test
     public void empty()
     {
         BigIntegerSummaryStatistics statistics = new BigIntegerSummaryStatistics();
-        Assert.assertEquals(0L, statistics.getCount());
-        Assert.assertEquals(BigInteger.ZERO, statistics.getSum());
-        Assert.assertEquals(BigDecimal.ZERO, statistics.getAverage());
-        Assert.assertNull(statistics.getMin());
-        Assert.assertNull(statistics.getMax());
+        assertEquals(0L, statistics.getCount());
+        assertEquals(BigInteger.ZERO, statistics.getSum());
+        assertEquals(BigDecimal.ZERO, statistics.getAverage());
+        assertNull(statistics.getMin());
+        assertNull(statistics.getMax());
     }
 
     @Test
@@ -91,19 +94,19 @@ public class BigIntegerSummaryStatisticsTest
                         .toList()
                         .stream()
                         .collect(Collectors2.summarizingBigInteger(BigInteger::valueOf));
-        Assert.assertEquals(BigInteger.valueOf(15L), statistics.getSum());
-        Assert.assertEquals(5L, statistics.getCount());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMin());
-        Assert.assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMax());
-        Assert.assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
-        Assert.assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
+        assertEquals(BigInteger.valueOf(15L), statistics.getSum());
+        assertEquals(5L, statistics.getCount());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMin());
+        assertEquals(BigInteger.valueOf(1L), statistics.getMinOptional().get());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMax());
+        assertEquals(BigInteger.valueOf(5L), statistics.getMaxOptional().get());
+        assertEquals(BigDecimal.valueOf(3L), statistics.getAverage());
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.333333333333333333333333333333333"),
                 IntLists.mutable.with(2, 2, 6)
                         .collect(Long::valueOf)
@@ -111,7 +114,7 @@ public class BigIntegerSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigInteger(BigInteger::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.666666666666666666666666666666667"),
                 IntLists.mutable.with(2, 3, 6)
                         .collect(Long::valueOf)
@@ -119,7 +122,7 @@ public class BigIntegerSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigInteger(BigInteger::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("1"),
                 IntLists.mutable.with(1, 1, 1)
                         .collect(Long::valueOf)
@@ -127,7 +130,7 @@ public class BigIntegerSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigInteger(BigInteger::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("4"),
                 IntLists.mutable.with(2, 3, 4, 5, 6)
                         .collect(Long::valueOf)
@@ -135,7 +138,7 @@ public class BigIntegerSummaryStatisticsTest
                         .collect(Collectors2.summarizingBigInteger(BigInteger::valueOf))
                         .getAverage());
 
-        Assert.assertEquals(
+        assertEquals(
                 new BigDecimal("3.8"),
                 IntLists.mutable.with(2, 3, 4, 5, 5)
                         .collect(Long::valueOf)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
@@ -49,8 +49,11 @@ import org.eclipse.collections.impl.partition.set.PartitionUnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /*
 Do not merge this test with Collectors2Test. Doing so will fail the build. This is due to a bug in ASM.
@@ -71,24 +74,24 @@ public class Collectors2AdditionalTest
     public void chunk()
     {
         MutableList<MutableList<Integer>> chunked0 = this.bigData.stream().collect(Collectors2.chunk(100));
-        Assert.assertEquals(LARGE_INTERVAL.toList().chunk(100), chunked0);
+        assertEquals(LARGE_INTERVAL.toList().chunk(100), chunked0);
         MutableList<MutableList<Integer>> chunked1 = this.bigData.stream().collect(Collectors2.chunk(333));
-        Assert.assertEquals(LARGE_INTERVAL.toList().chunk(333), chunked1);
+        assertEquals(LARGE_INTERVAL.toList().chunk(333), chunked1);
         MutableList<MutableList<Integer>> chunked2 = this.bigData.stream().collect(Collectors2.chunk(654));
-        Assert.assertEquals(LARGE_INTERVAL.toList().chunk(654), chunked2);
+        assertEquals(LARGE_INTERVAL.toList().chunk(654), chunked2);
         MutableList<MutableList<Integer>> chunked3 = this.smallData.stream().collect(Collectors2.chunk(SMALL_INTERVAL.size()));
-        Assert.assertEquals(SMALL_INTERVAL.toList().chunk(SMALL_INTERVAL.size()), chunked3);
+        assertEquals(SMALL_INTERVAL.toList().chunk(SMALL_INTERVAL.size()), chunked3);
         MutableList<MutableList<Integer>> chunked4 = this.smallData.stream().collect(Collectors2.chunk(SMALL_INTERVAL.size() - 1));
-        Assert.assertEquals(SMALL_INTERVAL.toList().chunk(SMALL_INTERVAL.size() - 1), chunked4);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Collectors2.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Collectors2.chunk(-10));
+        assertEquals(SMALL_INTERVAL.toList().chunk(SMALL_INTERVAL.size() - 1), chunked4);
+        assertThrows(IllegalArgumentException.class, () -> Collectors2.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> Collectors2.chunk(-10));
     }
 
     @Test
     public void chunkParallel()
     {
         MutableList<MutableList<Integer>> chunked = this.bigData.parallelStream().collect(Collectors2.chunk(100));
-        Assert.assertTrue(chunked.size() > 1);
+        assertTrue(chunked.size() > 1);
         Verify.assertAllSatisfy(chunked, each -> each.size() > 1 && each.size() <= 100);
     }
 
@@ -97,14 +100,14 @@ public class Collectors2AdditionalTest
     {
         MutableList<Integer> integers1 = Interval.oneTo(10).toList();
         MutableList<Integer> integers2 = Interval.oneTo(10).toList().toReversed();
-        Assert.assertEquals(
+        assertEquals(
                 integers1.zip(integers2),
                 integers1.stream().collect(Collectors2.zip(integers2)));
         MutableList<Integer> integers3 = Interval.oneTo(9).toList().toReversed();
-        Assert.assertEquals(
+        assertEquals(
                 integers1.zip(integers3),
                 integers1.stream().collect(Collectors2.zip(integers3)));
-        Assert.assertEquals(
+        assertEquals(
                 integers3.zip(integers1),
                 integers3.stream().collect(Collectors2.zip(integers1)));
     }
@@ -115,14 +118,14 @@ public class Collectors2AdditionalTest
         MutableList<Integer> integers1 = Interval.oneTo(10).toList();
         MutableList<Integer> integers2 = Interval.oneTo(10).toList().toReversed();
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> integers1.parallelStream().collect(Collectors2.zip(integers2)));
+        assertThrows(UnsupportedOperationException.class, () -> integers1.parallelStream().collect(Collectors2.zip(integers2)));
     }
 
     @Test
     public void zipWithIndex()
     {
         MutableList<Integer> integers1 = Interval.oneTo(10).toList();
-        Assert.assertEquals(
+        assertEquals(
                 integers1.zipWithIndex().collect(each -> PrimitiveTuples.pair(each.getOne(), each.getTwo().intValue())),
                 integers1.stream().collect(Collectors2.zipWithIndex()));
     }
@@ -131,17 +134,17 @@ public class Collectors2AdditionalTest
     public void zipWithIndexParallel()
     {
         MutableList<Integer> integers1 = Interval.oneTo(10).toList();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> integers1.parallelStream().collect(Collectors2.zipWithIndex()));
+        assertThrows(UnsupportedOperationException.class, () -> integers1.parallelStream().collect(Collectors2.zipWithIndex()));
     }
 
     @Test
     public void sumByInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue),
                 SMALL_INTERVAL.stream().collect(Collectors2.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue)));
 
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue),
                 LARGE_INTERVAL.stream().collect(Collectors2.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue)));
     }
@@ -149,7 +152,7 @@ public class Collectors2AdditionalTest
     @Test
     public void sumByIntParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue),
                 LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByInt(each -> Integer.valueOf(each.intValue() % 2), Integer::intValue)));
     }
@@ -159,11 +162,11 @@ public class Collectors2AdditionalTest
     {
         MutableList<Long> smallLongs = SMALL_INTERVAL.collect(Long::valueOf).toList();
         MutableList<Long> largeLongs = LARGE_INTERVAL.collect(Long::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 smallLongs.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue),
                 smallLongs.stream().collect(Collectors2.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue)));
 
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue),
                 largeLongs.stream().collect(Collectors2.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue)));
     }
@@ -172,7 +175,7 @@ public class Collectors2AdditionalTest
     public void sumByLongParallel()
     {
         MutableList<Long> largeLongs = LARGE_INTERVAL.collect(Long::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue),
                 largeLongs.parallelStream().collect(Collectors2.sumByLong(each -> Integer.valueOf(each.intValue() % 2), Long::longValue)));
     }
@@ -182,11 +185,11 @@ public class Collectors2AdditionalTest
     {
         MutableList<Float> smallLongs = SMALL_INTERVAL.collect(Float::valueOf).toList();
         MutableList<Float> largeLongs = LARGE_INTERVAL.collect(Float::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 smallLongs.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue),
                 smallLongs.stream().collect(Collectors2.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue)));
 
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue),
                 largeLongs.stream().collect(Collectors2.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue)));
     }
@@ -195,7 +198,7 @@ public class Collectors2AdditionalTest
     public void sumByFloatParallel()
     {
         MutableList<Float> largeLongs = LARGE_INTERVAL.collect(Float::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue),
                 largeLongs.parallelStream().collect(Collectors2.sumByFloat(each -> Integer.valueOf(each.intValue() % 2), Float::floatValue)));
     }
@@ -205,11 +208,11 @@ public class Collectors2AdditionalTest
     {
         MutableList<Double> smallLongs = SMALL_INTERVAL.collect(Double::valueOf).toList();
         MutableList<Double> largeLongs = LARGE_INTERVAL.collect(Double::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 smallLongs.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue),
                 smallLongs.stream().collect(Collectors2.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue)));
 
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue),
                 largeLongs.stream().collect(Collectors2.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue)));
     }
@@ -218,7 +221,7 @@ public class Collectors2AdditionalTest
     public void sumByDoubleParallel()
     {
         MutableList<Double> largeLongs = LARGE_INTERVAL.collect(Double::valueOf).toList();
-        Assert.assertEquals(
+        assertEquals(
                 largeLongs.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue),
                 largeLongs.parallelStream().collect(Collectors2.sumByDouble(each -> Integer.valueOf(each.intValue() % 2), Double::doubleValue)));
     }
@@ -226,11 +229,11 @@ public class Collectors2AdditionalTest
     @Test
     public void sumByBigInteger()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigInteger(SMALL_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue())),
                 SMALL_INTERVAL.stream().collect(Collectors2.sumByBigInteger(each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue()))));
 
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigInteger(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue())),
                 LARGE_INTERVAL.stream().collect(Collectors2.sumByBigInteger(each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue()))));
     }
@@ -238,7 +241,7 @@ public class Collectors2AdditionalTest
     @Test
     public void sumByBigIntegerParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigInteger(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue())),
                 LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByBigInteger(each -> Integer.valueOf(each.intValue() % 2), each -> BigInteger.valueOf(each.longValue()))));
     }
@@ -246,11 +249,11 @@ public class Collectors2AdditionalTest
     @Test
     public void sumByBigDecimal()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigDecimal(SMALL_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new),
                 SMALL_INTERVAL.stream().collect(Collectors2.sumByBigDecimal(each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigDecimal(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new),
                 LARGE_INTERVAL.stream().collect(Collectors2.sumByBigDecimal(each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new)));
     }
@@ -258,7 +261,7 @@ public class Collectors2AdditionalTest
     @Test
     public void sumByBigDecimalParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Iterate.sumByBigDecimal(LARGE_INTERVAL, each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new),
                 LARGE_INTERVAL.parallelStream().collect(Collectors2.sumByBigDecimal(each -> Integer.valueOf(each.intValue() % 2), BigDecimal::new)));
     }
@@ -266,13 +269,13 @@ public class Collectors2AdditionalTest
     @Test
     public void select()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().select(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().select(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().select(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.select(IntegerPredicates.isEven(), Bags.mutable::empty)));
     }
@@ -280,13 +283,13 @@ public class Collectors2AdditionalTest
     @Test
     public void selectParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().select(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().select(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().select(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.select(IntegerPredicates.isEven(), Bags.mutable::empty)));
     }
@@ -294,15 +297,15 @@ public class Collectors2AdditionalTest
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty)));
@@ -311,15 +314,15 @@ public class Collectors2AdditionalTest
     @Test
     public void selectWithParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().selectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.selectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty)));
@@ -328,13 +331,13 @@ public class Collectors2AdditionalTest
     @Test
     public void reject()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().reject(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().reject(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().reject(IntegerPredicates.isEven()),
                 this.bigData.stream().collect(Collectors2.reject(IntegerPredicates.isEven(), Bags.mutable::empty)));
     }
@@ -342,13 +345,13 @@ public class Collectors2AdditionalTest
     @Test
     public void rejectParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().reject(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().reject(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().reject(IntegerPredicates.isEven()),
                 this.bigData.parallelStream().collect(Collectors2.reject(IntegerPredicates.isEven(), Bags.mutable::empty)));
     }
@@ -356,15 +359,15 @@ public class Collectors2AdditionalTest
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.stream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty)));
@@ -373,15 +376,15 @@ public class Collectors2AdditionalTest
     @Test
     public void rejectWithParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().rejectWith(Predicates2.greaterThan(), HALF_SIZE),
                 this.bigData.parallelStream()
                         .collect(Collectors2.rejectWith(Predicates2.greaterThan(), HALF_SIZE, Bags.mutable::empty)));
@@ -393,18 +396,18 @@ public class Collectors2AdditionalTest
         PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partition(IntegerPredicates.isEven());
         PartitionMutableList<Integer> actualList = this.bigData.stream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionFastList::new));
-        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
-        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        assertEquals(expectedList.getSelected(), actualList.getSelected());
+        assertEquals(expectedList.getRejected(), actualList.getRejected());
         PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partition(IntegerPredicates.isEven());
         PartitionMutableSet<Integer> actualSet = this.bigData.stream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionUnifiedSet::new));
-        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
-        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        assertEquals(expectedSet.getRejected(), actualSet.getRejected());
         PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partition(IntegerPredicates.isEven());
         PartitionMutableBag<Integer> actualBag = this.bigData.stream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionHashBag::new));
-        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
-        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+        assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        assertEquals(expectedBag.getRejected(), actualBag.getRejected());
     }
 
     @Test
@@ -413,18 +416,18 @@ public class Collectors2AdditionalTest
         PartitionMutableList<Integer> expectedList = LARGE_INTERVAL.toList().partition(IntegerPredicates.isEven());
         PartitionMutableList<Integer> actualList = this.bigData.parallelStream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionFastList::new));
-        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
-        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        assertEquals(expectedList.getSelected(), actualList.getSelected());
+        assertEquals(expectedList.getRejected(), actualList.getRejected());
         PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet().partition(IntegerPredicates.isEven());
         PartitionMutableSet<Integer> actualSet = this.bigData.parallelStream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionUnifiedSet::new));
-        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
-        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        assertEquals(expectedSet.getRejected(), actualSet.getRejected());
         PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag().partition(IntegerPredicates.isEven());
         PartitionMutableBag<Integer> actualBag = this.bigData.parallelStream()
                 .collect(Collectors2.partition(IntegerPredicates.isEven(), PartitionHashBag::new));
-        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
-        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+        assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        assertEquals(expectedBag.getRejected(), actualBag.getRejected());
     }
 
     @Test
@@ -434,20 +437,20 @@ public class Collectors2AdditionalTest
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableList<Integer> actualList = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
-        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
-        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        assertEquals(expectedList.getSelected(), actualList.getSelected());
+        assertEquals(expectedList.getRejected(), actualList.getRejected());
         PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet()
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableSet<Integer> actualSet = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
-        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
-        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        assertEquals(expectedSet.getRejected(), actualSet.getRejected());
         PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag()
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableBag<Integer> actualBag = this.bigData.stream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
-        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
-        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+        assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        assertEquals(expectedBag.getRejected(), actualBag.getRejected());
     }
 
     @Test
@@ -457,32 +460,32 @@ public class Collectors2AdditionalTest
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableList<Integer> actualList = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionFastList::new));
-        Assert.assertEquals(expectedList.getSelected(), actualList.getSelected());
-        Assert.assertEquals(expectedList.getRejected(), actualList.getRejected());
+        assertEquals(expectedList.getSelected(), actualList.getSelected());
+        assertEquals(expectedList.getRejected(), actualList.getRejected());
         PartitionMutableSet<Integer> expectedSet = LARGE_INTERVAL.toSet()
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableSet<Integer> actualSet = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionUnifiedSet::new));
-        Assert.assertEquals(expectedSet.getSelected(), actualSet.getSelected());
-        Assert.assertEquals(expectedSet.getRejected(), actualSet.getRejected());
+        assertEquals(expectedSet.getSelected(), actualSet.getSelected());
+        assertEquals(expectedSet.getRejected(), actualSet.getRejected());
         PartitionMutableBag<Integer> expectedBag = LARGE_INTERVAL.toBag()
                 .partitionWith(Predicates2.greaterThan(), HALF_SIZE);
         PartitionMutableBag<Integer> actualBag = this.bigData.parallelStream()
                 .collect(Collectors2.partitionWith(Predicates2.greaterThan(), HALF_SIZE, PartitionHashBag::new));
-        Assert.assertEquals(expectedBag.getSelected(), actualBag.getSelected());
-        Assert.assertEquals(expectedBag.getRejected(), actualBag.getRejected());
+        assertEquals(expectedBag.getSelected(), actualBag.getSelected());
+        assertEquals(expectedBag.getRejected(), actualBag.getRejected());
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().collect(Functions.getToString()),
                 this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().collect(Functions.getToString()),
                 this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().collect(Functions.getToString()),
                 this.bigData.stream().collect(Collectors2.collect(Functions.getToString(), Bags.mutable::empty)));
     }
@@ -490,13 +493,13 @@ public class Collectors2AdditionalTest
     @Test
     public void collectParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().collect(Functions.getToString()),
                 this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().collect(Functions.getToString()),
                 this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().collect(Functions.getToString()),
                 this.bigData.parallelStream().collect(Collectors2.collect(Functions.getToString(), Bags.mutable::empty)));
     }
@@ -505,16 +508,16 @@ public class Collectors2AdditionalTest
     public void flatCollect()
     {
         MutableList<Interval> list = Lists.mutable.with(SMALL_INTERVAL, SMALL_INTERVAL, SMALL_INTERVAL);
-        Assert.assertEquals(
+        assertEquals(
                 list.flatCollect(Functions.identity()),
                 list.stream().collect(Collectors2.flatCollect(Functions.identity(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 list.flatCollect(Functions.identity()),
                 list.stream().collect(Collectors2.flatCollect(Functions.identity(), CompositeFastList::new)));
-        Assert.assertEquals(
+        assertEquals(
                 list.toSet().flatCollect(Functions.identity()),
                 list.stream().collect(Collectors2.flatCollect(Functions.identity(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 list.toBag().flatCollect(Functions.identity()),
                 list.stream().collect(Collectors2.flatCollect(Functions.identity(), Bags.mutable::empty)));
         List<MutableList<String>> lists = Lists.mutable.with(
@@ -523,23 +526,23 @@ public class Collectors2AdditionalTest
                 Lists.mutable.with("e"));
         MutableList<String> flattened =
                 lists.stream().collect(Collectors2.flatCollect(l -> l, Lists.mutable::empty));
-        Assert.assertEquals(Lists.mutable.with("a", "b", "c", "d", "e"), flattened);
+        assertEquals(Lists.mutable.with("a", "b", "c", "d", "e"), flattened);
     }
 
     @Test
     public void flatCollectParallel()
     {
         MutableList<Interval> list = Lists.mutable.withNValues(20000, () -> SMALL_INTERVAL);
-        Assert.assertEquals(
+        assertEquals(
                 list.flatCollect(Functions.identity()),
                 list.parallelStream().collect(Collectors2.flatCollect(Functions.identity(), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 list.flatCollect(Functions.identity()),
                 list.parallelStream().collect(Collectors2.flatCollect(Functions.identity(), CompositeFastList::new)));
-        Assert.assertEquals(
+        assertEquals(
                 list.toSet().flatCollect(Functions.identity()),
                 list.parallelStream().collect(Collectors2.flatCollect(Functions.identity(), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 list.toBag().flatCollect(Functions.identity()),
                 list.parallelStream().collect(Collectors2.flatCollect(Functions.identity(), Bags.mutable::empty)));
     }
@@ -547,15 +550,15 @@ public class Collectors2AdditionalTest
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.stream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.stream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.stream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Bags.mutable::empty)));
@@ -564,15 +567,15 @@ public class Collectors2AdditionalTest
     @Test
     public void collectWithParallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toList().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.parallelStream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Lists.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toSet().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.parallelStream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Sets.mutable::empty)));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.toBag().collectWith(Integer::sum, Integer.valueOf(10)),
                 this.bigData.parallelStream()
                         .collect(Collectors2.collectWith(Integer::sum, Integer.valueOf(10), Bags.mutable::empty)));
@@ -585,7 +588,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable.empty());
         BooleanList actual =
                 this.smallData.stream().collect(Collectors2.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -595,7 +598,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable.empty());
         BooleanList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectBoolean(each -> each % 2 == 0, BooleanLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -605,7 +608,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable.empty());
         ByteList actual =
                 this.smallData.stream().collect(Collectors2.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -615,7 +618,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable.empty());
         ByteList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectByte(each -> (byte) (each % Byte.MAX_VALUE), ByteLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -625,7 +628,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable.empty());
         CharList actual =
                 this.smallData.stream().collect(Collectors2.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -635,7 +638,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable.empty());
         CharList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectChar(each -> (char) (each % Character.MAX_VALUE), CharLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -645,7 +648,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable.empty());
         ShortList actual =
                 this.smallData.stream().collect(Collectors2.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -655,7 +658,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable.empty());
         ShortList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectShort(each -> (short) (each % Short.MAX_VALUE), ShortLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -665,7 +668,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectInt(Integer::intValue, IntLists.mutable.empty());
         IntList actual =
                 this.smallData.stream().collect(Collectors2.collectInt(each -> each, IntLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -675,7 +678,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectInt(Integer::intValue, IntLists.mutable.empty());
         IntList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectInt(each -> each, IntLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -685,7 +688,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectFloat(Integer::floatValue, FloatLists.mutable.empty());
         FloatList actual =
                 this.smallData.stream().collect(Collectors2.collectFloat(each -> (float) each, FloatLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -695,7 +698,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectFloat(Integer::floatValue, FloatLists.mutable.empty());
         FloatList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectFloat(each -> (float) each, FloatLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -705,7 +708,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectLong(Integer::longValue, LongLists.mutable.empty());
         LongList actual =
                 this.smallData.stream().collect(Collectors2.collectLong(each -> (long) each, LongLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -715,7 +718,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectLong(Integer::longValue, LongLists.mutable.empty());
         LongList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectLong(each -> (long) each, LongLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -725,7 +728,7 @@ public class Collectors2AdditionalTest
                 SMALL_INTERVAL.collectDouble(Integer::doubleValue, DoubleLists.mutable.empty());
         DoubleList actual =
                 this.smallData.stream().collect(Collectors2.collectDouble(each -> (double) each, DoubleLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -735,7 +738,7 @@ public class Collectors2AdditionalTest
                 LARGE_INTERVAL.collectDouble(Integer::doubleValue, DoubleLists.mutable.empty());
         DoubleList actual =
                 this.bigData.parallelStream().collect(Collectors2.collectDouble(each -> (double) each, DoubleLists.mutable::empty));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -746,9 +749,9 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .stream()
                         .collect(Collectors2.summarizingBigDecimal(vh -> BigDecimal.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigDecimal.valueOf(2_500_000L), summaryStatistics.getSum());
-        Assert.assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMax());
+        assertEquals(BigDecimal.valueOf(2_500_000L), summaryStatistics.getSum());
+        assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMin());
+        assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMax());
     }
 
     @Test
@@ -759,9 +762,9 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .parallelStream()
                         .collect(Collectors2.summarizingBigDecimal(vh -> BigDecimal.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigDecimal.valueOf(2_500_000L), summaryStatistics.getSum());
-        Assert.assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMin());
-        Assert.assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMax());
+        assertEquals(BigDecimal.valueOf(2_500_000L), summaryStatistics.getSum());
+        assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMin());
+        assertEquals(BigDecimal.valueOf(100L), summaryStatistics.getMax());
     }
 
     @Test
@@ -772,7 +775,7 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .stream()
                         .collect(Collectors2.summingBigDecimal(vh -> BigDecimal.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigDecimal.valueOf(2_500_000L), sum);
+        assertEquals(BigDecimal.valueOf(2_500_000L), sum);
     }
 
     @Test
@@ -783,7 +786,7 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .parallelStream()
                         .collect(Collectors2.summingBigDecimal(vh -> BigDecimal.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigDecimal.valueOf(2_500_000L), sum);
+        assertEquals(BigDecimal.valueOf(2_500_000L), sum);
     }
 
     @Test
@@ -794,9 +797,9 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .stream()
                         .collect(Collectors2.summarizingBigInteger(vh -> BigInteger.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigInteger.valueOf(2_500_000L), summaryStatistics.getSum());
-        Assert.assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMin());
-        Assert.assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMax());
+        assertEquals(BigInteger.valueOf(2_500_000L), summaryStatistics.getSum());
+        assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMin());
+        assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMax());
     }
 
     @Test
@@ -807,9 +810,9 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .parallelStream()
                         .collect(Collectors2.summarizingBigInteger(vh -> BigInteger.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigInteger.valueOf(2_500_000L), summaryStatistics.getSum());
-        Assert.assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMin());
-        Assert.assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMax());
+        assertEquals(BigInteger.valueOf(2_500_000L), summaryStatistics.getSum());
+        assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMin());
+        assertEquals(BigInteger.valueOf(100L), summaryStatistics.getMax());
     }
 
     @Test
@@ -820,7 +823,7 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .stream()
                         .collect(Collectors2.summingBigInteger(vh -> BigInteger.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigInteger.valueOf(2_500_000L), sum);
+        assertEquals(BigInteger.valueOf(2_500_000L), sum);
     }
 
     @Test
@@ -831,6 +834,6 @@ public class Collectors2AdditionalTest
                 Lists.mutable.withNValues(25_000, () -> valueHolder)
                         .parallelStream()
                         .collect(Collectors2.summingBigInteger(vh -> BigInteger.valueOf(vh.getLongValue())));
-        Assert.assertEquals(BigInteger.valueOf(2_500_000L), sum);
+        assertEquals(BigInteger.valueOf(2_500_000L), sum);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -55,8 +55,9 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public final class Collectors2Test
 {
@@ -69,16 +70,16 @@ public final class Collectors2Test
     @Test
     public void makeString0()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString(),
                 this.smallData.stream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString()),
                 this.smallData.stream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString(),
                 this.bigData.stream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString()),
                 this.bigData.stream().collect(Collectors2.makeString()));
     }
@@ -86,16 +87,16 @@ public final class Collectors2Test
     @Test
     public void makeString0Parallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString(),
                 this.smallData.parallelStream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString()),
                 this.smallData.parallelStream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString(),
                 this.bigData.parallelStream().collect(Collectors2.makeString()));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString()),
                 this.bigData.parallelStream().collect(Collectors2.makeString()));
     }
@@ -103,16 +104,16 @@ public final class Collectors2Test
     @Test
     public void makeString1()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString("/"),
                 this.smallData.stream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString("/")),
                 this.smallData.stream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString("/"),
                 this.bigData.stream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString("/")),
                 this.bigData.stream().collect(Collectors2.makeString("/")));
     }
@@ -120,16 +121,16 @@ public final class Collectors2Test
     @Test
     public void makeString1Parallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString("/"),
                 this.smallData.parallelStream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString("/")),
                 this.smallData.parallelStream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString("/"),
                 this.bigData.parallelStream().collect(Collectors2.makeString("/")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString("/")),
                 this.bigData.parallelStream().collect(Collectors2.makeString("/")));
     }
@@ -137,16 +138,16 @@ public final class Collectors2Test
     @Test
     public void makeString3()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString("[", "/", "]"),
                 this.smallData.stream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString("[", "/", "]")),
                 this.smallData.stream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString("[", "/", "]"),
                 this.bigData.stream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString("[", "/", "]")),
                 this.bigData.stream().collect(Collectors2.makeString("[", "/", "]")));
     }
@@ -154,16 +155,16 @@ public final class Collectors2Test
     @Test
     public void makeString3Parallel()
     {
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.makeString("[", "/", "]"),
                 this.smallData.parallelStream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 SMALL_INTERVAL.reduceInPlace(Collectors2.makeString("[", "/", "]")),
                 this.smallData.parallelStream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.makeString("[", "/", "]"),
                 this.bigData.parallelStream().collect(Collectors2.makeString("[", "/", "]")));
-        Assert.assertEquals(
+        assertEquals(
                 LARGE_INTERVAL.reduceInPlace(Collectors2.makeString("[", "/", "]")),
                 this.bigData.parallelStream().collect(Collectors2.makeString("[", "/", "]")));
     }
@@ -173,9 +174,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toList();
         MutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -183,9 +184,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = LARGE_INTERVAL.toList();
         MutableList<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -193,9 +194,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toList();
         ImmutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -203,9 +204,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = LARGE_INTERVAL.toList();
         ImmutableList<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -213,9 +214,9 @@ public final class Collectors2Test
     {
         MutableSet<Integer> expected = SMALL_INTERVAL.toSet();
         MutableSet<Integer> actual = this.smallData.stream().collect(Collectors2.toSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -223,9 +224,9 @@ public final class Collectors2Test
     {
         MutableSet<Integer> expected = LARGE_INTERVAL.toSet();
         MutableSet<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -233,9 +234,9 @@ public final class Collectors2Test
     {
         MutableSet<Integer> expected = SMALL_INTERVAL.toSet();
         ImmutableSet<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -243,9 +244,9 @@ public final class Collectors2Test
     {
         MutableSet<Integer> expected = LARGE_INTERVAL.toSet();
         ImmutableSet<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -253,9 +254,9 @@ public final class Collectors2Test
     {
         MutableBag<Integer> expected = SMALL_INTERVAL.toBag();
         MutableBag<Integer> actual = this.smallData.stream().collect(Collectors2.toBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -263,9 +264,9 @@ public final class Collectors2Test
     {
         MutableBag<Integer> expected = LARGE_INTERVAL.toBag();
         MutableBag<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -273,9 +274,9 @@ public final class Collectors2Test
     {
         MutableBag<Integer> expected = SMALL_INTERVAL.toBag();
         ImmutableBag<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -283,9 +284,9 @@ public final class Collectors2Test
     {
         MutableBag<Integer> expected = LARGE_INTERVAL.toBag();
         ImmutableBag<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -294,10 +295,10 @@ public final class Collectors2Test
         Multimap<String, Integer> expected = SMALL_INTERVAL.groupBy(Object::toString);
         MutableListMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableListMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -306,10 +307,10 @@ public final class Collectors2Test
         Multimap<String, Integer> expected = LARGE_INTERVAL.groupBy(Object::toString);
         MutableListMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableListMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -318,10 +319,10 @@ public final class Collectors2Test
         Multimap<String, String> expected = SMALL_INTERVAL.collect(Object::toString).groupBy(Object::toString);
         MutableListMultimap<String, String> actual =
                 this.smallData.stream().collect(Collectors2.toListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableListMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -330,10 +331,10 @@ public final class Collectors2Test
         Multimap<String, String> expected = LARGE_INTERVAL.collect(Object::toString).groupBy(Object::toString);
         MutableListMultimap<String, String> actual =
                 this.bigData.parallelStream().collect(Collectors2.toListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableListMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -342,10 +343,10 @@ public final class Collectors2Test
         MutableSetMultimap<String, Integer> expected = SMALL_INTERVAL.toSet().groupBy(Object::toString);
         MutableSetMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSetMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -354,10 +355,10 @@ public final class Collectors2Test
         MutableSetMultimap<String, Integer> expected = LARGE_INTERVAL.toSet().groupBy(Object::toString);
         MutableSetMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSetMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -367,10 +368,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toSet().collect(Object::toString).groupBy(Object::toString);
         MutableSetMultimap<String, String> actual =
                 this.smallData.stream().collect(Collectors2.toSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSetMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -380,10 +381,10 @@ public final class Collectors2Test
                 LARGE_INTERVAL.toSet().collect(Object::toString).groupBy(Object::toString);
         MutableSetMultimap<String, String> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSetMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -392,10 +393,10 @@ public final class Collectors2Test
         MutableBagMultimap<String, Integer> expected = SMALL_INTERVAL.toBag().groupBy(Object::toString);
         MutableBagMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBagMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -404,10 +405,10 @@ public final class Collectors2Test
         MutableBagMultimap<String, Integer> expected = LARGE_INTERVAL.toBag().groupBy(Object::toString);
         MutableBagMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBagMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -417,10 +418,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toBag().collect(Object::toString).groupBy(Object::toString);
         MutableBagMultimap<String, String> actual =
                 this.smallData.stream().collect(Collectors2.toBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBagMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -430,10 +431,10 @@ public final class Collectors2Test
                 LARGE_INTERVAL.toBag().collect(Object::toString).groupBy(Object::toString);
         MutableBagMultimap<String, String> actual =
                 this.bigData.parallelStream().collect(Collectors2.toBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBagMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -447,7 +448,7 @@ public final class Collectors2Test
                 Collectors.groupingBy(
                         each -> each % 2,
                         Collectors2.toBagMultimap(each -> each % 5)));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -461,8 +462,8 @@ public final class Collectors2Test
                 Collectors.groupingBy(
                         each -> each % 2,
                         Collectors2.partition(each -> each % 5 == 0, PartitionHashBag::new)));
-        Assert.assertEquals(expected.get(0).getSelected(), actual.get(0).getSelected());
-        Assert.assertEquals(expected.get(0).getRejected(), actual.get(0).getRejected());
+        assertEquals(expected.get(0).getSelected(), actual.get(0).getSelected());
+        assertEquals(expected.get(0).getRejected(), actual.get(0).getRejected());
     }
 
     @Test
@@ -472,7 +473,7 @@ public final class Collectors2Test
                 Collectors.groupingBy(each -> each % 2, Collectors2.chunk(10)));
         Map<Integer, MutableList<MutableList<Integer>>> actual = Interval.oneTo(100).reduceInPlace(
                 Collectors.groupingBy(each -> each % 2, Collectors2.chunk(10)));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -482,7 +483,7 @@ public final class Collectors2Test
                 Collectors.groupingBy(each -> each % 2, Collectors2.collectInt(Integer::intValue, IntBags.mutable::empty)));
         Map<Integer, MutableIntCollection> actual = Interval.oneTo(100).reduceInPlace(
                 Collectors.groupingBy(each -> each % 2, Collectors2.collectInt(Integer::intValue, IntBags.mutable::empty)));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -492,7 +493,7 @@ public final class Collectors2Test
                 Collectors.groupingBy(each -> each % 2, Collectors2.sumByInt(each -> each % 5, Integer::intValue)));
         Map<Integer, MutableObjectLongMap<Integer>> actual = Interval.oneTo(100).reduceInPlace(
                 Collectors.groupingBy(each -> each % 2, Collectors2.sumByInt(each -> each % 5, Integer::intValue)));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -500,9 +501,9 @@ public final class Collectors2Test
     {
         MutableStack<Integer> expected = Stacks.mutable.ofAll(SMALL_INTERVAL);
         MutableStack<Integer> actual = this.smallData.stream().collect(Collectors2.toStack());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableStack<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toStack());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -510,9 +511,9 @@ public final class Collectors2Test
     {
         MutableStack<Integer> expected = Stacks.mutable.ofAll(LARGE_INTERVAL);
         MutableStack<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toStack());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableStack<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toStack());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -520,9 +521,9 @@ public final class Collectors2Test
     {
         MutableStack<Integer> expected = Stacks.mutable.ofAll(SMALL_INTERVAL);
         ImmutableStack<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableStack());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableStack<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableStack());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -530,9 +531,9 @@ public final class Collectors2Test
     {
         MutableStack<Integer> expected = Stacks.mutable.ofAll(LARGE_INTERVAL);
         ImmutableStack<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableStack());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableStack<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableStack());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -541,10 +542,10 @@ public final class Collectors2Test
         MutableMap<String, Integer> expected = SMALL_INTERVAL.toMap(Object::toString, i -> i);
         MutableMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -553,10 +554,10 @@ public final class Collectors2Test
         MutableMap<String, Integer> expected = LARGE_INTERVAL.toMap(Object::toString, i -> i);
         MutableMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -565,11 +566,11 @@ public final class Collectors2Test
         MutableMap<String, Integer> expected = SMALL_INTERVAL.toMap(Object::toString, i -> i);
         ImmutableMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         ImmutableMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -578,10 +579,10 @@ public final class Collectors2Test
         MutableMap<String, Integer> expected = LARGE_INTERVAL.toMap(Object::toString, i -> i);
         ImmutableMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -594,10 +595,10 @@ public final class Collectors2Test
         });
         MutableBiMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBiMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -610,10 +611,10 @@ public final class Collectors2Test
         });
         MutableBiMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableBiMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -626,10 +627,10 @@ public final class Collectors2Test
         });
         ImmutableBiMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBiMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -642,10 +643,10 @@ public final class Collectors2Test
         });
         ImmutableBiMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBiMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableBiMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -653,9 +654,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSet();
         MutableSortedSet<Integer> actual = this.smallData.stream().collect(Collectors2.toSortedSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -663,9 +664,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSet();
         MutableSortedSet<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toSortedSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -673,9 +674,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSetBy(Object::toString);
         MutableSortedSet<Integer> actual = this.smallData.stream().collect(Collectors2.toSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -684,9 +685,9 @@ public final class Collectors2Test
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSetBy(Object::toString);
         MutableSortedSet<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -694,9 +695,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSet();
         ImmutableSortedSet<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSortedSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -704,9 +705,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSet();
         ImmutableSortedSet<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableSortedSet());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSet());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -714,9 +715,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSetBy(Object::toString);
         ImmutableSortedSet<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -724,9 +725,9 @@ public final class Collectors2Test
     {
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSetBy(Object::toString);
         ImmutableSortedSet<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSetBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -734,9 +735,9 @@ public final class Collectors2Test
     {
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBag();
         MutableSortedBag<Integer> actual = this.smallData.stream().collect(Collectors2.toSortedBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -744,9 +745,9 @@ public final class Collectors2Test
     {
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBag();
         MutableSortedBag<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toSortedBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -755,9 +756,9 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBagBy(Object::toString);
         MutableSortedBag<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -766,9 +767,9 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBagBy(Object::toString);
         MutableSortedBag<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -776,9 +777,9 @@ public final class Collectors2Test
     {
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBag();
         ImmutableSortedBag<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSortedBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -786,9 +787,9 @@ public final class Collectors2Test
     {
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBag();
         ImmutableSortedBag<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableSortedBag());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBag());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -797,9 +798,9 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBagBy(Object::toString);
         ImmutableSortedBag<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -808,9 +809,9 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBagBy(Object::toString);
         ImmutableSortedBag<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBagBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -819,10 +820,10 @@ public final class Collectors2Test
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSet(Comparator.reverseOrder());
         MutableSortedSet<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -831,10 +832,10 @@ public final class Collectors2Test
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSet(Comparator.reverseOrder());
         MutableSortedSet<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSet<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -843,10 +844,10 @@ public final class Collectors2Test
         MutableSortedSet<Integer> expected = SMALL_INTERVAL.toSortedSet(Comparator.reverseOrder());
         ImmutableSortedSet<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -855,10 +856,10 @@ public final class Collectors2Test
         MutableSortedSet<Integer> expected = LARGE_INTERVAL.toSortedSet(Comparator.reverseOrder());
         ImmutableSortedSet<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedSet<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedSet(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -867,10 +868,10 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBag(Comparator.reverseOrder());
         MutableSortedBag<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -879,10 +880,10 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBag(Comparator.reverseOrder());
         MutableSortedBag<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedBag<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -891,10 +892,10 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = SMALL_INTERVAL.toSortedBag(Comparator.reverseOrder());
         ImmutableSortedBag<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -903,10 +904,10 @@ public final class Collectors2Test
         MutableSortedBag<Integer> expected = LARGE_INTERVAL.toSortedBag(Comparator.reverseOrder());
         ImmutableSortedBag<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedBag<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedBag(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -914,9 +915,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedList();
         MutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toSortedList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -924,9 +925,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedList();
         MutableList<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toSortedList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -934,9 +935,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedListBy(Object::toString);
         MutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -945,9 +946,9 @@ public final class Collectors2Test
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedListBy(Object::toString);
         MutableList<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -955,9 +956,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedList();
         ImmutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSortedList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -965,9 +966,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedList();
         ImmutableList<Integer> actual = this.bigData.parallelStream().collect(Collectors2.toImmutableSortedList());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedList());
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -975,9 +976,9 @@ public final class Collectors2Test
     {
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedListBy(Object::toString);
         ImmutableList<Integer> actual = this.smallData.stream().collect(Collectors2.toImmutableSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -986,9 +987,9 @@ public final class Collectors2Test
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedListBy(Object::toString);
         ImmutableList<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedListBy(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -997,10 +998,10 @@ public final class Collectors2Test
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedList(Comparator.reverseOrder());
         MutableList<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1009,10 +1010,10 @@ public final class Collectors2Test
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedList(Comparator.reverseOrder());
         MutableList<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableList<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1021,10 +1022,10 @@ public final class Collectors2Test
         MutableSortedMap<String, Integer> expected = SMALL_INTERVAL.toSortedMap(Object::toString, i -> i);
         MutableSortedMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1033,10 +1034,10 @@ public final class Collectors2Test
         MutableSortedMap<String, Integer> expected = LARGE_INTERVAL.toSortedMap(Object::toString, i -> i);
         MutableSortedMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1047,12 +1048,12 @@ public final class Collectors2Test
         MutableSortedMap<String, Integer> actual = this.smallData
                 .stream()
                 .collect(Collectors2.toSortedMap(Comparator.reverseOrder(), Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedMap(Comparator.reverseOrder(),
                         Object::toString,
                         i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1063,12 +1064,12 @@ public final class Collectors2Test
         MutableSortedMap<String, Integer> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toSortedMap(Comparator.reverseOrder(), Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedMap(Comparator.reverseOrder(),
                         Object::toString,
                         i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1078,10 +1079,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toSortedMapBy(Object::toString, Object::toString, i -> i);
         MutableSortedMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1092,10 +1093,10 @@ public final class Collectors2Test
         MutableSortedMap<String, Integer> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1105,10 +1106,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toSortedMap(Object::toString, i -> i).toImmutable();
         ImmutableSortedMap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1118,10 +1119,10 @@ public final class Collectors2Test
                 LARGE_INTERVAL.toSortedMap(Object::toString, i -> i).toImmutable();
         ImmutableSortedMap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMap(Object::toString, i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1132,12 +1133,12 @@ public final class Collectors2Test
         ImmutableSortedMap<String, Integer> actual = this.smallData
                 .stream()
                 .collect(Collectors2.toImmutableSortedMap(Comparator.reverseOrder(), Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMap(
                 Comparator.reverseOrder(),
                 Object::toString,
                 i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1148,12 +1149,12 @@ public final class Collectors2Test
         ImmutableSortedMap<String, Integer> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toImmutableSortedMap(Comparator.reverseOrder(), Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMap(
                 Comparator.reverseOrder(),
                 Object::toString,
                 i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1164,12 +1165,12 @@ public final class Collectors2Test
         ImmutableSortedMap<String, Integer> actual = this.smallData
                 .stream()
                 .collect(Collectors2.toImmutableSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 = SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMapBy(
                 Object::toString,
                 Object::toString,
                 i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1180,12 +1181,12 @@ public final class Collectors2Test
         ImmutableSortedMap<String, Integer> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toImmutableSortedMapBy(Object::toString, Object::toString, i -> i));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSortedMap<String, Integer> actual2 = LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedMapBy(
                 Object::toString,
                 Object::toString,
                 i -> i));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1194,10 +1195,10 @@ public final class Collectors2Test
         MutableList<Integer> expected = SMALL_INTERVAL.toSortedList(Comparator.reverseOrder());
         ImmutableList<Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1206,10 +1207,10 @@ public final class Collectors2Test
         MutableList<Integer> expected = LARGE_INTERVAL.toSortedList(Comparator.reverseOrder());
         ImmutableList<Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableList<Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSortedList(Comparator.reverseOrder()));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1218,10 +1219,10 @@ public final class Collectors2Test
         Multimap<String, Integer> expected = SMALL_INTERVAL.groupBy(Object::toString);
         ImmutableListMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableListMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1230,10 +1231,10 @@ public final class Collectors2Test
         Multimap<String, Integer> expected = LARGE_INTERVAL.groupBy(Object::toString);
         ImmutableListMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableListMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableListMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1243,10 +1244,10 @@ public final class Collectors2Test
         ImmutableListMultimap<String, String> actual = this.smallData
                 .stream()
                 .collect(Collectors2.toImmutableListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableListMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1256,10 +1257,10 @@ public final class Collectors2Test
         ImmutableListMultimap<String, String> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toImmutableListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableListMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableListMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1268,10 +1269,10 @@ public final class Collectors2Test
         MutableSetMultimap<String, Integer> expected = SMALL_INTERVAL.toSet().groupBy(Object::toString);
         ImmutableSetMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSetMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1280,10 +1281,10 @@ public final class Collectors2Test
         MutableSetMultimap<String, Integer> expected = LARGE_INTERVAL.toSet().groupBy(Object::toString);
         ImmutableSetMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSetMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSetMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1293,10 +1294,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toSet().collect(Object::toString).groupBy(Object::toString);
         ImmutableSetMultimap<String, String> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSetMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1307,10 +1308,10 @@ public final class Collectors2Test
         ImmutableSetMultimap<String, String> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toImmutableSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableSetMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableSetMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1319,10 +1320,10 @@ public final class Collectors2Test
         MutableBagMultimap<String, Integer> expected = SMALL_INTERVAL.toBag().groupBy(Object::toString);
         ImmutableBagMultimap<String, Integer> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBagMultimap<String, Integer> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1331,10 +1332,10 @@ public final class Collectors2Test
         MutableBagMultimap<String, Integer> expected = LARGE_INTERVAL.toBag().groupBy(Object::toString);
         ImmutableBagMultimap<String, Integer> actual =
                 this.bigData.parallelStream().collect(Collectors2.toImmutableBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBagMultimap<String, Integer> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableBagMultimap(Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1344,10 +1345,10 @@ public final class Collectors2Test
                 SMALL_INTERVAL.toBag().collect(Object::toString).groupBy(Object::toString);
         ImmutableBagMultimap<String, String> actual =
                 this.smallData.stream().collect(Collectors2.toImmutableBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBagMultimap<String, String> actual2 =
                 SMALL_INTERVAL.reduceInPlace(Collectors2.toImmutableBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1358,10 +1359,10 @@ public final class Collectors2Test
         ImmutableBagMultimap<String, String> actual = this.bigData
                 .parallelStream()
                 .collect(Collectors2.toImmutableBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         ImmutableBagMultimap<String, String> actual2 =
                 LARGE_INTERVAL.reduceInPlace(Collectors2.toImmutableBagMultimap(Object::toString, Object::toString));
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -1369,9 +1370,9 @@ public final class Collectors2Test
     {
         Interval integers = Interval.oneTo(100);
         MutableBag<Integer> counts = integers.stream().collect(Collectors2.countBy(i -> i % 2));
-        Assert.assertEquals(integers.countBy(i -> i % 2), counts);
-        Assert.assertEquals(50, counts.occurrencesOf(0));
-        Assert.assertEquals(50, counts.occurrencesOf(1));
+        assertEquals(integers.countBy(i -> i % 2), counts);
+        assertEquals(50, counts.occurrencesOf(0));
+        assertEquals(50, counts.occurrencesOf(1));
     }
 
     @Test
@@ -1379,9 +1380,9 @@ public final class Collectors2Test
     {
         Interval integers = Interval.oneTo(100000);
         MutableBag<Integer> counts = integers.parallelStream().collect(Collectors2.countBy(i -> i % 2));
-        Assert.assertEquals(integers.countBy(i -> i % 2), counts);
-        Assert.assertEquals(50000, counts.occurrencesOf(0));
-        Assert.assertEquals(50000, counts.occurrencesOf(1));
+        assertEquals(integers.countBy(i -> i % 2), counts);
+        assertEquals(50000, counts.occurrencesOf(0));
+        assertEquals(50000, counts.occurrencesOf(1));
     }
 
     @Test
@@ -1393,9 +1394,9 @@ public final class Collectors2Test
 
         MutableBag<Integer> counts = intervals.stream().collect(Collectors2.countByEach(iv -> iv.collect(i -> i % 2)));
 
-        Assert.assertEquals(Interval.oneTo(100).countBy(i -> i % 2), counts);
-        Assert.assertEquals(50, counts.occurrencesOf(0));
-        Assert.assertEquals(50, counts.occurrencesOf(1));
+        assertEquals(Interval.oneTo(100).countBy(i -> i % 2), counts);
+        assertEquals(50, counts.occurrencesOf(0));
+        assertEquals(50, counts.occurrencesOf(1));
     }
 
     @Test
@@ -1407,9 +1408,9 @@ public final class Collectors2Test
 
         MutableBag<Integer> counts = intervals.parallelStream().collect(Collectors2.countByEach(iv -> iv.collect(i -> i % 2)));
 
-        Assert.assertEquals(Interval.oneTo(100000).countBy(i -> i % 2), counts);
-        Assert.assertEquals(50000, counts.occurrencesOf(0));
-        Assert.assertEquals(50000, counts.occurrencesOf(1));
+        assertEquals(Interval.oneTo(100000).countBy(i -> i % 2), counts);
+        assertEquals(50000, counts.occurrencesOf(0));
+        assertEquals(50000, counts.occurrencesOf(1));
     }
 
     @Test
@@ -1425,7 +1426,7 @@ public final class Collectors2Test
         Verify.assertIterableSize(2, products.get(3));
         Verify.assertIterableSize(3, products.get(4));
         Verify.assertIterableSize(2, products.get(5));
-        Assert.assertEquals(SMALL_INTERVAL.toList().groupByEach(groupByFunction), products);
+        assertEquals(SMALL_INTERVAL.toList().groupByEach(groupByFunction), products);
     }
 
     @Test
@@ -1441,7 +1442,7 @@ public final class Collectors2Test
         Verify.assertIterableSize(2, products.get(3));
         Verify.assertIterableSize(3, products.get(4));
         Verify.assertIterableSize(2, products.get(5));
-        Assert.assertEquals(SMALL_INTERVAL.toList().groupByEach(groupByFunction), products);
+        assertEquals(SMALL_INTERVAL.toList().groupByEach(groupByFunction), products);
     }
 
     @Test
@@ -1449,7 +1450,7 @@ public final class Collectors2Test
     {
         MutableMap<Integer, Integer> expectedMap = SMALL_INTERVAL.groupByUniqueKey(id -> id, Maps.mutable.empty());
         MutableMap<Integer, Integer> actualMap = SMALL_INTERVAL.stream().collect(Collectors2.groupByUniqueKey(id -> id, Maps.mutable::empty));
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1463,7 +1464,7 @@ public final class Collectors2Test
     {
         MutableMap<Integer, Integer> expectedMap = LARGE_INTERVAL.groupByUniqueKey(id -> id, Maps.mutable.empty());
         MutableMap<Integer, Integer> actualMap = LARGE_INTERVAL.parallelStream().collect(Collectors2.groupByUniqueKey(id -> id, Maps.mutable::empty));
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1483,7 +1484,7 @@ public final class Collectors2Test
     {
         MutableMap<Integer, Integer> expectedMap = SMALL_INTERVAL.toList().aggregateBy(each -> each % 2, () -> 0, Integer::sum);
         MutableMap<Integer, Integer> actualMap = SMALL_INTERVAL.stream().collect(Collectors2.aggregateBy(each -> each % 2, () -> 0, Integer::sum, Maps.mutable::empty));
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 
     @Test
@@ -1491,7 +1492,7 @@ public final class Collectors2Test
     {
         MutableMap<Integer, Integer> expectedMap = LARGE_INTERVAL.toList().aggregateBy(each -> each % 2, () -> 0, Integer::sum);
         MutableMap<Integer, Integer> actualMap = LARGE_INTERVAL.parallelStream().collect(Collectors2.aggregateBy(each -> each % 2, () -> 0, Integer::sum, Maps.mutable::empty));
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
@@ -28,8 +28,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BagsTest
 {
@@ -53,7 +59,7 @@ public class BagsTest
         Bag<Integer> bag = HashBag.newBagWith(1, 2, 2, 3, 3, 3);
         Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofAll(bag));
         Verify.assertInstanceOf(MutableBag.class, bagFactory.ofAll(bag));
-        Assert.assertNotSame(bagFactory.ofAll(bag), bag);
+        assertNotSame(bagFactory.ofAll(bag), bag);
         Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofAll(FastList.newListWith(1, 2, 2, 3, 3, 3)));
         Verify.assertInstanceOf(MutableBag.class, bagFactory.ofAll(FastList.newListWith(1, 2, 2, 3, 3, 3)));
         Verify.assertBagsEqual(HashBag.newBagWith(1, 2, 3, 4, 5), bagFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
@@ -75,65 +81,65 @@ public class BagsTest
     public void immutables()
     {
         ImmutableBagFactory bagFactory = Bags.immutable;
-        Assert.assertEquals(HashBag.newBag(), bagFactory.of());
+        assertEquals(HashBag.newBag(), bagFactory.of());
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of());
-        Assert.assertEquals(HashBag.newBagWith(1), bagFactory.of(1));
+        assertEquals(HashBag.newBagWith(1), bagFactory.of(1));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1));
-        Assert.assertEquals(HashBag.newBagWith(1, 2), bagFactory.of(1, 2));
+        assertEquals(HashBag.newBagWith(1, 2), bagFactory.of(1, 2));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3), bagFactory.of(1, 2, 3));
+        assertEquals(HashBag.newBagWith(1, 2, 3), bagFactory.of(1, 2, 3));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4), bagFactory.of(1, 2, 3, 4));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4), bagFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5), bagFactory.of(1, 2, 3, 4, 5));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5), bagFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6), bagFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6), bagFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7), bagFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7), bagFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(HashBag.newBagWith(3, 2, 1), bagFactory.ofAll(HashBag.newBagWith(1, 2, 3)));
+        assertEquals(HashBag.newBagWith(3, 2, 1), bagFactory.ofAll(HashBag.newBagWith(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofAll(HashBag.newBagWith(1, 2, 3)));
-        Assert.assertEquals(HashBag.newBagWith(3, 2, 1), bagFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(HashBag.newBagWith(3, 2, 1), bagFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.fromStream(Stream.of(1, 2, 3)));
-        Assert.assertEquals(HashBag.newBagWith(1), bagFactory.ofOccurrences(1, 1));
+        assertEquals(HashBag.newBagWith(1), bagFactory.ofOccurrences(1, 1));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 2), bagFactory.ofOccurrences(1, 1, 2, 2));
+        assertEquals(HashBag.newBagWith(1, 2, 2), bagFactory.ofOccurrences(1, 1, 2, 2));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
+        assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
+        assertEquals(HashBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
         Verify.assertInstanceOf(ImmutableBag.class, bagFactory.ofOccurrences(1, 1, 2, 2, 3, 3, 4, 4));
     }
 
     @Test
     public void emptyBag()
     {
-        Assert.assertTrue(Bags.immutable.of().isEmpty());
+        assertTrue(Bags.immutable.of().isEmpty());
     }
 
     @Test
     public void newBagWith()
     {
         ImmutableBag<String> bag = Bags.immutable.of();
-        Assert.assertEquals(bag, Bags.immutable.of(bag.toArray()));
-        Assert.assertEquals(bag = bag.newWith("1"), Bags.immutable.of("1"));
-        Assert.assertEquals(bag = bag.newWith("2"), Bags.immutable.of("1", "2"));
-        Assert.assertEquals(bag = bag.newWith("3"), Bags.immutable.of("1", "2", "3"));
-        Assert.assertEquals(bag = bag.newWith("4"), Bags.immutable.of("1", "2", "3", "4"));
-        Assert.assertEquals(bag = bag.newWith("5"), Bags.immutable.of("1", "2", "3", "4", "5"));
-        Assert.assertEquals(bag = bag.newWith("6"), Bags.immutable.of("1", "2", "3", "4", "5", "6"));
-        Assert.assertEquals(bag = bag.newWith("7"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7"));
-        Assert.assertEquals(bag = bag.newWith("8"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
-        Assert.assertEquals(bag = bag.newWith("9"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
-        Assert.assertEquals(bag = bag.newWith("10"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
-        Assert.assertEquals(bag = bag.newWith("11"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
-        Assert.assertEquals(bag = bag.newWith("12"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+        assertEquals(bag, Bags.immutable.of(bag.toArray()));
+        assertEquals(bag = bag.newWith("1"), Bags.immutable.of("1"));
+        assertEquals(bag = bag.newWith("2"), Bags.immutable.of("1", "2"));
+        assertEquals(bag = bag.newWith("3"), Bags.immutable.of("1", "2", "3"));
+        assertEquals(bag = bag.newWith("4"), Bags.immutable.of("1", "2", "3", "4"));
+        assertEquals(bag = bag.newWith("5"), Bags.immutable.of("1", "2", "3", "4", "5"));
+        assertEquals(bag = bag.newWith("6"), Bags.immutable.of("1", "2", "3", "4", "5", "6"));
+        assertEquals(bag = bag.newWith("7"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7"));
+        assertEquals(bag = bag.newWith("8"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        assertEquals(bag = bag.newWith("9"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        assertEquals(bag = bag.newWith("10"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        assertEquals(bag = bag.newWith("11"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(bag = bag.newWith("12"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
     }
 
     @Test
@@ -154,7 +160,7 @@ public class BagsTest
         MutableBag<String> bags5 = Bags.mutable.withInitialCapacity(32);
         this.assertPresizedBagEquals((HashBag<String>) bags5, 64L);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Bags.mutable.withInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Bags.mutable.withInitialCapacity(-6));
     }
 
     @Test
@@ -175,7 +181,7 @@ public class BagsTest
         MutableBag<String> bags5 = Bags.mutable.ofInitialCapacity(32);
         this.assertPresizedBagEquals((HashBag<String>) bags5, 64L);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Bags.mutable.ofInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Bags.mutable.ofInitialCapacity(-6));
     }
 
     private void assertPresizedBagEquals(HashBag<String> bag, long length)
@@ -191,20 +197,20 @@ public class BagsTest
             Field values = ObjectIntHashMap.class.getDeclaredField("values");
             values.setAccessible(true);
 
-            Assert.assertEquals(length, ((Object[]) keys.get(items)).length);
-            Assert.assertEquals(length, ((int[]) values.get(items)).length);
+            assertEquals(length, ((Object[]) keys.get(items)).length);
+            assertEquals(length, ((int[]) values.get(items)).length);
         }
         catch (SecurityException e)
         {
-            Assert.fail("Unable to modify the visibility of the field " + e.getMessage());
+            fail("Unable to modify the visibility of the field " + e.getMessage());
         }
         catch (NoSuchFieldException e)
         {
-            Assert.fail("No field named " + e.getMessage());
+            fail("No field named " + e.getMessage());
         }
         catch (IllegalAccessException e)
         {
-            Assert.fail("No access to the field " + e.getMessage());
+            fail("No access to the field " + e.getMessage());
         }
     }
 
@@ -213,17 +219,17 @@ public class BagsTest
     public void newBagWithArray()
     {
         ImmutableBag<String> bag = Bags.immutable.of();
-        Assert.assertEquals(bag = bag.newWith("1"), Bags.immutable.of(new String[]{"1"}));
-        Assert.assertEquals(bag = bag.newWith("2"), Bags.immutable.of(new String[]{"1", "2"}));
-        Assert.assertEquals(bag = bag.newWith("3"), Bags.immutable.of(new String[]{"1", "2", "3"}));
-        Assert.assertEquals(bag = bag.newWith("4"), Bags.immutable.of(new String[]{"1", "2", "3", "4"}));
-        Assert.assertEquals(bag = bag.newWith("5"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
-        Assert.assertEquals(bag = bag.newWith("6"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
-        Assert.assertEquals(bag = bag.newWith("7"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
-        Assert.assertEquals(bag = bag.newWith("8"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
-        Assert.assertEquals(bag = bag.newWith("9"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
-        Assert.assertEquals(bag = bag.newWith("10"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
-        Assert.assertEquals(bag = bag.newWith("11"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(bag = bag.newWith("1"), Bags.immutable.of(new String[]{"1"}));
+        assertEquals(bag = bag.newWith("2"), Bags.immutable.of(new String[]{"1", "2"}));
+        assertEquals(bag = bag.newWith("3"), Bags.immutable.of(new String[]{"1", "2", "3"}));
+        assertEquals(bag = bag.newWith("4"), Bags.immutable.of(new String[]{"1", "2", "3", "4"}));
+        assertEquals(bag = bag.newWith("5"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
+        assertEquals(bag = bag.newWith("6"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        assertEquals(bag = bag.newWith("7"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        assertEquals(bag = bag.newWith("8"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        assertEquals(bag = bag.newWith("9"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        assertEquals(bag = bag.newWith("10"), Bags.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        assertEquals(bag = bag.newWith("11"), Bags.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
     }
 
     @Test
@@ -231,27 +237,27 @@ public class BagsTest
     {
         ImmutableBag<String> bag = Bags.immutable.of();
         HashBag<String> hashBag = HashBag.newBagWith("1");
-        Assert.assertEquals(bag = bag.newWith("1"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("1"), hashBag.toImmutable());
         hashBag.add("2");
-        Assert.assertEquals(bag = bag.newWith("2"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("2"), hashBag.toImmutable());
         hashBag.add("3");
-        Assert.assertEquals(bag = bag.newWith("3"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("3"), hashBag.toImmutable());
         hashBag.add("4");
-        Assert.assertEquals(bag = bag.newWith("4"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("4"), hashBag.toImmutable());
         hashBag.add("5");
-        Assert.assertEquals(bag = bag.newWith("5"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("5"), hashBag.toImmutable());
         hashBag.add("6");
-        Assert.assertEquals(bag = bag.newWith("6"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("6"), hashBag.toImmutable());
         hashBag.add("7");
-        Assert.assertEquals(bag = bag.newWith("7"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("7"), hashBag.toImmutable());
         hashBag.add("8");
-        Assert.assertEquals(bag = bag.newWith("8"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("8"), hashBag.toImmutable());
         hashBag.add("9");
-        Assert.assertEquals(bag = bag.newWith("9"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("9"), hashBag.toImmutable());
         hashBag.add("10");
-        Assert.assertEquals(bag = bag.newWith("10"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("10"), hashBag.toImmutable());
         hashBag.add("11");
-        Assert.assertEquals(bag = bag.newWith("11"), hashBag.toImmutable());
+        assertEquals(bag = bag.newWith("11"), hashBag.toImmutable());
     }
 
     @Test
@@ -263,13 +269,13 @@ public class BagsTest
 
     private void testMultiReaderApi(MultiReaderBagFactory bagFactory)
     {
-        Assert.assertEquals(MultiReaderHashBag.newBag(), bagFactory.of());
+        assertEquals(MultiReaderHashBag.newBag(), bagFactory.of());
         Verify.assertInstanceOf(MultiReaderBag.class, bagFactory.of());
-        Assert.assertEquals(MultiReaderHashBag.newBag(), bagFactory.with());
+        assertEquals(MultiReaderHashBag.newBag(), bagFactory.with());
         Verify.assertInstanceOf(MultiReaderBag.class, bagFactory.with());
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(1), bagFactory.of(1));
+        assertEquals(MultiReaderHashBag.newBagWith(1), bagFactory.of(1));
         Verify.assertInstanceOf(MultiReaderBag.class, bagFactory.of(1));
-        Assert.assertEquals(MultiReaderHashBag.newBagWith(1, 2, 3), bagFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
+        assertEquals(MultiReaderHashBag.newBagWith(1, 2, 3), bagFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
         Verify.assertInstanceOf(MultiReaderBag.class, bagFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
     }
 
@@ -285,7 +291,7 @@ public class BagsTest
         ImmutableBag<Integer> empty = Bags.immutable.withAll(Collections.emptyList());
         ImmutableBag<Integer> integers = Bags.immutable.<Integer>empty().newWithAll(Lists.immutable.empty());
         ImmutableBag<Integer> empty2 = Bags.immutable.withAll(integers);
-        Assert.assertSame(Bags.immutable.empty(), empty);
-        Assert.assertSame(Bags.immutable.empty(), empty2);
+        assertSame(Bags.immutable.empty(), empty);
+        assertSame(Bags.immutable.empty(), empty2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class BiMapsTest
 {
@@ -30,27 +32,27 @@ public class BiMapsTest
     public void immutable()
     {
         ImmutableBiMapFactory factory = BiMaps.immutable;
-        Assert.assertEquals(HashBiMap.newMap(), factory.of());
+        assertEquals(HashBiMap.newMap(), factory.of());
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of());
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2"), factory.of(1, "2"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2"), factory.of(1, "2"));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of(1, "2"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4"), factory.of(1, "2", 3, "4"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4"), factory.of(1, "2", 3, "4"));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of(1, "2", 3, "4"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6"), factory.of(1, "2", 3, "4", 5, "6"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6"), factory.of(1, "2", 3, "4", 5, "6"));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of(1, "2", 3, "4", 5, "6"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8"))));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8"))));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, 8))));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(Maps.immutable.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(Maps.immutable.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(Maps.immutable.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8")));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8")));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8")));
         Map<Integer, String> map1 = HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8");
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(map1));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(map1));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(map1));
         ImmutableBiMap<Integer, String> map2 = BiMaps.immutable.with(1, "2", 3, "4", 5, "6", 7, "8");
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(map2.castToMap()));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(map2.castToMap()));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(map2.castToMap()));
     }
 
@@ -58,15 +60,15 @@ public class BiMapsTest
     public void mutable()
     {
         MutableBiMapFactory factory = BiMaps.mutable;
-        Assert.assertEquals(HashBiMap.newMap(), factory.of());
+        assertEquals(HashBiMap.newMap(), factory.of());
         Verify.assertInstanceOf(MutableBiMap.class, factory.of());
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2"), factory.of(1, "2"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2"), factory.of(1, "2"));
         Verify.assertInstanceOf(MutableBiMap.class, factory.of(1, "2"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4"), factory.of(1, "2", 3, "4"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4"), factory.of(1, "2", 3, "4"));
         Verify.assertInstanceOf(MutableBiMap.class, factory.of(1, "2", 3, "4"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6"), factory.of(1, "2", 3, "4", 5, "6"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6"), factory.of(1, "2", 3, "4", 5, "6"));
         Verify.assertInstanceOf(MutableBiMap.class, factory.of(1, "2", 3, "4", 5, "6"));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
+        assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
         Verify.assertInstanceOf(MutableBiMap.class, factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
     }
 
@@ -77,8 +79,8 @@ public class BiMapsTest
         Map<Integer, Integer> integers =
                 BiMaps.immutable.<Integer, Integer>empty().newWithMap(Maps.mutable.empty()).castToMap();
         ImmutableBiMap<Integer, Integer> empty2 = BiMaps.immutable.withAll(integers);
-        Assert.assertSame(BiMaps.immutable.empty(), empty);
-        Assert.assertSame(BiMaps.immutable.empty(), empty2);
+        assertSame(BiMaps.immutable.empty(), empty);
+        assertSame(BiMaps.immutable.empty(), empty2);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/FixedSizeMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/FixedSizeMapFactoryTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.factory;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class FixedSizeMapFactoryTest
 {
@@ -101,19 +103,19 @@ public class FixedSizeMapFactoryTest
         MutableMap<Key, Integer> map1 = Maps.fixedSize.of(key, 1, duplicateKey1, 2);
         Verify.assertSize(1, map1);
         Verify.assertContainsKeyValue(key, 2, map1);
-        Assert.assertSame(key, map1.keysView().getFirst());
+        assertSame(key, map1.keysView().getFirst());
 
         Key duplicateKey2 = new Key("key");
         MutableMap<Key, Integer> map2 = Maps.fixedSize.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
         Verify.assertSize(1, map2);
         Verify.assertContainsKeyValue(key, 3, map2);
-        Assert.assertSame(key, map1.keysView().getFirst());
+        assertSame(key, map1.keysView().getFirst());
 
         Key duplicateKey3 = new Key("key");
         MutableMap<Key, Integer> map3 = Maps.fixedSize.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
         Verify.assertSize(2, map3);
         Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
-        Assert.assertSame(key, map3.keysView().detect(key::equals));
+        assertSame(key, map3.keysView().detect(key::equals));
     }
 
     @Test
@@ -121,6 +123,6 @@ public class FixedSizeMapFactoryTest
 
     {
         MutableMap<String, String> map = Maps.fixedSize.of("key1", "value1", "key2", "value2", "key3", "value3");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.withMap(Maps.fixedSize.of("key4", "value4")));
+        assertThrows(UnsupportedOperationException.class, () -> map.withMap(Maps.fixedSize.of("key4", "value4")));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyBagsTest.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class HashingStrategyBagsTest
 {
@@ -28,28 +29,28 @@ public class HashingStrategyBagsTest
     public void mutable()
     {
         MutableHashingStrategyBagFactory factory = HashingStrategyBags.mutable;
-        Assert.assertEquals(HashBag.newBag(), factory.of(HashingStrategies.defaultStrategy()));
+        assertEquals(HashBag.newBag(), factory.of(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(HashBag.newBag(), factory.empty(HashingStrategies.defaultStrategy()));
+        assertEquals(HashBag.newBag(), factory.empty(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(MutableBag.class, factory.empty(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(HashBag.newBagWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
+        assertEquals(HashBag.newBagWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(HashBag.newBagWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
         Verify.assertInstanceOf(MutableBag.class, factory.of(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
 
         MutableList<Person> people =
                 Lists.mutable.of(new Person("Alex", "Smith"), new Person("John", "Smith"), new Person("John", "Brown"));
 
-        Assert.assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.fromFunction(Person::getLastName)).withAll(people),
+        assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.fromFunction(Person::getLastName)).withAll(people),
                 factory.fromFunction(Person::getLastName).withAll(people));
 
-        Assert.assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.fromFunction(Person::getFirstName)).withAll(people),
+        assertEquals(HashBagWithHashingStrategy.newBagWith(HashingStrategies.fromFunction(Person::getFirstName)).withAll(people),
                 factory.fromFunction(Person::getFirstName).withAll(people));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyMapsTest.java
@@ -22,8 +22,9 @@ import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingSt
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class HashingStrategyMapsTest
 {
@@ -31,15 +32,15 @@ public class HashingStrategyMapsTest
     public void immutable()
     {
         ImmutableHashingStrategyMapFactory factory = HashingStrategyMaps.immutable;
-        Assert.assertEquals(UnifiedMap.newMap(), factory.of(HashingStrategies.defaultStrategy()));
+        assertEquals(UnifiedMap.newMap(), factory.of(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
     }
 
@@ -47,15 +48,15 @@ public class HashingStrategyMapsTest
     public void mutable()
     {
         MutableHashingStrategyMapFactory factory = HashingStrategyMaps.mutable;
-        Assert.assertEquals(UnifiedMap.newMap(), factory.of(HashingStrategies.defaultStrategy()));
+        assertEquals(UnifiedMap.newMap(), factory.of(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(MutableMap.class, factory.of(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
         Verify.assertInstanceOf(MutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
         Verify.assertInstanceOf(MutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableMap.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
 
         MutableList<Pair<Person, String>> pairs = Lists.mutable.of(
@@ -63,11 +64,11 @@ public class HashingStrategyMapsTest
                 Tuples.pair(new Person("Alex", "Smith"), "B"),
                 Tuples.pair(new Person("Jeff", "Johnson"), "D"));
 
-        Assert.assertEquals(
+        assertEquals(
                 new UnifiedMapWithHashingStrategy<Person, String>(HashingStrategies.fromFunction(Person::getLastName)).withAllKeyValues(pairs),
                 factory.<Person, String, String>fromFunction(Person::getLastName).withAllKeyValues(pairs));
 
-        Assert.assertEquals(
+        assertEquals(
                 new UnifiedMapWithHashingStrategy<Person, String>(HashingStrategies.fromFunction(Person::getFirstName)).withAllKeyValues(pairs),
                 factory.<Person, String, String>fromFunction(Person::getFirstName).withAllKeyValues(pairs));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategySetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategySetsTest.java
@@ -20,8 +20,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class HashingStrategySetsTest
 {
@@ -29,21 +30,21 @@ public class HashingStrategySetsTest
     public void immutable()
     {
         ImmutableHashingStrategySetFactory factory = HashingStrategySets.immutable;
-        Assert.assertEquals(UnifiedSet.newSet(), factory.of(HashingStrategies.defaultStrategy()));
+        assertEquals(UnifiedSet.newSet(), factory.of(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(UnifiedSet.newSetWith(), factory.of(HashingStrategies.defaultStrategy(), null));
+        assertEquals(UnifiedSet.newSetWith(), factory.of(HashingStrategies.defaultStrategy(), null));
         Verify.assertInstanceOf(ImmutableSet.class, factory.of(HashingStrategies.defaultStrategy(), null));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 1), factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
+        assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 1), factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
         Verify.assertInstanceOf(ImmutableSet.class, factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 3), factory.withInitialCapacity(HashingStrategies.defaultStrategy(), 3));
+        assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 3), factory.withInitialCapacity(HashingStrategies.defaultStrategy(), 3));
         Verify.assertInstanceOf(ImmutableSet.class, factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 3));
     }
 
@@ -51,31 +52,31 @@ public class HashingStrategySetsTest
     public void mutable()
     {
         MutableHashingStrategySetFactory factory = HashingStrategySets.mutable;
-        Assert.assertEquals(UnifiedSet.newSet(), factory.of(HashingStrategies.defaultStrategy()));
+        assertEquals(UnifiedSet.newSet(), factory.of(HashingStrategies.defaultStrategy()));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy()));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(HashingStrategies.defaultStrategy(), 1, 2));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy(), 1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
         Verify.assertInstanceOf(MutableSet.class, factory.of(HashingStrategies.defaultStrategy(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 1), factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
+        assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 1), factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
         Verify.assertInstanceOf(MutableSet.class, factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 1));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 3), factory.withInitialCapacity(HashingStrategies.defaultStrategy(), 3));
+        assertEquals(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.defaultStrategy(), 3), factory.withInitialCapacity(HashingStrategies.defaultStrategy(), 3));
         Verify.assertInstanceOf(MutableSet.class, factory.ofInitialCapacity(HashingStrategies.defaultStrategy(), 3));
 
         MutableSet<Person> people =
                 Sets.mutable.of(new Person("Alex", "Smith"), new Person("John", "Smith"), new Person("John", "Brown"));
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSetWithHashingStrategy.newSetWith(HashingStrategies.fromFunction(Person::getLastName)).withAll(people),
                 factory.fromFunction(Person::getLastName).withAll(people));
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSetWithHashingStrategy.newSetWith(HashingStrategies.fromFunction(Person::getLastName)).withAll(people),
                 factory.fromFunction(Person::getFirstName).withAll(people));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
@@ -30,8 +30,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ListsTest
 {
@@ -39,72 +45,72 @@ public class ListsTest
     public void immutables()
     {
         ImmutableListFactory listFactory = Lists.immutable;
-        Assert.assertEquals(FastList.newList(), listFactory.of());
-        Assert.assertEquals(FastList.newList(), listFactory.with());
-        Assert.assertEquals(FastList.newList(), listFactory.empty());
+        assertEquals(FastList.newList(), listFactory.of());
+        assertEquals(FastList.newList(), listFactory.with());
+        assertEquals(FastList.newList(), listFactory.empty());
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of());
         Verify.assertInstanceOf(ImmutableList.class, listFactory.with());
         Verify.assertInstanceOf(ImmutableList.class, listFactory.empty());
-        Assert.assertEquals(FastList.newListWith(1), listFactory.of(1));
+        assertEquals(FastList.newListWith(1), listFactory.of(1));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1));
-        Assert.assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
+        assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
+        assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.ofAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableList.class, listFactory.fromStream(Stream.of(1, 2, 3)));
-        Assert.assertEquals(Lists.mutable.of(1, 2, 3), listFactory.withAllSorted(Lists.mutable.<Integer>of(3, 1, 2)));
+        assertEquals(Lists.mutable.of(1, 2, 3), listFactory.withAllSorted(Lists.mutable.<Integer>of(3, 1, 2)));
     }
 
     @Test
     public void mutables()
     {
         MutableListFactory listFactory = Lists.mutable;
-        Assert.assertEquals(FastList.newList(), listFactory.of());
-        Assert.assertEquals(FastList.newList(), listFactory.with());
-        Assert.assertEquals(FastList.newList(), listFactory.empty());
+        assertEquals(FastList.newList(), listFactory.of());
+        assertEquals(FastList.newList(), listFactory.with());
+        assertEquals(FastList.newList(), listFactory.empty());
         Verify.assertInstanceOf(MutableList.class, listFactory.of());
         Verify.assertInstanceOf(MutableList.class, listFactory.with());
         Verify.assertInstanceOf(MutableList.class, listFactory.empty());
-        Assert.assertEquals(FastList.newListWith(1), listFactory.of(1));
+        assertEquals(FastList.newListWith(1), listFactory.of(1));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1));
-        Assert.assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
+        assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
+        assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(MutableList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
         Verify.assertInstanceOf(MutableList.class, listFactory.ofAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(MutableList.class, listFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
@@ -115,19 +121,19 @@ public class ListsTest
         MutableList<Integer> actual = Lists.mutable.wrapCopy(integers);
         MutableList<Integer> expected = Lists.mutable.with(1, 2, 3, 4);
         integers[0] = Integer.valueOf(4);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void immutableWithListTest()
     {
-        Assert.assertEquals(Lists.mutable.of(), Lists.mutable.of().toImmutable());
-        Assert.assertEquals(Lists.mutable.of(1).without(1), Lists.mutable.of(1).without(1).toImmutable());
+        assertEquals(Lists.mutable.of(), Lists.mutable.of().toImmutable());
+        assertEquals(Lists.mutable.of(1).without(1), Lists.mutable.of(1).without(1).toImmutable());
         for (int i = 0; i < 12; i++)
         {
             MutableList<Integer> integers = Interval.fromTo(0, i).toList();
-            Assert.assertEquals(integers, integers.toImmutable());
-            Assert.assertEquals(integers.toImmutable(), integers.toImmutable());
+            assertEquals(integers, integers.toImmutable());
+            assertEquals(integers.toImmutable(), integers.toImmutable());
         }
     }
 
@@ -135,35 +141,35 @@ public class ListsTest
     public void fixedSize()
     {
         FixedSizeListFactory listFactory = Lists.fixedSize;
-        Assert.assertEquals(FastList.newList(), listFactory.of());
-        Assert.assertEquals(FastList.newList(), listFactory.with());
-        Assert.assertEquals(FastList.newList(), listFactory.empty());
+        assertEquals(FastList.newList(), listFactory.of());
+        assertEquals(FastList.newList(), listFactory.with());
+        assertEquals(FastList.newList(), listFactory.empty());
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of());
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.with());
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.empty());
-        Assert.assertEquals(FastList.newListWith(1), listFactory.of(1));
+        assertEquals(FastList.newListWith(1), listFactory.of(1));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1));
-        Assert.assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
+        assertEquals(FastList.newListWith(1, 2), listFactory.of(1, 2));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.of(1, 2, 3));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
+        assertEquals(FastList.newListWith(1, 2, 3, 4), listFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), listFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), listFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), listFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.ofAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(FastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(FixedSizeList.class, listFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
@@ -176,17 +182,17 @@ public class ListsTest
 
     private void testMultiReaderApi(MultiReaderListFactory listFactory)
     {
-        Assert.assertEquals(MultiReaderFastList.newList(), listFactory.of());
-        Assert.assertEquals(MultiReaderFastList.newList(), listFactory.with());
-        Assert.assertEquals(MultiReaderFastList.newList(), listFactory.empty());
+        assertEquals(MultiReaderFastList.newList(), listFactory.of());
+        assertEquals(MultiReaderFastList.newList(), listFactory.with());
+        assertEquals(MultiReaderFastList.newList(), listFactory.empty());
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.of());
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.with());
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.empty());
-        Assert.assertEquals(MultiReaderFastList.newListWith(1), listFactory.of(1));
+        assertEquals(MultiReaderFastList.newListWith(1), listFactory.of(1));
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.of(1));
-        Assert.assertEquals(MultiReaderFastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(MultiReaderFastList.newListWith(1, 2, 3), listFactory.ofAll(FastList.newListWith(1, 2, 3)));
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.ofAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(MultiReaderFastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(MultiReaderFastList.newListWith(1, 2, 3), listFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(MultiReaderList.class, listFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
@@ -194,8 +200,8 @@ public class ListsTest
     public void castToList()
     {
         List<Object> list = Lists.immutable.of().castToList();
-        Assert.assertNotNull(list);
-        Assert.assertSame(Lists.immutable.of(), list);
+        assertNotNull(list);
+        assertSame(Lists.immutable.of(), list);
     }
 
     @Test
@@ -239,14 +245,14 @@ public class ListsTest
         MutableList<Integer> list = Lists.fixedSize.of(1);
         ImmutableList<Integer> immutableList = list.toImmutable();
         Verify.assertInstanceOf(ImmutableList.class, Lists.immutable.ofAll(list));
-        Assert.assertSame(Lists.immutable.ofAll(immutableList.castToList()), immutableList);
+        assertSame(Lists.immutable.ofAll(immutableList.castToList()), immutableList);
     }
 
     @Test
     public void emptyList()
     {
-        Assert.assertTrue(Lists.immutable.of().isEmpty());
-        Assert.assertSame(Lists.immutable.of(), Lists.immutable.of());
+        assertTrue(Lists.immutable.of().isEmpty());
+        assertSame(Lists.immutable.of(), Lists.immutable.of());
         Verify.assertPostSerializedIdentity(Lists.immutable.of());
     }
 
@@ -271,7 +277,7 @@ public class ListsTest
         MutableList<String> list6 = Lists.mutable.ofInitialCapacity(65);
         this.assertPresizedListEquals(65, (FastList<String>) list6);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Lists.mutable.ofInitialCapacity(-12));
+        assertThrows(IllegalArgumentException.class, () -> Lists.mutable.ofInitialCapacity(-12));
     }
 
     @Test
@@ -292,7 +298,7 @@ public class ListsTest
         MutableList<String> list5 = Lists.mutable.withInitialCapacity(32);
         this.assertPresizedListEquals(32, (FastList<String>) list5);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Lists.mutable.withInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Lists.mutable.withInitialCapacity(-6));
     }
 
     private void assertPresizedListEquals(int initialCapacity, FastList<String> list)
@@ -302,19 +308,19 @@ public class ListsTest
             Field itemsField = FastList.class.getDeclaredField("items");
             itemsField.setAccessible(true);
             Object[] items = (Object[]) itemsField.get(list);
-            Assert.assertEquals(initialCapacity, items.length);
+            assertEquals(initialCapacity, items.length);
         }
         catch (SecurityException ignored)
         {
-            Assert.fail("Unable to modify the visibility of the field 'items' on FastList");
+            fail("Unable to modify the visibility of the field 'items' on FastList");
         }
         catch (NoSuchFieldException ignored)
         {
-            Assert.fail("No field named 'items' in FastList");
+            fail("No field named 'items' in FastList");
         }
         catch (IllegalAccessException ignored)
         {
-            Assert.fail("No access to the field 'items' in FastList");
+            fail("No access to the field 'items' in FastList");
         }
     }
 
@@ -339,7 +345,7 @@ public class ListsTest
         MutableList<String> list6 = Lists.multiReader.ofInitialCapacity(65);
         ListsTest.assertPresizedMultiReaderListEquals(65, (MultiReaderFastList<String>) list6);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Lists.multiReader.ofInitialCapacity(-12));
+        assertThrows(IllegalArgumentException.class, () -> Lists.multiReader.ofInitialCapacity(-12));
     }
 
     @Test
@@ -360,7 +366,7 @@ public class ListsTest
         MutableList<String> list5 = Lists.multiReader.withInitialCapacity(32);
         ListsTest.assertPresizedMultiReaderListEquals(32, (MultiReaderFastList<String>) list5);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Lists.multiReader.withInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Lists.multiReader.withInitialCapacity(-6));
     }
 
     @Test
@@ -372,8 +378,8 @@ public class ListsTest
                 Lists.mutable.withNValues(10, () -> new Integer(1));
         MutableList<Integer> multiReader =
                 Lists.multiReader.withNValues(10, () -> new Integer(1));
-        Assert.assertEquals(expected, mutable);
-        Assert.assertEquals(expected, multiReader);
+        assertEquals(expected, mutable);
+        assertEquals(expected, multiReader);
     }
 
     private static void assertPresizedMultiReaderListEquals(int initialCapacity, MultiReaderFastList<String> list)
@@ -386,7 +392,7 @@ public class ListsTest
             Field itemsField = FastList.class.getDeclaredField("items");
             itemsField.setAccessible(true);
             Object[] items = (Object[]) itemsField.get(delegate);
-            Assert.assertEquals(initialCapacity, items.length);
+            assertEquals(initialCapacity, items.length);
         }
         catch (SecurityException | NoSuchFieldException | IllegalAccessException e)
         {
@@ -398,36 +404,36 @@ public class ListsTest
     public void newListWith()
     {
         ImmutableList<String> list = Lists.immutable.of();
-        Assert.assertEquals(list, Lists.immutable.of(list.toArray()));
-        Assert.assertEquals(list = list.newWith("1"), Lists.immutable.of("1"));
-        Assert.assertEquals(list = list.newWith("2"), Lists.immutable.of("1", "2"));
-        Assert.assertEquals(list = list.newWith("3"), Lists.immutable.of("1", "2", "3"));
-        Assert.assertEquals(list = list.newWith("4"), Lists.immutable.of("1", "2", "3", "4"));
-        Assert.assertEquals(list = list.newWith("5"), Lists.immutable.of("1", "2", "3", "4", "5"));
-        Assert.assertEquals(list = list.newWith("6"), Lists.immutable.of("1", "2", "3", "4", "5", "6"));
-        Assert.assertEquals(list = list.newWith("7"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7"));
-        Assert.assertEquals(list = list.newWith("8"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
-        Assert.assertEquals(list = list.newWith("9"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
-        Assert.assertEquals(list = list.newWith("10"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
-        Assert.assertEquals(list = list.newWith("11"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
-        Assert.assertEquals(list = list.newWith("12"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+        assertEquals(list, Lists.immutable.of(list.toArray()));
+        assertEquals(list = list.newWith("1"), Lists.immutable.of("1"));
+        assertEquals(list = list.newWith("2"), Lists.immutable.of("1", "2"));
+        assertEquals(list = list.newWith("3"), Lists.immutable.of("1", "2", "3"));
+        assertEquals(list = list.newWith("4"), Lists.immutable.of("1", "2", "3", "4"));
+        assertEquals(list = list.newWith("5"), Lists.immutable.of("1", "2", "3", "4", "5"));
+        assertEquals(list = list.newWith("6"), Lists.immutable.of("1", "2", "3", "4", "5", "6"));
+        assertEquals(list = list.newWith("7"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7"));
+        assertEquals(list = list.newWith("8"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        assertEquals(list = list.newWith("9"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        assertEquals(list = list.newWith("10"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        assertEquals(list = list.newWith("11"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(list = list.newWith("12"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
     }
 
     @Test
     public void newListWithArray()
     {
         ImmutableList<String> list = Lists.immutable.of();
-        Assert.assertEquals(list = list.newWith("1"), Lists.immutable.of(new String[]{"1"}));
-        Assert.assertEquals(list = list.newWith("2"), Lists.immutable.of(new String[]{"1", "2"}));
-        Assert.assertEquals(list = list.newWith("3"), Lists.immutable.of(new String[]{"1", "2", "3"}));
-        Assert.assertEquals(list = list.newWith("4"), Lists.immutable.of(new String[]{"1", "2", "3", "4"}));
-        Assert.assertEquals(list = list.newWith("5"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
-        Assert.assertEquals(list = list.newWith("6"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
-        Assert.assertEquals(list = list.newWith("7"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
-        Assert.assertEquals(list = list.newWith("8"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
-        Assert.assertEquals(list = list.newWith("9"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
-        Assert.assertEquals(list = list.newWith("10"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
-        Assert.assertEquals(list = list.newWith("11"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(list = list.newWith("1"), Lists.immutable.of(new String[]{"1"}));
+        assertEquals(list = list.newWith("2"), Lists.immutable.of(new String[]{"1", "2"}));
+        assertEquals(list = list.newWith("3"), Lists.immutable.of(new String[]{"1", "2", "3"}));
+        assertEquals(list = list.newWith("4"), Lists.immutable.of(new String[]{"1", "2", "3", "4"}));
+        assertEquals(list = list.newWith("5"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
+        assertEquals(list = list.newWith("6"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        assertEquals(list = list.newWith("7"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        assertEquals(list = list.newWith("8"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        assertEquals(list = list.newWith("9"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        assertEquals(list = list.newWith("10"), Lists.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        assertEquals(list = list.newWith("11"), Lists.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
     }
 
     @Test
@@ -435,27 +441,27 @@ public class ListsTest
     {
         ImmutableList<String> list = Lists.immutable.of();
         FastList<String> fastList = FastList.newListWith("1");
-        Assert.assertEquals(list = list.newWith("1"), fastList.toImmutable());
-        Assert.assertEquals(list = list.newWith("2"), fastList.with("2").toImmutable());
-        Assert.assertEquals(list = list.newWith("3"), fastList.with("3").toImmutable());
-        Assert.assertEquals(list = list.newWith("4"), fastList.with("4").toImmutable());
-        Assert.assertEquals(list = list.newWith("5"), fastList.with("5").toImmutable());
-        Assert.assertEquals(list = list.newWith("6"), fastList.with("6").toImmutable());
-        Assert.assertEquals(list = list.newWith("7"), fastList.with("7").toImmutable());
-        Assert.assertEquals(list = list.newWith("8"), fastList.with("8").toImmutable());
-        Assert.assertEquals(list = list.newWith("9"), fastList.with("9").toImmutable());
-        Assert.assertEquals(list = list.newWith("10"), fastList.with("10").toImmutable());
-        Assert.assertEquals(list = list.newWith("11"), fastList.with("11").toImmutable());
+        assertEquals(list = list.newWith("1"), fastList.toImmutable());
+        assertEquals(list = list.newWith("2"), fastList.with("2").toImmutable());
+        assertEquals(list = list.newWith("3"), fastList.with("3").toImmutable());
+        assertEquals(list = list.newWith("4"), fastList.with("4").toImmutable());
+        assertEquals(list = list.newWith("5"), fastList.with("5").toImmutable());
+        assertEquals(list = list.newWith("6"), fastList.with("6").toImmutable());
+        assertEquals(list = list.newWith("7"), fastList.with("7").toImmutable());
+        assertEquals(list = list.newWith("8"), fastList.with("8").toImmutable());
+        assertEquals(list = list.newWith("9"), fastList.with("9").toImmutable());
+        assertEquals(list = list.newWith("10"), fastList.with("10").toImmutable());
+        assertEquals(list = list.newWith("11"), fastList.with("11").toImmutable());
     }
 
     @Test
     public void newListWithWithList()
     {
-        Assert.assertEquals(FastList.newList(), Lists.immutable.ofAll(FastList.newList()));
+        assertEquals(FastList.newList(), Lists.immutable.ofAll(FastList.newList()));
         for (int i = 0; i < 12; i++)
         {
             List<Integer> list = Interval.fromTo(0, i);
-            Assert.assertEquals(list, Lists.immutable.ofAll(list));
+            assertEquals(list, Lists.immutable.ofAll(list));
         }
     }
 
@@ -465,21 +471,21 @@ public class ListsTest
         ImmutableList<Integer> empty = Lists.immutable.withAll(Collections.emptyList());
         ImmutableList<Integer> integers = Lists.immutable.<Integer>empty().newWithAll(Lists.immutable.empty());
         ImmutableList<Integer> empty2 = Lists.immutable.withAll(integers);
-        Assert.assertSame(Lists.immutable.empty(), empty);
-        Assert.assertSame(Lists.immutable.empty(), empty2);
+        assertSame(Lists.immutable.empty(), empty);
+        assertSame(Lists.immutable.empty(), empty2);
     }
 
     @Test
     public void withAllSortedImmutable()
     {
-        Assert.assertEquals(Lists.immutable.of(1, 5, 50, 100),
+        assertEquals(Lists.immutable.of(1, 5, 50, 100),
                 Lists.immutable.withAllSorted(Lists.mutable.of(50, 5, 100, 1)));
     }
 
     @Test
     public void withAllSortedImmutableWithComparator()
     {
-        Assert.assertEquals(Lists.immutable.of(100, 50, 5, 1),
+        assertEquals(Lists.immutable.of(100, 50, 5, 1),
                 Lists.immutable.withAllSorted(Comparators.reverseNaturalOrder(), Lists.mutable.of(50, 5, 100, 1)));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -26,8 +26,12 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 public class MapsTest
 {
@@ -35,15 +39,15 @@ public class MapsTest
     public void immutable()
     {
         ImmutableMapFactory factory = Maps.immutable;
-        Assert.assertEquals(UnifiedMap.newMap(), factory.of());
+        assertEquals(UnifiedMap.newMap(), factory.of());
         Verify.assertInstanceOf(ImmutableMap.class, factory.of());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(1, 2));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableMap.class, factory.of(1, 2, 3, 4, 5, 6, 7, 8));
     }
 
@@ -51,24 +55,24 @@ public class MapsTest
     public void immutableWithDuplicateKeys()
     {
         ImmutableMapFactory factory = Maps.immutable;
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), factory.of(1, 2, 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), factory.of(1, 2, 3, 4, 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), factory.of(1, 2, 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), factory.of(1, 2, 3, 4, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), factory.of(1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), factory.of(1, 2, 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), factory.of(1, 2, 3, 4, 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), factory.of(1, 2, 1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), factory.of(1, 2, 3, 4, 3, 4));
     }
 
     @Test
     public void fixedSize()
     {
         FixedSizeMapFactory undertest = Maps.fixedSize;
-        Assert.assertEquals(UnifiedMap.newMap(), undertest.of());
+        assertEquals(UnifiedMap.newMap(), undertest.of());
         Verify.assertInstanceOf(FixedSizeMap.class, undertest.of());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), undertest.of(1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), undertest.of(1, 2));
         Verify.assertInstanceOf(FixedSizeMap.class, undertest.of(1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), undertest.of(1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), undertest.of(1, 2, 3, 4));
         Verify.assertInstanceOf(FixedSizeMap.class, undertest.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), undertest.of(1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 5, 6), undertest.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(FixedSizeMap.class, undertest.of(1, 2, 3, 4, 5, 6));
     }
 
@@ -76,26 +80,26 @@ public class MapsTest
     public void fixedSizeWithDuplicateKeys()
     {
         FixedSizeMapFactory undertest = Maps.fixedSize;
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2), undertest.of(1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), undertest.of(1, 2, 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), undertest.of(1, 2, 3, 4, 1, 2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), undertest.of(1, 2, 1, 2, 3, 4));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), undertest.of(1, 2, 3, 4, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2), undertest.of(1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2), undertest.of(1, 2, 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 1, 2), undertest.of(1, 2, 3, 4, 1, 2));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 1, 2, 3, 4), undertest.of(1, 2, 1, 2, 3, 4));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4, 3, 4), undertest.of(1, 2, 3, 4, 3, 4));
     }
 
     @Test
     public void copyMap()
     {
-        Assert.assertEquals(Maps.fixedSize.of(1, "One"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
+        assertEquals(Maps.fixedSize.of(1, "One"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
 
-        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
 
-        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
 
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
     }
 
@@ -122,30 +126,30 @@ public class MapsTest
     @Test
     public void duplicates()
     {
-        Assert.assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0), Maps.immutable.of(0, 0, 0, 0, 0, 0, 0, 0));
 
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1), Maps.immutable.of(1, 1, 0, 0, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 2, 2), Maps.immutable.of(0, 0, 2, 2, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 3, 3), Maps.immutable.of(0, 0, 0, 0, 3, 3));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1), Maps.immutable.of(1, 1, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 2, 2), Maps.immutable.of(0, 0, 2, 2, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 3, 3), Maps.immutable.of(0, 0, 0, 0, 3, 3));
 
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1), Maps.immutable.of(1, 1, 0, 0, 0, 0, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 2, 2), Maps.immutable.of(0, 0, 2, 2, 0, 0, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 3, 3), Maps.immutable.of(0, 0, 0, 0, 3, 3, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 4, 4), Maps.immutable.of(0, 0, 0, 0, 0, 0, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1), Maps.immutable.of(1, 1, 0, 0, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 2, 2), Maps.immutable.of(0, 0, 2, 2, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 3, 3), Maps.immutable.of(0, 0, 0, 0, 3, 3, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 4, 4), Maps.immutable.of(0, 0, 0, 0, 0, 0, 4, 4));
 
-        Assert.assertEquals(Maps.immutable.of(0, 0, 2, 2, 3, 3, 4, 4), Maps.immutable.of(0, 0, 2, 2, 3, 3, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 3, 3, 4, 4), Maps.immutable.of(1, 1, 0, 0, 3, 3, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 4, 4), Maps.immutable.of(1, 1, 2, 2, 0, 0, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), Maps.immutable.of(1, 1, 2, 2, 3, 3, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 2, 2, 3, 3, 4, 4), Maps.immutable.of(0, 0, 2, 2, 3, 3, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 3, 3, 4, 4), Maps.immutable.of(1, 1, 0, 0, 3, 3, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 4, 4), Maps.immutable.of(1, 1, 2, 2, 0, 0, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2, 3, 3), Maps.immutable.of(1, 1, 2, 2, 3, 3, 0, 0));
 
-        Assert.assertEquals(Maps.immutable.of(0, 0, 3, 3, 4, 4), Maps.immutable.of(0, 0, 0, 0, 3, 3, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 2, 2, 4, 4), Maps.immutable.of(0, 0, 2, 2, 0, 0, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 2, 2, 3, 3), Maps.immutable.of(0, 0, 2, 2, 3, 3, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 4, 4), Maps.immutable.of(1, 1, 0, 0, 0, 0, 4, 4));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 3, 3), Maps.immutable.of(1, 1, 0, 0, 3, 3, 0, 0));
-        Assert.assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2), Maps.immutable.of(1, 1, 2, 2, 0, 0, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 3, 3, 4, 4), Maps.immutable.of(0, 0, 0, 0, 3, 3, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 2, 2, 4, 4), Maps.immutable.of(0, 0, 2, 2, 0, 0, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 2, 2, 3, 3), Maps.immutable.of(0, 0, 2, 2, 3, 3, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 4, 4), Maps.immutable.of(1, 1, 0, 0, 0, 0, 4, 4));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 3, 3), Maps.immutable.of(1, 1, 0, 0, 3, 3, 0, 0));
+        assertEquals(Maps.immutable.of(0, 0, 1, 1, 2, 2), Maps.immutable.of(1, 1, 2, 2, 0, 0, 0, 0));
     }
 
     @Test
@@ -157,26 +161,26 @@ public class MapsTest
         ImmutableMap<Key, Integer> map1 = Maps.immutable.of(key, 1, duplicateKey1, 2);
         Verify.assertSize(1, map1);
         Verify.assertContainsKeyValue(key, 2, map1);
-        Assert.assertSame(key, map1.keysView().getFirst());
+        assertSame(key, map1.keysView().getFirst());
 
         Key duplicateKey2 = new Key("key");
         ImmutableMap<Key, Integer> map2 = Maps.immutable.of(key, 1, duplicateKey1, 2, duplicateKey2, 3);
         Verify.assertSize(1, map2);
         Verify.assertContainsKeyValue(key, 3, map2);
-        Assert.assertSame(key, map2.keysView().getFirst());
+        assertSame(key, map2.keysView().getFirst());
 
         Key duplicateKey3 = new Key("key");
         ImmutableMap<Key, Integer> map3 = Maps.immutable.of(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
         Verify.assertSize(2, map3);
         Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
-        Assert.assertSame(key, map3.keysView().detect(key::equals));
+        assertSame(key, map3.keysView().detect(key::equals));
     }
 
     @Test
     public void sortedMaps()
     {
         MutableSortedMapFactory factory = SortedMaps.mutable;
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.ofSortedMap(UnifiedMap.newWithKeysValues(1, 2, 3, 4)));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 2, 3, 4), factory.ofSortedMap(UnifiedMap.newWithKeysValues(1, 2, 3, 4)));
     }
 
     @Test
@@ -197,7 +201,7 @@ public class MapsTest
         MutableMap<String, String> map3 = Maps.mutable.ofInitialCapacity(20);
         this.assertPresizedMapSizeEquals(20, (UnifiedMap<String, String>) map3);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Maps.mutable.ofInitialCapacity(-12));
+        assertThrows(IllegalArgumentException.class, () -> Maps.mutable.ofInitialCapacity(-12));
     }
 
     @Test
@@ -218,7 +222,7 @@ public class MapsTest
         MutableMap<String, String> map5 = Maps.mutable.withInitialCapacity(17);
         this.assertPresizedMapSizeEquals(17, (UnifiedMap<String, String>) map5);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Maps.mutable.ofInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Maps.mutable.ofInitialCapacity(-6));
     }
 
     private void assertPresizedMapSizeEquals(int initialCapacity, UnifiedMap<String, String> map)
@@ -237,19 +241,19 @@ public class MapsTest
             }
             capacity <<= 1;
 
-            Assert.assertEquals(capacity, table.length);
+            assertEquals(capacity, table.length);
         }
         catch (SecurityException ignored)
         {
-            Assert.fail("Unable to modify the visibility of the table on UnifiedMap");
+            fail("Unable to modify the visibility of the table on UnifiedMap");
         }
         catch (NoSuchFieldException ignored)
         {
-            Assert.fail("No field named table UnifiedMap");
+            fail("No field named table UnifiedMap");
         }
         catch (IllegalAccessException ignored)
         {
-            Assert.fail("No access the field table in UnifiedMap");
+            fail("No access the field table in UnifiedMap");
         }
     }
 
@@ -258,16 +262,16 @@ public class MapsTest
     {
         MutableMapFactory factory = Maps.mutable;
 
-        Assert.assertEquals(UnifiedMap.newMap(), factory.ofMap(new HashMap<>()));
+        assertEquals(UnifiedMap.newMap(), factory.ofMap(new HashMap<>()));
         Verify.assertInstanceOf(UnifiedMap.class, factory.ofMap(new HashMap<>()));
 
-        Assert.assertEquals(UnifiedMap.newMap(), factory.ofMapIterable(Maps.immutable.with()));
+        assertEquals(UnifiedMap.newMap(), factory.ofMapIterable(Maps.immutable.with()));
         Verify.assertInstanceOf(UnifiedMap.class, factory.ofMapIterable(Maps.immutable.with()));
 
-        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMap(Maps.mutable.with(1, 1)));
+        assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMap(Maps.mutable.with(1, 1)));
         Verify.assertInstanceOf(UnifiedMap.class, factory.ofMap(Maps.mutable.with(1, 1)));
 
-        Assert.assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMapIterable(Maps.mutable.with(1, 1)));
+        assertEquals(UnifiedMap.newMapWith(Tuples.pair(1, 1)), factory.ofMapIterable(Maps.mutable.with(1, 1)));
         Verify.assertInstanceOf(UnifiedMap.class, factory.ofMapIterable(Maps.mutable.with(1, 1)));
     }
 
@@ -278,7 +282,7 @@ public class MapsTest
         Map<Integer, Integer> integers =
                 Maps.immutable.<Integer, Integer>empty().newWithMap(Maps.mutable.empty()).castToMap();
         ImmutableMap<Integer, Integer> empty2 = Maps.immutable.withAll(integers);
-        Assert.assertSame(Maps.immutable.empty(), empty);
-        Assert.assertSame(Maps.immutable.empty(), empty2);
+        assertSame(Maps.immutable.empty(), empty);
+        assertSame(Maps.immutable.empty(), empty2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MultimapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MultimapsTest.java
@@ -32,8 +32,11 @@ import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class MultimapsTest
 {
@@ -45,12 +48,12 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         ImmutableListMultimap<Integer, Integer> one = Multimaps.immutable.list.of(1, 1);
-        Assert.assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1)), one);
         ImmutableListMultimap<Integer, Integer> two = Multimaps.immutable.list.of(1, 1, 2, 2);
-        Assert.assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         ImmutableListMultimap<Integer, Integer> three = Multimaps.immutable.list.of(1, 1, 2, 2, 3, 3);
         ListMultimap<Integer, Integer> expectedThree = FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
+        assertEquals(expectedThree, three);
     }
 
     @Test
@@ -61,12 +64,12 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         ImmutableSetMultimap<Integer, Integer> one = Multimaps.immutable.set.of(1, 1);
-        Assert.assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
         ImmutableSetMultimap<Integer, Integer> two = Multimaps.immutable.set.of(1, 1, 2, 2);
-        Assert.assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         ImmutableSetMultimap<Integer, Integer> three = Multimaps.immutable.set.of(1, 1, 2, 2, 3, 3);
         SetMultimap<Integer, Integer> expectedThree = UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
+        assertEquals(expectedThree, three);
     }
 
     @Test
@@ -77,14 +80,14 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         ImmutableSortedSetMultimap<Integer, Integer> one = Multimaps.immutable.sortedSet.of(Integer::compareTo, 1, 1);
-        Assert.assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
         ImmutableSortedSetMultimap<Integer, Integer> two = Multimaps.immutable.sortedSet.of(Integer::compareTo, 1, 1, 2, 2);
-        Assert.assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         ImmutableSortedSetMultimap<String, String> toStringOffTwo = Multimaps.immutable.sortedSet.of(String::compareTo, "A", "B");
-        Assert.assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair("A", "B")), toStringOffTwo);
+        assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair("A", "B")), toStringOffTwo);
         ImmutableSortedSetMultimap<Integer, Integer> three = Multimaps.immutable.sortedSet.of(Integer::compareTo, 1, 1, 2, 2, 3, 3);
         SortedSetMultimap<Integer, Integer> expectedThree = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
+        assertEquals(expectedThree, three);
     }
 
     @Test
@@ -93,37 +96,37 @@ public class MultimapsTest
         ImmutableSortedBagMultimap<Integer, Integer> emptyWith = Multimaps.immutable.sortedBag.with(Integer::compareTo);
         ImmutableSortedBagMultimap<Integer, Integer> emptyOf = Multimaps.immutable.sortedBag.of(Integer::compareTo);
         Verify.assertEmpty(emptyWith);
-        Assert.assertNotNull(emptyWith.comparator());
+        assertNotNull(emptyWith.comparator());
         Verify.assertEmpty(emptyOf);
-        Assert.assertNotNull(emptyOf.comparator());
+        assertNotNull(emptyOf.comparator());
         ImmutableSortedBagMultimap<Integer, Integer> oneOf = Multimaps.immutable.sortedBag.of(Integer::compareTo, 1, 1);
         ImmutableSortedBagMultimap<Integer, Integer> oneWith = Multimaps.immutable.sortedBag.with(Integer::compareTo, 1, 1);
         TreeBagMultimap<Integer, Integer> expectedOne = TreeBagMultimap.newMultimap(Tuples.pair(1, 1));
-        Assert.assertEquals(expectedOne, oneOf);
-        Assert.assertNotNull(oneOf.comparator());
-        Assert.assertEquals(expectedOne, oneWith);
-        Assert.assertNotNull(oneWith.comparator());
+        assertEquals(expectedOne, oneOf);
+        assertNotNull(oneOf.comparator());
+        assertEquals(expectedOne, oneWith);
+        assertNotNull(oneWith.comparator());
         ImmutableSortedBagMultimap<String, String> toStringOfTwo = Multimaps.immutable.sortedBag.of(String::compareTo, "A", "B");
         ImmutableSortedBagMultimap<String, String> toStringWithTwo = Multimaps.immutable.sortedBag.with(String::compareTo, "A", "B");
         TreeBagMultimap<String, String> expectedStringOfTwo = TreeBagMultimap.newMultimap(Tuples.pair("A", "B"));
-        Assert.assertEquals(expectedStringOfTwo, toStringOfTwo);
-        Assert.assertNotNull(toStringOfTwo.comparator());
-        Assert.assertEquals(expectedStringOfTwo, toStringWithTwo);
-        Assert.assertNotNull(toStringWithTwo.comparator());
+        assertEquals(expectedStringOfTwo, toStringOfTwo);
+        assertNotNull(toStringOfTwo.comparator());
+        assertEquals(expectedStringOfTwo, toStringWithTwo);
+        assertNotNull(toStringWithTwo.comparator());
         TreeBagMultimap<Integer, Integer> expectedTwo = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2));
         ImmutableSortedBagMultimap<Integer, Integer> twoOf = Multimaps.immutable.sortedBag.of(Integer::compareTo, 1, 1, 2, 2);
         ImmutableSortedBagMultimap<Integer, Integer> twoWith = Multimaps.immutable.sortedBag.with(Integer::compareTo, 1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, twoOf);
-        Assert.assertNotNull(twoOf);
-        Assert.assertEquals(expectedTwo, twoWith);
-        Assert.assertNotNull(twoWith.comparator());
+        assertEquals(expectedTwo, twoOf);
+        assertNotNull(twoOf);
+        assertEquals(expectedTwo, twoWith);
+        assertNotNull(twoWith.comparator());
         ImmutableSortedBagMultimap<Integer, Integer> threeOf = Multimaps.immutable.sortedBag.of(Integer::compareTo, 1, 1, 2, 2, 3, 3);
         ImmutableSortedBagMultimap<Integer, Integer> threeWith = Multimaps.immutable.sortedBag.with(Integer::compareTo, 1, 1, 2, 2, 3, 3);
         SortedBagMultimap<Integer, Integer> expectedThree = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, threeOf);
-        Assert.assertNotNull(threeOf.comparator());
-        Assert.assertEquals(expectedThree, threeWith);
-        Assert.assertNotNull(threeWith.comparator());
+        assertEquals(expectedThree, threeOf);
+        assertNotNull(threeOf.comparator());
+        assertEquals(expectedThree, threeWith);
+        assertNotNull(threeWith.comparator());
     }
 
     @Test
@@ -132,37 +135,37 @@ public class MultimapsTest
         ImmutableSortedBagMultimap<Integer, Integer> emptyWith = Multimaps.immutable.sortedBag.with();
         ImmutableSortedBagMultimap<Integer, Integer> emptyOf = Multimaps.immutable.sortedBag.of();
         Verify.assertEmpty(emptyWith);
-        Assert.assertNull(emptyWith.comparator());
+        assertNull(emptyWith.comparator());
         Verify.assertEmpty(emptyOf);
-        Assert.assertNull(emptyOf.comparator());
+        assertNull(emptyOf.comparator());
         ImmutableSortedBagMultimap<Integer, Integer> oneOf = Multimaps.immutable.sortedBag.of(1, 1);
         ImmutableSortedBagMultimap<Integer, Integer> oneWith = Multimaps.immutable.sortedBag.with(1, 1);
         TreeBagMultimap<Integer, Integer> expectedOne = TreeBagMultimap.newMultimap(Tuples.pair(1, 1));
-        Assert.assertEquals(expectedOne, oneOf);
-        Assert.assertNull(oneOf.comparator());
-        Assert.assertEquals(expectedOne, oneWith);
-        Assert.assertNull(oneWith.comparator());
+        assertEquals(expectedOne, oneOf);
+        assertNull(oneOf.comparator());
+        assertEquals(expectedOne, oneWith);
+        assertNull(oneWith.comparator());
         ImmutableSortedBagMultimap<String, String> toStringOfTwo = Multimaps.immutable.sortedBag.of("A", "B");
         ImmutableSortedBagMultimap<String, String> toStringWithTwo = Multimaps.immutable.sortedBag.with("A", "B");
         TreeBagMultimap<String, String> expectedStringOfTwo = TreeBagMultimap.newMultimap(Tuples.pair("A", "B"));
-        Assert.assertEquals(expectedStringOfTwo, toStringOfTwo);
-        Assert.assertNull(toStringOfTwo.comparator());
-        Assert.assertEquals(expectedStringOfTwo, toStringWithTwo);
-        Assert.assertNull(toStringWithTwo.comparator());
+        assertEquals(expectedStringOfTwo, toStringOfTwo);
+        assertNull(toStringOfTwo.comparator());
+        assertEquals(expectedStringOfTwo, toStringWithTwo);
+        assertNull(toStringWithTwo.comparator());
         TreeBagMultimap<Integer, Integer> expectedTwo = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2));
         ImmutableSortedBagMultimap<Integer, Integer> twoOf = Multimaps.immutable.sortedBag.of(1, 1, 2, 2);
         ImmutableSortedBagMultimap<Integer, Integer> twoWith = Multimaps.immutable.sortedBag.with(1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, twoOf);
-        Assert.assertNotNull(twoOf);
-        Assert.assertEquals(expectedTwo, twoWith);
-        Assert.assertNull(twoWith.comparator());
+        assertEquals(expectedTwo, twoOf);
+        assertNotNull(twoOf);
+        assertEquals(expectedTwo, twoWith);
+        assertNull(twoWith.comparator());
         ImmutableSortedBagMultimap<Integer, Integer> threeOf = Multimaps.immutable.sortedBag.of(1, 1, 2, 2, 3, 3);
         ImmutableSortedBagMultimap<Integer, Integer> threeWith = Multimaps.immutable.sortedBag.with(1, 1, 2, 2, 3, 3);
         SortedBagMultimap<Integer, Integer> expectedThree = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, threeOf);
-        Assert.assertNull(threeOf.comparator());
-        Assert.assertEquals(expectedThree, threeWith);
-        Assert.assertNull(threeWith.comparator());
+        assertEquals(expectedThree, threeOf);
+        assertNull(threeOf.comparator());
+        assertEquals(expectedThree, threeWith);
+        assertNull(threeWith.comparator());
     }
 
     @Test
@@ -173,12 +176,12 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         ImmutableBagMultimap<Integer, Integer> one = Multimaps.immutable.bag.of(1, 1);
-        Assert.assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1)), one);
         ImmutableBagMultimap<Integer, Integer> two = Multimaps.immutable.bag.of(1, 1, 2, 2);
-        Assert.assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         ImmutableBagMultimap<Integer, Integer> three = Multimaps.immutable.bag.of(1, 1, 2, 2, 3, 3);
         BagMultimap<Integer, Integer> expectedThree = HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
+        assertEquals(expectedThree, three);
     }
 
     @Test
@@ -189,13 +192,13 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         MutableListMultimap<Integer, Integer> one = Multimaps.mutable.list.of(1, 1);
-        Assert.assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1)), one);
         MutableListMultimap<Integer, Integer> two = Multimaps.mutable.list.of(1, 1, 2, 2);
-        Assert.assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         MutableListMultimap<Integer, Integer> three = Multimaps.mutable.list.of(1, 1, 2, 2, 3, 3);
         ListMultimap<Integer, Integer> expectedThree = FastListMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.list.withAll(three));
+        assertEquals(expectedThree, three);
+        assertEquals(expectedThree, Multimaps.mutable.list.withAll(three));
     }
 
     @Test
@@ -206,13 +209,13 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         MutableSetMultimap<Integer, Integer> one = Multimaps.mutable.set.of(1, 1);
-        Assert.assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
         MutableSetMultimap<Integer, Integer> two = Multimaps.mutable.set.of(1, 1, 2, 2);
-        Assert.assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         MutableSetMultimap<Integer, Integer> three = Multimaps.mutable.set.of(1, 1, 2, 2, 3, 3);
         SetMultimap<Integer, Integer> expectedThree = UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.set.withAll(three));
+        assertEquals(expectedThree, three);
+        assertEquals(expectedThree, Multimaps.mutable.set.withAll(three));
     }
 
     @Test
@@ -223,13 +226,13 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         MutableSortedSetMultimap<Integer, Integer> one = Multimaps.mutable.sortedSet.of(Integer::compareTo, 1, 1);
-        Assert.assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1)), one);
         MutableSortedSetMultimap<Integer, Integer> two = Multimaps.mutable.sortedSet.of(Integer::compareTo, 1, 1, 2, 2);
-        Assert.assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         MutableSortedSetMultimap<Integer, Integer> three = Multimaps.mutable.sortedSet.of(Integer::compareTo, 1, 1, 2, 2, 3, 3);
         SortedSetMultimap<Integer, Integer> expectedThree = TreeSortedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.sortedSet.withAll(three));
+        assertEquals(expectedThree, three);
+        assertEquals(expectedThree, Multimaps.mutable.sortedSet.withAll(three));
     }
 
     @Test
@@ -240,13 +243,13 @@ public class MultimapsTest
         Verify.assertEmpty(empty);
         Verify.assertEmpty(emptyWith);
         MutableBagMultimap<Integer, Integer> one = Multimaps.mutable.bag.of(1, 1);
-        Assert.assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1)), one);
+        assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1)), one);
         MutableBagMultimap<Integer, Integer> two = Multimaps.mutable.bag.of(1, 1, 2, 2);
-        Assert.assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
+        assertEquals(HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2)), two);
         MutableBagMultimap<Integer, Integer> three = Multimaps.mutable.bag.of(1, 1, 2, 2, 3, 3);
         BagMultimap<Integer, Integer> expectedThree = HashBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, three);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.bag.withAll(three));
+        assertEquals(expectedThree, three);
+        assertEquals(expectedThree, Multimaps.mutable.bag.withAll(three));
     }
 
     @Test
@@ -256,40 +259,40 @@ public class MultimapsTest
         MutableSortedBagMultimap<Object, Object> emptyWith = Multimaps.mutable.sortedBag.with();
         MutableSortedBagMultimap<Object, Object> emptyOf = Multimaps.mutable.sortedBag.of();
         Verify.assertEmpty(empty);
-        Assert.assertNull(empty.comparator());
+        assertNull(empty.comparator());
         Verify.assertEmpty(emptyWith);
-        Assert.assertNull(emptyWith.comparator());
+        assertNull(emptyWith.comparator());
         Verify.assertEmpty(emptyOf);
-        Assert.assertNull(emptyOf.comparator());
+        assertNull(emptyOf.comparator());
         TreeBagMultimap<Integer, Integer> expectedOne = TreeBagMultimap.newMultimap(Tuples.pair(1, 1));
         MutableSortedBagMultimap<Integer, Integer> withOne = Multimaps.mutable.sortedBag.with(1, 1);
-        Assert.assertEquals(expectedOne, withOne);
-        Assert.assertNull(withOne.comparator());
+        assertEquals(expectedOne, withOne);
+        assertNull(withOne.comparator());
         MutableSortedBagMultimap<Integer, Integer> ofOne = Multimaps.mutable.sortedBag.of(1, 1);
-        Assert.assertEquals(expectedOne, ofOne);
-        Assert.assertNull(ofOne.comparator());
+        assertEquals(expectedOne, ofOne);
+        assertNull(ofOne.comparator());
         TreeBagMultimap<String, String> expectedOneStrings = TreeBagMultimap.newMultimap(Tuples.pair("A", "B"));
         MutableSortedBagMultimap<String, String> withStrings = Multimaps.mutable.sortedBag.with("A", "B");
-        Assert.assertEquals(expectedOneStrings, withStrings);
-        Assert.assertNull(withStrings.comparator());
+        assertEquals(expectedOneStrings, withStrings);
+        assertNull(withStrings.comparator());
         MutableSortedBagMultimap<String, String> ofStrings = Multimaps.mutable.sortedBag.of("A", "B");
-        Assert.assertEquals(expectedOneStrings, ofStrings);
-        Assert.assertNull(ofStrings.comparator());
+        assertEquals(expectedOneStrings, ofStrings);
+        assertNull(ofStrings.comparator());
         TreeBagMultimap<Integer, Integer> expectedTwo = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2));
         MutableSortedBagMultimap<Integer, Integer> withTwoItems = Multimaps.mutable.sortedBag.with(1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, withTwoItems);
-        Assert.assertNull(withTwoItems.comparator());
+        assertEquals(expectedTwo, withTwoItems);
+        assertNull(withTwoItems.comparator());
         MutableSortedBagMultimap<Integer, Integer> ofTwoItems = Multimaps.mutable.sortedBag.of(1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, ofTwoItems);
-        Assert.assertNull(ofTwoItems.comparator());
+        assertEquals(expectedTwo, ofTwoItems);
+        assertNull(ofTwoItems.comparator());
         MutableSortedBagMultimap<Integer, Integer> threeWith = Multimaps.mutable.sortedBag.with(1, 1, 2, 2, 3, 3);
-        Assert.assertNull(threeWith.comparator());
+        assertNull(threeWith.comparator());
         MutableSortedBagMultimap<Integer, Integer> threeOf = Multimaps.mutable.sortedBag.of(1, 1, 2, 2, 3, 3);
-        Assert.assertNull(threeOf.comparator());
+        assertNull(threeOf.comparator());
         SortedBagMultimap<Integer, Integer> expectedThree = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, threeWith);
-        Assert.assertEquals(expectedThree, threeOf);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.sortedBag.withAll(threeWith));
+        assertEquals(expectedThree, threeWith);
+        assertEquals(expectedThree, threeOf);
+        assertEquals(expectedThree, Multimaps.mutable.sortedBag.withAll(threeWith));
     }
 
     @Test
@@ -299,40 +302,40 @@ public class MultimapsTest
         MutableSortedBagMultimap<String, String> emptyWith = Multimaps.mutable.sortedBag.with(String::compareTo);
         MutableSortedBagMultimap<String, String> emptyOf = Multimaps.mutable.sortedBag.of(String::compareTo);
         Verify.assertEmpty(empty);
-        Assert.assertNotNull(empty.comparator());
+        assertNotNull(empty.comparator());
         Verify.assertEmpty(emptyWith);
-        Assert.assertNotNull(emptyWith.comparator());
+        assertNotNull(emptyWith.comparator());
         Verify.assertEmpty(emptyOf);
-        Assert.assertNotNull(emptyOf.comparator());
+        assertNotNull(emptyOf.comparator());
         TreeBagMultimap<Integer, Integer> expectedOne = TreeBagMultimap.newMultimap(Tuples.pair(1, 1));
         MutableSortedBagMultimap<Integer, Integer> withOne = Multimaps.mutable.sortedBag.with(Integer::compareTo, 1, 1);
-        Assert.assertEquals(expectedOne, withOne);
-        Assert.assertNotNull(withOne.comparator());
+        assertEquals(expectedOne, withOne);
+        assertNotNull(withOne.comparator());
         MutableSortedBagMultimap<Integer, Integer> ofOne = Multimaps.mutable.sortedBag.of(Integer::compareTo, 1, 1);
-        Assert.assertEquals(expectedOne, ofOne);
-        Assert.assertNotNull(ofOne.comparator());
+        assertEquals(expectedOne, ofOne);
+        assertNotNull(ofOne.comparator());
         TreeBagMultimap<String, String> expectedOneStrings = TreeBagMultimap.newMultimap(Tuples.pair("A", "B"));
         MutableSortedBagMultimap<String, String> withStrings = Multimaps.mutable.sortedBag.with(String::compareTo, "A", "B");
-        Assert.assertEquals(expectedOneStrings, withStrings);
-        Assert.assertNotNull(withStrings.comparator());
+        assertEquals(expectedOneStrings, withStrings);
+        assertNotNull(withStrings.comparator());
         MutableSortedBagMultimap<String, String> ofStrings = Multimaps.mutable.sortedBag.of(String::compareTo, "A", "B");
-        Assert.assertEquals(expectedOneStrings, ofStrings);
-        Assert.assertNotNull(ofStrings.comparator());
+        assertEquals(expectedOneStrings, ofStrings);
+        assertNotNull(ofStrings.comparator());
         TreeBagMultimap<Integer, Integer> expectedTwo = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2));
         MutableSortedBagMultimap<Integer, Integer> withTwoItems = Multimaps.mutable.sortedBag.with(Integer::compareTo, 1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, withTwoItems);
-        Assert.assertNotNull(withTwoItems.comparator());
+        assertEquals(expectedTwo, withTwoItems);
+        assertNotNull(withTwoItems.comparator());
         MutableSortedBagMultimap<Integer, Integer> ofTwoItems = Multimaps.mutable.sortedBag.of(Integer::compareTo, 1, 1, 2, 2);
-        Assert.assertEquals(expectedTwo, ofTwoItems);
-        Assert.assertNotNull(ofTwoItems.comparator());
+        assertEquals(expectedTwo, ofTwoItems);
+        assertNotNull(ofTwoItems.comparator());
         MutableSortedBagMultimap<Integer, Integer> threeWith = Multimaps.mutable.sortedBag.with(Integer::compareTo, 1, 1, 2, 2, 3, 3);
-        Assert.assertNotNull(threeWith.comparator());
+        assertNotNull(threeWith.comparator());
         MutableSortedBagMultimap<Integer, Integer> threeOf = Multimaps.mutable.sortedBag.of(Integer::compareTo, 1, 1, 2, 2, 3, 3);
-        Assert.assertNotNull(threeOf.comparator());
+        assertNotNull(threeOf.comparator());
         SortedBagMultimap<Integer, Integer> expectedThree = TreeBagMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(2, 2), Tuples.pair(3, 3));
-        Assert.assertEquals(expectedThree, threeWith);
-        Assert.assertEquals(expectedThree, threeOf);
-        Assert.assertEquals(expectedThree, Multimaps.mutable.sortedBag.withAll(threeWith));
+        assertEquals(expectedThree, threeWith);
+        assertEquals(expectedThree, threeOf);
+        assertEquals(expectedThree, Multimaps.mutable.sortedBag.withAll(threeWith));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
@@ -40,10 +40,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SetsTest
 {
@@ -195,21 +201,21 @@ public class SetsTest
     public void unionAllUnique()
     {
         MutableSet<String> names = Sets.unionAll(this.uniqueSets.get(0), this.uniqueSets.get(1), this.uniqueSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", "Jane", "Sarah", "Mary", "Fido", "Spike", "Spuds", null), names);
+        assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", "Jane", "Sarah", "Mary", "Fido", "Spike", "Spuds", null), names);
     }
 
     @Test
     public void unionAllOverlapping()
     {
         MutableSet<String> names = Sets.unionAll(this.overlappingSets.get(0), this.overlappingSets.get(1), this.overlappingSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", "Larry", "Paul", null), names);
+        assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", "Larry", "Paul", null), names);
     }
 
     @Test
     public void unionAllIdentical()
     {
         MutableSet<String> names = Sets.unionAll(this.identicalSets.get(0), this.identicalSets.get(1), this.identicalSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", null), names);
+        assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", null), names);
     }
 
     @Test
@@ -306,21 +312,21 @@ public class SetsTest
     public void intersectAllUnique()
     {
         MutableSet<String> names = Sets.intersectAll(this.uniqueSets.get(0), this.uniqueSets.get(1), this.uniqueSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith(), names);
+        assertEquals(UnifiedSet.newSetWith(), names);
     }
 
     @Test
     public void intersectAllOverlapping()
     {
         MutableSet<String> names = Sets.intersectAll(this.overlappingSets.get(0), this.overlappingSets.get(1), this.overlappingSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Dick"), names);
+        assertEquals(UnifiedSet.newSetWith("Dick"), names);
     }
 
     @Test
     public void intersectAllIdentical()
     {
         MutableSet<String> names = Sets.intersectAll(this.identicalSets.get(0), this.identicalSets.get(1), this.identicalSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", null), names);
+        assertEquals(UnifiedSet.newSetWith("Tom", "Dick", "Harry", null), names);
     }
 
     @Test
@@ -399,7 +405,7 @@ public class SetsTest
     public void differenceAllUnique()
     {
         MutableSet<String> names = Sets.differenceAll(this.uniqueSets.get(0), this.uniqueSets.get(1), this.uniqueSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Harry", "Tom", "Dick", null), names);
+        assertEquals(UnifiedSet.newSetWith("Harry", "Tom", "Dick", null), names);
         Verify.assertSetsEqual(
                 names,
                 Sets.difference(Sets.difference(this.uniqueSets.get(0), this.uniqueSets.get(1)), this.uniqueSets.get(2)));
@@ -409,7 +415,7 @@ public class SetsTest
     public void differenceAllOverlapping()
     {
         MutableSet<String> names = Sets.differenceAll(this.overlappingSets.get(0), this.overlappingSets.get(1), this.overlappingSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith("Harry"), names);
+        assertEquals(UnifiedSet.newSetWith("Harry"), names);
         Verify.assertSetsEqual(
                 names,
                 Sets.difference(Sets.difference(this.overlappingSets.get(0), this.overlappingSets.get(1)), this.overlappingSets.get(2)));
@@ -419,7 +425,7 @@ public class SetsTest
     public void differenceAllIdentical()
     {
         MutableSet<String> names = Sets.differenceAll(this.identicalSets.get(0), this.identicalSets.get(1), this.identicalSets.get(2));
-        Assert.assertEquals(UnifiedSet.newSetWith(), names);
+        assertEquals(UnifiedSet.newSetWith(), names);
         Verify.assertSetsEqual(
                 names,
                 Sets.difference(Sets.difference(this.identicalSets.get(0), this.identicalSets.get(1)), this.identicalSets.get(2)));
@@ -502,8 +508,8 @@ public class SetsTest
     {
         MutableSet<String> emptySet = mSet();
         MutableSet<String> singletonSet = mSet("Bertha");
-        Assert.assertTrue(Sets.isSubsetOf(emptySet, singletonSet));
-        Assert.assertFalse(Sets.isSubsetOf(singletonSet, emptySet));
+        assertTrue(Sets.isSubsetOf(emptySet, singletonSet));
+        assertFalse(Sets.isSubsetOf(singletonSet, emptySet));
     }
 
     @Test
@@ -511,8 +517,8 @@ public class SetsTest
     {
         MutableSet<String> singletonSet = UnifiedSet.newSetWith("Bertha");
         MutableSet<String> doubletonSet = UnifiedSet.newSetWith("Bertha", "Myra");
-        Assert.assertTrue(Sets.isSubsetOf(singletonSet, doubletonSet));
-        Assert.assertFalse(Sets.isSubsetOf(doubletonSet, singletonSet));
+        assertTrue(Sets.isSubsetOf(singletonSet, doubletonSet));
+        assertFalse(Sets.isSubsetOf(doubletonSet, singletonSet));
     }
 
     @Test
@@ -520,8 +526,8 @@ public class SetsTest
     {
         MutableSet<String> setA = UnifiedSet.newSetWith("Bertha", null, "Myra");
         MutableSet<String> setB = UnifiedSet.newSetWith("Myra", "Bertha", null);
-        Assert.assertTrue(Sets.isSubsetOf(setA, setB));
-        Assert.assertTrue(Sets.isSubsetOf(setB, setA));
+        assertTrue(Sets.isSubsetOf(setA, setB));
+        assertTrue(Sets.isSubsetOf(setB, setA));
     }
 
     @Test
@@ -529,8 +535,8 @@ public class SetsTest
     {
         MutableSet<String> emptySet = mSet();
         MutableSet<String> singletonSet = UnifiedSet.newSetWith("Bertha");
-        Assert.assertTrue(Sets.isProperSubsetOf(emptySet, singletonSet));
-        Assert.assertFalse(Sets.isProperSubsetOf(singletonSet, emptySet));
+        assertTrue(Sets.isProperSubsetOf(emptySet, singletonSet));
+        assertFalse(Sets.isProperSubsetOf(singletonSet, emptySet));
     }
 
     @Test
@@ -538,8 +544,8 @@ public class SetsTest
     {
         MutableSet<String> singletonSet = UnifiedSet.newSetWith("Bertha");
         MutableSet<String> doubletonSet = UnifiedSet.newSetWith("Bertha", "Myra");
-        Assert.assertTrue(Sets.isProperSubsetOf(singletonSet, doubletonSet));
-        Assert.assertFalse(Sets.isProperSubsetOf(doubletonSet, singletonSet));
+        assertTrue(Sets.isProperSubsetOf(singletonSet, doubletonSet));
+        assertFalse(Sets.isProperSubsetOf(doubletonSet, singletonSet));
     }
 
     @Test
@@ -547,8 +553,8 @@ public class SetsTest
     {
         MutableSet<String> setA = UnifiedSet.newSetWith("Bertha", null, "Myra");
         MutableSet<String> setB = UnifiedSet.newSetWith("Myra", "Bertha", null);
-        Assert.assertFalse(Sets.isProperSubsetOf(setA, setB));
-        Assert.assertFalse(Sets.isProperSubsetOf(setB, setA));
+        assertFalse(Sets.isProperSubsetOf(setA, setB));
+        assertFalse(Sets.isProperSubsetOf(setB, setA));
     }
 
     private <E> void assertUnionProperties(
@@ -654,7 +660,7 @@ public class SetsTest
     {
         Verify.assertSetsEqual(setA, setB);
         Object[] expectedItems = setB.toArray((E[]) new Object[setB.size()]);
-        Assert.assertEquals(Lists.mutable.with(expectedItems), FastList.newList(setA));
+        assertEquals(Lists.mutable.with(expectedItems), FastList.newList(setA));
     }
 
     private <E> void assertForwardAndBackward(
@@ -673,35 +679,35 @@ public class SetsTest
 
     private <E> Procedure2<Set<E>, E[]> containsExactlyProcedure()
     {
-        return (set, elements) -> Assert.assertEquals(UnifiedSet.newSetWith(elements), set);
+        return (set, elements) -> assertEquals(UnifiedSet.newSetWith(elements), set);
     }
 
     private <E> Procedure2<Set<E>, E[]> containsExactlyInOrderProcedure()
     {
-        return (set, elements) -> Assert.assertEquals(Lists.mutable.with((Object[]) elements), FastList.newList(set));
+        return (set, elements) -> assertEquals(Lists.mutable.with((Object[]) elements), FastList.newList(set));
     }
 
     @Test
     public void immutables()
     {
         ImmutableSetFactory setFactory = Sets.immutable;
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.empty());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.of());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.with());
+        assertEquals(UnifiedSet.newSet(), setFactory.empty());
+        assertEquals(UnifiedSet.newSet(), setFactory.of());
+        assertEquals(UnifiedSet.newSet(), setFactory.with());
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of());
-        Assert.assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
+        assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of(1));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of(1, 2, 3));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.of(1, 2, 3, 4, 5));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
         Verify.assertInstanceOf(ImmutableSet.class, setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
     }
 
@@ -709,23 +715,23 @@ public class SetsTest
     public void mutables()
     {
         MutableSetFactory setFactory = Sets.mutable;
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.empty());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.of());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.with());
+        assertEquals(UnifiedSet.newSet(), setFactory.empty());
+        assertEquals(UnifiedSet.newSet(), setFactory.of());
+        assertEquals(UnifiedSet.newSet(), setFactory.with());
         Verify.assertInstanceOf(MutableSet.class, setFactory.of());
-        Assert.assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
+        assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
         Verify.assertInstanceOf(MutableSet.class, setFactory.of(1));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
         Verify.assertInstanceOf(MutableSet.class, setFactory.of(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
         Verify.assertInstanceOf(MutableSet.class, setFactory.of(1, 2, 3));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(MutableSet.class, setFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.of(1, 2, 3, 4, 5));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(MutableSet.class, setFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
         Verify.assertInstanceOf(MutableSet.class, setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
         Verify.assertInstanceOf(MutableSet.class, setFactory.fromStream(Stream.of(1, 2, 3, 4, 5)));
     }
 
@@ -733,23 +739,23 @@ public class SetsTest
     public void fixedSize()
     {
         FixedSizeSetFactory setFactory = Sets.fixedSize;
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.of());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.with());
-        Assert.assertEquals(UnifiedSet.newSet(), setFactory.empty());
+        assertEquals(UnifiedSet.newSet(), setFactory.of());
+        assertEquals(UnifiedSet.newSet(), setFactory.with());
+        assertEquals(UnifiedSet.newSet(), setFactory.empty());
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.of());
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.with());
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.empty());
-        Assert.assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
+        assertEquals(UnifiedSet.newSetWith(1), setFactory.of(1));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.of(1));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2), setFactory.of(1, 2));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.of(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), setFactory.of(1, 2, 3));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.of(1, 2, 3));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.ofAll(Sets.mutable.of(1, 2, 3, 4)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.ofAll(Sets.mutable.of(1, 2, 3, 4)));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.ofAll(Sets.mutable.of(1, 2, 3, 4)));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.fromStream(Stream.of(1, 2, 3, 4)));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), setFactory.fromStream(Stream.of(1, 2, 3, 4)));
         Verify.assertInstanceOf(FixedSizeSet.class, setFactory.fromStream(Stream.of(1, 2, 3, 4)));
     }
 
@@ -762,18 +768,18 @@ public class SetsTest
 
     private void testMultiReaderApi(MultiReaderSetFactory setFactory)
     {
-        Assert.assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.of());
+        assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.of());
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.of());
-        Assert.assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.with());
+        assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.with());
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.with());
-        Assert.assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.ofInitialCapacity(1));
+        assertEquals(MultiReaderUnifiedSet.newSet(), setFactory.ofInitialCapacity(1));
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.ofInitialCapacity(1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> setFactory.ofInitialCapacity(-1));
-        Assert.assertEquals(MultiReaderUnifiedSet.newSetWith(1), setFactory.of(1));
+        assertThrows(IllegalArgumentException.class, () -> setFactory.ofInitialCapacity(-1));
+        assertEquals(MultiReaderUnifiedSet.newSetWith(1), setFactory.of(1));
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.of(1));
-        Assert.assertEquals(MultiReaderUnifiedSet.newSetWith(1, 2, 3), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
+        assertEquals(MultiReaderUnifiedSet.newSetWith(1, 2, 3), setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.ofAll(UnifiedSet.newSetWith(1, 2, 3)));
-        Assert.assertEquals(MultiReaderUnifiedSet.newSetWith(1, 2, 3), setFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(MultiReaderUnifiedSet.newSetWith(1, 2, 3), setFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(MultiReaderSet.class, setFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
@@ -790,13 +796,13 @@ public class SetsTest
                 UnifiedSet.newSetWith(1, 3),
                 UnifiedSet.newSetWith(2, 3),
                 UnifiedSet.newSetWith(1, 2, 3));
-        Assert.assertEquals(expectedPowerSet, Sets.powerSet(set));
+        assertEquals(expectedPowerSet, Sets.powerSet(set));
     }
 
     @Test
     public void powerSet_empty()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(UnifiedSet.newSet()),
                 Sets.powerSet(UnifiedSet.newSet()));
     }
@@ -813,7 +819,7 @@ public class SetsTest
                 Tuples.pair(2, 3),
                 Tuples.pair(1, 4),
                 Tuples.pair(2, 4));
-        Assert.assertEquals(expectedCartesianProduct1, Sets.cartesianProduct(set1, set2).toBag());
+        assertEquals(expectedCartesianProduct1, Sets.cartesianProduct(set1, set2).toBag());
         MutableBag<Pair<Integer, Integer>> expectedCartesianProduct2 = Bags.mutable.of(
                 Tuples.pair(2, 1),
                 Tuples.pair(3, 1),
@@ -821,7 +827,7 @@ public class SetsTest
                 Tuples.pair(2, 2),
                 Tuples.pair(3, 2),
                 Tuples.pair(4, 2));
-        Assert.assertEquals(expectedCartesianProduct2, Sets.cartesianProduct(set2, set1).toBag());
+        assertEquals(expectedCartesianProduct2, Sets.cartesianProduct(set2, set1).toBag());
     }
 
     @Test
@@ -834,7 +840,7 @@ public class SetsTest
                 Tuples.pair(1, 2),
                 Tuples.pair(2, 1),
                 Tuples.pair(2, 2));
-        Assert.assertEquals(expectedCartesianProduct, Sets.cartesianProduct(set1, set2).toBag());
+        assertEquals(expectedCartesianProduct, Sets.cartesianProduct(set1, set2).toBag());
     }
 
     @Test
@@ -849,7 +855,7 @@ public class SetsTest
                 Tuples.pair(2, 3),
                 Tuples.pair(1, 4),
                 Tuples.pair(2, 4));
-        Assert.assertEquals(expectedCartesianProduct, Sets.cartesianProduct(set1, set2, Tuples::pair).toBag());
+        assertEquals(expectedCartesianProduct, Sets.cartesianProduct(set1, set2, Tuples::pair).toBag());
         MutableBag<List<Integer>> expectedCartesianProduct2 = Bags.mutable.of(
                 Lists.mutable.with(2, 1),
                 Lists.mutable.with(3, 1),
@@ -857,7 +863,7 @@ public class SetsTest
                 Lists.mutable.with(2, 2),
                 Lists.mutable.with(3, 2),
                 Lists.mutable.with(4, 2));
-        Assert.assertEquals(
+        assertEquals(
                 expectedCartesianProduct2,
                 Sets.cartesianProduct(set2, set1, (one, two) -> Lists.mutable.with(one, two)).toBag());
     }
@@ -865,7 +871,7 @@ public class SetsTest
     @Test
     public void cartesianProduct_empty()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(),
                 HashBag.newBag(Sets.cartesianProduct(
                         Sets.mutable.with(1, 2),
@@ -876,8 +882,8 @@ public class SetsTest
     public void castToSet()
     {
         Set<Object> set = Sets.immutable.of().castToSet();
-        Assert.assertNotNull(set);
-        Assert.assertSame(Sets.immutable.of(), set);
+        assertNotNull(set);
+        assertSame(Sets.immutable.of(), set);
     }
 
     @Test
@@ -888,7 +894,7 @@ public class SetsTest
         ImmutableSet<Integer> immutableSet = set.toImmutable();
         Verify.assertInstanceOf(ImmutableSet.class, Sets.immutable.ofAll(set));
         Verify.assertInstanceOf(ImmutableSet.class, Sets.immutable.ofAll(Sets.mutable.with(1, 2, 3, 4, 5)));
-        Assert.assertSame(Sets.immutable.ofAll(immutableSet.castToSet()), immutableSet);
+        assertSame(Sets.immutable.ofAll(immutableSet.castToSet()), immutableSet);
     }
 
     @Test
@@ -928,15 +934,15 @@ public class SetsTest
     @Test
     public void emptySet()
     {
-        Assert.assertTrue(Sets.immutable.empty().isEmpty());
-        Assert.assertSame(Sets.immutable.empty(), Sets.immutable.empty());
+        assertTrue(Sets.immutable.empty().isEmpty());
+        assertSame(Sets.immutable.empty(), Sets.immutable.empty());
         Verify.assertPostSerializedIdentity(Sets.immutable.empty());
     }
 
     @Test
     public void newSetWith()
     {
-        Assert.assertSame(Sets.immutable.empty(), Sets.immutable.of(Sets.immutable.empty().toArray()));
+        assertSame(Sets.immutable.empty(), Sets.immutable.of(Sets.immutable.empty().toArray()));
         Verify.assertSize(1, Sets.immutable.of(1).castToSet());
         Verify.assertSize(1, Sets.immutable.of(1, 1).castToSet());
         Verify.assertSize(1, Sets.immutable.of(1, 1, 1).castToSet());
@@ -974,35 +980,35 @@ public class SetsTest
         ImmutableSet<Key> set1 = Sets.immutable.of(key, duplicateKey1);
         Verify.assertSize(1, set1);
         Verify.assertContains(key, set1);
-        Assert.assertSame(key, set1.getFirst());
+        assertSame(key, set1.getFirst());
 
         Key duplicateKey2 = new Key("key");
         ImmutableSet<Key> set2 = Sets.immutable.of(key, duplicateKey1, duplicateKey2);
         Verify.assertSize(1, set2);
         Verify.assertContains(key, set2);
-        Assert.assertSame(key, set2.getFirst());
+        assertSame(key, set2.getFirst());
 
         Key duplicateKey3 = new Key("key");
         ImmutableSet<Key> set3 = Sets.immutable.of(key, new Key("not a dupe"), duplicateKey3);
         Verify.assertSize(2, set3);
         Verify.assertContainsAll("immutable set", set3, key, new Key("not a dupe"));
-        Assert.assertSame(key, set3.detect(key::equals));
+        assertSame(key, set3.detect(key::equals));
 
         Key duplicateKey4 = new Key("key");
         ImmutableSet<Key> set4 = Sets.immutable.of(key, new Key("not a dupe"), duplicateKey3, duplicateKey4);
         Verify.assertSize(2, set4);
         Verify.assertContainsAll("immutable set", set4, key, new Key("not a dupe"));
-        Assert.assertSame(key, set4.detect(key::equals));
+        assertSame(key, set4.detect(key::equals));
 
         ImmutableSet<Key> set5 = Sets.immutable.of(key, new Key("not a dupe"), new Key("me neither"), duplicateKey4);
         Verify.assertSize(3, set5);
         Verify.assertContainsAll("immutable set", set5, key, new Key("not a dupe"), new Key("me neither"));
-        Assert.assertSame(key, set5.detect(key::equals));
+        assertSame(key, set5.detect(key::equals));
 
         ImmutableSet<Key> set6 = Sets.immutable.of(key, duplicateKey2, duplicateKey3, duplicateKey4);
         Verify.assertSize(1, set6);
         Verify.assertContains(key, set6);
-        Assert.assertSame(key, set6.detect(key::equals));
+        assertSame(key, set6.detect(key::equals));
     }
 
     @Test
@@ -1032,7 +1038,7 @@ public class SetsTest
         MutableSet<String> set6 = Sets.mutable.ofInitialCapacity(65);
         this.assertPresizedSetSizeEquals(65, (UnifiedSet<String>) set6);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Sets.mutable.ofInitialCapacity(-12));
+        assertThrows(IllegalArgumentException.class, () -> Sets.mutable.ofInitialCapacity(-12));
     }
 
     @Test
@@ -1053,7 +1059,7 @@ public class SetsTest
         MutableSet<String> set5 = Sets.mutable.withInitialCapacity(32);
         this.assertPresizedSetSizeEquals(32, (UnifiedSet<String>) set5);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Sets.mutable.withInitialCapacity(-6));
+        assertThrows(IllegalArgumentException.class, () -> Sets.mutable.withInitialCapacity(-6));
     }
 
     private void assertPresizedSetSizeEquals(int initialCapacity, UnifiedSet<String> set)
@@ -1070,19 +1076,19 @@ public class SetsTest
             {
                 capacity <<= 1;
             }
-            Assert.assertEquals(capacity, table.length);
+            assertEquals(capacity, table.length);
         }
         catch (SecurityException ignored)
         {
-            Assert.fail("Unable to modify the visibility of the field 'table' on UnifiedSet");
+            fail("Unable to modify the visibility of the field 'table' on UnifiedSet");
         }
         catch (NoSuchFieldException ignored)
         {
-            Assert.fail("No field named 'table' in UnifiedSet");
+            fail("No field named 'table' in UnifiedSet");
         }
         catch (IllegalAccessException ignored)
         {
-            Assert.fail("No access to the field 'table' in UnifiedSet");
+            fail("No access to the field 'table' in UnifiedSet");
         }
     }
 
@@ -1092,7 +1098,7 @@ public class SetsTest
         ImmutableSet<Integer> empty = Sets.immutable.withAll(Collections.emptyList());
         ImmutableSet<Integer> integers = Sets.immutable.<Integer>empty().newWithAll(Lists.immutable.empty());
         ImmutableSet<Integer> empty2 = Sets.immutable.withAll(integers);
-        Assert.assertSame(Sets.immutable.empty(), empty);
-        Assert.assertSame(Sets.immutable.empty(), empty2);
+        assertSame(Sets.immutable.empty(), empty);
+        assertSame(Sets.immutable.empty(), empty2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedMapsTest.java
@@ -11,8 +11,9 @@
 package org.eclipse.collections.impl.factory;
 
 import org.eclipse.collections.api.factory.map.sorted.MutableSortedMapFactory;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class SortedMapsTest
 {
@@ -20,7 +21,7 @@ public class SortedMapsTest
     public void mutables()
     {
         MutableSortedMapFactory factory = SortedMaps.mutable;
-        Assert.assertEquals(SortedMaps.mutable.empty(), factory.empty());
-        Assert.assertEquals(SortedMaps.mutable.empty(Integer::compare), factory.empty(Integer::compare));
+        assertEquals(SortedMaps.mutable.empty(), factory.empty());
+        assertEquals(SortedMaps.mutable.empty(Integer::compare), factory.empty(Integer::compare));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class SortedSetsTest
 {
@@ -30,65 +32,65 @@ public class SortedSetsTest
     public void immutables()
     {
         ImmutableSortedSetFactory factory = SortedSets.immutable;
-        Assert.assertEquals(UnifiedSet.newSet(), factory.of());
+        assertEquals(UnifiedSet.newSet(), factory.of());
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of());
-        Assert.assertEquals(UnifiedSet.newSet(), factory.with());
+        assertEquals(UnifiedSet.newSet(), factory.with());
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.with());
-        Assert.assertEquals(TreeSortedSet.newSet(Comparators.reverseNaturalOrder()), factory.empty(Comparators.reverseNaturalOrder()));
+        assertEquals(TreeSortedSet.newSet(Comparators.reverseNaturalOrder()), factory.empty(Comparators.reverseNaturalOrder()));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.empty(Comparators.reverseNaturalOrder()));
-        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of(new Integer[0]));
-        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of((Object[]) null));
-        Assert.assertEquals(UnifiedSet.newSetWith(), factory.of(Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder()).comparator(), factory.of(Comparators.reverseNaturalOrder()).comparator());
-        Assert.assertEquals(TreeSortedSet.newSetWith().comparator(), factory.of((Comparator<Integer>) null).comparator());
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(1, 2, 2));
+        assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of(new Integer[0]));
+        assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of((Object[]) null));
+        assertEquals(UnifiedSet.newSetWith(), factory.of(Comparators.reverseNaturalOrder()));
+        assertEquals(TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder()).comparator(), factory.of(Comparators.reverseNaturalOrder()).comparator());
+        assertEquals(TreeSortedSet.newSetWith().comparator(), factory.of((Comparator<Integer>) null).comparator());
+        assertEquals(UnifiedSet.newSetWith(1, 2), factory.of(1, 2, 2));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(1, 2, 3, 4));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), factory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(
+        assertEquals(
                 SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8),
                 factory.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableSortedSet.class, factory.of(Comparators.reverseNaturalOrder(), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 8));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
-        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
-        Assert.assertEquals(SortedSets.mutable.empty(), factory.ofSortedSet(SortedSets.mutable.with()));
-        Assert.assertEquals(SortedSets.mutable.empty(Integer::compare), factory.ofSortedSet(SortedSets.mutable.with(Integer::compare)));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.ofAll(null, Lists.mutable.empty()));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).comparator(), factory.ofAll(Comparators.reverseNaturalOrder(), SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)).comparator());
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.immutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8).castToSortedSet()));
+        assertEquals(SortedSets.mutable.empty(), factory.ofSortedSet(SortedSets.mutable.with()));
+        assertEquals(SortedSets.mutable.empty(Integer::compare), factory.ofSortedSet(SortedSets.mutable.with(Integer::compare)));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8), factory.ofSortedSet(SortedSets.mutable.of(Comparators.reverseNaturalOrder(), 1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.ofAll(null, Lists.mutable.empty()));
     }
 
     @Test
     public void mutables()
     {
         MutableSortedSetFactory factory = SortedSets.mutable;
-        Assert.assertEquals(TreeSortedSet.newSet(), factory.of());
+        assertEquals(TreeSortedSet.newSet(), factory.of());
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of());
-        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2), factory.of(1, 2, 2));
+        assertEquals(TreeSortedSet.newSetWith(1, 2), factory.of(1, 2, 2));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of(1, 2));
-        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4), factory.of(1, 2, 3, 4));
+        assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4), factory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of(1, 2, 3, 4));
-        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6), factory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(TreeSortedSet.newSetWith(1, 2, 3, 4, 5, 6, 7, 8), factory.ofAll(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.ofAll(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
-        Assert.assertEquals(TreeSortedSet.newSet(Comparators.naturalOrder()), factory.of(Comparators.naturalOrder()));
+        assertEquals(TreeSortedSet.newSet(Comparators.naturalOrder()), factory.of(Comparators.naturalOrder()));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.of(Comparators.naturalOrder()));
-        Assert.assertEquals(TreeSortedSet.newSetWith(8, 7, 6, 5, 4, 3, 2, 1), factory.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
+        assertEquals(TreeSortedSet.newSetWith(8, 7, 6, 5, 4, 3, 2, 1), factory.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
         Verify.assertInstanceOf(MutableSortedSet.class, factory.ofAll(Comparators.reverseNaturalOrder(), FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8)));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StacksTest.java
@@ -18,8 +18,10 @@ import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StacksTest
 {
@@ -27,31 +29,31 @@ public class StacksTest
     public void immutables()
     {
         ImmutableStackFactory stackFactory = Stacks.immutable;
-        Assert.assertEquals(ArrayStack.newStack(), stackFactory.of());
+        assertEquals(ArrayStack.newStack(), stackFactory.of());
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of());
-        Assert.assertEquals(ArrayStack.newStackWith(1), stackFactory.of(1));
+        assertEquals(ArrayStack.newStackWith(1), stackFactory.of(1));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2), stackFactory.of(1, 2));
+        assertEquals(ArrayStack.newStackWith(1, 2), stackFactory.of(1, 2));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.of(1, 2, 3));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.of(1, 2, 3));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), stackFactory.of(1, 2, 3, 4));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), stackFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), stackFactory.of(1, 2, 3, 4, 5));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), stackFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), stackFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), stackFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), stackFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), stackFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(ArrayStack.newStackWith(3, 2, 1), stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        assertEquals(ArrayStack.newStackWith(3, 2, 1), stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(ImmutableStack.class, stackFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
@@ -59,57 +61,57 @@ public class StacksTest
     public void mutables()
     {
         MutableStackFactory stackFactory = Stacks.mutable;
-        Assert.assertEquals(ArrayStack.newStack(), stackFactory.of());
+        assertEquals(ArrayStack.newStack(), stackFactory.of());
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of());
-        Assert.assertEquals(ArrayStack.newStackWith(1), stackFactory.of(1));
+        assertEquals(ArrayStack.newStackWith(1), stackFactory.of(1));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2), stackFactory.of(1, 2));
+        assertEquals(ArrayStack.newStackWith(1, 2), stackFactory.of(1, 2));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.of(1, 2, 3));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.of(1, 2, 3));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), stackFactory.of(1, 2, 3, 4));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4), stackFactory.of(1, 2, 3, 4));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), stackFactory.of(1, 2, 3, 4, 5));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5), stackFactory.of(1, 2, 3, 4, 5));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), stackFactory.of(1, 2, 3, 4, 5, 6));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6), stackFactory.of(1, 2, 3, 4, 5, 6));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), stackFactory.of(1, 2, 3, 4, 5, 6, 7));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7), stackFactory.of(1, 2, 3, 4, 5, 6, 7));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        Assert.assertEquals(ArrayStack.newStackWith(3, 2, 1), stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
+        assertEquals(ArrayStack.newStackWith(3, 2, 1), stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.ofAll(ArrayStack.newStackWith(1, 2, 3)));
-        Assert.assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.fromStream(Stream.of(1, 2, 3)));
+        assertEquals(ArrayStack.newStackWith(1, 2, 3), stackFactory.fromStream(Stream.of(1, 2, 3)));
         Verify.assertInstanceOf(MutableStack.class, stackFactory.fromStream(Stream.of(1, 2, 3)));
     }
 
     @Test
     public void emptyStack()
     {
-        Assert.assertTrue(Stacks.immutable.of().isEmpty());
+        assertTrue(Stacks.immutable.of().isEmpty());
     }
 
     @Test
     public void newStackWith()
     {
         ImmutableStack<String> stack = Stacks.immutable.of();
-        Assert.assertEquals(stack, Stacks.immutable.of(stack.toArray()));
-        Assert.assertEquals(stack = stack.push("1"), Stacks.immutable.of("1"));
-        Assert.assertEquals(stack = stack.push("2"), Stacks.immutable.of("1", "2"));
-        Assert.assertEquals(stack = stack.push("3"), Stacks.immutable.of("1", "2", "3"));
-        Assert.assertEquals(stack = stack.push("4"), Stacks.immutable.of("1", "2", "3", "4"));
-        Assert.assertEquals(stack = stack.push("5"), Stacks.immutable.of("1", "2", "3", "4", "5"));
-        Assert.assertEquals(stack = stack.push("6"), Stacks.immutable.of("1", "2", "3", "4", "5", "6"));
-        Assert.assertEquals(stack = stack.push("7"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7"));
-        Assert.assertEquals(stack = stack.push("8"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
-        Assert.assertEquals(stack = stack.push("9"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
-        Assert.assertEquals(stack = stack.push("10"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
-        Assert.assertEquals(stack = stack.push("11"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
-        Assert.assertEquals(stack = stack.push("12"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
+        assertEquals(stack, Stacks.immutable.of(stack.toArray()));
+        assertEquals(stack = stack.push("1"), Stacks.immutable.of("1"));
+        assertEquals(stack = stack.push("2"), Stacks.immutable.of("1", "2"));
+        assertEquals(stack = stack.push("3"), Stacks.immutable.of("1", "2", "3"));
+        assertEquals(stack = stack.push("4"), Stacks.immutable.of("1", "2", "3", "4"));
+        assertEquals(stack = stack.push("5"), Stacks.immutable.of("1", "2", "3", "4", "5"));
+        assertEquals(stack = stack.push("6"), Stacks.immutable.of("1", "2", "3", "4", "5", "6"));
+        assertEquals(stack = stack.push("7"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7"));
+        assertEquals(stack = stack.push("8"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8"));
+        assertEquals(stack = stack.push("9"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9"));
+        assertEquals(stack = stack.push("10"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        assertEquals(stack = stack.push("11"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(stack = stack.push("12"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -117,17 +119,17 @@ public class StacksTest
     public void newStackWithArray()
     {
         ImmutableStack<String> stack = Stacks.immutable.of();
-        Assert.assertEquals(stack = stack.push("1"), Stacks.immutable.of(new String[]{"1"}));
-        Assert.assertEquals(stack = stack.push("2"), Stacks.immutable.of(new String[]{"1", "2"}));
-        Assert.assertEquals(stack = stack.push("3"), Stacks.immutable.of(new String[]{"1", "2", "3"}));
-        Assert.assertEquals(stack = stack.push("4"), Stacks.immutable.of(new String[]{"1", "2", "3", "4"}));
-        Assert.assertEquals(stack = stack.push("5"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
-        Assert.assertEquals(stack = stack.push("6"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
-        Assert.assertEquals(stack = stack.push("7"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
-        Assert.assertEquals(stack = stack.push("8"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
-        Assert.assertEquals(stack = stack.push("9"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
-        Assert.assertEquals(stack = stack.push("10"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
-        Assert.assertEquals(stack = stack.push("11"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
+        assertEquals(stack = stack.push("1"), Stacks.immutable.of(new String[]{"1"}));
+        assertEquals(stack = stack.push("2"), Stacks.immutable.of(new String[]{"1", "2"}));
+        assertEquals(stack = stack.push("3"), Stacks.immutable.of(new String[]{"1", "2", "3"}));
+        assertEquals(stack = stack.push("4"), Stacks.immutable.of(new String[]{"1", "2", "3", "4"}));
+        assertEquals(stack = stack.push("5"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5"}));
+        assertEquals(stack = stack.push("6"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6"}));
+        assertEquals(stack = stack.push("7"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7"}));
+        assertEquals(stack = stack.push("8"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8"}));
+        assertEquals(stack = stack.push("9"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9"}));
+        assertEquals(stack = stack.push("10"), Stacks.immutable.of(new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}));
+        assertEquals(stack = stack.push("11"), Stacks.immutable.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"));
     }
 
     @Test
@@ -135,38 +137,38 @@ public class StacksTest
     {
         ImmutableStack<String> stack = Stacks.immutable.of();
         ArrayStack<String> arrayStack = ArrayStack.newStackWith("1");
-        Assert.assertEquals(stack = stack.push("1"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("1"), arrayStack.toImmutable());
         arrayStack.push("2");
-        Assert.assertEquals(stack = stack.push("2"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("2"), arrayStack.toImmutable());
         arrayStack.push("3");
-        Assert.assertEquals(stack = stack.push("3"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("3"), arrayStack.toImmutable());
         arrayStack.push("4");
-        Assert.assertEquals(stack = stack.push("4"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("4"), arrayStack.toImmutable());
         arrayStack.push("5");
-        Assert.assertEquals(stack = stack.push("5"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("5"), arrayStack.toImmutable());
         arrayStack.push("6");
-        Assert.assertEquals(stack = stack.push("6"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("6"), arrayStack.toImmutable());
         arrayStack.push("7");
-        Assert.assertEquals(stack = stack.push("7"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("7"), arrayStack.toImmutable());
         arrayStack.push("8");
-        Assert.assertEquals(stack = stack.push("8"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("8"), arrayStack.toImmutable());
         arrayStack.push("9");
-        Assert.assertEquals(stack = stack.push("9"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("9"), arrayStack.toImmutable());
         arrayStack.push("10");
-        Assert.assertEquals(stack = stack.push("10"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("10"), arrayStack.toImmutable());
         arrayStack.push("11");
-        Assert.assertEquals(stack = stack.push("11"), arrayStack.toImmutable());
+        assertEquals(stack = stack.push("11"), arrayStack.toImmutable());
     }
 
     @Test
     public void newStackWithWithStack()
     {
         ArrayStack<Object> expected = ArrayStack.newStack();
-        Assert.assertEquals(expected, Stacks.mutable.ofAll(ArrayStack.newStack()));
+        assertEquals(expected, Stacks.mutable.ofAll(ArrayStack.newStack()));
         expected.push(1);
-        Assert.assertEquals(ArrayStack.newStackWith(1), Stacks.mutable.ofAll(expected));
+        assertEquals(ArrayStack.newStackWith(1), Stacks.mutable.ofAll(expected));
         expected.push(2);
-        Assert.assertEquals(ArrayStack.newStackWith(2, 1), Stacks.mutable.ofAll(expected));
+        assertEquals(ArrayStack.newStackWith(2, 1), Stacks.mutable.ofAll(expected));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StringsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StringsTest.java
@@ -12,8 +12,10 @@ package org.eclipse.collections.impl.factory;
 
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.string.immutable.CodePointAdapter;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StringsTest
 {
@@ -21,27 +23,27 @@ public class StringsTest
     public void asChars()
     {
         CharAdapter adapter = Strings.asChars("The quick brown fox jumps over the lazy dog.");
-        Assert.assertTrue(adapter.contains('T'));
+        assertTrue(adapter.contains('T'));
     }
 
     @Test
     public void toChars()
     {
         CharAdapter adapter = Strings.toChars('H', 'e', 'l', 'l', 'o');
-        Assert.assertEquals(2, adapter.count(c -> c == 'l'));
+        assertEquals(2, adapter.count(c -> c == 'l'));
     }
 
     @Test
     public void asCodePoints()
     {
         CodePointAdapter adapter = Strings.asCodePoints("The quick brown fox jumps over the lazy dog.");
-        Assert.assertTrue(adapter.contains((int) 'T'));
+        assertTrue(adapter.contains((int) 'T'));
     }
 
     @Test
     public void toCodePoints()
     {
         CodePointAdapter adapter = Strings.toCodePoints((int) 'H', (int) 'e', (int) 'l', (int) 'l', (int) 'o');
-        Assert.assertEquals(2, adapter.count(i -> i == (int) 'l'));
+        assertEquals(2, adapter.count(i -> i == (int) 'l'));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanBagsTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.factory.bag.primitive.ImmutableBooleanBagFactory;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class BooleanBagsTest
 {
@@ -23,29 +25,29 @@ public class BooleanBagsTest
     public void immutables()
     {
         ImmutableBooleanBagFactory bagFactory = BooleanBags.immutable;
-        Assert.assertEquals(new BooleanHashBag(), bagFactory.of());
+        assertEquals(new BooleanHashBag(), bagFactory.of());
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), bagFactory.of(true));
+        assertEquals(BooleanHashBag.newBagWith(true), bagFactory.of(true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false), bagFactory.of(true, false));
+        assertEquals(BooleanHashBag.newBagWith(true, false), bagFactory.of(true, false));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), bagFactory.of(true, false, true));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), bagFactory.of(true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false), bagFactory.of(true, false, true, false));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false), bagFactory.of(true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), bagFactory.of(true, false, true, false, true));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true), bagFactory.of(true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false), bagFactory.of(true, false, true, false, true, false));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false), bagFactory.of(true, false, true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true, false));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true), bagFactory.of(true, false, true, false, true, false, true));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true), bagFactory.of(true, false, true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true, false, true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true), bagFactory.of(true, false, true, false, true, false, true, true));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true), bagFactory.of(true, false, true, false, true, false, true, true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true, true), bagFactory.of(true, false, true, false, true, false, true, true, true));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true, true), bagFactory.of(true, false, true, false, true, false, true, true, true));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true, true, false), bagFactory.of(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true, false, true, false, true, true, true, false), bagFactory.of(true, false, true, false, true, false, true, true, true, false));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.of(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), bagFactory.ofAll(BooleanHashBag.newBagWith(true, false, true)));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), bagFactory.ofAll(BooleanHashBag.newBagWith(true, false, true)));
         Verify.assertInstanceOf(ImmutableBooleanBag.class, bagFactory.ofAll(BooleanHashBag.newBagWith(true, false, true)));
     }
 
@@ -53,7 +55,7 @@ public class BooleanBagsTest
     public void emptyBag()
     {
         Verify.assertEmpty(BooleanBags.immutable.of());
-        Assert.assertSame(BooleanBags.immutable.of(), BooleanBags.immutable.of());
+        assertSame(BooleanBags.immutable.of(), BooleanBags.immutable.of());
         Verify.assertPostSerializedIdentity(BooleanBags.immutable.of());
     }
 
@@ -61,19 +63,19 @@ public class BooleanBagsTest
     public void newBagWith()
     {
         ImmutableBooleanBag bag = BooleanBags.immutable.of();
-        Assert.assertEquals(bag, BooleanBags.immutable.of(bag.toArray()));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false, true));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false, true, false));
+        assertEquals(bag, BooleanBags.immutable.of(bag.toArray()));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false, true));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(true, false, true, false, true, false, true, true, true, false, true, false));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -81,17 +83,17 @@ public class BooleanBagsTest
     public void newBagWithArray()
     {
         ImmutableBooleanBag bag = BooleanBags.immutable.of();
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true}));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true}));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true}));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true}));
-        Assert.assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
-        Assert.assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true}));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true}));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true}));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true}));
+        assertEquals(bag = bag.newWith(false), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
+        assertEquals(bag = bag.newWith(true), BooleanBags.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
     }
 
     @Test
@@ -99,26 +101,26 @@ public class BooleanBagsTest
     {
         ImmutableBooleanBag bag = BooleanBags.immutable.of();
         BooleanHashBag booleanHashBag = BooleanHashBag.newBagWith(true);
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.toImmutable());
-        Assert.assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
-        Assert.assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.toImmutable());
+        assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
+        assertEquals(bag = bag.newWith(false), booleanHashBag.with(false).toImmutable());
+        assertEquals(bag = bag.newWith(true), booleanHashBag.with(true).toImmutable());
     }
 
     @Test
     public void newBagWithWithBag()
     {
-        Assert.assertEquals(new BooleanHashBag(), BooleanBags.immutable.ofAll(new BooleanHashBag()));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true)));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true, false)));
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true, false, true)));
+        assertEquals(new BooleanHashBag(), BooleanBags.immutable.ofAll(new BooleanHashBag()));
+        assertEquals(BooleanHashBag.newBagWith(true), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true)));
+        assertEquals(BooleanHashBag.newBagWith(true, false), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true, false)));
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), BooleanBags.immutable.ofAll(BooleanHashBag.newBagWith(true, false, true)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanListsTest.java
@@ -17,8 +17,10 @@ import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class BooleanListsTest
 {
@@ -26,27 +28,27 @@ public class BooleanListsTest
     public void mutables()
     {
         MutableBooleanListFactory listFactory = BooleanLists.mutable;
-        Assert.assertEquals(new BooleanArrayList(), listFactory.empty());
+        assertEquals(new BooleanArrayList(), listFactory.empty());
         Verify.assertInstanceOf(MutableBooleanList.class, listFactory.empty());
 
-        Assert.assertEquals(new BooleanArrayList(), listFactory.of());
+        assertEquals(new BooleanArrayList(), listFactory.of());
         Verify.assertInstanceOf(MutableBooleanList.class, listFactory.of());
 
-        Assert.assertEquals(new BooleanArrayList(), listFactory.with());
+        assertEquals(new BooleanArrayList(), listFactory.with());
         Verify.assertInstanceOf(MutableBooleanList.class, listFactory.with());
 
-        Assert.assertEquals(new BooleanArrayList(true, true, false), listFactory.with(true, true, false));
-        Assert.assertEquals(new BooleanArrayList(false, true, false), listFactory.of(false, true, false));
-        Assert.assertEquals(new BooleanArrayList(false, true, false), listFactory.wrapCopy(false, true, false));
+        assertEquals(new BooleanArrayList(true, true, false), listFactory.with(true, true, false));
+        assertEquals(new BooleanArrayList(false, true, false), listFactory.of(false, true, false));
+        assertEquals(new BooleanArrayList(false, true, false), listFactory.wrapCopy(false, true, false));
 
-        Assert.assertEquals(new BooleanArrayList(false, true, false),
+        assertEquals(new BooleanArrayList(false, true, false),
                 listFactory.ofAll(new BooleanArrayList(false, true, false)));
-        Assert.assertEquals(new BooleanArrayList(false, true, false, true),
+        assertEquals(new BooleanArrayList(false, true, false, true),
                 listFactory.withAll(new BooleanArrayList(false, true, false, true)));
 
-        Assert.assertEquals(new BooleanArrayList(false, true, false),
+        assertEquals(new BooleanArrayList(false, true, false),
                 listFactory.ofAll(Lists.mutable.of(false, true, false)));
-        Assert.assertEquals(new BooleanArrayList(false, true, false, true),
+        assertEquals(new BooleanArrayList(false, true, false, true),
                 listFactory.withAll(Lists.mutable.of(false, true, false, true)));
     }
 
@@ -54,29 +56,29 @@ public class BooleanListsTest
     public void immutables()
     {
         ImmutableBooleanListFactory listFactory = BooleanLists.immutable;
-        Assert.assertEquals(new BooleanArrayList(), listFactory.of());
+        assertEquals(new BooleanArrayList(), listFactory.of());
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), listFactory.of(true));
+        assertEquals(BooleanArrayList.newListWith(true), listFactory.of(true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false), listFactory.of(true, false));
+        assertEquals(BooleanArrayList.newListWith(true, false), listFactory.of(true, false));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), listFactory.of(true, false, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true), listFactory.of(true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false), listFactory.of(true, false, true, false));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false), listFactory.of(true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true), listFactory.of(true, false, true, false, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true), listFactory.of(true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false), listFactory.of(true, false, true, false, true, false));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false), listFactory.of(true, false, true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true, false));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true), listFactory.of(true, false, true, false, true, false, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true), listFactory.of(true, false, true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true, false, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true), listFactory.of(true, false, true, false, true, false, true, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true), listFactory.of(true, false, true, false, true, false, true, true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true, true), listFactory.of(true, false, true, false, true, false, true, true, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true, true), listFactory.of(true, false, true, false, true, false, true, true, true));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true, true, false), listFactory.of(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, false, true, true, true, false), listFactory.of(true, false, true, false, true, false, true, true, true, false));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.of(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), listFactory.ofAll(BooleanArrayList.newListWith(true, false, true)));
+        assertEquals(BooleanArrayList.newListWith(true, false, true), listFactory.ofAll(BooleanArrayList.newListWith(true, false, true)));
         Verify.assertInstanceOf(ImmutableBooleanList.class, listFactory.ofAll(BooleanArrayList.newListWith(true, false, true)));
     }
 
@@ -84,7 +86,7 @@ public class BooleanListsTest
     public void emptyList()
     {
         Verify.assertEmpty(BooleanLists.immutable.of());
-        Assert.assertSame(BooleanLists.immutable.of(), BooleanLists.immutable.of());
+        assertSame(BooleanLists.immutable.of(), BooleanLists.immutable.of());
         Verify.assertPostSerializedIdentity(BooleanLists.immutable.of());
     }
 
@@ -92,19 +94,19 @@ public class BooleanListsTest
     public void newListWith()
     {
         ImmutableBooleanList list = BooleanLists.immutable.of();
-        Assert.assertEquals(list, BooleanLists.immutable.of(list.toArray()));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false, true));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false, true, false));
+        assertEquals(list, BooleanLists.immutable.of(list.toArray()));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false, true));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(true, false, true, false, true, false, true, true, true, false, true, false));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -112,17 +114,17 @@ public class BooleanListsTest
     public void newListWithArray()
     {
         ImmutableBooleanList list = BooleanLists.immutable.of();
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true}));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true}));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true}));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true}));
-        Assert.assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
-        Assert.assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true}));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true}));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true}));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true}));
+        assertEquals(list = list.newWith(false), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
+        assertEquals(list = list.newWith(true), BooleanLists.immutable.of(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
     }
 
     @Test
@@ -130,26 +132,26 @@ public class BooleanListsTest
     {
         ImmutableBooleanList list = BooleanLists.immutable.of();
         BooleanArrayList booleanArrayList = BooleanArrayList.newListWith(true);
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.toImmutable());
-        Assert.assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
-        Assert.assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
-        Assert.assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
-        Assert.assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
-        Assert.assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.toImmutable());
+        assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
+        assertEquals(list = list.newWith(false), booleanArrayList.with(false).toImmutable());
+        assertEquals(list = list.newWith(true), booleanArrayList.with(true).toImmutable());
     }
 
     @Test
     public void newListWithWithList()
     {
-        Assert.assertEquals(new BooleanArrayList(), BooleanLists.immutable.ofAll(new BooleanArrayList()));
-        Assert.assertEquals(BooleanArrayList.newListWith(true), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true, false, true)));
+        assertEquals(new BooleanArrayList(), BooleanLists.immutable.ofAll(new BooleanArrayList()));
+        assertEquals(BooleanArrayList.newListWith(true), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true)));
+        assertEquals(BooleanArrayList.newListWith(true, false), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanArrayList.newListWith(true, false, true), BooleanLists.immutable.ofAll(BooleanArrayList.newListWith(true, false, true)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanSetsTest.java
@@ -23,8 +23,10 @@ import org.eclipse.collections.api.tuple.primitive.BooleanBooleanPair;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class BooleanSetsTest
 {
@@ -37,29 +39,29 @@ public class BooleanSetsTest
 
     private void assertImmutableSetFactory(ImmutableBooleanSetFactory setFactory)
     {
-        Assert.assertEquals(new BooleanHashSet(), setFactory.with());
+        assertEquals(new BooleanHashSet(), setFactory.with());
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), setFactory.with(true));
+        assertEquals(BooleanHashSet.newSetWith(true), setFactory.with(true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), setFactory.with(true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false), setFactory.with(true, false));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.with(true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.with(true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false), setFactory.with(true, false, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false), setFactory.with(true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true), setFactory.with(true, false, true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true), setFactory.with(true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false), setFactory.with(true, false, true, false, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false), setFactory.with(true, false, true, false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true), setFactory.with(true, false, true, false, true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true), setFactory.with(true, false, true, false, true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true), setFactory.with(true, false, true, false, true, false, true, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true), setFactory.with(true, false, true, false, true, false, true, true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true), setFactory.with(true, false, true, false, true, false, true, true, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true), setFactory.with(true, false, true, false, true, false, true, true, true));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true, false), setFactory.with(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true, false), setFactory.with(true, false, true, false, true, false, true, true, true, false));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
         Verify.assertInstanceOf(ImmutableBooleanSet.class, setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
     }
 
@@ -72,29 +74,29 @@ public class BooleanSetsTest
 
     private void assertMutableSetFactory(MutableBooleanSetFactory setFactory)
     {
-        Assert.assertEquals(new BooleanHashSet(), setFactory.with());
+        assertEquals(new BooleanHashSet(), setFactory.with());
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), setFactory.with(true));
+        assertEquals(BooleanHashSet.newSetWith(true), setFactory.with(true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), setFactory.with(true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false), setFactory.with(true, false));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.with(true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.with(true, false, true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false), setFactory.with(true, false, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false), setFactory.with(true, false, true, false));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true), setFactory.with(true, false, true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true), setFactory.with(true, false, true, false, true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false), setFactory.with(true, false, true, false, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false), setFactory.with(true, false, true, false, true, false));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true), setFactory.with(true, false, true, false, true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true), setFactory.with(true, false, true, false, true, false, true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true), setFactory.with(true, false, true, false, true, false, true, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true), setFactory.with(true, false, true, false, true, false, true, true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true), setFactory.with(true, false, true, false, true, false, true, true, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true), setFactory.with(true, false, true, false, true, false, true, true, true));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true, false), setFactory.with(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false, true, false, true, true, true, false), setFactory.with(true, false, true, false, true, false, true, true, true, false));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.with(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
         Verify.assertInstanceOf(MutableBooleanSet.class, setFactory.withAll(BooleanHashSet.newSetWith(true, false, true)));
     }
 
@@ -102,7 +104,7 @@ public class BooleanSetsTest
     public void emptySet()
     {
         Verify.assertEmpty(BooleanSets.immutable.with());
-        Assert.assertSame(BooleanSets.immutable.with(), BooleanSets.immutable.with());
+        assertSame(BooleanSets.immutable.with(), BooleanSets.immutable.with());
         Verify.assertPostSerializedIdentity(BooleanSets.immutable.with());
     }
 
@@ -110,19 +112,19 @@ public class BooleanSetsTest
     public void newSetWith()
     {
         ImmutableBooleanSet set = BooleanSets.immutable.with();
-        Assert.assertEquals(set, BooleanSets.immutable.with(set.toArray()));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false, true));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false, true, false));
+        assertEquals(set, BooleanSets.immutable.with(set.toArray()));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false, true));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(true, false, true, false, true, false, true, true, true, false, true, false));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -130,17 +132,17 @@ public class BooleanSetsTest
     public void newSetWithArray()
     {
         ImmutableBooleanSet set = BooleanSets.immutable.with();
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true}));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true}));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true}));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true}));
-        Assert.assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
-        Assert.assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true}));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true}));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true}));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true}));
+        assertEquals(set = set.newWith(false), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true, false}));
+        assertEquals(set = set.newWith(true), BooleanSets.immutable.with(new boolean[]{true, false, true, false, true, false, true, true, true, false, true}));
     }
 
     @Test
@@ -148,54 +150,54 @@ public class BooleanSetsTest
     {
         ImmutableBooleanSet set = BooleanSets.immutable.with();
         BooleanHashSet booleanHashSet = BooleanHashSet.newSetWith(true);
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.toImmutable());
-        Assert.assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
-        Assert.assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
-        Assert.assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
-        Assert.assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
-        Assert.assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.toImmutable());
+        assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
+        assertEquals(set = set.newWith(false), booleanHashSet.with(false).toImmutable());
+        assertEquals(set = set.newWith(true), booleanHashSet.with(true).toImmutable());
     }
 
     @Test
     public void newSetWithWithSet()
     {
-        Assert.assertEquals(new BooleanHashSet(), BooleanSets.immutable.withAll(new BooleanHashSet()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(new BooleanHashSet(), BooleanSets.immutable.withAll(new BooleanHashSet()));
+        assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.withAll(BooleanHashSet.newSetWith(true, false, true)));
     }
 
     @Test
     public void ofAllBooleanIterable()
     {
-        Assert.assertEquals(new BooleanHashSet(), BooleanSets.immutable.ofAll(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true, false, true)));
+        assertEquals(new BooleanHashSet(), BooleanSets.immutable.ofAll(BooleanLists.mutable.empty()));
+        assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.ofAll(BooleanLists.mutable.with(true, false, true)));
 
-        Assert.assertEquals(new BooleanHashSet(), BooleanSets.mutable.ofAll(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true, false, true)));
+        assertEquals(new BooleanHashSet(), BooleanSets.mutable.ofAll(BooleanLists.mutable.empty()));
+        assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.mutable.ofAll(BooleanLists.mutable.with(true, false, true)));
     }
 
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new BooleanHashSet(), BooleanSets.immutable.ofAll(Lists.mutable.empty()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.ofAll(Lists.mutable.with(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.ofAll(Lists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.ofAll(Lists.mutable.with(true, false, true)));
+        assertEquals(new BooleanHashSet(), BooleanSets.immutable.ofAll(Lists.mutable.empty()));
+        assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.immutable.ofAll(Lists.mutable.with(true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.immutable.ofAll(Lists.mutable.with(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.immutable.ofAll(Lists.mutable.with(true, false, true)));
 
-        Assert.assertEquals(new BooleanHashSet(), BooleanSets.mutable.ofAll(Lists.mutable.empty()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.mutable.ofAll(Lists.mutable.with(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.mutable.ofAll(Lists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.mutable.ofAll(Lists.mutable.with(true, false, true)));
+        assertEquals(new BooleanHashSet(), BooleanSets.mutable.ofAll(Lists.mutable.empty()));
+        assertEquals(BooleanHashSet.newSetWith(true), BooleanSets.mutable.ofAll(Lists.mutable.with(true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanSets.mutable.ofAll(Lists.mutable.with(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false, true), BooleanSets.mutable.ofAll(Lists.mutable.with(true, false, true)));
     }
 
     @Test
@@ -218,6 +220,6 @@ public class BooleanSetsTest
                 PrimitiveTuples.pair(false, true),
                 PrimitiveTuples.pair(false, false));
 
-        Assert.assertEquals(expected, booleanBooleanPairs.toSet());
+        assertEquals(expected, booleanBooleanPairs.toSet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanStacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanStacksTest.java
@@ -16,8 +16,10 @@ import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BooleanStacksTest
 {
@@ -25,60 +27,60 @@ public class BooleanStacksTest
     public void immutables()
     {
         ImmutableBooleanStackFactory stackFactory = BooleanStacks.immutable;
-        Assert.assertEquals(BooleanArrayStack.newStackWith(), stackFactory.of());
+        assertEquals(BooleanArrayStack.newStackWith(), stackFactory.of());
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of());
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true), stackFactory.of(true));
+        assertEquals(BooleanArrayStack.newStackWith(true), stackFactory.of(true));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(true));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(false), stackFactory.of(false));
+        assertEquals(BooleanArrayStack.newStackWith(false), stackFactory.of(false));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(false));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(false, true), stackFactory.of(false, true));
+        assertEquals(BooleanArrayStack.newStackWith(false, true), stackFactory.of(false, true));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(false, true));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false), stackFactory.of(true, false));
+        assertEquals(BooleanArrayStack.newStackWith(true, false), stackFactory.of(true, false));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(true, false));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(false, true, false), stackFactory.of(false, true, false));
+        assertEquals(BooleanArrayStack.newStackWith(false, true, false), stackFactory.of(false, true, false));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(false, true, false));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, true), stackFactory.of(true, false, true));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, true), stackFactory.of(true, false, true));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(true, false, true));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(false, true, false, false), stackFactory.of(false, true, false, false));
+        assertEquals(BooleanArrayStack.newStackWith(false, true, false, false), stackFactory.of(false, true, false, false));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(false, true, false, false));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, true, true), stackFactory.of(true, false, true, true));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, true, true), stackFactory.of(true, false, true, true));
         Verify.assertInstanceOf(ImmutableBooleanStack.class, stackFactory.of(true, false, true, true));
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(BooleanStacks.immutable.of().isEmpty());
-        Assert.assertTrue(BooleanStacks.mutable.of().isEmpty());
+        assertTrue(BooleanStacks.immutable.of().isEmpty());
+        assertTrue(BooleanStacks.mutable.of().isEmpty());
     }
 
     @Test
     public void newStackWith_immutable()
     {
         ImmutableBooleanStack stack = BooleanStacks.immutable.of();
-        Assert.assertEquals(stack, BooleanStacks.immutable.of(stack.toArray()));
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true));
-        Assert.assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(true, false));
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true, false, true));
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true, false, true, true));
-        Assert.assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(true, false, true, true, false));
+        assertEquals(stack, BooleanStacks.immutable.of(stack.toArray()));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true));
+        assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(true, false));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true, false, true));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(true, false, true, true));
+        assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(true, false, true, true, false));
     }
 
     @Test
     public void newStackWith_mutable()
     {
         MutableBooleanStack stack = BooleanStacks.mutable.of();
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(stack.toArray()));
+        assertEquals(stack, BooleanStacks.mutable.of(stack.toArray()));
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(true));
+        assertEquals(stack, BooleanStacks.mutable.of(true));
         stack.push(false);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(true, false));
+        assertEquals(stack, BooleanStacks.mutable.of(true, false));
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(true, false, true));
+        assertEquals(stack, BooleanStacks.mutable.of(true, false, true));
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(true, false, true, true));
+        assertEquals(stack, BooleanStacks.mutable.of(true, false, true, true));
         stack.push(false);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(true, false, true, true, false));
+        assertEquals(stack, BooleanStacks.mutable.of(true, false, true, true, false));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -86,11 +88,11 @@ public class BooleanStacksTest
     public void newStackWithArray_immutable()
     {
         ImmutableBooleanStack stack = BooleanStacks.immutable.of();
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true}));
-        Assert.assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(new boolean[]{true, false}));
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true, false, true}));
-        Assert.assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true, false, true, true}));
-        Assert.assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(new boolean[]{true, false, true, true, false}));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true}));
+        assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(new boolean[]{true, false}));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true, false, true}));
+        assertEquals(stack = stack.push(true), BooleanStacks.immutable.of(new boolean[]{true, false, true, true}));
+        assertEquals(stack = stack.push(false), BooleanStacks.immutable.of(new boolean[]{true, false, true, true, false}));
     }
 
     @SuppressWarnings("RedundantArrayCreation")
@@ -99,57 +101,57 @@ public class BooleanStacksTest
     {
         MutableBooleanStack stack = BooleanStacks.mutable.of();
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true}));
+        assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true}));
         stack.push(false);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false}));
+        assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false}));
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true}));
+        assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true}));
         stack.push(true);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true, true}));
+        assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true, true}));
         stack.push(false);
-        Assert.assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true, true, false}));
+        assertEquals(stack, BooleanStacks.mutable.of(new boolean[]{true, false, true, true, false}));
     }
 
     @Test
     public void ofAllBooleanIterable()
     {
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAll(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAll(BooleanLists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.immutable.ofAll(BooleanLists.mutable.with(true, false, false, true)));
 
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAll(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAll(BooleanLists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.mutable.ofAll(BooleanLists.mutable.with(true, false, false, true)));
     }
 
     @Test
     public void ofAllIterable()
     {
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAll(Lists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.immutable.ofAll(Lists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.immutable.ofAll(Lists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.immutable.ofAll(Lists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAll(Lists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.immutable.ofAll(Lists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.immutable.ofAll(Lists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.immutable.ofAll(Lists.mutable.with(true, false, false, true)));
 
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAll(Lists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.mutable.ofAll(Lists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.mutable.ofAll(Lists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.mutable.ofAll(Lists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAll(Lists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackWith(true), BooleanStacks.mutable.ofAll(Lists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false), BooleanStacks.mutable.ofAll(Lists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackWith(true, false, false, true), BooleanStacks.mutable.ofAll(Lists.mutable.with(true, false, false, true)));
     }
 
     @Test
     public void ofAllReversed()
     {
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, false, true), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, false, true), BooleanStacks.immutable.ofAllReversed(BooleanLists.mutable.with(true, false, false, true)));
 
-        Assert.assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.empty()));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true)));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true, false)));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, false, true), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true, false, false, true)));
+        assertEquals(new BooleanArrayStack(), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.empty()));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true)));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true, false)));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, false, true), BooleanStacks.mutable.ofAllReversed(BooleanLists.mutable.with(true, false, false, true)));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/iterator/SingletonBooleanIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/iterator/SingletonBooleanIteratorTest.java
@@ -13,8 +13,12 @@ package org.eclipse.collections.impl.iterator;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.iterator.BooleanIterator;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SingletonBooleanIteratorTest
 {
@@ -22,24 +26,24 @@ public class SingletonBooleanIteratorTest
     public void hasNext()
     {
         BooleanIterator iterator = new SingletonBooleanIterator(false);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         iterator.next();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void next()
     {
         SingletonBooleanIterator iterator = new SingletonBooleanIterator(false);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(false, iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(false, iterator.next());
+        assertFalse(iterator.hasNext());
         try
         {
             iterator.next();
-            Assert.fail("NoSuchElementException should have been thrown");
+            fail("NoSuchElementException should have been thrown");
         }
         catch (NoSuchElementException e)
         {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
@@ -67,10 +67,16 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractLazyIterableTestCase
 {
@@ -84,10 +90,10 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(
+        assertArrayEquals(
                 FastList.newListWith(1, 2).toArray(),
                 this.lazyIterable.select(Predicates.lessThan(3)).toArray());
-        Assert.assertArrayEquals(
+        assertArrayEquals(
                 FastList.newListWith(1, 2).toArray(),
                 this.lazyIterable.select(Predicates.lessThan(3)).toArray(new Object[2]));
     }
@@ -95,28 +101,28 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.lazyIterable.contains(3));
-        Assert.assertFalse(this.lazyIterable.contains(8));
+        assertTrue(this.lazyIterable.contains(3));
+        assertFalse(this.lazyIterable.contains(8));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.lazyIterable.containsAllIterable(FastList.newListWith(3)));
-        Assert.assertFalse(this.lazyIterable.containsAllIterable(FastList.newListWith(8)));
+        assertTrue(this.lazyIterable.containsAllIterable(FastList.newListWith(3)));
+        assertFalse(this.lazyIterable.containsAllIterable(FastList.newListWith(8)));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.lazyIterable.containsAllArguments(3));
-        Assert.assertFalse(this.lazyIterable.containsAllArguments(8));
+        assertTrue(this.lazyIterable.containsAllArguments(3));
+        assertFalse(this.lazyIterable.containsAllArguments(8));
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2),
                 this.lazyIterable.select(Predicates.lessThan(3)).toList());
     }
@@ -124,7 +130,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2),
                 this.lazyIterable.selectWith(Predicates2.lessThan(), 3, FastList.newList()));
     }
@@ -132,7 +138,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void selectWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2),
                 this.lazyIterable.select(Predicates.lessThan(3), FastList.newList()));
     }
@@ -140,13 +146,13 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void reject()
     {
-        Assert.assertEquals(FastList.newListWith(3, 4, 5, 6, 7), this.lazyIterable.reject(Predicates.lessThan(3)).toList());
+        assertEquals(FastList.newListWith(3, 4, 5, 6, 7), this.lazyIterable.reject(Predicates.lessThan(3)).toList());
     }
 
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 4, 5, 6, 7),
                 this.lazyIterable.rejectWith(Predicates2.lessThan(), 3, FastList.newList()));
     }
@@ -154,7 +160,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void rejectWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 4, 5, 6, 7),
                 this.lazyIterable.reject(Predicates.lessThan(3), FastList.newList()));
     }
@@ -163,22 +169,22 @@ public abstract class AbstractLazyIterableTestCase
     public void partition()
     {
         PartitionIterable<Integer> partition = this.lazyIterable.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iList(2, 4, 6), partition.getSelected());
-        Assert.assertEquals(iList(1, 3, 5, 7), partition.getRejected());
+        assertEquals(iList(2, 4, 6), partition.getSelected());
+        assertEquals(iList(1, 3, 5, 7), partition.getRejected());
     }
 
     @Test
     public void partitionWith()
     {
         PartitionIterable<Integer> partition = this.lazyIterable.partitionWith(Predicates2.in(), this.lazyIterable.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iList(2, 4, 6), partition.getSelected());
-        Assert.assertEquals(iList(1, 3, 5, 7), partition.getRejected());
+        assertEquals(iList(2, 4, 6), partition.getSelected());
+        assertEquals(iList(1, 3, 5, 7), partition.getRejected());
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 3, 5),
                 this.newWith(1, 2.0, 3, 4.0, 5).selectInstancesOf(Integer.class).toList());
     }
@@ -186,7 +192,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void collect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3", "4", "5", "6", "7"),
                 this.lazyIterable.collect(String::valueOf).toList());
     }
@@ -194,7 +200,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void collectBoolean()
     {
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayList.newListWith(true, true, true, true, true, true, true),
                 this.lazyIterable.collectBoolean(PrimitiveFunctions.integerIsPositive()).toList());
     }
@@ -204,16 +210,16 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableBooleanCollection target = new BooleanArrayList();
         MutableBooleanCollection result = this.lazyIterable.collectBoolean(PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayList.newListWith(true, true, true, true, true, true, true),
                 result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectByte()
     {
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7), this.lazyIterable.collectByte(PrimitiveFunctions.unboxIntegerToByte()).toList());
+        assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7), this.lazyIterable.collectByte(PrimitiveFunctions.unboxIntegerToByte()).toList());
     }
 
     @Test
@@ -221,14 +227,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableByteCollection target = new ByteArrayList();
         MutableByteCollection result = this.lazyIterable.collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7), result.toList());
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectChar()
     {
-        Assert.assertEquals(
+        assertEquals(
                 CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4, (char) 5, (char) 6, (char) 7),
                 this.lazyIterable.collectChar(PrimitiveFunctions.unboxIntegerToChar()).toList());
     }
@@ -238,14 +244,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableCharCollection target = new CharArrayList();
         MutableCharCollection result = this.lazyIterable.collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertEquals(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4, (char) 5, (char) 6, (char) 7), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4, (char) 5, (char) 6, (char) 7), result.toList());
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectDouble()
     {
-        Assert.assertEquals(DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d), this.lazyIterable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()).toList());
+        assertEquals(DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d), this.lazyIterable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()).toList());
     }
 
     @Test
@@ -253,15 +259,15 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableDoubleCollection target = new DoubleArrayList();
         MutableDoubleCollection result = this.lazyIterable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertEquals(
+        assertEquals(
                 DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
                 this.lazyIterable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()).toList());
     }
@@ -271,15 +277,15 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableFloatCollection target = new FloatArrayList();
         MutableFloatCollection result = this.lazyIterable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertEquals(
+        assertEquals(
                 FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectInt()
     {
-        Assert.assertEquals(IntArrayList.newListWith(1, 2, 3, 4, 5, 6, 7), this.lazyIterable.collectInt(PrimitiveFunctions.unboxIntegerToInt()).toList());
+        assertEquals(IntArrayList.newListWith(1, 2, 3, 4, 5, 6, 7), this.lazyIterable.collectInt(PrimitiveFunctions.unboxIntegerToInt()).toList());
     }
 
     @Test
@@ -287,14 +293,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableIntCollection target = new IntArrayList();
         MutableIntCollection result = this.lazyIterable.collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertEquals(IntArrayList.newListWith(1, 2, 3, 4, 5, 6, 7), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(IntArrayList.newListWith(1, 2, 3, 4, 5, 6, 7), result.toList());
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 LongArrayList.newListWith(1L, 2L, 3L, 4L, 5L, 6L, 7L),
                 this.lazyIterable.collectLong(PrimitiveFunctions.unboxIntegerToLong()).toList());
     }
@@ -304,14 +310,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableLongCollection target = new LongArrayList();
         MutableLongCollection result = this.lazyIterable.collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertEquals(LongArrayList.newListWith(1L, 2L, 3L, 4L, 5L, 6L, 7L), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(LongArrayList.newListWith(1L, 2L, 3L, 4L, 5L, 6L, 7L), result.toList());
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectShort()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4, (short) 5, (short) 6, (short) 7),
                 this.lazyIterable.collectShort(PrimitiveFunctions.unboxIntegerToShort()).toList());
     }
@@ -321,14 +327,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         MutableShortCollection target = new ShortArrayList();
         MutableShortCollection result = this.lazyIterable.collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertEquals(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4, (short) 5, (short) 6, (short) 7), result.toList());
-        Assert.assertSame("Target list sent as parameter not returned", target, result);
+        assertEquals(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4, (short) 5, (short) 6, (short) 7), result.toList());
+        assertSame("Target list sent as parameter not returned", target, result);
     }
 
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ", "6 ", "7 "),
                 this.lazyIterable.collectWith((argument1, argument2) -> argument1 + argument2, " ", FastList.newList()));
     }
@@ -336,7 +342,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void collectWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3", "4", "5", "6", "7"),
                 this.lazyIterable.collect(String::valueOf, FastList.newList()));
     }
@@ -345,13 +351,13 @@ public abstract class AbstractLazyIterableTestCase
     public void take()
     {
         LazyIterable<Integer> lazyIterable = this.lazyIterable;
-        Assert.assertEquals(FastList.newList(), lazyIterable.take(0).toList());
-        Assert.assertEquals(FastList.newListWith(1), lazyIterable.take(1).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2), lazyIterable.take(2).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), lazyIterable.take(lazyIterable.size() - 1).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(lazyIterable.size()).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(10).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(Integer.MAX_VALUE).toList());
+        assertEquals(FastList.newList(), lazyIterable.take(0).toList());
+        assertEquals(FastList.newListWith(1), lazyIterable.take(1).toList());
+        assertEquals(FastList.newListWith(1, 2), lazyIterable.take(2).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), lazyIterable.take(lazyIterable.size() - 1).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(lazyIterable.size()).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(10).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.take(Integer.MAX_VALUE).toList());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -364,12 +370,12 @@ public abstract class AbstractLazyIterableTestCase
     public void drop()
     {
         LazyIterable<Integer> lazyIterable = this.lazyIterable;
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.drop(0).toList());
-        Assert.assertEquals(FastList.newListWith(3, 4, 5, 6, 7), lazyIterable.drop(2).toList());
-        Assert.assertEquals(FastList.newListWith(7), lazyIterable.drop(lazyIterable.size() - 1).toList());
-        Assert.assertEquals(FastList.newList(), lazyIterable.drop(lazyIterable.size()).toList());
-        Assert.assertEquals(FastList.newList(), lazyIterable.drop(10).toList());
-        Assert.assertEquals(FastList.newList(), lazyIterable.drop(Integer.MAX_VALUE).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.drop(0).toList());
+        assertEquals(FastList.newListWith(3, 4, 5, 6, 7), lazyIterable.drop(2).toList());
+        assertEquals(FastList.newListWith(7), lazyIterable.drop(lazyIterable.size() - 1).toList());
+        assertEquals(FastList.newList(), lazyIterable.drop(lazyIterable.size()).toList());
+        assertEquals(FastList.newList(), lazyIterable.drop(10).toList());
+        assertEquals(FastList.newList(), lazyIterable.drop(Integer.MAX_VALUE).toList());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -382,12 +388,12 @@ public abstract class AbstractLazyIterableTestCase
     public void takeWhile()
     {
         LazyIterable<Integer> lazyIterable = this.lazyIterable;
-        Assert.assertEquals(FastList.newList(), lazyIterable.takeWhile(Predicates.alwaysFalse()).toList());
-        Assert.assertEquals(FastList.newListWith(1), lazyIterable.takeWhile(each -> each <= 1).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2), lazyIterable.takeWhile(each -> each <= 2).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), lazyIterable.takeWhile(each -> each <= lazyIterable.size() - 1).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(each -> each <= lazyIterable.size()).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(Predicates.alwaysTrue()).toList());
+        assertEquals(FastList.newList(), lazyIterable.takeWhile(Predicates.alwaysFalse()).toList());
+        assertEquals(FastList.newListWith(1), lazyIterable.takeWhile(each -> each <= 1).toList());
+        assertEquals(FastList.newListWith(1, 2), lazyIterable.takeWhile(each -> each <= 2).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), lazyIterable.takeWhile(each -> each <= lazyIterable.size() - 1).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(each -> each <= lazyIterable.size()).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.takeWhile(Predicates.alwaysTrue()).toList());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -400,11 +406,11 @@ public abstract class AbstractLazyIterableTestCase
     public void dropWhile()
     {
         LazyIterable<Integer> lazyIterable = this.lazyIterable;
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.dropWhile(Predicates.alwaysFalse()).toList());
-        Assert.assertEquals(FastList.newListWith(3, 4, 5, 6, 7), lazyIterable.dropWhile(each -> each <= 2).toList());
-        Assert.assertEquals(FastList.newListWith(7), lazyIterable.dropWhile(each -> each <= lazyIterable.size() - 1).toList());
-        Assert.assertEquals(FastList.newList(), lazyIterable.dropWhile(each -> each <= lazyIterable.size()).toList());
-        Assert.assertEquals(FastList.newList(), lazyIterable.dropWhile(Predicates.alwaysTrue()).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7), lazyIterable.dropWhile(Predicates.alwaysFalse()).toList());
+        assertEquals(FastList.newListWith(3, 4, 5, 6, 7), lazyIterable.dropWhile(each -> each <= 2).toList());
+        assertEquals(FastList.newListWith(7), lazyIterable.dropWhile(each -> each <= lazyIterable.size() - 1).toList());
+        assertEquals(FastList.newList(), lazyIterable.dropWhile(each -> each <= lazyIterable.size()).toList());
+        assertEquals(FastList.newList(), lazyIterable.dropWhile(Predicates.alwaysTrue()).toList());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -416,37 +422,37 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detect(Integer.valueOf(3)::equals));
-        Assert.assertNull(this.lazyIterable.detect(Integer.valueOf(8)::equals));
+        assertEquals(Integer.valueOf(3), this.lazyIterable.detect(Integer.valueOf(3)::equals));
+        assertNull(this.lazyIterable.detect(Integer.valueOf(8)::equals));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detectWith(Object::equals, Integer.valueOf(3)));
-        Assert.assertNull(this.lazyIterable.detectWith(Object::equals, Integer.valueOf(8)));
+        assertEquals(Integer.valueOf(3), this.lazyIterable.detectWith(Object::equals, Integer.valueOf(3)));
+        assertNull(this.lazyIterable.detectWith(Object::equals, Integer.valueOf(8)));
     }
 
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectOptional(Integer.valueOf(3)::equals));
-        Assert.assertEquals(Optional.empty(), this.lazyIterable.detectOptional(Integer.valueOf(8)::equals));
+        assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectOptional(Integer.valueOf(3)::equals));
+        assertEquals(Optional.empty(), this.lazyIterable.detectOptional(Integer.valueOf(8)::equals));
     }
 
     @Test
     public void detectWithOptional()
     {
-        Assert.assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(3)));
-        Assert.assertEquals(Optional.empty(), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(8)));
+        assertEquals(Optional.of(Integer.valueOf(3)), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(3)));
+        assertEquals(Optional.empty(), this.lazyIterable.detectWithOptional(Object::equals, Integer.valueOf(8)));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(Integer.valueOf(1000));
-        Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detectWithIfNone(Object::equals, Integer.valueOf(3), function));
-        Assert.assertEquals(Integer.valueOf(1000), this.lazyIterable.detectWithIfNone(Object::equals, Integer.valueOf(8), function));
+        assertEquals(Integer.valueOf(3), this.lazyIterable.detectWithIfNone(Object::equals, Integer.valueOf(3), function));
+        assertEquals(Integer.valueOf(1000), this.lazyIterable.detectWithIfNone(Object::equals, Integer.valueOf(8), function));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -476,25 +482,25 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).min(Integer::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max(Integer::compareTo));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max(Integer::compareTo));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.newWith(1, 3, 2).minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).maxBy(String::valueOf));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -524,75 +530,75 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(3, 1, 2).min());
+        assertEquals(Integer.valueOf(1), this.newWith(3, 1, 2).min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 3, 2).max());
     }
 
     @Test
     public void detectIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(9);
-        Assert.assertEquals(Integer.valueOf(3), this.lazyIterable.detectIfNone(Integer.valueOf(3)::equals, function));
-        Assert.assertEquals(Integer.valueOf(9), this.lazyIterable.detectIfNone(Integer.valueOf(8)::equals, function));
+        assertEquals(Integer.valueOf(3), this.lazyIterable.detectIfNone(Integer.valueOf(3)::equals, function));
+        assertEquals(Integer.valueOf(9), this.lazyIterable.detectIfNone(Integer.valueOf(8)::equals, function));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.lazyIterable.anySatisfy(String.class::isInstance));
-        Assert.assertTrue(this.lazyIterable.anySatisfy(Integer.class::isInstance));
+        assertFalse(this.lazyIterable.anySatisfy(String.class::isInstance));
+        assertTrue(this.lazyIterable.anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.lazyIterable.anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertTrue(this.lazyIterable.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.lazyIterable.anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(this.lazyIterable.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.lazyIterable.allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(this.lazyIterable.allSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.lazyIterable.allSatisfy(Integer.class::isInstance));
+        assertFalse(this.lazyIterable.allSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.lazyIterable.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(this.lazyIterable.allSatisfyWith(Object::equals, 1));
+        assertTrue(this.lazyIterable.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.lazyIterable.allSatisfyWith(Object::equals, 1));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.lazyIterable.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(this.lazyIterable.noneSatisfy(String.class::isInstance));
+        assertFalse(this.lazyIterable.noneSatisfy(Integer.class::isInstance));
+        assertTrue(this.lazyIterable.noneSatisfy(String.class::isInstance));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertFalse(this.lazyIterable.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertTrue(this.lazyIterable.noneSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(this.lazyIterable.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertTrue(this.lazyIterable.noneSatisfyWith(Predicates2.instanceOf(), String.class));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(7, this.lazyIterable.count(Integer.class::isInstance));
+        assertEquals(7, this.lazyIterable.count(Integer.class::isInstance));
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3"),
                 this.newWith(1, 2, 3).collectIf(
                         Integer.class::isInstance,
@@ -602,7 +608,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void collectIfWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3"),
                 this.newWith(1, 2, 3).collectIf(
                         Integer.class::isInstance,
@@ -613,21 +619,21 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
-        Assert.assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
+        assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
+        assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1).getOnly());
+        assertEquals(Integer.valueOf(1), this.newWith(1).getOnly());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -645,8 +651,8 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertTrue(this.newWith(1, 2).notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertTrue(this.newWith(1, 2).notEmpty());
     }
 
     @Test
@@ -654,14 +660,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         RichIterable<Integer> objects = this.newWith(1, 2, 3);
         Integer result = objects.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Test
     public void toList()
     {
         MutableList<Integer> list = this.newWith(1, 2, 3, 4).toList();
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), list);
     }
 
     @Test
@@ -669,7 +675,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 1, 5, 3, 4);
         MutableList<Integer> list = integers.toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), list);
     }
 
     @Test
@@ -677,7 +683,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), list);
+        assertEquals(FastList.newListWith(4, 3, 2, 1), list);
     }
 
     @Test
@@ -685,7 +691,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         LazyIterable<Integer> integers = this.newWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), list);
     }
 
     @Test
@@ -717,7 +723,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableSet<Integer> set = integers.toSet();
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
     }
 
     @Test
@@ -726,7 +732,7 @@ public abstract class AbstractLazyIterableTestCase
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableMap<String, String> map =
                 integers.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -761,13 +767,13 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
+        assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("[1, 2, 3]", '[' + this.newWith(1, 2, 3).makeString() + ']');
+        assertEquals("[1, 2, 3]", '[' + this.newWith(1, 2, 3).makeString() + ']');
     }
 
     @Test
@@ -775,7 +781,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         Appendable builder = new StringBuilder();
         this.newWith(1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 2, 3", builder.toString());
+        assertEquals("1, 2, 3", builder.toString());
     }
 
     @Test
@@ -790,11 +796,11 @@ public abstract class AbstractLazyIterableTestCase
 
         Multimap<Boolean, Integer> multimap =
                 this.lazyIterable.groupBy(isOddFunction);
-        Assert.assertEquals(expected, multimap.toMap());
+        assertEquals(expected, multimap.toMap());
 
         Multimap<Boolean, Integer> multimap2 =
                 this.lazyIterable.groupBy(isOddFunction, FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, multimap2.toMap());
+        assertEquals(expected, multimap2.toMap());
     }
 
     @Test
@@ -808,17 +814,17 @@ public abstract class AbstractLazyIterableTestCase
 
         Multimap<Integer, Integer> actual =
                 this.lazyIterable.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 this.lazyIterable.groupByEach(new NegativeIntervalFunction(), FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newWith(1, 2, 3).groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newWith(1, 2, 3).groupByUniqueKey(id -> id));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -831,7 +837,7 @@ public abstract class AbstractLazyIterableTestCase
     public void groupByUniqueKey_target()
     {
         MutableMap<Integer, Integer> integers = this.newWith(1, 2, 3).groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -848,24 +854,24 @@ public abstract class AbstractLazyIterableTestCase
         List<Object> nullsMinusOne = Collections.nCopies(this.lazyIterable.size() - 1, null);
 
         LazyIterable<Pair<Integer, Object>> pairs = this.lazyIterable.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 this.lazyIterable.toSet(),
                 pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         LazyIterable<Pair<Integer, Object>> pairsPlusOne = this.lazyIterable.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 this.lazyIterable.toSet(),
                 pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toSet());
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         LazyIterable<Pair<Integer, Object>> pairsMinusOne = this.lazyIterable.zip(nullsMinusOne);
-        Assert.assertEquals(this.lazyIterable.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(this.lazyIterable.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
+        assertEquals(this.lazyIterable.size() - 1, pairsMinusOne.size());
+        assertTrue(this.lazyIterable.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.lazyIterable.zip(nulls).toSet(),
                 this.lazyIterable.zip(nulls, UnifiedSet.newSet()));
     }
@@ -875,14 +881,14 @@ public abstract class AbstractLazyIterableTestCase
     {
         LazyIterable<Pair<Integer, Integer>> pairs = this.lazyIterable.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 this.lazyIterable.toSet(),
                 pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(this.lazyIterable.size() - 1).toSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.lazyIterable.zipWithIndex().toSet(),
                 this.lazyIterable.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -892,7 +898,7 @@ public abstract class AbstractLazyIterableTestCase
     {
         LazyIterable<RichIterable<Integer>> groups = this.lazyIterable.chunk(2);
         RichIterable<Integer> sizes = groups.collect(RichIterable::size);
-        Assert.assertEquals(Bags.mutable.of(2, 2, 2, 1), sizes.toBag());
+        assertEquals(Bags.mutable.of(2, 2, 2, 1), sizes.toBag());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -904,7 +910,7 @@ public abstract class AbstractLazyIterableTestCase
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.lazyIterable.toBag(), this.lazyIterable.chunk(10).getFirst().toBag());
+        assertEquals(this.lazyIterable.toBag(), this.lazyIterable.chunk(10).getFirst().toBag());
     }
 
     @Test
@@ -915,13 +921,13 @@ public abstract class AbstractLazyIterableTestCase
         LazyIterable<Integer> list = this.lazyIterable.tap(appendProcedure);
 
         Verify.assertIterablesEqual(this.lazyIterable, list);
-        Assert.assertEquals("1234567", tapStringBuilder.toString());
+        assertEquals("1234567", tapStringBuilder.toString());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertSame(this.lazyIterable, this.lazyIterable.asLazy());
+        assertSame(this.lazyIterable, this.lazyIterable.asLazy());
     }
 
     @Test
@@ -957,7 +963,7 @@ public abstract class AbstractLazyIterableTestCase
     public void distinct()
     {
         LazyIterable<Integer> integers = this.newWith(3, 2, 2, 4, 1, 3, 1, 5);
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith(1, 2, 3, 4, 5),
                 integers.distinct().toBag());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ChunkIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ChunkIterableTest.java
@@ -12,9 +12,10 @@ package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ChunkIterableTest
 {
@@ -31,7 +32,7 @@ public class ChunkIterableTest
     public void forEach()
     {
         this.undertest.forEach(Procedures.cast(this.buffer::append));
-        Assert.assertEquals("[1, 2][3, 4][5]", this.buffer.toString());
+        assertEquals("[1, 2][3, 4][5]", this.buffer.toString());
     }
 
     @Test
@@ -43,7 +44,7 @@ public class ChunkIterableTest
             this.buffer.append(index);
         });
 
-        Assert.assertEquals("|[1, 2]0|[3, 4]1|[5]2", this.buffer.toString());
+        assertEquals("|[1, 2]0|[3, 4]1|[5]2", this.buffer.toString());
     }
 
     @Test
@@ -54,6 +55,6 @@ public class ChunkIterableTest
             this.buffer.append(argument1);
             this.buffer.append(argument2);
         }, 'A');
-        Assert.assertEquals("|[1, 2]A|[3, 4]A|[5]A", this.buffer.toString());
+        assertEquals("|[1, 2]A|[3, 4]A|[5]A", this.buffer.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CollectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CollectIterableTest.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CollectIterableTest extends AbstractLazyIterableTestCase
 {
@@ -39,7 +41,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         Appendable builder = new StringBuilder();
         Procedure<String> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -51,7 +53,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("1021324354", builder.toString());
+        assertEquals("1021324354", builder.toString());
     }
 
     @Override
@@ -64,7 +66,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         {
             builder.append(each);
         }
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -73,7 +75,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<String> select = new CollectIterable<>(Interval.oneTo(5), String::valueOf);
         StringBuilder builder = new StringBuilder();
         select.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Override
@@ -82,7 +84,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<String> collect = new CollectIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), String::valueOf);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("3", "2", "4", "1", "5"),
                 collect.distinct().toList());
     }
@@ -92,7 +94,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         CollectIterable<Integer, String> collect = new CollectIterable<>(FastList.newListWith(1, 2, 3, 4, 5), String::valueOf);
         int sum = collect.injectInto(0, (int value, String each) -> value + Integer.parseInt(each));
-        Assert.assertEquals(15, sum);
+        assertEquals(15, sum);
     }
 
     @Test
@@ -100,7 +102,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         CollectIterable<Long, String> collect = new CollectIterable<>(FastList.newListWith(1L, 2L, 3L, 4L, 5L), String::valueOf);
         long sum = collect.injectInto(0L, (long value, String each) -> value + Long.parseLong(each));
-        Assert.assertEquals(15L, sum);
+        assertEquals(15L, sum);
     }
 
     @Test
@@ -108,7 +110,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         CollectIterable<Double, String> collect = new CollectIterable<>(FastList.newListWith(1.1d, 1.2d, 1.3d, 1.4d), String::valueOf);
         double sum = collect.injectInto(2.2d, (value, each) -> value + Double.parseDouble(each));
-        Assert.assertEquals(7.2, sum, 0.1);
+        assertEquals(7.2, sum, 0.1);
     }
 
     @Test
@@ -116,21 +118,21 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         CollectIterable<Float, String> collect = new CollectIterable<>(FastList.newListWith(1.1f, 1.2f, 1.3f, 1.4f), String::valueOf);
         float sum = collect.injectInto(2.2f, (float value, String each) -> value + Float.parseFloat(each));
-        Assert.assertEquals(7.2, sum, 0.1);
+        assertEquals(7.2, sum, 0.1);
     }
 
     @Test
     public void getFirstOnEmpty()
     {
         CollectIterable<Integer, String> collect = new CollectIterable<>(FastList.newList(), String::valueOf);
-        Assert.assertNull(collect.getFirst());
+        assertNull(collect.getFirst());
     }
 
     @Test
     public void getLastOnEmpty()
     {
         CollectIterable<Integer, String> collect = new CollectIterable<>(FastList.newList(), String::valueOf);
-        Assert.assertNull(collect.getLast());
+        assertNull(collect.getLast());
     }
 
     @Override
@@ -139,7 +141,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
     {
         LazyIterable<String> stringNums = Interval.fromTo(0, 3).collect(Functions.getToString());
         stringNums.toArray();
-        Assert.assertEquals(Lists.immutable.of("0", "1", "2", "3"), Lists.immutable.ofAll(stringNums));
+        assertEquals(Lists.immutable.of("0", "1", "2", "3"), Lists.immutable.ofAll(stringNums));
     }
 
     @Override
@@ -150,8 +152,8 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         CollectIterable<Integer, Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detect(each -> each.equals(3)).longValue());
-        Assert.assertNull(collect.detect(each -> each.equals(100)));
+        assertEquals(3L, collect.detect(each -> each.equals(3)).longValue());
+        assertNull(collect.detect(each -> each.equals(100)));
     }
 
     @Override
@@ -162,8 +164,8 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         CollectIterable<Integer, Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detectIfNone(each -> each.equals(3), () -> Integer.valueOf(0)).longValue());
-        Assert.assertNull(collect.detectIfNone(each -> each.equals(100), () -> null));
+        assertEquals(3L, collect.detectIfNone(each -> each.equals(3), () -> Integer.valueOf(0)).longValue());
+        assertNull(collect.detectIfNone(each -> each.equals(100), () -> null));
     }
 
     @Override
@@ -174,8 +176,8 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         LazyIterable<Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detectWith((each, ignore) -> each.equals(3), null).longValue());
-        Assert.assertNull(collect.detectWith((each, ignore) -> each.equals(100), null));
+        assertEquals(3L, collect.detectWith((each, ignore) -> each.equals(3), null).longValue());
+        assertNull(collect.detectWith((each, ignore) -> each.equals(100), null));
     }
 
     @Override
@@ -186,8 +188,8 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         LazyIterable<Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detectWithIfNone((each, ignore) -> each.equals(3), null, () -> Integer.valueOf(0)).longValue());
-        Assert.assertNull(collect.detectWithIfNone((each, ignore) -> each.equals(100), null, () -> null));
+        assertEquals(3L, collect.detectWithIfNone((each, ignore) -> each.equals(3), null, () -> Integer.valueOf(0)).longValue());
+        assertNull(collect.detectWithIfNone((each, ignore) -> each.equals(100), null, () -> null));
     }
 
     @Override
@@ -198,8 +200,8 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         CollectIterable<Integer, Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detectOptional(each -> each.equals(3)).get().longValue());
-        Assert.assertNull(collect.detectOptional(each -> each.equals(100)).orElse(null));
+        assertEquals(3L, collect.detectOptional(each -> each.equals(3)).get().longValue());
+        assertNull(collect.detectOptional(each -> each.equals(100)).orElse(null));
     }
 
     @Override
@@ -210,7 +212,7 @@ public class CollectIterableTest extends AbstractLazyIterableTestCase
         AtomicInteger functionCount = new AtomicInteger(0);
         MultiReaderList<Integer> integers = Lists.multiReader.withAll(Interval.oneTo(5));
         LazyIterable<Integer> collect = new CollectIterable<>(integers, functionCount::addAndGet);
-        Assert.assertEquals(3L, collect.detectWithOptional((each, ignore) -> each.equals(3), null).get().longValue());
-        Assert.assertNull(collect.detectWithOptional((each, ignore) -> each.equals(100), null).orElse(null));
+        assertEquals(3L, collect.detectWithOptional((each, ignore) -> each.equals(3), null).get().longValue());
+        assertNull(collect.detectWithOptional((each, ignore) -> each.equals(100), null).orElse(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
@@ -21,8 +21,11 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class CompositeIterableTest extends AbstractLazyIterableTestCase
 {
@@ -42,14 +45,14 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
         {
             builder.append(each);
         }
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
     public void emptyIterator()
     {
         LazyIterable<String> list = new CompositeIterable<>();
-        Assert.assertFalse(list.iterator().hasNext());
+        assertFalse(list.iterator().hasNext());
     }
 
     @Test
@@ -105,7 +108,7 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
         List<Integer> expected = Interval.oneTo(5);
         iterables.add(expected);
         iterables.add(() -> { throw new RuntimeException("Iterator should not be invoked eagerly"); });
-        Assert.assertEquals(expected, iterables.take(expected.size()).toList());
+        assertEquals(expected, iterables.take(expected.size()).toList());
     }
 
     @Override
@@ -116,7 +119,7 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
         CompositeIterable<Integer> composite = new CompositeIterable<>();
         MutableList<Integer> expected = FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5);
         composite.add(expected);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1, 5),
                 composite.distinct().toList());
     }
@@ -128,8 +131,8 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
                 FastList.newListWith(1, 2),
                 FastList.newList(),
                 FastList.newListWith(3, 4, 5, 6));
-        Assert.assertEquals(Integer.valueOf(3), composite.detect(Integer.valueOf(3)::equals));
-        Assert.assertNull(composite.detect(Integer.valueOf(8)::equals));
+        assertEquals(Integer.valueOf(3), composite.detect(Integer.valueOf(3)::equals));
+        assertNull(composite.detect(Integer.valueOf(8)::equals));
     }
 
     @Override
@@ -139,8 +142,8 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
                 FastList.newListWith(1, 2),
                 FastList.newList(),
                 FastList.newListWith(3, 4, 5, 6));
-        Assert.assertEquals(Integer.valueOf(3), composite.detectWith(Object::equals, Integer.valueOf(3)));
-        Assert.assertNull(composite.detectWith(Object::equals, Integer.valueOf(8)));
+        assertEquals(Integer.valueOf(3), composite.detectWith(Object::equals, Integer.valueOf(3)));
+        assertNull(composite.detectWith(Object::equals, Integer.valueOf(8)));
     }
 
     @Override
@@ -150,8 +153,8 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
                 FastList.newListWith(1, 2),
                 FastList.newList(),
                 FastList.newListWith(3, 4, 5, 6));
-        Assert.assertEquals(Optional.of(Integer.valueOf(3)), composite.detectOptional(Integer.valueOf(3)::equals));
-        Assert.assertEquals(Optional.empty(), composite.detectOptional(Integer.valueOf(8)::equals));
+        assertEquals(Optional.of(Integer.valueOf(3)), composite.detectOptional(Integer.valueOf(3)::equals));
+        assertEquals(Optional.empty(), composite.detectOptional(Integer.valueOf(8)::equals));
     }
 
     @Override
@@ -161,7 +164,7 @@ public class CompositeIterableTest extends AbstractLazyIterableTestCase
                 FastList.newListWith(1, 2),
                 FastList.newList(),
                 FastList.newListWith(3, 4, 5, 6));
-        Assert.assertEquals(Optional.of(Integer.valueOf(3)), composite.detectWithOptional(Object::equals, Integer.valueOf(3)));
-        Assert.assertEquals(Optional.empty(), composite.detectWithOptional(Object::equals, Integer.valueOf(8)));
+        assertEquals(Optional.of(Integer.valueOf(3)), composite.detectWithOptional(Object::equals, Integer.valueOf(3)));
+        assertEquals(Optional.empty(), composite.detectWithOptional(Object::equals, Integer.valueOf(8)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DistinctIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DistinctIterableTest.java
@@ -19,8 +19,10 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.lazy.iterator.DistinctIterator;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class DistinctIterableTest extends AbstractLazyIterableTestCase
 {
@@ -37,7 +39,7 @@ public class DistinctIterableTest extends AbstractLazyIterableTestCase
         Appendable builder = new StringBuilder();
         Procedure<Integer> appendProcedure = Procedures.append(builder);
         distinct.forEach(appendProcedure);
-        Assert.assertEquals("3124", builder.toString());
+        assertEquals("3124", builder.toString());
     }
 
     @Test
@@ -49,7 +51,7 @@ public class DistinctIterableTest extends AbstractLazyIterableTestCase
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("102132435465768798", builder.toString());
+        assertEquals("102132435465768798", builder.toString());
     }
 
     @Override
@@ -62,7 +64,7 @@ public class DistinctIterableTest extends AbstractLazyIterableTestCase
         {
             builder.append(each);
         }
-        Assert.assertEquals("31245", builder.toString());
+        assertEquals("31245", builder.toString());
     }
 
     @Test
@@ -71,7 +73,7 @@ public class DistinctIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> distinct = new DistinctIterable<>(FastList.newListWith(1, 3, 3, 2, 5, 4, 2, 5, 4));
         StringBuilder builder = new StringBuilder();
         distinct.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("13254", builder.toString());
+        assertEquals("13254", builder.toString());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -93,8 +95,8 @@ public class DistinctIterableTest extends AbstractLazyIterableTestCase
         super.distinct();
         LazyIterable<Integer> distinct = new DistinctIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5));
         LazyIterable<Integer> distinctDistinct = distinct.distinct();
-        Assert.assertSame(distinctDistinct, distinct);
-        Assert.assertEquals(
+        assertSame(distinctDistinct, distinct);
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1, 5),
                 distinctDistinct.toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropIterableTest.java
@@ -19,9 +19,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DropIterableTest extends AbstractLazyIterableTestCase
 {
@@ -52,14 +53,14 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
     @Test
     public void basic()
     {
-        Assert.assertEquals(3, this.dropIterable.size());
-        Assert.assertEquals(FastList.newListWith(3, 4, 5), this.dropIterable.toList());
+        assertEquals(3, this.dropIterable.size());
+        assertEquals(FastList.newListWith(3, 4, 5), this.dropIterable.toList());
 
-        Assert.assertEquals(0, this.emptyListDropIterable.size());
-        Assert.assertEquals(5, this.zeroCountDropIterable.size());
-        Assert.assertEquals(1, this.nearCountDropIterable.size());
-        Assert.assertEquals(0, this.sameCountDropIterable.size());
-        Assert.assertEquals(0, this.higherCountDropIterable.size());
+        assertEquals(0, this.emptyListDropIterable.size());
+        assertEquals(5, this.zeroCountDropIterable.size());
+        assertEquals(1, this.nearCountDropIterable.size());
+        assertEquals(0, this.sameCountDropIterable.size());
+        assertEquals(0, this.higherCountDropIterable.size());
     }
 
     @Test
@@ -67,27 +68,27 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
     {
         Sum sum1 = new IntegerSum(0);
         this.dropIterable.forEach(new SumProcedure<>(sum1));
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListDropIterable.forEach(new SumProcedure<>(sum2));
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.zeroCountDropIterable.forEach(new SumProcedure<>(sum3));
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.nearCountDropIterable.forEach(new SumProcedure<>(sum5));
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         this.sameCountDropIterable.forEach(new SumProcedure<>(sum6));
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
 
         Sum sum7 = new IntegerSum(0);
         this.higherCountDropIterable.forEach(new SumProcedure<>(sum7));
-        Assert.assertEquals(0, sum7.getValue().intValue());
+        assertEquals(0, sum7.getValue().intValue());
     }
 
     @Test
@@ -101,35 +102,35 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
         };
 
         this.dropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2), indices);
-        Assert.assertEquals(12, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0, 1, 2), indices);
+        assertEquals(12, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.emptyListDropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(0, indices.size());
+        assertEquals(0, indices.size());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.zeroCountDropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
-        Assert.assertEquals(15, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        assertEquals(15, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.nearCountDropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0), indices);
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0), indices);
+        assertEquals(5, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.sameCountDropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(0, indices.size());
+        assertEquals(0, indices.size());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.higherCountDropIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(0, indices.size());
+        assertEquals(0, indices.size());
     }
 
     @Test
@@ -139,27 +140,27 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
 
         Sum sum1 = new IntegerSum(0);
         this.dropIterable.forEachWith(sumAdditionProcedure, sum1);
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListDropIterable.forEachWith(sumAdditionProcedure, sum2);
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.zeroCountDropIterable.forEachWith(sumAdditionProcedure, sum3);
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.nearCountDropIterable.forEachWith(sumAdditionProcedure, sum5);
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         this.sameCountDropIterable.forEachWith(sumAdditionProcedure, sum6);
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
 
         Sum sum7 = new IntegerSum(0);
         this.higherCountDropIterable.forEachWith(sumAdditionProcedure, sum7);
-        Assert.assertEquals(0, sum7.getValue().intValue());
+        assertEquals(0, sum7.getValue().intValue());
     }
 
     @Override
@@ -171,42 +172,42 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
         {
             sum1.add(each);
         }
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         for (Integer each : this.emptyListDropIterable)
         {
             sum2.add(each);
         }
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         for (Integer each : this.zeroCountDropIterable)
         {
             sum3.add(each);
         }
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         for (Integer each : this.nearCountDropIterable)
         {
             sum5.add(each);
         }
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         for (Integer each : this.sameCountDropIterable)
         {
             sum6.add(each);
         }
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
 
         Sum sum7 = new IntegerSum(0);
         for (Integer each : this.higherCountDropIterable)
         {
             sum7.add(each);
         }
-        Assert.assertEquals(0, sum7.getValue().intValue());
+        assertEquals(0, sum7.getValue().intValue());
     }
 
     @Override
@@ -220,7 +221,7 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
     public void distinct()
     {
         super.distinct();
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4, 5),
                 new DropIterable<>(FastList.newListWith(1, 1, 2, 3, 3, 3, 4, 5), 2).distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
@@ -20,9 +20,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DropWhileIterableTest extends AbstractLazyIterableTestCase
 {
@@ -45,13 +46,13 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
     @Test
     public void basic()
     {
-        Assert.assertEquals(3, this.dropWhileIterable.size());
-        Assert.assertEquals(FastList.newListWith(3, 4, 5), this.dropWhileIterable.toList());
+        assertEquals(3, this.dropWhileIterable.size());
+        assertEquals(FastList.newListWith(3, 4, 5), this.dropWhileIterable.toList());
 
-        Assert.assertEquals(0, this.emptyListDropWhileIterable.size());
-        Assert.assertEquals(5, this.alwaysFalseDropWhileIterable.size());
-        Assert.assertEquals(1, this.mostlyFalseDropWhileIterable.size());
-        Assert.assertEquals(0, this.alwaysTrueDropWhileIterable.size());
+        assertEquals(0, this.emptyListDropWhileIterable.size());
+        assertEquals(5, this.alwaysFalseDropWhileIterable.size());
+        assertEquals(1, this.mostlyFalseDropWhileIterable.size());
+        assertEquals(0, this.alwaysTrueDropWhileIterable.size());
     }
 
     @Test
@@ -59,23 +60,23 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
     {
         Sum sum1 = new IntegerSum(0);
         this.dropWhileIterable.forEach(new SumProcedure<>(sum1));
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListDropWhileIterable.forEach(new SumProcedure<>(sum2));
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.alwaysFalseDropWhileIterable.forEach(new SumProcedure<>(sum3));
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.mostlyFalseDropWhileIterable.forEach(new SumProcedure<>(sum5));
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         this.alwaysTrueDropWhileIterable.forEach(new SumProcedure<>(sum6));
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
     }
 
     @Test
@@ -89,30 +90,30 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
         };
 
         this.dropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2), indices);
-        Assert.assertEquals(12, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0, 1, 2), indices);
+        assertEquals(12, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.emptyListDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(0, indices.size());
+        assertEquals(0, indices.size());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.alwaysFalseDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
-        Assert.assertEquals(15, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        assertEquals(15, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.mostlyFalseDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(FastList.newListWith(0), indices);
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(FastList.newListWith(0), indices);
+        assertEquals(5, sum.getValue().intValue());
 
         indices.clear();
         sum.add(sum.getValue().intValue() * -1);
         this.alwaysTrueDropWhileIterable.forEachWithIndex(indexRecordingAndSumProcedure);
-        Assert.assertEquals(0, indices.size());
+        assertEquals(0, indices.size());
     }
 
     @Test
@@ -122,23 +123,23 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
 
         Sum sum1 = new IntegerSum(0);
         this.dropWhileIterable.forEachWith(sumAdditionProcedure, sum1);
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListDropWhileIterable.forEachWith(sumAdditionProcedure, sum2);
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.alwaysFalseDropWhileIterable.forEachWith(sumAdditionProcedure, sum3);
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.mostlyFalseDropWhileIterable.forEachWith(sumAdditionProcedure, sum5);
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         this.alwaysTrueDropWhileIterable.forEachWith(sumAdditionProcedure, sum6);
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
     }
 
     @Override
@@ -150,35 +151,35 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
         {
             sum1.add(each);
         }
-        Assert.assertEquals(12, sum1.getValue().intValue());
+        assertEquals(12, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         for (Integer each : this.emptyListDropWhileIterable)
         {
             sum2.add(each);
         }
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         for (Integer each : this.alwaysFalseDropWhileIterable)
         {
             sum3.add(each);
         }
-        Assert.assertEquals(15, sum3.getValue().intValue());
+        assertEquals(15, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         for (Integer each : this.mostlyFalseDropWhileIterable)
         {
             sum5.add(each);
         }
-        Assert.assertEquals(5, sum5.getValue().intValue());
+        assertEquals(5, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         for (Integer each : this.alwaysTrueDropWhileIterable)
         {
             sum6.add(each);
         }
-        Assert.assertEquals(0, sum6.getValue().intValue());
+        assertEquals(0, sum6.getValue().intValue());
     }
 
     @Override
@@ -192,7 +193,7 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
     public void distinct()
     {
         super.distinct();
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4, 5),
                 new DropWhileIterable<>(FastList.newListWith(1, 1, 2, 3, 3, 3, 4, 5), each -> each % 2 != 0).distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/FlatCollectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/FlatCollectIterableTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
 {
@@ -34,7 +35,7 @@ public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
         Appendable builder = new StringBuilder();
         Procedure<Integer> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("112123123412345", builder.toString());
+        assertEquals("112123123412345", builder.toString());
     }
 
     @Test
@@ -46,7 +47,7 @@ public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("10112213243516273849110211312413514", builder.toString());
+        assertEquals("10112213243516273849110211312413514", builder.toString());
     }
 
     @Override
@@ -59,7 +60,7 @@ public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
         {
             builder.append(each);
         }
-        Assert.assertEquals("112123123412345", builder.toString());
+        assertEquals("112123123412345", builder.toString());
     }
 
     @Test
@@ -68,7 +69,7 @@ public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new FlatCollectIterable<>(Interval.oneTo(5), Interval::oneTo);
         StringBuilder builder = new StringBuilder();
         select.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("112123123412345", builder.toString());
+        assertEquals("112123123412345", builder.toString());
     }
 
     @Override
@@ -77,7 +78,7 @@ public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<Integer> iterable = new FlatCollectIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), Interval::oneTo);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2, 3, 4, 5),
                 iterable.distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/LazyIterableAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/LazyIterableAdapterTest.java
@@ -17,10 +17,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
 {
@@ -38,14 +39,14 @@ public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new LazyIterableAdapter<>(Interval.oneTo(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(15, sum.getValue().intValue());
+        assertEquals(15, sum.getValue().intValue());
     }
 
     @Test
     public void into()
     {
         int sum = new LazyIterableAdapter<>(Interval.oneTo(5)).into(FastList.newList()).injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(15, sum);
+        assertEquals(15, sum);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
 
             LOGGER.info("value={} index={}", object, index);
         });
-        Assert.assertEquals(25, sum.getValue().intValue());
+        assertEquals(25, sum.getValue().intValue());
     }
 
     @Override
@@ -72,7 +73,7 @@ public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
         {
             sum.add(each);
         }
-        Assert.assertEquals(15, sum.getValue().intValue());
+        assertEquals(15, sum.getValue().intValue());
     }
 
     @Test
@@ -81,7 +82,7 @@ public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new LazyIterableAdapter<>(Interval.oneTo(5));
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(15, sum.getValue().intValue());
+        assertEquals(15, sum.getValue().intValue());
     }
 
     @Override
@@ -90,7 +91,7 @@ public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<Integer> iterable = new LazyIterableAdapter<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1, 5),
                 iterable.distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/RejectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/RejectIterableTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class RejectIterableTest extends AbstractLazyIterableTestCase
 {
@@ -35,7 +36,7 @@ public class RejectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new RejectIterable<>(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Test
@@ -47,7 +48,7 @@ public class RejectIterableTest extends AbstractLazyIterableTestCase
             sum.add(object);
             sum.add(index);
         });
-        Assert.assertEquals(6, sum.getValue().intValue());
+        assertEquals(6, sum.getValue().intValue());
     }
 
     @Override
@@ -60,7 +61,7 @@ public class RejectIterableTest extends AbstractLazyIterableTestCase
         {
             sum.add(each);
         }
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Test
@@ -69,7 +70,7 @@ public class RejectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new RejectIterable<>(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Override
@@ -78,7 +79,7 @@ public class RejectIterableTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<Integer> iterable = new RejectIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), Predicates.lessThan(2));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 5),
                 iterable.distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterableTest.java
@@ -16,10 +16,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
 {
@@ -37,7 +38,7 @@ public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new SelectInstancesOfIterable<>(FastList.newListWith(1, 2.0, 3, 4.0, 5), Integer.class);
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(9, sum.getValue().intValue());
+        assertEquals(9, sum.getValue().intValue());
     }
 
     @Test
@@ -51,7 +52,7 @@ public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
 
             LOGGER.info("value={} index={}", object, index);
         });
-        Assert.assertEquals(12, sum.getValue().intValue());
+        assertEquals(12, sum.getValue().intValue());
     }
 
     @Override
@@ -64,7 +65,7 @@ public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
         {
             sum.add(each);
         }
-        Assert.assertEquals(9, sum.getValue().intValue());
+        assertEquals(9, sum.getValue().intValue());
     }
 
     @Test
@@ -73,7 +74,7 @@ public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new SelectInstancesOfIterable<>(FastList.newListWith(1, 2.0, 3, 4.0, 5), Integer.class);
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(9, sum.getValue().intValue());
+        assertEquals(9, sum.getValue().intValue());
     }
 
     @Override
@@ -114,7 +115,7 @@ public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<Double> iterable = new SelectInstancesOfIterable<>(FastList.newListWith(3.0, 2.0, 3, 2.0, 4.0, 5, 1.0, 3.0, 1.0, 5.0), Double.class);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3.0, 2.0, 4.0, 1.0, 5.0),
                 iterable.distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectIterableTest.java
@@ -18,10 +18,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class SelectIterableTest extends AbstractLazyIterableTestCase
 {
@@ -39,7 +40,7 @@ public class SelectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new SelectIterable<>(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Test
@@ -53,7 +54,7 @@ public class SelectIterableTest extends AbstractLazyIterableTestCase
 
             LOGGER.info("value={} index={}", object, index);
         });
-        Assert.assertEquals(13, sum.getValue().intValue());
+        assertEquals(13, sum.getValue().intValue());
     }
 
     @Override
@@ -66,7 +67,7 @@ public class SelectIterableTest extends AbstractLazyIterableTestCase
         {
             sum.add(each);
         }
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Test
@@ -75,7 +76,7 @@ public class SelectIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> select = new SelectIterable<>(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Override
@@ -84,7 +85,7 @@ public class SelectIterableTest extends AbstractLazyIterableTestCase
     {
         super.distinct();
         LazyIterable<Integer> iterable = new SelectIterable<>(FastList.newListWith(5, 3, 2, 2, 4, 1, 3, 1, 5), Predicates.lessThan(5));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1),
                 iterable.distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeIterableTest.java
@@ -20,9 +20,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TakeIterableTest extends AbstractLazyIterableTestCase
 {
@@ -51,13 +52,13 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
     @Test
     public void basic()
     {
-        Assert.assertEquals(2, this.takeIterable.size());
-        Assert.assertEquals(FastList.newListWith(1, 2), this.takeIterable.toList());
+        assertEquals(2, this.takeIterable.size());
+        assertEquals(FastList.newListWith(1, 2), this.takeIterable.toList());
 
-        Assert.assertEquals(0, this.emptyListTakeIterable.size());
-        Assert.assertEquals(0, this.zeroCountTakeIterable.size());
-        Assert.assertEquals(5, this.higherCountTakeIterable.size());
-        Assert.assertEquals(5, this.sameCountTakeIterable.size());
+        assertEquals(0, this.emptyListTakeIterable.size());
+        assertEquals(0, this.zeroCountTakeIterable.size());
+        assertEquals(5, this.higherCountTakeIterable.size());
+        assertEquals(5, this.sameCountTakeIterable.size());
     }
 
     @Test
@@ -65,23 +66,23 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
     {
         CountProcedure<Integer> cb1 = new CountProcedure<>();
         this.takeIterable.forEach(cb1);
-        Assert.assertEquals(2, cb1.getCount());
+        assertEquals(2, cb1.getCount());
 
         CountProcedure<Integer> cb2 = new CountProcedure<>();
         this.emptyListTakeIterable.forEach(cb2);
-        Assert.assertEquals(0, cb2.getCount());
+        assertEquals(0, cb2.getCount());
 
         CountProcedure<Integer> cb3 = new CountProcedure<>();
         this.zeroCountTakeIterable.forEach(cb3);
-        Assert.assertEquals(0, cb3.getCount());
+        assertEquals(0, cb3.getCount());
 
         CountProcedure<Integer> cb5 = new CountProcedure<>();
         this.sameCountTakeIterable.forEach(cb5);
-        Assert.assertEquals(5, cb5.getCount());
+        assertEquals(5, cb5.getCount());
 
         CountProcedure<Integer> cb6 = new CountProcedure<>();
         this.higherCountTakeIterable.forEach(cb6);
-        Assert.assertEquals(5, cb6.getCount());
+        assertEquals(5, cb6.getCount());
     }
 
     @Test
@@ -91,7 +92,7 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
         ObjectIntProcedure<Integer> indexRecordingProcedure = (each, index) -> indices.add(index);
 
         this.takeIterable.forEachWithIndex(indexRecordingProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1), indices);
+        assertEquals(FastList.newListWith(0, 1), indices);
 
         indices.clear();
         this.emptyListTakeIterable.forEachWithIndex(indexRecordingProcedure);
@@ -103,11 +104,11 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
 
         indices.clear();
         this.sameCountTakeIterable.forEachWithIndex(indexRecordingProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
 
         indices.clear();
         this.higherCountTakeIterable.forEachWithIndex(indexRecordingProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
     }
 
     @Test
@@ -117,23 +118,23 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
 
         Sum sum1 = new IntegerSum(0);
         this.takeIterable.forEachWith(sumAdditionProcedure, sum1);
-        Assert.assertEquals(3, sum1.getValue().intValue());
+        assertEquals(3, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListTakeIterable.forEachWith(sumAdditionProcedure, sum2);
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.zeroCountTakeIterable.forEachWith(sumAdditionProcedure, sum3);
-        Assert.assertEquals(0, sum3.getValue().intValue());
+        assertEquals(0, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.sameCountTakeIterable.forEachWith(sumAdditionProcedure, sum5);
-        Assert.assertEquals(15, sum5.getValue().intValue());
+        assertEquals(15, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         this.higherCountTakeIterable.forEachWith(sumAdditionProcedure, sum6);
-        Assert.assertEquals(15, sum6.getValue().intValue());
+        assertEquals(15, sum6.getValue().intValue());
     }
 
     @Override
@@ -145,35 +146,35 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
         {
             sum1.add(each);
         }
-        Assert.assertEquals(3, sum1.getValue().intValue());
+        assertEquals(3, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         for (Integer each : this.emptyListTakeIterable)
         {
             sum2.add(each);
         }
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         for (Integer each : this.zeroCountTakeIterable)
         {
             sum3.add(each);
         }
-        Assert.assertEquals(0, sum3.getValue().intValue());
+        assertEquals(0, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         for (Integer each : this.sameCountTakeIterable)
         {
             sum5.add(each);
         }
-        Assert.assertEquals(15, sum5.getValue().intValue());
+        assertEquals(15, sum5.getValue().intValue());
 
         Sum sum6 = new IntegerSum(0);
         for (Integer each : this.higherCountTakeIterable)
         {
             sum6.add(each);
         }
-        Assert.assertEquals(15, sum6.getValue().intValue());
+        assertEquals(15, sum6.getValue().intValue());
     }
 
     @Override
@@ -187,7 +188,7 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
     public void distinct()
     {
         super.distinct();
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1),
                 new TakeIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), 7).distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
@@ -21,9 +21,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
 {
@@ -44,12 +45,12 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
     @Test
     public void basic()
     {
-        Assert.assertEquals(2, this.takeWhileIterable.size());
-        Assert.assertEquals(FastList.newListWith(1, 2), this.takeWhileIterable.toList());
+        assertEquals(2, this.takeWhileIterable.size());
+        assertEquals(FastList.newListWith(1, 2), this.takeWhileIterable.toList());
 
-        Assert.assertEquals(0, this.emptyListTakeWhileIterable.size());
-        Assert.assertEquals(0, this.alwaysFalseTakeWhileIterable.size());
-        Assert.assertEquals(5, this.alwaysTrueTakeWhileIterable.size());
+        assertEquals(0, this.emptyListTakeWhileIterable.size());
+        assertEquals(0, this.alwaysFalseTakeWhileIterable.size());
+        assertEquals(5, this.alwaysTrueTakeWhileIterable.size());
     }
 
     @Test
@@ -57,19 +58,19 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
     {
         CountProcedure<Integer> cb1 = new CountProcedure<>();
         this.takeWhileIterable.forEach(cb1);
-        Assert.assertEquals(2, cb1.getCount());
+        assertEquals(2, cb1.getCount());
 
         CountProcedure<Integer> cb2 = new CountProcedure<>();
         this.emptyListTakeWhileIterable.forEach(cb2);
-        Assert.assertEquals(0, cb2.getCount());
+        assertEquals(0, cb2.getCount());
 
         CountProcedure<Integer> cb3 = new CountProcedure<>();
         this.alwaysFalseTakeWhileIterable.forEach(cb3);
-        Assert.assertEquals(0, cb3.getCount());
+        assertEquals(0, cb3.getCount());
 
         CountProcedure<Integer> cb5 = new CountProcedure<>();
         this.alwaysTrueTakeWhileIterable.forEach(cb5);
-        Assert.assertEquals(5, cb5.getCount());
+        assertEquals(5, cb5.getCount());
     }
 
     @Test
@@ -79,7 +80,7 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
         ObjectIntProcedure<Integer> indexRecordingProcedure = (each, index) -> indices.add(index);
 
         this.takeWhileIterable.forEachWithIndex(indexRecordingProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1), indices);
+        assertEquals(FastList.newListWith(0, 1), indices);
 
         indices.clear();
         this.emptyListTakeWhileIterable.forEachWithIndex(indexRecordingProcedure);
@@ -91,7 +92,7 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
 
         indices.clear();
         this.alwaysTrueTakeWhileIterable.forEachWithIndex(indexRecordingProcedure);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
+        assertEquals(FastList.newListWith(0, 1, 2, 3, 4), indices);
     }
 
     @Test
@@ -101,19 +102,19 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
 
         Sum sum1 = new IntegerSum(0);
         this.takeWhileIterable.forEachWith(sumAdditionProcedure, sum1);
-        Assert.assertEquals(3, sum1.getValue().intValue());
+        assertEquals(3, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         this.emptyListTakeWhileIterable.forEachWith(sumAdditionProcedure, sum2);
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         this.alwaysFalseTakeWhileIterable.forEachWith(sumAdditionProcedure, sum3);
-        Assert.assertEquals(0, sum3.getValue().intValue());
+        assertEquals(0, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         this.alwaysTrueTakeWhileIterable.forEachWith(sumAdditionProcedure, sum5);
-        Assert.assertEquals(15, sum5.getValue().intValue());
+        assertEquals(15, sum5.getValue().intValue());
     }
 
     @Override
@@ -125,28 +126,28 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
         {
             sum1.add(each);
         }
-        Assert.assertEquals(3, sum1.getValue().intValue());
+        assertEquals(3, sum1.getValue().intValue());
 
         Sum sum2 = new IntegerSum(0);
         for (Integer each : this.emptyListTakeWhileIterable)
         {
             sum2.add(each);
         }
-        Assert.assertEquals(0, sum2.getValue().intValue());
+        assertEquals(0, sum2.getValue().intValue());
 
         Sum sum3 = new IntegerSum(0);
         for (Integer each : this.alwaysFalseTakeWhileIterable)
         {
             sum3.add(each);
         }
-        Assert.assertEquals(0, sum3.getValue().intValue());
+        assertEquals(0, sum3.getValue().intValue());
 
         Sum sum5 = new IntegerSum(0);
         for (Integer each : this.alwaysTrueTakeWhileIterable)
         {
             sum5.add(each);
         }
-        Assert.assertEquals(15, sum5.getValue().intValue());
+        assertEquals(15, sum5.getValue().intValue());
     }
 
     @Override
@@ -160,7 +161,7 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
     public void distinct()
     {
         super.distinct();
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(3, 2, 4, 1),
                 new TakeWhileIterable<>(FastList.newListWith(3, 2, 2, 4, 1, 3, 1, 5), each -> each < 5).distinct().toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TapIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TapIterableTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TapIterableTest extends AbstractLazyIterableTestCase
 {
@@ -38,7 +39,7 @@ public class TapIterableTest extends AbstractLazyIterableTestCase
         LazyIterable<Integer> tap = new TapIterable<>(Interval.oneTo(5), appendProcedure);
         Procedure<Integer> appendDouble = each -> builder.append(each * 2);
         tap.forEach(appendDouble);
-        Assert.assertEquals("12243648510", builder.toString());
+        assertEquals("12243648510", builder.toString());
     }
 
     @Test
@@ -51,7 +52,7 @@ public class TapIterableTest extends AbstractLazyIterableTestCase
             builder.append(each * 2);
             builder.append(index);
         });
-        Assert.assertEquals("1202413624835104", builder.toString());
+        assertEquals("1202413624835104", builder.toString());
     }
 
     @Override
@@ -65,7 +66,7 @@ public class TapIterableTest extends AbstractLazyIterableTestCase
         {
             builder.append(each + 1);
         }
-        Assert.assertEquals("1223344556", builder.toString());
+        assertEquals("1223344556", builder.toString());
     }
 
     @Test
@@ -75,6 +76,6 @@ public class TapIterableTest extends AbstractLazyIterableTestCase
         Procedure<Integer> appendProcedure = Procedures.append(builder);
         LazyIterable<Integer> tap = new TapIterable<>(Interval.oneTo(5), appendProcedure);
         tap.forEachWith((each, aBuilder) -> aBuilder.append(each - 1), builder);
-        Assert.assertEquals("1021324354", builder.toString());
+        assertEquals("1021324354", builder.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipIterableTest.java
@@ -11,9 +11,10 @@
 package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ZipIterableTest
 {
@@ -38,7 +39,7 @@ public class ZipIterableTest
             sb.append(index);
         });
 
-        Assert.assertEquals("|a00|b11|c22", sb.toString());
+        assertEquals("|a00|b11|c22", sb.toString());
     }
 
     @Test
@@ -51,6 +52,6 @@ public class ZipIterableTest
             sb.append(each.getTwo());
         }, "|");
 
-        Assert.assertEquals("|a0|b1|c2", sb.toString());
+        assertEquals("|a0|b1|c2", sb.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipWithIndexIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipWithIndexIterableTest.java
@@ -12,9 +12,10 @@ package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Procedures;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ZipWithIndexIterableTest
 {
@@ -29,7 +30,7 @@ public class ZipWithIndexIterableTest
 
     private void assertBufferContains(String expected)
     {
-        Assert.assertEquals(expected, this.buffer.toString());
+        assertEquals(expected, this.buffer.toString());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/CollectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/CollectIteratorTest.java
@@ -14,10 +14,12 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CollectIteratorTest
 {
@@ -25,27 +27,27 @@ public class CollectIteratorTest
     public void iterator()
     {
         Iterator<String> iterator = new CollectIterator<>(iList(Boolean.TRUE), String::valueOf);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals("true", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals("true", iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void iteratorWithFunctionName()
     {
         Iterator<String> iterator = new CollectIterator<>(iList(Boolean.TRUE), String::valueOf);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals("true", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals("true", iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void iteratorWithFunctionNameAndIterator()
     {
         Iterator<String> iterator = new CollectIterator<>(iList(Boolean.TRUE).iterator(), String::valueOf);
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals("true", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals("true", iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test(expected = NoSuchElementException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DistinctIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DistinctIteratorTest.java
@@ -15,8 +15,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class DistinctIteratorTest
 {
@@ -40,14 +42,14 @@ public class DistinctIteratorTest
         {
             result.add(iterator.next());
         }
-        Assert.assertEquals(Lists.mutable.of(4, 1, 10, 100), result);
+        assertEquals(Lists.mutable.of(4, 1, 10, 100), result);
     }
 
     @Test(expected = NoSuchElementException.class)
     public void nextException()
     {
         Iterator<Integer> iterator = new DistinctIterator<>(Lists.mutable.empty());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         iterator.next();
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
@@ -15,8 +15,12 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link DropIterator}.
@@ -48,23 +52,23 @@ public class DropIteratorTest
     {
         for (int i = count; i < size; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(Integer.valueOf(i + 1), iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(Integer.valueOf(i + 1), iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).remove());
+        assertThrows(UnsupportedOperationException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).remove());
     }
 
     @Test
     public void noSuchElementException()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).next());
+        assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.<Integer>of(), 0).next());
 
-        Assert.assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.of(1, 2, 3), 4).next());
+        assertThrows(NoSuchElementException.class, () -> new DropIterator<>(Lists.fixedSize.of(1, 2, 3), 4).next());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/FlatCollectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/FlatCollectIteratorTest.java
@@ -15,8 +15,9 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
 
 public class FlatCollectIteratorTest
 {
@@ -41,6 +42,6 @@ public class FlatCollectIteratorTest
                         Lists.fixedSize.of(),
                         Lists.fixedSize.of(expected)),
                 Functions.getPassThru());
-        Assert.assertSame(expected, flattenIterator.next());
+        assertSame(expected, flattenIterator.next());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectInstancesOfIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectInstancesOfIteratorTest.java
@@ -16,8 +16,10 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SelectInstancesOfIteratorTest
 {
@@ -36,18 +38,18 @@ public class SelectInstancesOfIteratorTest
         {
             result.add(iterator.next());
         }
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), result);
+        assertEquals(FastList.newListWith(1, 3, 5), result);
     }
 
     @Test
     public void noSuchElementException()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new SelectInstancesOfIterator<>(Lists.fixedSize.of(), Object.class).next());
+        assertThrows(NoSuchElementException.class, () -> new SelectInstancesOfIterator<>(Lists.fixedSize.of(), Object.class).next());
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> new SelectInstancesOfIterator<>(Lists.fixedSize.of(), Object.class).remove());
+        assertThrows(UnsupportedOperationException.class, () -> new SelectInstancesOfIterator<>(Lists.fixedSize.of(), Object.class).remove());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectIteratorTest.java
@@ -16,8 +16,12 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class SelectIteratorTest
 {
@@ -43,21 +47,21 @@ public class SelectIteratorTest
     {
         for (int i = 0; i < 4; i++)
         {
-            Assert.assertTrue(newIterator.hasNext());
-            Assert.assertEquals(Boolean.TRUE, newIterator.next());
+            assertTrue(newIterator.hasNext());
+            assertEquals(Boolean.TRUE, newIterator.next());
         }
-        Assert.assertFalse(newIterator.hasNext());
+        assertFalse(newIterator.hasNext());
     }
 
     @Test
     public void noSuchElementException()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new SelectIterator<>(Lists.fixedSize.of(), ignored -> true).next());
+        assertThrows(NoSuchElementException.class, () -> new SelectIterator<>(Lists.fixedSize.of(), ignored -> true).next());
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> new SelectIterator<>(Lists.fixedSize.of(), ignored -> true).remove());
+        assertThrows(UnsupportedOperationException.class, () -> new SelectIterator<>(Lists.fixedSize.of(), ignored -> true).remove());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeIteratorTest.java
@@ -15,8 +15,12 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link TakeIterator}.
@@ -48,23 +52,23 @@ public class TakeIteratorTest
     {
         for (int i = 0; i < count; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(Integer.valueOf(i + 1), iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(Integer.valueOf(i + 1), iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> new TakeIterator<>(Lists.fixedSize.<Integer>of(), 0).remove());
+        assertThrows(UnsupportedOperationException.class, () -> new TakeIterator<>(Lists.fixedSize.<Integer>of(), 0).remove());
     }
 
     @Test
     public void noSuchElementException()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new TakeIterator<>(Lists.fixedSize.<Integer>of(), 0).next());
+        assertThrows(NoSuchElementException.class, () -> new TakeIterator<>(Lists.fixedSize.<Integer>of(), 0).next());
 
-        Assert.assertThrows(NoSuchElementException.class, () -> new TakeIterator<>(Lists.fixedSize.of(1, 2, 3), 0).next());
+        assertThrows(NoSuchElementException.class, () -> new TakeIterator<>(Lists.fixedSize.of(1, 2, 3), 0).next());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
@@ -16,8 +16,12 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link TakeWhileIterator}.
@@ -49,10 +53,10 @@ public class TakeWhileIteratorTest
     {
         for (int i = 0; i < count; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(Integer.valueOf(i + 1), iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(Integer.valueOf(i + 1), iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -61,24 +65,24 @@ public class TakeWhileIteratorTest
         Interval list = Interval.oneTo(5);
 
         Iterator<Integer> iterator1 = new TakeWhileIterator<>(list.iterator(), each -> each <= 1);
-        Assert.assertTrue(iterator1.hasNext());
-        Assert.assertTrue(iterator1.hasNext());
+        assertTrue(iterator1.hasNext());
+        assertTrue(iterator1.hasNext());
 
         iterator1.next();
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).remove());
+        assertThrows(UnsupportedOperationException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).remove());
     }
 
     @Test
     public void noSuchElementException()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).next());
+        assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.<Integer>of(), Predicates.alwaysTrue()).next());
 
-        Assert.assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.of(1, 2, 3), Predicates.alwaysFalse()).next());
+        assertThrows(NoSuchElementException.class, () -> new TakeWhileIterator<>(Lists.fixedSize.of(1, 2, 3), Predicates.alwaysFalse()).next());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TapIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TapIteratorTest.java
@@ -17,8 +17,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class TapIteratorTest
 {
@@ -42,7 +44,7 @@ public class TapIteratorTest
         Object expected = new Object();
         Iterator<Object> iterator = new TapIterator<>(
                 Lists.fixedSize.of(expected), object -> { });
-        Assert.assertSame(expected, iterator.next());
+        assertSame(expected, iterator.next());
     }
 
     @Test
@@ -61,6 +63,6 @@ public class TapIteratorTest
         {
             intList.add(iterator.next().get());
         }
-        Assert.assertEquals(IntLists.mutable.of(10, 20, 30), intList);
+        assertEquals(IntLists.mutable.of(10, 20, 30), intList);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/ParallelIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/ParallelIterableTestCase.java
@@ -51,9 +51,14 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public abstract class ParallelIterableTestCase
 {
@@ -66,7 +71,7 @@ public abstract class ParallelIterableTestCase
     {
         this.executorService = Executors.newFixedThreadPool(10);
         this.batchSize = 2;
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @After
@@ -115,7 +120,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toArray()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith(this.getExpected().toArray()),
                 HashBag.newBagWith(this.classUnderTest().toArray()));
     }
@@ -123,7 +128,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toArray_array()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashBag.newBagWith(this.getExpected().toArray(new Object[10])),
                 HashBag.newBagWith(this.classUnderTest().toArray(new Object[10])));
     }
@@ -133,7 +138,7 @@ public abstract class ParallelIterableTestCase
     {
         MutableCollection<Integer> actual = HashBag.<Integer>newBag().asSynchronized();
         this.classUnderTest().forEach(CollectionAddProcedure.on(actual));
-        Assert.assertEquals(this.getExpected().toBag(), actual);
+        assertEquals(this.getExpected().toBag(), actual);
     }
 
     @Test
@@ -141,7 +146,7 @@ public abstract class ParallelIterableTestCase
     {
         MutableCollection<Integer> actual = HashBag.<Integer>newBag().asSynchronized();
         this.classUnderTest().forEachWith(Procedures2.addToCollection(), actual);
-        Assert.assertEquals(this.getExpected().toBag(), actual);
+        assertEquals(this.getExpected().toBag(), actual);
     }
 
     @Test
@@ -149,15 +154,15 @@ public abstract class ParallelIterableTestCase
     {
         Predicate<Integer> predicate = Predicates.greaterThan(1).and(Predicates.lessThan(4));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().select(predicate),
                 this.getActual(this.classUnderTest().select(predicate)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().select(predicate).toList().toBag(),
                 this.classUnderTest().select(predicate).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().select(predicate).toBag(),
                 this.classUnderTest().select(predicate).toBag());
     }
@@ -165,15 +170,15 @@ public abstract class ParallelIterableTestCase
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4),
                 this.getActual(this.classUnderTest().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4).toList().toBag(),
                 this.classUnderTest().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4).toBag(),
                 this.classUnderTest().selectWith(Predicates2.greaterThan(), 1).selectWith(Predicates2.lessThan(), 4).toBag());
     }
@@ -183,15 +188,15 @@ public abstract class ParallelIterableTestCase
     {
         Predicate<Integer> predicate = Predicates.lessThanOrEqualTo(1).and(Predicates.greaterThanOrEqualTo(4));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().reject(predicate),
                 this.getActual(this.classUnderTest().reject(predicate)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().reject(predicate).toList().toBag(),
                 this.classUnderTest().reject(predicate).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().reject(predicate).toBag(),
                 this.classUnderTest().reject(predicate).toBag());
     }
@@ -199,15 +204,15 @@ public abstract class ParallelIterableTestCase
     @Test
     public void rejectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4),
                 this.getActual(this.classUnderTest().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4).toList().toBag(),
                 this.classUnderTest().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4).toBag(),
                 this.classUnderTest().rejectWith(Predicates2.lessThanOrEqualTo(), 1).rejectWith(Predicates2.greaterThanOrEqualTo(), 4).toBag());
     }
@@ -215,19 +220,19 @@ public abstract class ParallelIterableTestCase
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectInstancesOf(Integer.class),
                 this.getActual(this.classUnderTest().selectInstancesOf(Integer.class)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectInstancesOf(String.class),
                 this.getActual(this.classUnderTest().selectInstancesOf(String.class)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectInstancesOf(Integer.class).toList().toBag(),
                 this.classUnderTest().selectInstancesOf(Integer.class).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().selectInstancesOf(Integer.class).toBag(),
                 this.classUnderTest().selectInstancesOf(Integer.class).toBag());
 
@@ -239,7 +244,7 @@ public abstract class ParallelIterableTestCase
             return integer;
         };
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collect(numberFunction).selectInstancesOf(Integer.class),
                 this.getActual(this.classUnderTest().collect(numberFunction).selectInstancesOf(Integer.class)));
     }
@@ -247,20 +252,20 @@ public abstract class ParallelIterableTestCase
     @Test
     public void collect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collect(String::valueOf),
                 this.getActual(this.classUnderTest().collect(String::valueOf)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collect(String::valueOf, HashBag.newBag()),
                 this.classUnderTest().collect(String::valueOf).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collect(String::valueOf).toBag(),
                 this.classUnderTest().collect(String::valueOf).toBag());
 
         Object constant = new Object();
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collect(ignored -> constant, HashBag.newBag()),
                 this.classUnderTest().collect(ignored -> constant).toList().toBag());
     }
@@ -270,20 +275,20 @@ public abstract class ParallelIterableTestCase
     {
         Function2<Integer, String, String> appendFunction = (argument1, argument2) -> argument1 + argument2;
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectWith(appendFunction, "!"),
                 this.getActual(this.classUnderTest().collectWith(appendFunction, "!")));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectWith(appendFunction, "!", HashBag.newBag()),
                 this.classUnderTest().collectWith(appendFunction, "!").toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectWith(appendFunction, "!").toBag(),
                 this.classUnderTest().collectWith(appendFunction, "!").toBag());
 
         Object constant = new Object();
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectWith((ignored1, ignored2) -> constant, "!", HashBag.newBag()),
                 this.classUnderTest().collectWith((ignored1, ignored2) -> constant, "!").toList().toBag());
     }
@@ -293,20 +298,20 @@ public abstract class ParallelIterableTestCase
     {
         Predicate<Integer> predicate = Predicates.greaterThan(1).and(Predicates.lessThan(4));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectIf(predicate, String::valueOf),
                 this.getActual(this.classUnderTest().collectIf(predicate, String::valueOf)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectIf(predicate, String::valueOf, HashBag.newBag()),
                 this.classUnderTest().collectIf(predicate, String::valueOf).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectIf(predicate, String::valueOf).toBag(),
                 this.classUnderTest().collectIf(predicate, String::valueOf).toBag());
 
         Object constant = new Object();
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().collectIf(predicate, ignored -> constant, HashBag.newBag()),
                 this.classUnderTest().collectIf(predicate, ignored -> constant).toList().toBag());
     }
@@ -315,15 +320,15 @@ public abstract class ParallelIterableTestCase
     public void flatCollect()
     {
         Function<Integer, Iterable<Integer>> intervalFunction = Interval::oneTo;
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().flatCollect(intervalFunction),
                 this.getActual(this.classUnderTest().flatCollect(intervalFunction)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().flatCollect(intervalFunction, HashBag.newBag()),
                 this.classUnderTest().flatCollect(intervalFunction).toList().toBag());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCollect().flatCollect(intervalFunction, HashBag.newBag()),
                 this.classUnderTest().flatCollect(intervalFunction).toBag());
     }
@@ -331,30 +336,30 @@ public abstract class ParallelIterableTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().detect(Integer.valueOf(3)::equals));
-        Assert.assertNull(this.classUnderTest().detect(Integer.valueOf(8)::equals));
+        assertEquals(Integer.valueOf(3), this.classUnderTest().detect(Integer.valueOf(3)::equals));
+        assertNull(this.classUnderTest().detect(Integer.valueOf(8)::equals));
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().detectIfNone(Integer.valueOf(3)::equals, () -> 8));
-        Assert.assertEquals(Integer.valueOf(8), this.classUnderTest().detectIfNone(Integer.valueOf(6)::equals, () -> 8));
+        assertEquals(Integer.valueOf(3), this.classUnderTest().detectIfNone(Integer.valueOf(3)::equals, () -> 8));
+        assertEquals(Integer.valueOf(8), this.classUnderTest().detectIfNone(Integer.valueOf(6)::equals, () -> 8));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().detectWith(Object::equals, Integer.valueOf(3)));
-        Assert.assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(8)));
+        assertEquals(Integer.valueOf(3), this.classUnderTest().detectWith(Object::equals, Integer.valueOf(3)));
+        assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(8)));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(Integer.valueOf(1000));
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(3), function));
-        Assert.assertEquals(Integer.valueOf(1000), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(8), function));
+        assertEquals(Integer.valueOf(3), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(3), function));
+        assertEquals(Integer.valueOf(1000), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(8), function));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -372,25 +377,25 @@ public abstract class ParallelIterableTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(4), this.classUnderTest().max(Integer::compareTo));
+        assertEquals(Integer.valueOf(4), this.classUnderTest().max(Integer::compareTo));
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(4), this.classUnderTest().maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(4), this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -408,121 +413,121 @@ public abstract class ParallelIterableTestCase
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(4), this.classUnderTest().max());
+        assertEquals(Integer.valueOf(4), this.classUnderTest().max());
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(0)));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(1)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(2)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(3)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(4)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(5)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(0)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(1)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(2)));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(3)));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThan(4)));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThan(5)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(0)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(1)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(2)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(3)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(4)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.lessThan(5)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(0)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(1)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(2)));
+        assertTrue(this.classUnderTest().anySatisfy(Predicates.greaterThan(3)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThan(4)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThan(5)));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 1));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 2));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 3));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 5));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 0));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 1));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 2));
-        Assert.assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 3));
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 4));
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 5));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 0));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 1));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 2));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 3));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 4));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 5));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 0));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 1));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 2));
+        assertTrue(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 3));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 4));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThan(), 5));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(0)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(1)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(2)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(3)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(4)));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(5)));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Predicates.greaterThan(0)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(1)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(2)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(3)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(4)));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(5)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(0)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(1)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(2)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(3)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.lessThan(4)));
+        assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(5)));
+        assertTrue(this.classUnderTest().allSatisfy(Predicates.greaterThan(0)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(1)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(2)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(3)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(4)));
+        assertFalse(this.classUnderTest().allSatisfy(Predicates.greaterThan(5)));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 1));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 2));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 3));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 5));
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 0));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 1));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 2));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 3));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 4));
-        Assert.assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 5));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 0));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 1));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 2));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 3));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 4));
+        assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 5));
+        assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 0));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 1));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 2));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 3));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 4));
+        assertFalse(this.classUnderTest().allSatisfyWith(Predicates2.greaterThan(), 5));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(0)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(1)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(2)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(3)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(4)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(5)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(0)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(1)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(2)));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(3)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThan(4)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThan(5)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(0)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(1)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(2)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(3)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(4)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.lessThan(5)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(0)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(1)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(2)));
+        assertFalse(this.classUnderTest().noneSatisfy(Predicates.greaterThan(3)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThan(4)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThan(5)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 1));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 2));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 3));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 4));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 5));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 0));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 1));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 2));
-        Assert.assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 3));
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 4));
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 5));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 0));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 1));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 2));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 3));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 4));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 5));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 0));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 1));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 2));
+        assertFalse(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 3));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 4));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThan(), 5));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().count(IntegerPredicates.isEven()),
                 this.classUnderTest().count(IntegerPredicates.isEven()));
     }
@@ -530,7 +535,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void countWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().countWith(Predicates2.greaterThan(), 2),
                 this.classUnderTest().countWith(Predicates2.greaterThan(), 2));
     }
@@ -540,13 +545,13 @@ public abstract class ParallelIterableTestCase
     {
         if (this.isOrdered())
         {
-            Assert.assertEquals(
+            assertEquals(
                     this.getExpected().toList(),
                     this.classUnderTest().toList());
         }
         else
         {
-            Assert.assertEquals(
+            assertEquals(
                     this.getExpected().toList().toBag(),
                     this.classUnderTest().toList().toBag());
         }
@@ -555,7 +560,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedList(),
                 this.classUnderTest().toSortedList());
     }
@@ -563,7 +568,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedList_comparator()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedList(Comparators.reverseNaturalOrder()),
                 this.classUnderTest().toSortedList(Comparators.reverseNaturalOrder()));
     }
@@ -571,7 +576,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedListBy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedListBy(String::valueOf),
                 this.classUnderTest().toSortedListBy(String::valueOf));
     }
@@ -579,7 +584,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSet()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet(),
                 this.classUnderTest().toSet());
     }
@@ -611,7 +616,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedBag()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedBag(),
                 this.classUnderTest().toSortedBag());
     }
@@ -619,7 +624,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedBag_comparator()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedBag(Comparators.reverseNaturalOrder()),
                 this.classUnderTest().toSortedBag(Comparators.reverseNaturalOrder()));
     }
@@ -627,7 +632,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toSortedBagBy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSortedBagBy(String::valueOf),
                 this.classUnderTest().toSortedBagBy(String::valueOf));
     }
@@ -635,7 +640,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void toMap()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toMap(String::valueOf, String::valueOf),
                 this.classUnderTest().toMap(String::valueOf, String::valueOf));
     }
@@ -758,12 +763,12 @@ public abstract class ParallelIterableTestCase
                     throw new IOException("Test exception");
                 }
             });
-            Assert.fail();
+            fail();
         }
         catch (RuntimeException e)
         {
             IOException cause = (IOException) e.getCause();
-            Assert.assertEquals("Test exception", cause.getMessage());
+            assertEquals("Test exception", cause.getMessage());
         }
     }
 
@@ -771,14 +776,14 @@ public abstract class ParallelIterableTestCase
     {
         if (this.isOrdered())
         {
-            Assert.assertEquals(expectedString, actualString);
+            assertEquals(expectedString, actualString);
         }
         else
         {
-            Assert.assertEquals(
+            assertEquals(
                     CharHashBag.newBagWith(expectedString.toCharArray()),
                     CharHashBag.newBagWith(actualString.toCharArray()));
-            Assert.assertTrue(Pattern.matches(regex, actualString));
+            assertTrue(Pattern.matches(regex, actualString));
         }
     }
 
@@ -787,7 +792,7 @@ public abstract class ParallelIterableTestCase
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -795,7 +800,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }
@@ -805,7 +810,7 @@ public abstract class ParallelIterableTestCase
     {
         if (this.isUnique())
         {
-            Assert.assertEquals(
+            assertEquals(
                     this.getExpected().groupByUniqueKey(id -> id),
                     this.classUnderTest().groupByUniqueKey(id -> id));
         }
@@ -820,7 +825,7 @@ public abstract class ParallelIterableTestCase
             {
                 return;
             }
-            Assert.fail();
+            fail();
         }
     }
 
@@ -829,7 +834,7 @@ public abstract class ParallelIterableTestCase
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().aggregateBy(isOddFunction, () -> 0, (integer11, integer21) -> integer11 + integer21),
                 this.classUnderTest().aggregateBy(isOddFunction, () -> 0, (integer1, integer2) -> integer1 + integer2));
     }
@@ -841,7 +846,7 @@ public abstract class ParallelIterableTestCase
 
         Function2<Boolean, AtomicInteger, Pair<Boolean, Integer>> atomicIntToInt = (argument1, argument2) -> Tuples.pair(argument1, argument2.get());
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().aggregateInPlaceBy(isOddFunction, AtomicInteger::new, AtomicInteger::addAndGet).collect(atomicIntToInt),
                 this.classUnderTest().aggregateInPlaceBy(isOddFunction, AtomicInteger::new, AtomicInteger::addAndGet).collect(atomicIntToInt));
     }
@@ -849,7 +854,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void sumOfInt()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().sumOfInt(Integer::intValue),
                 this.classUnderTest().sumOfInt(Integer::intValue));
     }
@@ -857,7 +862,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void sumOfLong()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().sumOfLong(Integer::longValue),
                 this.classUnderTest().sumOfLong(Integer::longValue));
     }
@@ -865,7 +870,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void sumOfFloat()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().sumOfFloat(Integer::floatValue),
                 this.classUnderTest().sumOfFloat(Integer::floatValue),
                 0.0);
@@ -885,7 +890,7 @@ public abstract class ParallelIterableTestCase
             this.batchSize = batchSize;
 
             ParallelIterable<Integer> testCollection = this.newWith(list.toArray(new Integer[]{}));
-            Assert.assertEquals(
+            assertEquals(
                     "Batch size: " + this.batchSize,
                     baseline,
                     testCollection.sumOfFloat(roundingSensitiveElementFunction),
@@ -896,7 +901,7 @@ public abstract class ParallelIterableTestCase
     @Test
     public void sumOfDouble()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().sumOfDouble(Integer::doubleValue),
                 this.classUnderTest().sumOfDouble(Integer::doubleValue),
                 0.0);
@@ -916,7 +921,7 @@ public abstract class ParallelIterableTestCase
             this.batchSize = batchSize;
 
             ParallelIterable<Integer> testCollection = this.newWith(list.toArray(new Integer[]{}));
-            Assert.assertEquals(
+            assertEquals(
                     "Batch size: " + this.batchSize,
                     baseline,
                     testCollection.sumOfDouble(roundingSensitiveElementFunction),
@@ -927,10 +932,10 @@ public abstract class ParallelIterableTestCase
     @Test
     public void asUnique()
     {
-        Assert.assertEquals(this.getExpected().toSet(), this.classUnderTest().asUnique().toSet());
-        Assert.assertEquals(this.getExpected().toList().toSet(), this.classUnderTest().asUnique().toList().toSet());
+        assertEquals(this.getExpected().toSet(), this.classUnderTest().asUnique().toSet());
+        assertEquals(this.getExpected().toList().toSet(), this.classUnderTest().asUnique().toList().toSet());
 
-        Assert.assertEquals(this.getExpected().collect(each -> "!").toSet().toList(), this.classUnderTest().collect(each -> "!").asUnique().toList());
+        assertEquals(this.getExpected().collect(each -> "!").toSet().toList(), this.classUnderTest().collect(each -> "!").asUnique().toList());
     }
 
     @Test
@@ -946,7 +951,7 @@ public abstract class ParallelIterableTestCase
         {
             ExecutionException executionException = (ExecutionException) e.getCause();
             RuntimeException runtimeException = (RuntimeException) executionException.getCause();
-            Assert.assertEquals("Execution exception", runtimeException.getMessage());
+            assertEquals("Execution exception", runtimeException.getMessage());
         }
     }
 
@@ -963,7 +968,7 @@ public abstract class ParallelIterableTestCase
         {
             ExecutionException executionException = (ExecutionException) e.getCause();
             RuntimeException runtimeException = (RuntimeException) executionException.getCause();
-            Assert.assertEquals("Execution exception", runtimeException.getMessage());
+            assertEquals("Execution exception", runtimeException.getMessage());
         }
     }
 
@@ -980,7 +985,7 @@ public abstract class ParallelIterableTestCase
         {
             ExecutionException executionException = (ExecutionException) e.getCause();
             RuntimeException runtimeException = (RuntimeException) executionException.getCause();
-            Assert.assertEquals("Execution exception", runtimeException.getMessage());
+            assertEquals("Execution exception", runtimeException.getMessage());
         }
     }
 
@@ -997,7 +1002,7 @@ public abstract class ParallelIterableTestCase
         {
             ExecutionException executionException = (ExecutionException) e.getCause();
             RuntimeException runtimeException = (RuntimeException) executionException.getCause();
-            Assert.assertEquals("Execution exception", runtimeException.getMessage());
+            assertEquals("Execution exception", runtimeException.getMessage());
         }
     }
 
@@ -1014,7 +1019,7 @@ public abstract class ParallelIterableTestCase
         {
             ExecutionException executionException = (ExecutionException) e.getCause();
             RuntimeException runtimeException = (RuntimeException) executionException.getCause();
-            Assert.assertEquals("Execution exception", runtimeException.getMessage());
+            assertEquals("Execution exception", runtimeException.getMessage());
         }
     }
 
@@ -1034,8 +1039,8 @@ public abstract class ParallelIterableTestCase
                         throw new AssertionError();
                     }
                 }));
-        Assert.assertTrue(Thread.interrupted());
-        Assert.assertFalse(Thread.interrupted());
+        assertTrue(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @Test
@@ -1051,8 +1056,8 @@ public abstract class ParallelIterableTestCase
                 throw new AssertionError();
             }
         }));
-        Assert.assertTrue(Thread.interrupted());
-        Assert.assertFalse(Thread.interrupted());
+        assertTrue(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @Test
@@ -1068,8 +1073,8 @@ public abstract class ParallelIterableTestCase
                 throw new AssertionError();
             }
         }));
-        Assert.assertTrue(Thread.interrupted());
-        Assert.assertFalse(Thread.interrupted());
+        assertTrue(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @Test
@@ -1085,8 +1090,8 @@ public abstract class ParallelIterableTestCase
                 throw new AssertionError();
             }
         }));
-        Assert.assertTrue(Thread.interrupted());
-        Assert.assertFalse(Thread.interrupted());
+        assertTrue(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @Test
@@ -1102,26 +1107,26 @@ public abstract class ParallelIterableTestCase
                 throw new AssertionError();
             }
         }).toString());
-        Assert.assertTrue(Thread.interrupted());
-        Assert.assertFalse(Thread.interrupted());
+        assertTrue(Thread.interrupted());
+        assertFalse(Thread.interrupted());
     }
 
     @Test
     public void minWithEmptyBatch()
     {
         //there will be a batch contains [4, 4] that will return empty before computing min of the batch
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().select(Predicates.lessThan(4)).min());
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().reject(Predicates.greaterThan(3)).min());
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().asUnique().min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().select(Predicates.lessThan(4)).min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().reject(Predicates.greaterThan(3)).min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().asUnique().min());
     }
 
     @Test
     public void maxWithEmptyBatch()
     {
         //there will be a batch contains [4, 4] that will return empty before computing min of the batch
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().select(Predicates.lessThan(4)).max());
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().reject(Predicates.greaterThan(3)).max());
-        Assert.assertEquals(Integer.valueOf(4), this.classUnderTest().asUnique().max());
+        assertEquals(Integer.valueOf(3), this.classUnderTest().select(Predicates.lessThan(4)).max());
+        assertEquals(Integer.valueOf(3), this.classUnderTest().reject(Predicates.greaterThan(3)).max());
+        assertEquals(Integer.valueOf(4), this.classUnderTest().asUnique().max());
     }
 
     @Test(expected = NullPointerException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTestCase.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.ParallelBag;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class ParallelBagTestCase extends ParallelIterableTestCase
 {
@@ -54,7 +55,7 @@ public abstract class ParallelBagTestCase extends ParallelIterableTestCase
     {
         MutableBag<Integer> actual = HashBag.<Integer>newBag().asSynchronized();
         this.classUnderTest().forEachWithOccurrences(actual::addOccurrences);
-        Assert.assertEquals(this.getExpected().toBag(), actual);
+        assertEquals(this.getExpected().toBag(), actual);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/SynchronizedMutableListParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/SynchronizedMutableListParallelListIterableTest.java
@@ -23,8 +23,11 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.block.procedure.checked.CheckedProcedure;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SynchronizedMutableListParallelListIterableTest extends ParallelListIterableTestCase
 {
@@ -52,7 +55,7 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
         }
         catch (RuntimeException e)
         {
-            Assert.assertEquals("Execution exception", e.getMessage());
+            assertEquals("Execution exception", e.getMessage());
         }
     }
 
@@ -68,7 +71,7 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
         }
         catch (RuntimeException e)
         {
-            Assert.assertEquals("Execution exception", e.getMessage());
+            assertEquals("Execution exception", e.getMessage());
         }
     }
 
@@ -84,7 +87,7 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
         }
         catch (RuntimeException e)
         {
-            Assert.assertEquals("Execution exception", e.getMessage());
+            assertEquals("Execution exception", e.getMessage());
         }
     }
 
@@ -100,7 +103,7 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
         }
         catch (RuntimeException e)
         {
-            Assert.assertEquals("Execution exception", e.getMessage());
+            assertEquals("Execution exception", e.getMessage());
         }
     }
 
@@ -116,7 +119,7 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
         }
         catch (RuntimeException e)
         {
-            Assert.assertEquals("Execution exception", e.getMessage());
+            assertEquals("Execution exception", e.getMessage());
         }
     }
 
@@ -140,11 +143,11 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
                     }
                 }));
 
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
 
         MutableCollection<Integer> actual2 = HashBag.<Integer>newBag().asSynchronized();
         this.classUnderTest().forEach(CollectionAddProcedure.on(actual2));
-        Assert.assertEquals(this.getExpected().toBag(), actual2);
+        assertEquals(this.getExpected().toBag(), actual2);
     }
 
     @Override
@@ -162,9 +165,9 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
             }
         }));
 
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
 
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(1)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(1)));
     }
 
     @Override
@@ -182,9 +185,9 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
             }
         }));
 
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
 
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(5)));
+        assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(5)));
     }
 
     @Override
@@ -202,9 +205,9 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
             }
         }));
 
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
 
-        Assert.assertEquals(Integer.valueOf(3), this.classUnderTest().detect(Integer.valueOf(3)::equals));
+        assertEquals(Integer.valueOf(3), this.classUnderTest().detect(Integer.valueOf(3)::equals));
     }
 
     @Override
@@ -222,10 +225,10 @@ public class SynchronizedMutableListParallelListIterableTest extends ParallelLis
             }
         }).toString());
 
-        Assert.assertFalse(Thread.interrupted());
+        assertFalse(Thread.interrupted());
 
         MutableCollection<Integer> actual = HashBag.<Integer>newBag().asSynchronized();
         this.classUnderTest().forEach(CollectionAddProcedure.on(actual));
-        Assert.assertEquals(this.getExpected().toBag(), actual);
+        assertEquals(this.getExpected().toBag(), actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectDistinctSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectDistinctSetIterableTest.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectDistinctSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {
@@ -50,7 +51,7 @@ public class ParallelCollectDistinctSetIterableTest extends ParallelUnsortedSetI
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -59,7 +60,7 @@ public class ParallelCollectDistinctSetIterableTest extends ParallelUnsortedSetI
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectMultiReaderSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectMultiReaderSetIterableTest.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectMultiReaderSetIterableTest extends ParallelIterableTestCase
 {
@@ -69,7 +70,7 @@ public class ParallelCollectMultiReaderSetIterableTest extends ParallelIterableT
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -78,7 +79,7 @@ public class ParallelCollectMultiReaderSetIterableTest extends ParallelIterableT
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSelectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSelectSetIterableTest.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectSelectSetIterableTest extends ParallelIterableTestCase
 {
@@ -71,7 +72,7 @@ public class ParallelCollectSelectSetIterableTest extends ParallelIterableTestCa
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -80,7 +81,7 @@ public class ParallelCollectSelectSetIterableTest extends ParallelIterableTestCa
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSetIterableTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectSetIterableTest extends ParallelIterableTestCase
 {
@@ -68,7 +69,7 @@ public class ParallelCollectSetIterableTest extends ParallelIterableTestCase
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -77,7 +78,7 @@ public class ParallelCollectSetIterableTest extends ParallelIterableTestCase
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSynchronizedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSynchronizedSetIterableTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectSynchronizedSetIterableTest extends ParallelIterableTestCase
 {
@@ -70,7 +71,7 @@ public class ParallelCollectSynchronizedSetIterableTest extends ParallelIterable
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -79,7 +80,7 @@ public class ParallelCollectSynchronizedSetIterableTest extends ParallelIterable
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectDistinctSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectDistinctSetIterableTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectDistinctSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {
@@ -43,7 +44,7 @@ public class ParallelFlatCollectDistinctSetIterableTest extends ParallelUnsorted
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -52,7 +53,7 @@ public class ParallelFlatCollectDistinctSetIterableTest extends ParallelUnsorted
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectMultiReaderSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectMultiReaderSetIterableTest.java
@@ -20,8 +20,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectMultiReaderSetIterableTest extends ParallelIterableTestCase
 {
@@ -72,7 +73,7 @@ public class ParallelFlatCollectMultiReaderSetIterableTest extends ParallelItera
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -81,7 +82,7 @@ public class ParallelFlatCollectMultiReaderSetIterableTest extends ParallelItera
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSelectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSelectSetIterableTest.java
@@ -20,8 +20,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectSelectSetIterableTest extends ParallelIterableTestCase
 {
@@ -76,7 +77,7 @@ public class ParallelFlatCollectSelectSetIterableTest extends ParallelIterableTe
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -85,7 +86,7 @@ public class ParallelFlatCollectSelectSetIterableTest extends ParallelIterableTe
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSetIterableTest.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectSetIterableTest extends ParallelIterableTestCase
 {
@@ -71,7 +72,7 @@ public class ParallelFlatCollectSetIterableTest extends ParallelIterableTestCase
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -80,7 +81,7 @@ public class ParallelFlatCollectSetIterableTest extends ParallelIterableTestCase
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSynchronizedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSynchronizedSetIterableTest.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectSynchronizedSetIterableTest extends ParallelIterableTestCase
 {
@@ -73,7 +74,7 @@ public class ParallelFlatCollectSynchronizedSetIterableTest extends ParallelIter
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -82,7 +83,7 @@ public class ParallelFlatCollectSynchronizedSetIterableTest extends ParallelIter
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toBag().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelCollectDistinctTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelCollectDistinctTest.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class UnifiedSetWithHashingStrategyParallelCollectDistinctTest extends ParallelUnsortedSetIterableTestCase
 {
@@ -50,7 +51,7 @@ public class UnifiedSetWithHashingStrategyParallelCollectDistinctTest extends Pa
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -59,7 +60,7 @@ public class UnifiedSetWithHashingStrategyParallelCollectDistinctTest extends Pa
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableEmptySortedSetParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableEmptySortedSetParallelTest.java
@@ -21,8 +21,12 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableEmptySortedSetParallelTest extends NonParallelSortedSetIterableTestCase
 {
@@ -65,43 +69,43 @@ public class ImmutableEmptySortedSetParallelTest extends NonParallelSortedSetIte
     @Override
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(0)));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Predicates.greaterThanOrEqualTo(0)));
+        assertTrue(this.classUnderTest().allSatisfy(Predicates.lessThan(0)));
+        assertTrue(this.classUnderTest().allSatisfy(Predicates.greaterThanOrEqualTo(0)));
     }
 
     @Override
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
+        assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.lessThan(), 0));
+        assertTrue(this.classUnderTest().allSatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
     }
 
     @Override
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(0)));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThanOrEqualTo(0)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.lessThan(0)));
+        assertFalse(this.classUnderTest().anySatisfy(Predicates.greaterThanOrEqualTo(0)));
     }
 
     @Override
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.lessThan(), 0));
+        assertFalse(this.classUnderTest().anySatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
     }
 
     @Override
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(0)));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThanOrEqualTo(0)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.lessThan(0)));
+        assertTrue(this.classUnderTest().noneSatisfy(Predicates.greaterThanOrEqualTo(0)));
     }
 
     @Override
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 0));
-        Assert.assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.lessThan(), 0));
+        assertTrue(this.classUnderTest().noneSatisfyWith(Predicates2.greaterThanOrEqualTo(), 0));
     }
 
     @Override
@@ -113,26 +117,26 @@ public class ImmutableEmptySortedSetParallelTest extends NonParallelSortedSetIte
     @Override
     public void detect()
     {
-        Assert.assertNull(this.classUnderTest().detect(Integer.valueOf(0)::equals));
+        assertNull(this.classUnderTest().detect(Integer.valueOf(0)::equals));
     }
 
     @Override
     public void detectIfNone()
     {
-        Assert.assertEquals(Integer.valueOf(10), this.classUnderTest().detectIfNone(Integer.valueOf(0)::equals, () -> 10));
+        assertEquals(Integer.valueOf(10), this.classUnderTest().detectIfNone(Integer.valueOf(0)::equals, () -> 10));
     }
 
     @Override
     public void detectWith()
     {
-        Assert.assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(0)));
+        assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(0)));
     }
 
     @Override
     public void detectWithIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(Integer.valueOf(1000));
-        Assert.assertEquals(Integer.valueOf(1000), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(0), function));
+        assertEquals(Integer.valueOf(1000), this.classUnderTest().detectWithIfNone(Object::equals, Integer.valueOf(0), function));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelCollectDistinctSortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelCollectDistinctSortedSetIterableTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.lazy.parallel.set.ParallelUnsortedSetIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelCollectDistinctSortedSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {
@@ -51,7 +52,7 @@ public class ParallelCollectDistinctSortedSetIterableTest extends ParallelUnsort
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -60,7 +61,7 @@ public class ParallelCollectDistinctSortedSetIterableTest extends ParallelUnsort
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelFlatCollectDistinctSortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelFlatCollectDistinctSortedSetIterableTest.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.lazy.parallel.set.ParallelUnsortedSetIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ParallelFlatCollectDistinctSortedSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {
@@ -45,7 +46,7 @@ public class ParallelFlatCollectDistinctSortedSetIterableTest extends ParallelUn
     {
         Function<Integer, Boolean> isOddFunction = object -> IntegerPredicates.isOdd().accept(object);
 
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupBy(isOddFunction),
                 this.classUnderTest().groupBy(isOddFunction));
     }
@@ -54,7 +55,7 @@ public class ParallelFlatCollectDistinctSortedSetIterableTest extends ParallelUn
     @Override
     public void groupByEach()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpected().toSet().groupByEach(new NegativeIntervalFunction()),
                 this.classUnderTest().groupByEach(new NegativeIntervalFunction()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanIterableTest.java
@@ -21,8 +21,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CollectBooleanIterableTest
 {
@@ -42,21 +45,21 @@ public class CollectBooleanIterableTest
                 isTrueCount++;
             }
         }
-        Assert.assertEquals(3L, count);
-        Assert.assertEquals(2L, isTrueCount);
+        assertEquals(3L, count);
+        assertEquals(2L, isTrueCount);
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(3, this.booleanIterable.size());
+        assertEquals(3, this.booleanIterable.size());
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.booleanIterable.notEmpty());
-        Assert.assertFalse(this.booleanIterable.isEmpty());
+        assertTrue(this.booleanIterable.notEmpty());
+        assertFalse(this.booleanIterable.isEmpty());
     }
 
     @Test
@@ -70,110 +73,110 @@ public class CollectBooleanIterableTest
                 value[1]++;
             }
         });
-        Assert.assertEquals(3, value[0]);
-        Assert.assertEquals(2, value[1]);
+        assertEquals(3, value[0]);
+        assertEquals(2, value[1]);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2, this.booleanIterable.count(BooleanPredicates.equal(true)));
-        Assert.assertEquals(1, this.booleanIterable.count(BooleanPredicates.equal(false)));
+        assertEquals(2, this.booleanIterable.count(BooleanPredicates.equal(true)));
+        assertEquals(1, this.booleanIterable.count(BooleanPredicates.equal(false)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.booleanIterable.anySatisfy(BooleanPredicates.equal(true)));
+        assertTrue(this.booleanIterable.anySatisfy(BooleanPredicates.equal(true)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.booleanIterable.noneSatisfy(BooleanPredicates.equal(true)));
+        assertFalse(this.booleanIterable.noneSatisfy(BooleanPredicates.equal(true)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.booleanIterable.allSatisfy(BooleanPredicates.equal(false)));
+        assertFalse(this.booleanIterable.allSatisfy(BooleanPredicates.equal(false)));
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(2, this.booleanIterable.select(BooleanPredicates.equal(true)).size());
-        Assert.assertEquals(1, this.booleanIterable.select(BooleanPredicates.equal(false)).size());
+        assertEquals(2, this.booleanIterable.select(BooleanPredicates.equal(true)).size());
+        assertEquals(1, this.booleanIterable.select(BooleanPredicates.equal(false)).size());
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(1, this.booleanIterable.reject(BooleanPredicates.equal(true)).size());
-        Assert.assertEquals(2, this.booleanIterable.reject(BooleanPredicates.equal(false)).size());
+        assertEquals(1, this.booleanIterable.reject(BooleanPredicates.equal(true)).size());
+        assertEquals(2, this.booleanIterable.reject(BooleanPredicates.equal(false)).size());
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertTrue(this.booleanIterable.detectIfNone(BooleanPredicates.equal(true), false));
+        assertTrue(this.booleanIterable.detectIfNone(BooleanPredicates.equal(true), false));
     }
 
     @Test
     public void toArray()
     {
         boolean[] actual = Interval.zeroTo(2).collectBoolean(PrimitiveFunctions.integerIsPositive()).toArray();
-        Assert.assertEquals(3, actual.length);
-        Assert.assertFalse(actual[0]);
-        Assert.assertTrue(actual[1]);
-        Assert.assertTrue(actual[2]);
+        assertEquals(3, actual.length);
+        assertFalse(actual[0]);
+        assertTrue(actual[1]);
+        assertTrue(actual[2]);
     }
 
     @Test
     public void contains()
     {
-        Assert.assertFalse(Interval.fromTo(-4, 0).collectBoolean(PrimitiveFunctions.integerIsPositive()).contains(true));
-        Assert.assertTrue(Interval.fromTo(-2, 2).collectBoolean(PrimitiveFunctions.integerIsPositive()).contains(true));
+        assertFalse(Interval.fromTo(-4, 0).collectBoolean(PrimitiveFunctions.integerIsPositive()).contains(true));
+        assertTrue(Interval.fromTo(-2, 2).collectBoolean(PrimitiveFunctions.integerIsPositive()).contains(true));
     }
 
     @Test
     public void containsAllArray()
     {
         BooleanIterable booleanIterable = Interval.oneTo(3).collectBoolean(PrimitiveFunctions.integerIsPositive());
-        Assert.assertTrue(booleanIterable.containsAll(true));
-        Assert.assertTrue(booleanIterable.containsAll(true, true));
-        Assert.assertFalse(booleanIterable.containsAll(false));
-        Assert.assertFalse(booleanIterable.containsAll(false, false));
+        assertTrue(booleanIterable.containsAll(true));
+        assertTrue(booleanIterable.containsAll(true, true));
+        assertFalse(booleanIterable.containsAll(false));
+        assertFalse(booleanIterable.containsAll(false, false));
     }
 
     @Test
     public void containsAllIterable()
     {
         BooleanIterable booleanIterable = Interval.oneTo(3).collectBoolean(PrimitiveFunctions.integerIsPositive());
-        Assert.assertTrue(booleanIterable.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(booleanIterable.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(booleanIterable.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(booleanIterable.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(booleanIterable.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(booleanIterable.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(booleanIterable.containsAll(BooleanArrayList.newListWith(false)));
+        assertFalse(booleanIterable.containsAll(BooleanArrayList.newListWith(false, false)));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith("false", "true", "true"), this.booleanIterable.collect(String::valueOf).toList());
+        assertEquals(FastList.newListWith("false", "true", "true"), this.booleanIterable.collect(String::valueOf).toList());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[false, true, true]", this.booleanIterable.toString());
+        assertEquals("[false, true, true]", this.booleanIterable.toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("false, true, true", this.booleanIterable.makeString());
-        Assert.assertEquals("false/true/true", this.booleanIterable.makeString("/"));
-        Assert.assertEquals("[false, true, true]", this.booleanIterable.makeString("[", ", ", "]"));
+        assertEquals("false, true, true", this.booleanIterable.makeString());
+        assertEquals("false/true/true", this.booleanIterable.makeString("/"));
+        assertEquals("[false, true, true]", this.booleanIterable.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -181,37 +184,37 @@ public class CollectBooleanIterableTest
     {
         StringBuilder appendable = new StringBuilder();
         this.booleanIterable.appendString(appendable);
-        Assert.assertEquals("false, true, true", appendable.toString());
+        assertEquals("false, true, true", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         this.booleanIterable.appendString(appendable2, "/");
-        Assert.assertEquals("false/true/true", appendable2.toString());
+        assertEquals("false/true/true", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.booleanIterable.appendString(appendable3, "[", ", ", "]");
-        Assert.assertEquals(this.booleanIterable.toString(), appendable3.toString());
+        assertEquals(this.booleanIterable.toString(), appendable3.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true, true), this.booleanIterable.toList());
+        assertEquals(BooleanArrayList.newListWith(false, true, true), this.booleanIterable.toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(false, true), this.booleanIterable.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false, true), this.booleanIterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true, true), this.booleanIterable.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true, true), this.booleanIterable.toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(this.booleanIterable.toSet(), this.booleanIterable.asLazy().toSet());
+        assertEquals(this.booleanIterable.toSet(), this.booleanIterable.asLazy().toSet());
         Verify.assertInstanceOf(LazyBooleanIterable.class, this.booleanIterable.asLazy());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanToObjectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanToObjectIterableTest.java
@@ -17,8 +17,10 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CollectBooleanToObjectIterableTest
 {
@@ -34,7 +36,7 @@ public class CollectBooleanToObjectIterableTest
         Appendable builder = new StringBuilder();
         Procedure<Boolean> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
@@ -46,7 +48,7 @@ public class CollectBooleanToObjectIterableTest
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("true0false1true2false3true4", builder.toString());
+        assertEquals("true0false1true2false3true4", builder.toString());
     }
 
     @Test
@@ -58,7 +60,7 @@ public class CollectBooleanToObjectIterableTest
         {
             builder.append(each);
         }
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
@@ -67,13 +69,13 @@ public class CollectBooleanToObjectIterableTest
         InternalIterable<Boolean> select = this.newPrimitiveWith(true, false, true, false, true);
         StringBuilder builder = new StringBuilder();
         select.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(true, false, true, false, true),
                 this.newPrimitiveWith(true, false, true, false, true).selectInstancesOf(Boolean.class).toList());
     }
@@ -83,7 +85,7 @@ public class CollectBooleanToObjectIterableTest
     {
         Verify.assertIterableSize(2, this.newPrimitiveWith(true, false));
         Verify.assertIterableEmpty(this.newPrimitiveWith());
-        Assert.assertTrue(this.newPrimitiveWith(true, false).notEmpty());
+        assertTrue(this.newPrimitiveWith(true, false).notEmpty());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/FlatCollectBooleanToObjectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/FlatCollectBooleanToObjectIterableTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class FlatCollectBooleanToObjectIterableTest
 {
@@ -37,7 +41,7 @@ public class FlatCollectBooleanToObjectIterableTest
         Appendable builder = new StringBuilder();
         Procedure<Boolean> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
@@ -49,7 +53,7 @@ public class FlatCollectBooleanToObjectIterableTest
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("true0false1true2false3true4", builder.toString());
+        assertEquals("true0false1true2false3true4", builder.toString());
     }
 
     @Test
@@ -61,7 +65,7 @@ public class FlatCollectBooleanToObjectIterableTest
         {
             builder.append(each);
         }
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
@@ -70,13 +74,13 @@ public class FlatCollectBooleanToObjectIterableTest
         InternalIterable<Boolean> select = this.newPrimitiveWith(true, false, true, false, true);
         StringBuilder builder = new StringBuilder();
         select.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("truefalsetruefalsetrue", builder.toString());
+        assertEquals("truefalsetruefalsetrue", builder.toString());
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(true, false, true, false, true),
                 this.newPrimitiveWith(true, false, true, false, true).selectInstancesOf(Boolean.class).toList());
     }
@@ -86,7 +90,7 @@ public class FlatCollectBooleanToObjectIterableTest
     {
         Verify.assertIterableSize(2, this.newPrimitiveWith(true, false));
         Verify.assertIterableEmpty(this.newPrimitiveWith());
-        Assert.assertTrue(this.newPrimitiveWith(true, false).notEmpty());
+        assertTrue(this.newPrimitiveWith(true, false).notEmpty());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -98,56 +102,56 @@ public class FlatCollectBooleanToObjectIterableTest
     @Test
     public void detect()
     {
-        Assert.assertEquals(Boolean.TRUE, this.newPrimitiveWith(true, false).detect(Predicates.equal(Boolean.TRUE)));
-        Assert.assertNull(this.newPrimitiveWith(true).detect(Predicates.equal(Boolean.FALSE)));
+        assertEquals(Boolean.TRUE, this.newPrimitiveWith(true, false).detect(Predicates.equal(Boolean.TRUE)));
+        assertNull(this.newPrimitiveWith(true).detect(Predicates.equal(Boolean.FALSE)));
     }
 
     @Test
     public void detectOptional()
     {
-        Assert.assertEquals(Boolean.TRUE, this.newPrimitiveWith(true, false).detectOptional(Predicates.equal(Boolean.TRUE)).get());
-        Assert.assertFalse(this.newPrimitiveWith(true).detectOptional(Predicates.equal(Boolean.FALSE)).isPresent());
+        assertEquals(Boolean.TRUE, this.newPrimitiveWith(true, false).detectOptional(Predicates.equal(Boolean.TRUE)).get());
+        assertFalse(this.newPrimitiveWith(true).detectOptional(Predicates.equal(Boolean.FALSE)).isPresent());
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newPrimitiveWith(true).anySatisfy(Predicates.equal(Boolean.TRUE)));
-        Assert.assertFalse(this.newPrimitiveWith(true).anySatisfy(Predicates.equal(Boolean.FALSE)));
+        assertTrue(this.newPrimitiveWith(true).anySatisfy(Predicates.equal(Boolean.TRUE)));
+        assertFalse(this.newPrimitiveWith(true).anySatisfy(Predicates.equal(Boolean.FALSE)));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newPrimitiveWith(true).anySatisfyWith(Predicates2.equal(), Boolean.TRUE));
-        Assert.assertFalse(this.newPrimitiveWith(true).anySatisfyWith(Predicates2.equal(), Boolean.FALSE));
+        assertTrue(this.newPrimitiveWith(true).anySatisfyWith(Predicates2.equal(), Boolean.TRUE));
+        assertFalse(this.newPrimitiveWith(true).anySatisfyWith(Predicates2.equal(), Boolean.FALSE));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.newPrimitiveWith(true, false).allSatisfy(Predicates.equal(Boolean.TRUE)));
-        Assert.assertTrue(this.newPrimitiveWith(true).allSatisfy(Predicates.equal(Boolean.TRUE)));
+        assertFalse(this.newPrimitiveWith(true, false).allSatisfy(Predicates.equal(Boolean.TRUE)));
+        assertTrue(this.newPrimitiveWith(true).allSatisfy(Predicates.equal(Boolean.TRUE)));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertFalse(this.newPrimitiveWith(true, false).allSatisfyWith(Predicates2.equal(), Boolean.TRUE));
-        Assert.assertTrue(this.newPrimitiveWith(true).allSatisfyWith(Predicates2.equal(), Boolean.TRUE));
+        assertFalse(this.newPrimitiveWith(true, false).allSatisfyWith(Predicates2.equal(), Boolean.TRUE));
+        assertTrue(this.newPrimitiveWith(true).allSatisfyWith(Predicates2.equal(), Boolean.TRUE));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.newPrimitiveWith(true).noneSatisfy(Predicates.equal(Boolean.TRUE)));
-        Assert.assertTrue(this.newPrimitiveWith(false).noneSatisfy(Predicates.equal(Boolean.TRUE)));
+        assertFalse(this.newPrimitiveWith(true).noneSatisfy(Predicates.equal(Boolean.TRUE)));
+        assertTrue(this.newPrimitiveWith(false).noneSatisfy(Predicates.equal(Boolean.TRUE)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertFalse(this.newPrimitiveWith(true).noneSatisfyWith(Predicates2.equal(), Boolean.TRUE));
-        Assert.assertTrue(this.newPrimitiveWith(false).noneSatisfyWith(Predicates2.equal(), Boolean.TRUE));
+        assertFalse(this.newPrimitiveWith(true).noneSatisfyWith(Predicates2.equal(), Boolean.TRUE));
+        assertTrue(this.newPrimitiveWith(false).noneSatisfyWith(Predicates2.equal(), Boolean.TRUE));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyBooleanIterableAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyBooleanIterableAdapterTest.java
@@ -27,8 +27,11 @@ import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link LazyByteIterableAdapter}.
@@ -46,7 +49,7 @@ public class LazyBooleanIterableAdapterTest
         {
             sum += iterator.next() ? 1 : 0;
         }
-        Assert.assertEquals(2, sum);
+        assertEquals(2, sum);
     }
 
     @Test
@@ -54,7 +57,7 @@ public class LazyBooleanIterableAdapterTest
     {
         int[] sum = new int[1];
         this.iterable.forEach(each -> sum[0] += each ? 1 : 0);
-        Assert.assertEquals(2, sum[0]);
+        assertEquals(2, sum[0]);
     }
 
     @Test
@@ -66,31 +69,31 @@ public class LazyBooleanIterableAdapterTest
     @Test
     public void empty()
     {
-        Assert.assertFalse(this.iterable.isEmpty());
-        Assert.assertTrue(this.iterable.notEmpty());
+        assertFalse(this.iterable.isEmpty());
+        assertTrue(this.iterable.notEmpty());
         Verify.assertNotEmpty(this.iterable);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2, this.iterable.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(1, this.iterable.count(BooleanPredicates.isFalse()));
+        assertEquals(2, this.iterable.count(BooleanPredicates.isTrue()));
+        assertEquals(1, this.iterable.count(BooleanPredicates.isFalse()));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.iterable.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.iterable.anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.iterable.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.iterable.anySatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.iterable.allSatisfy(value -> true));
-        Assert.assertFalse(this.iterable.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.iterable.allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.iterable.allSatisfy(value -> true));
+        assertFalse(this.iterable.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.iterable.allSatisfy(BooleanPredicates.isTrue()));
     }
 
     @Test
@@ -110,9 +113,9 @@ public class LazyBooleanIterableAdapterTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertTrue(this.iterable.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(this.iterable.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.iterable.detectIfNone(value -> false, false));
+        assertTrue(this.iterable.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(this.iterable.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.iterable.detectIfNone(value -> false, false));
     }
 
     @Test
@@ -120,67 +123,67 @@ public class LazyBooleanIterableAdapterTest
     {
         RichIterable<String> collect = this.iterable.collect(String::valueOf);
         Verify.assertIterableSize(3, collect);
-        Assert.assertEquals("truefalsetrue", collect.makeString(""));
+        assertEquals("truefalsetrue", collect.makeString(""));
     }
 
     @Test
     public void lazyCollectPrimitives()
     {
-        Assert.assertEquals(BooleanLists.immutable.of(false, true, false), this.iterable.collectBoolean(e -> !e).toList());
-        Assert.assertEquals(CharLists.immutable.of((char) 1, (char) 0, (char) 1), this.iterable.asLazy().collectChar(e -> e ? (char) 1 : (char) 0).toList());
-        Assert.assertEquals(ByteLists.immutable.of((byte) 1, (byte) 0, (byte) 1), this.iterable.asLazy().collectByte(e -> e ? (byte) 1 : (byte) 0).toList());
-        Assert.assertEquals(ShortLists.immutable.of((short) 1, (short) 0, (short) 1), this.iterable.asLazy().collectShort(e -> e ? (short) 1 : (short) 0).toList());
-        Assert.assertEquals(IntLists.immutable.of(1, 0, 1), this.iterable.asLazy().collectInt(e -> e ? 1 : 0).toList());
-        Assert.assertEquals(FloatLists.immutable.of(1.0f, 0.0f, 1.0f), this.iterable.asLazy().collectFloat(e -> e ? 1.0f : 0.0f).toList());
-        Assert.assertEquals(LongLists.immutable.of(1L, 0L, 1L), this.iterable.asLazy().collectLong(e -> e ? 1L : 0L).toList());
-        Assert.assertEquals(DoubleLists.immutable.of(1.0, 0.0, 1.0), this.iterable.asLazy().collectDouble(e -> e ? 1.0 : 0.0).toList());
+        assertEquals(BooleanLists.immutable.of(false, true, false), this.iterable.collectBoolean(e -> !e).toList());
+        assertEquals(CharLists.immutable.of((char) 1, (char) 0, (char) 1), this.iterable.asLazy().collectChar(e -> e ? (char) 1 : (char) 0).toList());
+        assertEquals(ByteLists.immutable.of((byte) 1, (byte) 0, (byte) 1), this.iterable.asLazy().collectByte(e -> e ? (byte) 1 : (byte) 0).toList());
+        assertEquals(ShortLists.immutable.of((short) 1, (short) 0, (short) 1), this.iterable.asLazy().collectShort(e -> e ? (short) 1 : (short) 0).toList());
+        assertEquals(IntLists.immutable.of(1, 0, 1), this.iterable.asLazy().collectInt(e -> e ? 1 : 0).toList());
+        assertEquals(FloatLists.immutable.of(1.0f, 0.0f, 1.0f), this.iterable.asLazy().collectFloat(e -> e ? 1.0f : 0.0f).toList());
+        assertEquals(LongLists.immutable.of(1L, 0L, 1L), this.iterable.asLazy().collectLong(e -> e ? 1L : 0L).toList());
+        assertEquals(DoubleLists.immutable.of(1.0, 0.0, 1.0), this.iterable.asLazy().collectDouble(e -> e ? 1.0 : 0.0).toList());
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertTrue(Arrays.equals(new boolean[]{true, false, true}, this.iterable.toArray()));
+        assertTrue(Arrays.equals(new boolean[]{true, false, true}, this.iterable.toArray()));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.iterable.contains(true));
-        Assert.assertTrue(this.iterable.contains(false));
+        assertTrue(this.iterable.contains(true));
+        assertTrue(this.iterable.contains(false));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.iterable.containsAll(true, false));
-        Assert.assertTrue(this.iterable.containsAll(false, true));
-        Assert.assertTrue(this.iterable.containsAll());
+        assertTrue(this.iterable.containsAll(true, false));
+        assertTrue(this.iterable.containsAll(false, true));
+        assertTrue(this.iterable.containsAll());
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.iterable.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), this.iterable.toList());
+        assertEquals(BooleanArrayList.newListWith(true, false, true), this.iterable.toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.iterable.toSet());
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.iterable.toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true, true), this.iterable.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true, true), this.iterable.toBag());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/ReverseBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/ReverseBooleanIterableTest.java
@@ -20,8 +20,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ReverseBooleanIterable}.
@@ -40,19 +43,19 @@ public class ReverseBooleanIterableTest
     public void contains()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false).asReversed();
-        Assert.assertTrue(iterable.contains(false));
-        Assert.assertFalse(iterable.contains(true));
+        assertTrue(iterable.contains(false));
+        assertFalse(iterable.contains(true));
     }
 
     @Test
     public void containsAll()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(true, false, true).asReversed();
-        Assert.assertTrue(iterable.containsAll(true));
-        Assert.assertTrue(iterable.containsAll(true, false));
-        Assert.assertFalse(BooleanArrayList.newListWith(false, false).asReversed().containsAll(true));
-        Assert.assertFalse(BooleanArrayList.newListWith(false, false).asReversed().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(BooleanArrayList.newListWith(false, false, true).asReversed().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(iterable.containsAll(true));
+        assertTrue(iterable.containsAll(true, false));
+        assertFalse(BooleanArrayList.newListWith(false, false).asReversed().containsAll(true));
+        assertFalse(BooleanArrayList.newListWith(false, false).asReversed().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(BooleanArrayList.newListWith(false, false, true).asReversed().containsAll(BooleanArrayList.newListWith(true, false)));
     }
 
     @Test
@@ -60,12 +63,12 @@ public class ReverseBooleanIterableTest
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
         BooleanIterator iterator = iterable.booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.next());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -87,7 +90,7 @@ public class ReverseBooleanIterableTest
         boolean[] result = {true};
         iterable.forEach(each -> result[0] &= each);
 
-        Assert.assertFalse(result[0]);
+        assertFalse(result[0]);
     }
 
     @Test
@@ -102,35 +105,35 @@ public class ReverseBooleanIterableTest
     public void empty()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
-        Assert.assertTrue(iterable.notEmpty());
+        assertTrue(iterable.notEmpty());
         Verify.assertNotEmpty(iterable);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, BooleanArrayList.newListWith(false, false, true).asReversed().count(BooleanPredicates.equal(false)));
+        assertEquals(2L, BooleanArrayList.newListWith(false, false, true).asReversed().count(BooleanPredicates.equal(false)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(BooleanArrayList.newListWith(true, false).asReversed().anySatisfy(BooleanPredicates.equal(false)));
-        Assert.assertFalse(BooleanArrayList.newListWith(true).asReversed().anySatisfy(BooleanPredicates.equal(false)));
+        assertTrue(BooleanArrayList.newListWith(true, false).asReversed().anySatisfy(BooleanPredicates.equal(false)));
+        assertFalse(BooleanArrayList.newListWith(true).asReversed().anySatisfy(BooleanPredicates.equal(false)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(BooleanArrayList.newListWith(true, false).asReversed().allSatisfy(BooleanPredicates.equal(false)));
-        Assert.assertTrue(BooleanArrayList.newListWith(false, false).asReversed().allSatisfy(BooleanPredicates.equal(false)));
+        assertFalse(BooleanArrayList.newListWith(true, false).asReversed().allSatisfy(BooleanPredicates.equal(false)));
+        assertTrue(BooleanArrayList.newListWith(false, false).asReversed().allSatisfy(BooleanPredicates.equal(false)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(BooleanArrayList.newListWith(true, false).asReversed().noneSatisfy(BooleanPredicates.equal(false)));
-        Assert.assertTrue(BooleanArrayList.newListWith(false, false).asReversed().noneSatisfy(BooleanPredicates.equal(true)));
+        assertFalse(BooleanArrayList.newListWith(true, false).asReversed().noneSatisfy(BooleanPredicates.equal(false)));
+        assertTrue(BooleanArrayList.newListWith(false, false).asReversed().noneSatisfy(BooleanPredicates.equal(true)));
     }
 
     @Test
@@ -153,8 +156,8 @@ public class ReverseBooleanIterableTest
     public void detectIfNone()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false).asReversed();
-        Assert.assertFalse(iterable.detectIfNone(BooleanPredicates.equal(false), true));
-        Assert.assertTrue(iterable.detectIfNone(BooleanPredicates.equal(true), true));
+        assertFalse(iterable.detectIfNone(BooleanPredicates.equal(false), true));
+        assertTrue(iterable.detectIfNone(BooleanPredicates.equal(true), true));
     }
 
     @Test
@@ -168,28 +171,28 @@ public class ReverseBooleanIterableTest
     public void toArray()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
-        Assert.assertTrue(iterable.toArray()[0]);
-        Assert.assertFalse(iterable.toArray()[1]);
-        Assert.assertFalse(iterable.toArray()[2]);
+        assertTrue(iterable.toArray()[0]);
+        assertFalse(iterable.toArray()[1]);
+        assertFalse(iterable.toArray()[2]);
     }
 
     @Test
     public void testToString()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
-        Assert.assertEquals("[true, false, false]", iterable.toString());
-        Assert.assertEquals("[]", new BooleanArrayList().asReversed().toString());
+        assertEquals("[true, false, false]", iterable.toString());
+        assertEquals("[]", new BooleanArrayList().asReversed().toString());
     }
 
     @Test
     public void makeString()
     {
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
-        Assert.assertEquals("true, false, false", iterable.makeString());
-        Assert.assertEquals("true", BooleanArrayList.newListWith(true).makeString("/"));
-        Assert.assertEquals("true/false/false", iterable.makeString("/"));
-        Assert.assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
-        Assert.assertEquals("", new BooleanArrayList().asReversed().makeString());
+        assertEquals("true, false, false", iterable.makeString());
+        assertEquals("true", BooleanArrayList.newListWith(true).makeString("/"));
+        assertEquals("true/false/false", iterable.makeString("/"));
+        assertEquals(iterable.toString(), iterable.makeString("[", ", ", "]"));
+        assertEquals("", new BooleanArrayList().asReversed().makeString());
     }
 
     @Test
@@ -198,39 +201,39 @@ public class ReverseBooleanIterableTest
         BooleanIterable iterable = BooleanArrayList.newListWith(false, false, true).asReversed();
         StringBuilder appendable = new StringBuilder();
         new BooleanArrayList().asReversed().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         iterable.appendString(appendable2);
-        Assert.assertEquals("true, false, false", appendable2.toString());
+        assertEquals("true, false, false", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertEquals("true/false/false", appendable3.toString());
+        assertEquals("true/false/false", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         iterable.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(iterable.toString(), appendable4.toString());
+        assertEquals(iterable.toString(), appendable4.toString());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), BooleanArrayList.newListWith(true, false).asReversed().toList());
+        assertEquals(BooleanArrayList.newListWith(false, true), BooleanArrayList.newListWith(true, false).asReversed().toList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), BooleanArrayList.newListWith(true, false).asReversed().toSet());
+        assertEquals(BooleanHashSet.newSetWith(true, false), BooleanArrayList.newListWith(true, false).asReversed().toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false), BooleanArrayList.newListWith(true, false).asReversed().toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false), BooleanArrayList.newListWith(true, false).asReversed().toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), BooleanArrayList.newListWith(true, false).asReversed().asLazy().toList());
+        assertEquals(BooleanArrayList.newListWith(false, true), BooleanArrayList.newListWith(true, false).asReversed().asLazy().toList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/SelectBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/SelectBooleanIterableTest.java
@@ -14,8 +14,11 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SelectBooleanIterableTest
 {
@@ -29,7 +32,7 @@ public class SelectBooleanIterableTest
         {
             concat.append(iterator.next());
         }
-        Assert.assertEquals("truetrue", concat.toString());
+        assertEquals("truetrue", concat.toString());
     }
 
     @Test
@@ -38,97 +41,97 @@ public class SelectBooleanIterableTest
         String[] concat = new String[1];
         concat[0] = "";
         this.iterable.forEach(each -> concat[0] += each);
-        Assert.assertEquals("truetrue", concat[0]);
+        assertEquals("truetrue", concat[0]);
     }
 
     @Test
     public void injectInto()
     {
         MutableInteger result = this.iterable.injectInto(new MutableInteger(0), (object, value) -> object.add(value ? 1 : 0));
-        Assert.assertEquals(new MutableInteger(2), result);
+        assertEquals(new MutableInteger(2), result);
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(2L, this.iterable.size());
+        assertEquals(2L, this.iterable.size());
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.iterable.notEmpty());
-        Assert.assertFalse(this.iterable.isEmpty());
+        assertTrue(this.iterable.notEmpty());
+        assertFalse(this.iterable.isEmpty());
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, this.iterable.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.iterable.count(BooleanPredicates.isFalse()));
+        assertEquals(2L, this.iterable.count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.iterable.count(BooleanPredicates.isFalse()));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.iterable.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.iterable.anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.iterable.anySatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.iterable.anySatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.iterable.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.iterable.allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.iterable.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.iterable.allSatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(0L, this.iterable.select(BooleanPredicates.isFalse()).size());
-        Assert.assertEquals(2L, this.iterable.select(BooleanPredicates.equal(true)).size());
+        assertEquals(0L, this.iterable.select(BooleanPredicates.isFalse()).size());
+        assertEquals(2L, this.iterable.select(BooleanPredicates.equal(true)).size());
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(2L, this.iterable.reject(BooleanPredicates.isFalse()).size());
-        Assert.assertEquals(0L, this.iterable.reject(BooleanPredicates.equal(true)).size());
+        assertEquals(2L, this.iterable.reject(BooleanPredicates.isFalse()).size());
+        assertEquals(0L, this.iterable.reject(BooleanPredicates.equal(true)).size());
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertTrue(this.iterable.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(this.iterable.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(this.iterable.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(this.iterable.detectIfNone(BooleanPredicates.isFalse(), false));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(2L, this.iterable.collect(String::valueOf).size());
+        assertEquals(2L, this.iterable.collect(String::valueOf).size());
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertEquals(2L, this.iterable.toArray().length);
-        Assert.assertTrue(this.iterable.toArray()[0]);
-        Assert.assertTrue(this.iterable.toArray()[1]);
+        assertEquals(2L, this.iterable.toArray().length);
+        assertTrue(this.iterable.toArray()[0]);
+        assertTrue(this.iterable.toArray()[1]);
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.iterable.contains(true));
-        Assert.assertFalse(this.iterable.contains(false));
+        assertTrue(this.iterable.contains(true));
+        assertFalse(this.iterable.contains(false));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.iterable.containsAll(true, true));
-        Assert.assertFalse(this.iterable.containsAll(false, true));
-        Assert.assertFalse(this.iterable.containsAll(false, false));
+        assertTrue(this.iterable.containsAll(true, true));
+        assertFalse(this.iterable.containsAll(false, true));
+        assertFalse(this.iterable.containsAll(false, false));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/TapBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/TapBooleanIterableTest.java
@@ -16,8 +16,11 @@ import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.math.MutableInteger;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TapBooleanIterableTest
 {
@@ -33,7 +36,7 @@ public class TapBooleanIterableTest
         {
             iterator.next();
         }
-        Assert.assertEquals("truefalsefalsetrue", concat.toString());
+        assertEquals("truefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -43,7 +46,7 @@ public class TapBooleanIterableTest
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
         iterable.forEach(each -> { });
-        Assert.assertEquals("truefalsefalsetrue", concat.toString());
+        assertEquals("truefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -53,8 +56,8 @@ public class TapBooleanIterableTest
         TapBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
         MutableInteger result = iterable.injectInto(new MutableInteger(0), (object, value) -> object.add(value ? 1 : 0));
-        Assert.assertEquals(new MutableInteger(2), result);
-        Assert.assertEquals("truefalsefalsetrue", concat.toString());
+        assertEquals(new MutableInteger(2), result);
+        assertEquals("truefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -63,8 +66,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(4L, iterable.size());
-        Assert.assertEquals("truefalsefalsetrue", concat.toString());
+        assertEquals(4L, iterable.size());
+        assertEquals("truefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -73,8 +76,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertTrue(iterable.notEmpty());
-        Assert.assertFalse(iterable.isEmpty());
+        assertTrue(iterable.notEmpty());
+        assertFalse(iterable.isEmpty());
     }
 
     @Test
@@ -83,9 +86,9 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(2L, iterable.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(2L, iterable.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
+        assertEquals(2L, iterable.count(BooleanPredicates.isTrue()));
+        assertEquals(2L, iterable.count(BooleanPredicates.isFalse()));
+        assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -94,8 +97,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         TapBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertTrue(iterable.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(iterable.anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(iterable.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(iterable.anySatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -104,8 +107,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         TapBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertFalse(iterable.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(iterable.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(iterable.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(iterable.allSatisfy(BooleanPredicates.isFalse()));
     }
 
     @Test
@@ -114,9 +117,9 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(2L, iterable.select(BooleanPredicates.isFalse()).size());
-        Assert.assertEquals(2L, iterable.select(BooleanPredicates.equal(true)).size());
-        Assert.assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
+        assertEquals(2L, iterable.select(BooleanPredicates.isFalse()).size());
+        assertEquals(2L, iterable.select(BooleanPredicates.equal(true)).size());
+        assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -125,9 +128,9 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(2L, iterable.reject(BooleanPredicates.isFalse()).size());
-        Assert.assertEquals(2L, iterable.reject(BooleanPredicates.equal(true)).size());
-        Assert.assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
+        assertEquals(2L, iterable.reject(BooleanPredicates.isFalse()).size());
+        assertEquals(2L, iterable.reject(BooleanPredicates.equal(true)).size());
+        assertEquals("truefalsefalsetruetruefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -136,8 +139,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         TapBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertTrue(iterable.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(iterable.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(iterable.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(iterable.detectIfNone(BooleanPredicates.isFalse(), false));
     }
 
     @Test
@@ -146,8 +149,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(4L, iterable.collect(String::valueOf).size());
-        Assert.assertEquals("truefalsefalsetrue", concat.toString());
+        assertEquals(4L, iterable.collect(String::valueOf).size());
+        assertEquals("truefalsefalsetrue", concat.toString());
     }
 
     @Test
@@ -156,9 +159,9 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertEquals(4L, iterable.toArray().length);
-        Assert.assertTrue(iterable.toArray()[0]);
-        Assert.assertFalse(iterable.toArray()[1]);
+        assertEquals(4L, iterable.toArray().length);
+        assertTrue(iterable.toArray()[0]);
+        assertFalse(iterable.toArray()[1]);
     }
 
     @Test
@@ -167,8 +170,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertTrue(iterable.contains(true));
-        Assert.assertTrue(iterable.contains(false));
+        assertTrue(iterable.contains(true));
+        assertTrue(iterable.contains(false));
     }
 
     @Test
@@ -177,8 +180,8 @@ public class TapBooleanIterableTest
         StringBuilder concat = new StringBuilder();
         LazyBooleanIterable iterable = new TapBooleanIterable(this.list, concat::append);
 
-        Assert.assertTrue(iterable.containsAll(true, true));
-        Assert.assertTrue(iterable.containsAll(false, true));
-        Assert.assertTrue(iterable.containsAll(false, false));
+        assertTrue(iterable.containsAll(true, true));
+        assertTrue(iterable.containsAll(false, true));
+        assertTrue(iterable.containsAll(false, false));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -40,8 +40,14 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IntervalTest
 {
@@ -52,7 +58,7 @@ public class IntervalTest
                 .select(Predicates.lessThan(5))
                 .into(FastList.newList())
                 .injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(10, sum);
+        assertEquals(10, sum);
     }
 
     @Test
@@ -75,7 +81,7 @@ public class IntervalTest
         Verify.assertEqualsAndHashCode(Interval.fromTo(-1, -10), Interval.fromToExclusive(-1, -11));
 
         // MIN Value should throw an error
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromToExclusive(Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromToExclusive(Integer.MIN_VALUE, Integer.MIN_VALUE));
 
         Verify.assertSize(Integer.MAX_VALUE, Interval.fromToExclusive(Integer.MIN_VALUE, -1));
         Verify.assertSize(Integer.MAX_VALUE, Interval.fromToExclusive(0, Integer.MAX_VALUE));
@@ -108,17 +114,17 @@ public class IntervalTest
         Verify.assertSize(Integer.MAX_VALUE, Interval.fromTo(1, Integer.MAX_VALUE));
         Verify.assertSize(21, Interval.from(10).to(-10).by(-1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(-1, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(-1, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
         Verify.assertSize(Interval.fromTo(Integer.MIN_VALUE + 1, -1).size(), Interval.oneTo(Integer.MAX_VALUE));
 
-        Assert.assertEquals(Lists.mutable.with(0), Interval.fromToBy(0, 2, 3));
-        Assert.assertEquals(Lists.mutable.with(0), Interval.fromToBy(0, -2, -3));
-        Assert.assertEquals(Lists.mutable.with(1_000_000_000), Interval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
-        Assert.assertEquals(Lists.mutable.with(-1_000_000_000), Interval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
-        Assert.assertEquals(Lists.mutable.with(Integer.MIN_VALUE), Interval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
-        Assert.assertEquals(Lists.mutable.with(Integer.MAX_VALUE), Interval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
+        assertEquals(Lists.mutable.with(0), Interval.fromToBy(0, 2, 3));
+        assertEquals(Lists.mutable.with(0), Interval.fromToBy(0, -2, -3));
+        assertEquals(Lists.mutable.with(1_000_000_000), Interval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
+        assertEquals(Lists.mutable.with(-1_000_000_000), Interval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
+        assertEquals(Lists.mutable.with(Integer.MIN_VALUE), Interval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
+        assertEquals(Lists.mutable.with(Integer.MAX_VALUE), Interval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -130,8 +136,8 @@ public class IntervalTest
     @Test
     public void fromAndToAndBy_throws_step_is_incorrect()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.from(10).to(-10).by(1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.from(-10).to(10).by(-1));
+        assertThrows(IllegalArgumentException.class, () -> Interval.from(10).to(-10).by(1));
+        assertThrows(IllegalArgumentException.class, () -> Interval.from(-10).to(10).by(-1));
     }
 
     @Test
@@ -163,25 +169,25 @@ public class IntervalTest
         Interval interval3 = Interval.zeroTo(5);
         Verify.assertPostSerializedEqualsAndHashCode(interval1);
         Verify.assertEqualsAndHashCode(interval1, interval2);
-        Assert.assertNotEquals(interval1, interval3);
-        Assert.assertNotEquals(interval3, interval1);
+        assertNotEquals(interval1, interval3);
+        assertNotEquals(interval3, interval1);
 
         Verify.assertEqualsAndHashCode(Interval.fromToBy(1, 5, 2), Interval.fromToBy(1, 6, 2));
         Verify.assertEqualsAndHashCode(FastList.newListWith(1, 2, 3), Interval.fromTo(1, 3));
         Verify.assertEqualsAndHashCode(FastList.newListWith(3, 2, 1), Interval.fromTo(3, 1));
 
-        Assert.assertNotEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 3));
-        Assert.assertNotEquals(FastList.newListWith(1, 2, 4), Interval.fromTo(1, 3));
-        Assert.assertNotEquals(FastList.newListWith(3, 2, 0), Interval.fromTo(3, 1));
+        assertNotEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 3));
+        assertNotEquals(FastList.newListWith(1, 2, 4), Interval.fromTo(1, 3));
+        assertNotEquals(FastList.newListWith(3, 2, 0), Interval.fromTo(3, 1));
 
         Verify.assertEqualsAndHashCode(FastList.newListWith(-1, -2, -3), Interval.fromTo(-1, -3));
 
         Verify.assertEqualsAndHashCode(FastList.newListWith(1, 2), Interval.fromToExclusive(1, 3));
         Verify.assertEqualsAndHashCode(FastList.newListWith(3, 2, 1), Interval.fromToExclusive(3, 0));
 
-        Assert.assertNotEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromToExclusive(1, 4));
-        Assert.assertNotEquals(FastList.newListWith(1, 2, 4), Interval.fromToExclusive(1, 2));
-        Assert.assertNotEquals(FastList.newListWith(3, 2, 0), Interval.fromToExclusive(3, 1));
+        assertNotEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromToExclusive(1, 4));
+        assertNotEquals(FastList.newListWith(1, 2, 4), Interval.fromToExclusive(1, 2));
+        assertNotEquals(FastList.newListWith(3, 2, 0), Interval.fromToExclusive(3, 1));
     }
 
     @Test
@@ -190,7 +196,7 @@ public class IntervalTest
         MutableList<Integer> result = Lists.mutable.of();
         Interval interval = Interval.oneTo(5);
         interval.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
     }
 
     @Test
@@ -199,7 +205,7 @@ public class IntervalTest
         MutableList<Integer> result = Lists.mutable.of();
         Interval interval = Interval.oneTo(5);
         interval.forEach(CollectionAddProcedure.on(result), Executors.newSingleThreadExecutor());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
     }
 
     @Test
@@ -208,7 +214,7 @@ public class IntervalTest
         MutableList<Integer> result = Lists.mutable.of();
         Interval interval = Interval.fromToBy(5, 1, -1);
         interval.forEach(CollectionAddProcedure.on(result), Executors.newSingleThreadExecutor());
-        Assert.assertEquals(FastList.newListWith(5, 4, 3, 2, 1), result);
+        assertEquals(FastList.newListWith(5, 4, 3, 2, 1), result);
     }
 
     @Test
@@ -219,7 +225,7 @@ public class IntervalTest
         Interval.oneTo(3).run(() -> result.add(null), service);
         service.shutdown();
         service.awaitTermination(20, TimeUnit.SECONDS);
-        Assert.assertEquals(FastList.<String>newListWith(null, null, null), result);
+        assertEquals(FastList.<String>newListWith(null, null, null), result);
     }
 
     @Test
@@ -230,7 +236,7 @@ public class IntervalTest
         Interval.fromTo(3, 1).run(() -> result.add(null), service);
         service.shutdown();
         service.awaitTermination(20, TimeUnit.SECONDS);
-        Assert.assertEquals(FastList.<String>newListWith(null, null, null), result);
+        assertEquals(FastList.<String>newListWith(null, null, null), result);
     }
 
     @Test
@@ -242,16 +248,16 @@ public class IntervalTest
         Verify.assertSize(5, result);
         Verify.assertContains(1, result);
         Verify.assertContains(5, result);
-        Assert.assertEquals(Integer.valueOf(5), Iterate.getFirst(result));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.getLast(result));
+        assertEquals(Integer.valueOf(5), Iterate.getFirst(result));
+        assertEquals(Integer.valueOf(1), Iterate.getLast(result));
 
         result.clear();
         interval.reverseThis().reverseForEach(result::add);
         Verify.assertSize(5, result);
         Verify.assertContains(1, result);
         Verify.assertContains(5, result);
-        Assert.assertEquals(Integer.valueOf(1), Iterate.getFirst(result));
-        Assert.assertEquals(Integer.valueOf(5), Iterate.getLast(result));
+        assertEquals(Integer.valueOf(1), Iterate.getFirst(result));
+        assertEquals(Integer.valueOf(5), Iterate.getLast(result));
     }
 
     @Test
@@ -282,8 +288,8 @@ public class IntervalTest
     public void injectIntoOnFromToByInterval()
     {
         Interval interval = Interval.oneTo(5);
-        Assert.assertEquals(Integer.valueOf(20), interval.injectInto(5, AddFunction.INTEGER));
-        Assert.assertEquals(Integer.valueOf(20), interval.reverseThis().injectInto(5, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(20), interval.injectInto(5, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(20), interval.reverseThis().injectInto(5, AddFunction.INTEGER));
     }
 
     @Test
@@ -291,30 +297,30 @@ public class IntervalTest
     {
         Interval interval = Interval.fromToBy(2, 2, -2);
 
-        Assert.assertEquals(Integer.valueOf(0), interval.injectInto(-2, AddFunction.INTEGER));
-        Assert.assertEquals(Integer.valueOf(0), interval.reverseThis().injectInto(-2, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(0), interval.injectInto(-2, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(0), interval.reverseThis().injectInto(-2, AddFunction.INTEGER));
     }
 
     @Test
     public void sumInterval()
     {
         int sum = Interval.oneTo(5).injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(15, sum);
+        assertEquals(15, sum);
     }
 
     @Test
     public void maxInterval()
     {
         Integer value = Interval.oneTo(5).injectInto(0, Integer::max);
-        Assert.assertEquals(5, value.intValue());
+        assertEquals(5, value.intValue());
     }
 
     @Test
     public void reverseInjectIntoOnFromToByInterval()
     {
         Interval interval = Interval.oneTo(5);
-        Assert.assertEquals(Integer.valueOf(20), interval.reverseInjectInto(5, AddFunction.INTEGER));
-        Assert.assertEquals(Integer.valueOf(20), interval.reverseThis().reverseInjectInto(5, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(20), interval.reverseInjectInto(5, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(20), interval.reverseThis().reverseInjectInto(5, AddFunction.INTEGER));
     }
 
     @Test
@@ -340,16 +346,16 @@ public class IntervalTest
     public void selectOnFromToInterval()
     {
         Interval interval = Interval.oneTo(5);
-        Assert.assertEquals(FastList.newListWith(2, 4), interval.select(IntegerPredicates.isEven()).toList());
-        Assert.assertEquals(FastList.newListWith(4, 2), interval.reverseThis().select(IntegerPredicates.isEven()).toList());
+        assertEquals(FastList.newListWith(2, 4), interval.select(IntegerPredicates.isEven()).toList());
+        assertEquals(FastList.newListWith(4, 2), interval.reverseThis().select(IntegerPredicates.isEven()).toList());
     }
 
     @Test
     public void rejectOnFromToInterval()
     {
         Interval interval = Interval.oneTo(5);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), interval.reject(IntegerPredicates.isEven()).toList());
-        Assert.assertEquals(FastList.newListWith(5, 3, 1), interval.reverseThis().reject(IntegerPredicates.isEven()).toList());
+        assertEquals(FastList.newListWith(1, 3, 5), interval.reject(IntegerPredicates.isEven()).toList());
+        assertEquals(FastList.newListWith(5, 3, 1), interval.reverseThis().reject(IntegerPredicates.isEven()).toList());
     }
 
     @Test
@@ -359,23 +365,23 @@ public class IntervalTest
         Interval interval2 = interval.reverseThis();
         List<Integer> result = new ArrayList<>();
         interval2.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), result);
     }
 
     @Test
     public void intervalAsArray()
     {
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4, 5}, Interval.toArray(1, 5));
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 5}, Interval.toArray(1, 5));
     }
 
     @Test
     public void intervalAsIntArray()
     {
-        Assert.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, Interval.fromTo(1, 5).toIntArray());
-        Assert.assertArrayEquals(new int[]{1, 2, 3, 4}, Interval.fromToExclusive(1, 5).toIntArray());
-        Assert.assertArrayEquals(new int[]{5, 4, 3, 2}, Interval.fromToExclusive(5, 1).toIntArray());
-        Assert.assertArrayEquals(new int[]{-1, -2, -3, -4}, Interval.fromToExclusive(-1, -5).toIntArray());
-        Assert.assertArrayEquals(new int[]{-5, -4, -3, -2}, Interval.fromToExclusive(-5, -1).toIntArray());
+        assertArrayEquals(new int[]{1, 2, 3, 4, 5}, Interval.fromTo(1, 5).toIntArray());
+        assertArrayEquals(new int[]{1, 2, 3, 4}, Interval.fromToExclusive(1, 5).toIntArray());
+        assertArrayEquals(new int[]{5, 4, 3, 2}, Interval.fromToExclusive(5, 1).toIntArray());
+        assertArrayEquals(new int[]{-1, -2, -3, -4}, Interval.fromToExclusive(-1, -5).toIntArray());
+        assertArrayEquals(new int[]{-5, -4, -3, -2}, Interval.fromToExclusive(-5, -1).toIntArray());
     }
 
     @Test
@@ -383,10 +389,10 @@ public class IntervalTest
     {
         Integer[] array = Interval.toReverseArray(1, 5);
         Verify.assertSize(5, array);
-        Assert.assertTrue(ArrayIterate.contains(array, 1));
-        Assert.assertTrue(ArrayIterate.contains(array, 5));
-        Assert.assertEquals(ArrayIterate.getFirst(array), Integer.valueOf(5));
-        Assert.assertEquals(ArrayIterate.getLast(array), Integer.valueOf(1));
+        assertTrue(ArrayIterate.contains(array, 1));
+        assertTrue(ArrayIterate.contains(array, 5));
+        assertEquals(ArrayIterate.getFirst(array), Integer.valueOf(5));
+        assertEquals(ArrayIterate.getLast(array), Integer.valueOf(1));
     }
 
     @Test
@@ -416,9 +422,9 @@ public class IntervalTest
     @Test
     public void invalidIntervals()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(5, 1, 2));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(5, 1, 0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(-5, 1, -1));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(5, 1, 2));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(5, 1, 0));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromToBy(-5, 1, -1));
     }
 
     @Test
@@ -443,7 +449,7 @@ public class IntervalTest
     public void testToString()
     {
         Interval interval = Interval.evensFromTo(0, 10);
-        Assert.assertEquals("Interval from: 0 to: 10 step: 2 size: 6", interval.toString());
+        assertEquals("Interval from: 0 to: 10 step: 2 size: 6", interval.toString());
     }
 
     @Test
@@ -494,23 +500,23 @@ public class IntervalTest
     public void odds()
     {
         Interval interval1 = Interval.oddsFromTo(0, 10);
-        Assert.assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(interval1.containsNone(2, 4, 6, 8));
+        assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(interval1.containsNone(2, 4, 6, 8));
         Verify.assertSize(5, interval1);
 
         Interval reverseInterval1 = Interval.oddsFromTo(10, 0);
-        Assert.assertTrue(reverseInterval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(reverseInterval1.containsNone(0, 2, 4, 6, 8, 10));
+        assertTrue(reverseInterval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(reverseInterval1.containsNone(0, 2, 4, 6, 8, 10));
         Verify.assertSize(5, reverseInterval1);
 
         Interval interval2 = Interval.oddsFromTo(-5, 5);
-        Assert.assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
+        assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
         Verify.assertSize(6, interval2);
 
         Interval reverseInterval2 = Interval.oddsFromTo(5, -5);
-        Assert.assertTrue(reverseInterval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(reverseInterval2.containsNone(-4, -2, 0, 2, 4));
+        assertTrue(reverseInterval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(reverseInterval2.containsNone(-4, -2, 0, 2, 4));
         Verify.assertSize(6, reverseInterval2);
     }
 
@@ -578,13 +584,13 @@ public class IntervalTest
     public void contains()
     {
         Verify.assertContains(0, Interval.zero());
-        Assert.assertTrue(Interval.oneTo(5).containsAll(1, 5));
-        Assert.assertTrue(Interval.oneTo(5).containsNone(6, 7));
-        Assert.assertFalse(Interval.oneTo(5).containsAll(1, 6));
-        Assert.assertFalse(Interval.oneTo(5).containsNone(1, 6));
+        assertTrue(Interval.oneTo(5).containsAll(1, 5));
+        assertTrue(Interval.oneTo(5).containsNone(6, 7));
+        assertFalse(Interval.oneTo(5).containsAll(1, 6));
+        assertFalse(Interval.oneTo(5).containsNone(1, 6));
         Verify.assertNotContains(0, Interval.oneTo(5));
-        Assert.assertTrue(Interval.fromTo(-1, -5).containsAll(-1, -5));
-        Assert.assertTrue(Interval.fromToExclusive(-1, -5).containsAll(-1, -4));
+        assertTrue(Interval.fromTo(-1, -5).containsAll(-1, -5));
+        assertTrue(Interval.fromToExclusive(-1, -5).containsAll(-1, -4));
         Verify.assertNotContains(-5, Interval.fromToExclusive(-1, -5));
         Verify.assertNotContains(0, Interval.fromToExclusive(-1, -5));
         Verify.assertNotContains(1, Interval.fromTo(-1, -5));
@@ -597,16 +603,16 @@ public class IntervalTest
         Verify.assertNotContains(new Object(), Interval.zeroTo(5));
 
         Interval bigInterval = Interval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 1_000_000);
-        Assert.assertTrue(bigInterval.contains(Integer.MIN_VALUE + 1_000_000));
-        Assert.assertFalse(bigInterval.contains(Integer.MIN_VALUE + 1_000_001));
-        Assert.assertTrue(bigInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
-        Assert.assertFalse(bigInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
-        Assert.assertTrue(bigInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
-        Assert.assertFalse(bigInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
-        Assert.assertTrue(
+        assertTrue(bigInterval.contains(Integer.MIN_VALUE + 1_000_000));
+        assertFalse(bigInterval.contains(Integer.MIN_VALUE + 1_000_001));
+        assertTrue(bigInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
+        assertFalse(bigInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
+        assertTrue(bigInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
+        assertFalse(bigInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
+        assertTrue(
                 Interval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000)
                         .contains(1_000_000_000));
-        Assert.assertTrue(
+        assertTrue(
                 Interval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000)
                         .contains(-1_000_000_000));
 
@@ -614,39 +620,39 @@ public class IntervalTest
         int maxValue = 1_000_000_000;
         Interval largeInterval = Interval.fromToBy(minValue, maxValue, 10);
 
-        Assert.assertTrue(largeInterval.containsAll(
+        assertTrue(largeInterval.containsAll(
                 maxValue - 10,
                 maxValue - 100,
                 maxValue - 1000,
                 maxValue - 10000));
-        Assert.assertTrue(largeInterval.contains(minValue + 10));
+        assertTrue(largeInterval.contains(minValue + 10));
     }
 
     @Test
     public void largeReverseUnderflowTest()
     {
         Interval reverse = Interval.fromToBy(Integer.MAX_VALUE, Integer.MIN_VALUE + 10, -10);
-        Assert.assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
-        Assert.assertEquals(Integer.valueOf(Integer.MAX_VALUE), reverse.getFirst());
+        assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
+        assertEquals(Integer.valueOf(Integer.MAX_VALUE), reverse.getFirst());
         Integer expectedLast = Integer.valueOf(-2_147_483_633);
-        Assert.assertEquals(expectedLast, reverse.getLast());
-        Assert.assertTrue(reverse.contains(Integer.MAX_VALUE));
-        Assert.assertTrue(reverse.contains(7));
-        Assert.assertTrue(reverse.contains(-3));
-        Assert.assertTrue(reverse.contains(expectedLast));
-        Assert.assertTrue(reverse.contains(expectedLast + 1000));
-        Assert.assertEquals(214_748_364, reverse.indexOf(Integer.valueOf(7)));
-        Assert.assertEquals(214_748_365, reverse.indexOf(Integer.valueOf(-3)));
-        Assert.assertEquals(429_496_728, reverse.indexOf(expectedLast));
-        Assert.assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
+        assertEquals(expectedLast, reverse.getLast());
+        assertTrue(reverse.contains(Integer.MAX_VALUE));
+        assertTrue(reverse.contains(7));
+        assertTrue(reverse.contains(-3));
+        assertTrue(reverse.contains(expectedLast));
+        assertTrue(reverse.contains(expectedLast + 1000));
+        assertEquals(214_748_364, reverse.indexOf(Integer.valueOf(7)));
+        assertEquals(214_748_365, reverse.indexOf(Integer.valueOf(-3)));
+        assertEquals(429_496_728, reverse.indexOf(expectedLast));
+        assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
         Integer expectedAtIndex300Million = Integer.valueOf(-852_516_353);
-        Assert.assertTrue(reverse.contains(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
+        assertTrue(reverse.contains(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
         Integer expectedAtIndex400Million = Integer.valueOf(-1_852_516_353);
-        Assert.assertTrue(reverse.contains(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
+        assertTrue(reverse.contains(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
     }
 
     @Test
@@ -657,27 +663,27 @@ public class IntervalTest
         long expected = from.longValue() + second.longValue();
         Interval interval = Interval.fromToBy(from, Integer.MAX_VALUE, 8);
         Verify.assertSize(2, interval);
-        Assert.assertEquals(Lists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.countWith(Objects::equals, second));
-        Assert.assertEquals(expected, interval.sumOfLong(Integer::longValue));
+        assertEquals(Lists.mutable.with(from, second), interval);
+        assertEquals(1, interval.countWith(Objects::equals, second));
+        assertEquals(expected, interval.sumOfLong(Integer::longValue));
         MutableLong result = new MutableLong();
         interval.each(each -> result.add(each.longValue()));
-        Assert.assertEquals(expected, result.longValue());
+        assertEquals(expected, result.longValue());
         result.clear();
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(
                 2,
                 interval.injectInto(0, (int value, Integer each) -> value + 1));
-        Assert.assertEquals(
+        assertEquals(
                 2L,
                 interval.injectInto(0L, (long value, Integer each) -> value + 1));
-        Assert.assertEquals(
+        assertEquals(
                 2.0,
                 interval.injectInto(0.0, (double value, Integer each) -> value + 1.0),
                 0.0);
-        Assert.assertEquals(
+        assertEquals(
                 2.0f,
                 interval.injectInto(0.0f, (float value, Integer each) -> value + 1.0f),
                 0.0f);
@@ -690,24 +696,24 @@ public class IntervalTest
         Integer second = Integer.valueOf(Integer.MIN_VALUE + 2);
         long expected = (long) from + (long) second;
         Interval interval = Interval.fromToBy(from, Integer.MIN_VALUE, -8);
-        Assert.assertEquals(2, interval.size());
-        Assert.assertEquals(Lists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.countWith(Objects::equals, second));
+        assertEquals(2, interval.size());
+        assertEquals(Lists.mutable.with(from, second), interval);
+        assertEquals(1, interval.countWith(Objects::equals, second));
         MutableLong result = new MutableLong();
         interval.each(each -> result.add(each.longValue()));
-        Assert.assertEquals(expected, result.longValue());
-        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(expected, result.longValue());
+        assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        assertEquals(
                 2,
                 interval.injectInto(0, (int value, Integer each) -> value + 1));
-        Assert.assertEquals(
+        assertEquals(
                 2L,
                 interval.injectInto(0L, (long value, Integer each) -> value + 1));
-        Assert.assertEquals(
+        assertEquals(
                 2.0,
                 interval.injectInto(0.0, (double value, Integer each) -> value + 1.0),
                 0.0);
-        Assert.assertEquals(
+        assertEquals(
                 2.0f,
                 interval.injectInto(0.0f, (float value, Integer each) -> value + 1.0f),
                 0.0f);
@@ -716,30 +722,30 @@ public class IntervalTest
     @Test
     public void factorial()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> Interval.fromTo(-1, -5).factorial());
-        Assert.assertEquals(1, Interval.zero().factorial().intValue());
-        Assert.assertEquals(1, Interval.oneTo(1).factorial().intValue());
-        Assert.assertEquals(6, Interval.oneTo(3).factorial().intValue());
-        Assert.assertEquals(2432902008176640000L, Interval.oneTo(20).factorial().longValue());
-        Assert.assertEquals(new BigInteger("51090942171709440000"), Interval.oneTo(21).factorial());
-        Assert.assertEquals(new BigInteger("1405006117752879898543142606244511569936384000000000"), Interval.oneTo(42).factorial());
+        assertThrows(IllegalStateException.class, () -> Interval.fromTo(-1, -5).factorial());
+        assertEquals(1, Interval.zero().factorial().intValue());
+        assertEquals(1, Interval.oneTo(1).factorial().intValue());
+        assertEquals(6, Interval.oneTo(3).factorial().intValue());
+        assertEquals(2432902008176640000L, Interval.oneTo(20).factorial().longValue());
+        assertEquals(new BigInteger("51090942171709440000"), Interval.oneTo(21).factorial());
+        assertEquals(new BigInteger("1405006117752879898543142606244511569936384000000000"), Interval.oneTo(42).factorial());
     }
 
     @Test
     public void product()
     {
-        Assert.assertEquals(0, Interval.zero().product().intValue());
-        Assert.assertEquals(0, Interval.fromTo(-1, 1).product().intValue());
-        Assert.assertEquals(2, Interval.fromTo(-2, -1).product().intValue());
-        Assert.assertEquals(-6, Interval.fromTo(-3, -1).product().intValue());
-        Assert.assertEquals(0, Interval.fromToExclusive(-1, 1).product().intValue());
-        Assert.assertEquals(-2, Interval.fromToExclusive(-2, -1).product().intValue());
-        Assert.assertEquals(6, Interval.fromToExclusive(-3, -1).product().intValue());
-        Assert.assertEquals(200, Interval.fromToBy(10, 20, 10).product().intValue());
-        Assert.assertEquals(200, Interval.fromToBy(-10, -20, -10).product().intValue());
-        Assert.assertEquals(-6000, Interval.fromToBy(-10, -30, -10).product().intValue());
-        Assert.assertEquals(6000, Interval.fromToBy(30, 10, -10).product().intValue());
-        Assert.assertEquals(6000, Interval.fromToBy(30, 10, -10).reverseThis().product().intValue());
+        assertEquals(0, Interval.zero().product().intValue());
+        assertEquals(0, Interval.fromTo(-1, 1).product().intValue());
+        assertEquals(2, Interval.fromTo(-2, -1).product().intValue());
+        assertEquals(-6, Interval.fromTo(-3, -1).product().intValue());
+        assertEquals(0, Interval.fromToExclusive(-1, 1).product().intValue());
+        assertEquals(-2, Interval.fromToExclusive(-2, -1).product().intValue());
+        assertEquals(6, Interval.fromToExclusive(-3, -1).product().intValue());
+        assertEquals(200, Interval.fromToBy(10, 20, 10).product().intValue());
+        assertEquals(200, Interval.fromToBy(-10, -20, -10).product().intValue());
+        assertEquals(-6000, Interval.fromToBy(-10, -30, -10).product().intValue());
+        assertEquals(6000, Interval.fromToBy(30, 10, -10).product().intValue());
+        assertEquals(6000, Interval.fromToBy(30, 10, -10).reverseThis().product().intValue());
     }
 
     @Test
@@ -747,26 +753,26 @@ public class IntervalTest
     {
         Interval zero = Interval.zero();
         Iterator<Integer> zeroIterator = zero.iterator();
-        Assert.assertTrue(zeroIterator.hasNext());
-        Assert.assertEquals(Integer.valueOf(0), zeroIterator.next());
-        Assert.assertFalse(zeroIterator.hasNext());
+        assertTrue(zeroIterator.hasNext());
+        assertEquals(Integer.valueOf(0), zeroIterator.next());
+        assertFalse(zeroIterator.hasNext());
         Interval oneToFive = Interval.oneTo(5);
         Iterator<Integer> oneToFiveIterator = oneToFive.iterator();
         for (int i = 1; i < 6; i++)
         {
-            Assert.assertTrue(oneToFiveIterator.hasNext());
-            Assert.assertEquals(Integer.valueOf(i), oneToFiveIterator.next());
+            assertTrue(oneToFiveIterator.hasNext());
+            assertEquals(Integer.valueOf(i), oneToFiveIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
+        assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
         Interval threeToNegativeThree = Interval.fromTo(3, -3);
         Iterator<Integer> threeToNegativeThreeIterator = threeToNegativeThree.iterator();
         for (int i = 3; i > -4; i--)
         {
-            Assert.assertTrue(threeToNegativeThreeIterator.hasNext());
-            Assert.assertEquals(Integer.valueOf(i), threeToNegativeThreeIterator.next());
+            assertTrue(threeToNegativeThreeIterator.hasNext());
+            assertEquals(Integer.valueOf(i), threeToNegativeThreeIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> Interval.zeroTo(10).iterator().remove());
+        assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
+        assertThrows(UnsupportedOperationException.class, () -> Interval.zeroTo(10).iterator().remove());
     }
 
     @Test
@@ -774,12 +780,12 @@ public class IntervalTest
     {
         IntegerSum sum = new IntegerSum(0);
         Interval.oneTo(5).forEachWithIndex((ObjectIntProcedure<Integer>) (each, index) -> sum.add(each + index));
-        Assert.assertEquals(25, sum.getIntSum());
+        assertEquals(25, sum.getIntSum());
         IntegerSum zeroSum = new IntegerSum(0);
         Interval.fromTo(0, -4).forEachWithIndex((ObjectIntProcedure<Integer>) (each, index) -> zeroSum.add(each + index));
-        Assert.assertEquals(0, zeroSum.getIntSum());
+        assertEquals(0, zeroSum.getIntSum());
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> Interval.zeroTo(10).forEachWithIndex(null, -1, 10));
+        assertThrows(IndexOutOfBoundsException.class, () -> Interval.zeroTo(10).forEachWithIndex(null, -1, 10));
     }
 
     @Test
@@ -787,10 +793,10 @@ public class IntervalTest
     {
         IntegerSum sum = new IntegerSum(0);
         Interval.oneTo(5).run(() -> sum.add(1));
-        Assert.assertEquals(5, sum.getIntSum());
+        assertEquals(5, sum.getIntSum());
         IntegerSum sum2 = new IntegerSum(0);
         Interval.fromTo(5, 1).run(() -> sum2.add(1));
-        Assert.assertEquals(5, sum2.getIntSum());
+        assertEquals(5, sum2.getIntSum());
     }
 
     @Test
@@ -798,10 +804,10 @@ public class IntervalTest
     {
         IntegerSum sum = new IntegerSum(0);
         Interval.oneTo(5).forEachWith((Integer each, Integer parameter) -> sum.add(each + parameter), 0);
-        Assert.assertEquals(15, sum.getIntSum());
+        assertEquals(15, sum.getIntSum());
         IntegerSum sum2 = new IntegerSum(0);
         Interval.fromTo(5, 1).forEachWith((Integer each, Integer parameter) -> sum2.add(each + parameter), 0);
-        Assert.assertEquals(15, sum2.getIntSum());
+        assertEquals(15, sum2.getIntSum());
     }
 
     @Test
@@ -810,8 +816,8 @@ public class IntervalTest
         Interval interval = Interval.fromTo(10, -10).by(-5);
 
         MutableList<Integer> expected = FastList.newListWith(10, 0, -10);
-        Assert.assertEquals(expected, interval.select(IntegerPredicates.isEven()).toList());
-        Assert.assertEquals(expected, interval.select(IntegerPredicates.isEven(), FastList.newList()));
+        assertEquals(expected, interval.select(IntegerPredicates.isEven()).toList());
+        assertEquals(expected, interval.select(IntegerPredicates.isEven(), FastList.newList()));
     }
 
     @Test
@@ -820,7 +826,7 @@ public class IntervalTest
         Interval interval = Interval.fromTo(10, -10).by(-5);
 
         MutableList<Integer> expected = FastList.newListWith(5, -5);
-        Assert.assertEquals(expected, interval.reject(IntegerPredicates.isEven(), FastList.newList()));
+        assertEquals(expected, interval.reject(IntegerPredicates.isEven(), FastList.newList()));
     }
 
     @Test
@@ -829,26 +835,26 @@ public class IntervalTest
         Interval interval = Interval.fromTo(10, -10).by(-5);
 
         MutableList<String> expected = FastList.newListWith("10", "5", "0", "-5", "-10");
-        Assert.assertEquals(expected, interval.collect(String::valueOf).toList());
-        Assert.assertEquals(expected, interval.collect(String::valueOf, FastList.newList()));
+        assertEquals(expected, interval.collect(String::valueOf).toList());
+        assertEquals(expected, interval.collect(String::valueOf, FastList.newList()));
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(10), Interval.fromTo(10, -10).by(-5).getFirst());
-        Assert.assertEquals(Integer.valueOf(-10), Interval.fromTo(-10, 10).by(5).getFirst());
-        Assert.assertEquals(Integer.valueOf(0), Interval.zero().getFirst());
+        assertEquals(Integer.valueOf(10), Interval.fromTo(10, -10).by(-5).getFirst());
+        assertEquals(Integer.valueOf(-10), Interval.fromTo(-10, 10).by(5).getFirst());
+        assertEquals(Integer.valueOf(0), Interval.zero().getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals(Integer.valueOf(-10), Interval.fromTo(10, -10).by(-5).getLast());
-        Assert.assertEquals(Integer.valueOf(-10), Interval.fromTo(10, -12).by(-5).getLast());
-        Assert.assertEquals(Integer.valueOf(10), Interval.fromTo(-10, 10).by(5).getLast());
-        Assert.assertEquals(Integer.valueOf(10), Interval.fromTo(-10, 12).by(5).getLast());
-        Assert.assertEquals(Integer.valueOf(0), Interval.zero().getLast());
+        assertEquals(Integer.valueOf(-10), Interval.fromTo(10, -10).by(-5).getLast());
+        assertEquals(Integer.valueOf(-10), Interval.fromTo(10, -12).by(-5).getLast());
+        assertEquals(Integer.valueOf(10), Interval.fromTo(-10, 10).by(5).getLast());
+        assertEquals(Integer.valueOf(10), Interval.fromTo(-10, 12).by(5).getLast());
+        assertEquals(Integer.valueOf(0), Interval.zero().getLast());
     }
 
     @Test
@@ -858,13 +864,13 @@ public class IntervalTest
 
         MutableList<Integer> forwardResult = Lists.mutable.of();
         interval.forEach(CollectionAddProcedure.on(forwardResult), 1, 3);
-        Assert.assertEquals(FastList.newListWith(-5, 0, 5), forwardResult);
+        assertEquals(FastList.newListWith(-5, 0, 5), forwardResult);
 
         MutableList<Integer> backwardsResult = Lists.mutable.of();
         interval.forEach(CollectionAddProcedure.on(backwardsResult), 3, 1);
-        Assert.assertEquals(FastList.newListWith(5, 0, -5), backwardsResult);
+        assertEquals(FastList.newListWith(5, 0, -5), backwardsResult);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.forEach(null, -1, 3));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.forEach(null, -1, 3));
     }
 
     @Test
@@ -874,11 +880,11 @@ public class IntervalTest
 
         MutableList<Integer> forwardResult = Lists.mutable.of();
         interval.forEachWithIndex(new AddParametersProcedure(forwardResult), 1, 3);
-        Assert.assertEquals(FastList.newListWith(-4, 2, 8), forwardResult);
+        assertEquals(FastList.newListWith(-4, 2, 8), forwardResult);
 
         MutableList<Integer> backwardsResult = Lists.mutable.of();
         interval.forEachWithIndex(new AddParametersProcedure(backwardsResult), 3, 1);
-        Assert.assertEquals(FastList.newListWith(8, 2, -4), backwardsResult);
+        assertEquals(FastList.newListWith(8, 2, -4), backwardsResult);
     }
 
     @Test
@@ -889,68 +895,68 @@ public class IntervalTest
         MutableInteger counter = new MutableInteger(0);
         interval.forEach((Procedure<Integer>) each -> counter.add(1));
 
-        Assert.assertEquals(1, counter.toInteger().intValue());
+        assertEquals(1, counter.toInteger().intValue());
     }
 
     @Test
     public void indexOf()
     {
         Interval interval = Interval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.indexOf(-10));
-        Assert.assertEquals(1, interval.indexOf(-5));
-        Assert.assertEquals(2, interval.indexOf(0));
-        Assert.assertEquals(3, interval.indexOf(5));
-        Assert.assertEquals(4, interval.indexOf(10));
+        assertEquals(0, interval.indexOf(-10));
+        assertEquals(1, interval.indexOf(-5));
+        assertEquals(2, interval.indexOf(0));
+        assertEquals(3, interval.indexOf(5));
+        assertEquals(4, interval.indexOf(10));
 
-        Assert.assertEquals(-1, interval.indexOf(-15));
-        Assert.assertEquals(-1, interval.indexOf(-11));
-        Assert.assertEquals(-1, interval.indexOf(-9));
-        Assert.assertEquals(-1, interval.indexOf(11));
-        Assert.assertEquals(-1, interval.indexOf(15));
+        assertEquals(-1, interval.indexOf(-15));
+        assertEquals(-1, interval.indexOf(-11));
+        assertEquals(-1, interval.indexOf(-9));
+        assertEquals(-1, interval.indexOf(11));
+        assertEquals(-1, interval.indexOf(15));
 
         Interval backwardsInterval = Interval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsInterval.indexOf(10));
-        Assert.assertEquals(1, backwardsInterval.indexOf(5));
-        Assert.assertEquals(2, backwardsInterval.indexOf(0));
-        Assert.assertEquals(3, backwardsInterval.indexOf(-5));
-        Assert.assertEquals(4, backwardsInterval.indexOf(-10));
+        assertEquals(0, backwardsInterval.indexOf(10));
+        assertEquals(1, backwardsInterval.indexOf(5));
+        assertEquals(2, backwardsInterval.indexOf(0));
+        assertEquals(3, backwardsInterval.indexOf(-5));
+        assertEquals(4, backwardsInterval.indexOf(-10));
 
-        Assert.assertEquals(-1, backwardsInterval.indexOf(15));
-        Assert.assertEquals(-1, backwardsInterval.indexOf(11));
-        Assert.assertEquals(-1, backwardsInterval.indexOf(9));
-        Assert.assertEquals(-1, backwardsInterval.indexOf(-11));
-        Assert.assertEquals(-1, backwardsInterval.indexOf(-15));
+        assertEquals(-1, backwardsInterval.indexOf(15));
+        assertEquals(-1, backwardsInterval.indexOf(11));
+        assertEquals(-1, backwardsInterval.indexOf(9));
+        assertEquals(-1, backwardsInterval.indexOf(-11));
+        assertEquals(-1, backwardsInterval.indexOf(-15));
     }
 
     @Test
     public void lastIndexOf()
     {
         Interval interval = Interval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.lastIndexOf(-10));
-        Assert.assertEquals(1, interval.lastIndexOf(-5));
-        Assert.assertEquals(2, interval.lastIndexOf(0));
-        Assert.assertEquals(3, interval.lastIndexOf(5));
-        Assert.assertEquals(4, interval.lastIndexOf(10));
+        assertEquals(0, interval.lastIndexOf(-10));
+        assertEquals(1, interval.lastIndexOf(-5));
+        assertEquals(2, interval.lastIndexOf(0));
+        assertEquals(3, interval.lastIndexOf(5));
+        assertEquals(4, interval.lastIndexOf(10));
 
-        Assert.assertEquals(-1, interval.lastIndexOf(-15));
-        Assert.assertEquals(-1, interval.lastIndexOf(-11));
-        Assert.assertEquals(-1, interval.lastIndexOf(-9));
-        Assert.assertEquals(-1, interval.lastIndexOf(11));
-        Assert.assertEquals(-1, interval.lastIndexOf(15));
-        Assert.assertEquals(-1, interval.lastIndexOf(new Object()));
+        assertEquals(-1, interval.lastIndexOf(-15));
+        assertEquals(-1, interval.lastIndexOf(-11));
+        assertEquals(-1, interval.lastIndexOf(-9));
+        assertEquals(-1, interval.lastIndexOf(11));
+        assertEquals(-1, interval.lastIndexOf(15));
+        assertEquals(-1, interval.lastIndexOf(new Object()));
 
         Interval backwardsInterval = Interval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsInterval.lastIndexOf(10));
-        Assert.assertEquals(1, backwardsInterval.lastIndexOf(5));
-        Assert.assertEquals(2, backwardsInterval.lastIndexOf(0));
-        Assert.assertEquals(3, backwardsInterval.lastIndexOf(-5));
-        Assert.assertEquals(4, backwardsInterval.lastIndexOf(-10));
+        assertEquals(0, backwardsInterval.lastIndexOf(10));
+        assertEquals(1, backwardsInterval.lastIndexOf(5));
+        assertEquals(2, backwardsInterval.lastIndexOf(0));
+        assertEquals(3, backwardsInterval.lastIndexOf(-5));
+        assertEquals(4, backwardsInterval.lastIndexOf(-10));
 
-        Assert.assertEquals(-1, backwardsInterval.lastIndexOf(15));
-        Assert.assertEquals(-1, backwardsInterval.lastIndexOf(11));
-        Assert.assertEquals(-1, backwardsInterval.lastIndexOf(9));
-        Assert.assertEquals(-1, backwardsInterval.lastIndexOf(-11));
-        Assert.assertEquals(-1, backwardsInterval.lastIndexOf(-15));
+        assertEquals(-1, backwardsInterval.lastIndexOf(15));
+        assertEquals(-1, backwardsInterval.lastIndexOf(11));
+        assertEquals(-1, backwardsInterval.lastIndexOf(9));
+        assertEquals(-1, backwardsInterval.lastIndexOf(-11));
+        assertEquals(-1, backwardsInterval.lastIndexOf(-15));
     }
 
     @Test
@@ -963,22 +969,22 @@ public class IntervalTest
         Verify.assertItemAtIndex(Integer.valueOf(5), 3, interval);
         Verify.assertItemAtIndex(Integer.valueOf(10), 4, interval);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
     }
 
     @Test
     public void subList()
     {
         Interval interval = Interval.fromTo(1, 5);
-        Assert.assertEquals(FastList.newListWith(2, 3), interval.subList(1, 3));
+        assertEquals(FastList.newListWith(2, 3), interval.subList(1, 3));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(Interval.fromTo(1, 3).containsAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertFalse(Interval.fromTo(1, 3).containsAll(FastList.newListWith(1, 2, 4)));
+        assertTrue(Interval.fromTo(1, 3).containsAll(FastList.newListWith(1, 2, 3)));
+        assertFalse(Interval.fromTo(1, 3).containsAll(FastList.newListWith(1, 2, 4)));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -1045,40 +1051,40 @@ public class IntervalTest
     public void take()
     {
         Verify.assertIterableEmpty(Interval.fromTo(1, 3).take(0));
-        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).take(2));
-        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).take(3));
+        assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).take(2));
+        assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).take(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(1, 3).take(-1));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(1, 3).take(-1));
     }
 
     @Test
     public void drop()
     {
-        Assert.assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).drop(2));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).drop(0));
+        assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).drop(2));
+        assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).drop(0));
         Verify.assertIterableEmpty(Interval.fromTo(1, 2).drop(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(1, 3).drop(-1));
+        assertThrows(IllegalArgumentException.class, () -> Interval.fromTo(1, 3).drop(-1));
     }
 
     @Test
     public void takeWhile()
     {
         Verify.assertIterableEmpty(Interval.fromTo(1, 3).takeWhile(Predicates.alwaysFalse()).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).takeWhile(each -> each <= 2).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).takeWhile(Predicates.alwaysTrue()).toList());
+        assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 3).takeWhile(each -> each <= 2).toList());
+        assertEquals(FastList.newListWith(1, 2), Interval.fromTo(1, 2).takeWhile(Predicates.alwaysTrue()).toList());
 
-        Assert.assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).takeWhile(null));
+        assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).takeWhile(null));
     }
 
     @Test
     public void dropWhile()
     {
-        Assert.assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).dropWhile(each -> each <= 2).toList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).dropWhile(Predicates.alwaysFalse()).toList());
+        assertEquals(FastList.newListWith(3, 4), Interval.fromTo(1, 4).dropWhile(each -> each <= 2).toList());
+        assertEquals(FastList.newListWith(1, 2, 3, 4), Interval.fromTo(1, 4).dropWhile(Predicates.alwaysFalse()).toList());
         Verify.assertIterableEmpty(Interval.fromTo(1, 2).dropWhile(Predicates.alwaysTrue()).toList());
 
-        Assert.assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).dropWhile(null));
+        assertThrows(IllegalStateException.class, () -> Interval.fromTo(1, 3).dropWhile(null));
     }
 
     @Test
@@ -1086,14 +1092,14 @@ public class IntervalTest
     {
         LazyIterable<Integer> integers = Interval.oneTo(1000000000);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(1, 2, 3, 4, 5),
                 integers.distinct().take(5).toList());
 
         LazyIterable<Integer> lazyInterval = Interval.oneTo(1000000).flatCollect(Interval::oneTo);
         LazyIterable<Integer> distinct = lazyInterval.distinct();
         LazyIterable<Integer> take = distinct.take(5);
-        Assert.assertEquals(Lists.immutable.of(1, 2, 3, 4, 5), take.toList());
+        assertEquals(Lists.immutable.of(1, 2, 3, 4, 5), take.toList());
     }
 
     private static final class AddParametersProcedure implements ObjectIntProcedure<Integer>
@@ -1121,21 +1127,21 @@ public class IntervalTest
         lazyTapIterable.each(x ->
         {
         }); //force evaluation
-        Assert.assertEquals(interval, tapResult);
+        assertEquals(interval, tapResult);
     }
 
     @Test
     public void appendStringThrows()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> Interval.oneTo(5)
                         .appendString(new ThrowingAppendable()));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> Interval.oneTo(5)
                         .appendString(new ThrowingAppendable(), ", "));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> Interval.oneTo(5)
                         .appendString(new ThrowingAppendable(), "[", ", ", "]"));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableListTestCase.java
@@ -29,9 +29,14 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMemoryEfficientMutableListTestCase
 {
@@ -67,7 +72,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void replaceAll()
     {
         this.list.replaceAll(s -> "");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.withNValues(this.getSize(), () -> ""),
                 this.list);
     }
@@ -77,12 +82,12 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         this.list.shuffleThis();
         this.list.sort(Comparator.naturalOrder());
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list);
         this.list.shuffleThis();
         this.list.sort(null);
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list);
     }
@@ -92,8 +97,8 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         this.list.shuffleThis();
         MutableList<String> sortedList = this.list.sortThis();
-        Assert.assertSame(this.list, sortedList);
-        Assert.assertEquals(
+        assertSame(this.list, sortedList);
+        assertEquals(
                 this.getNStrings(),
                 sortedList);
     }
@@ -103,8 +108,8 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         this.list.shuffleThis();
         MutableList<String> sortedList = this.list.sortThis(Comparators.naturalOrder());
-        Assert.assertSame(this.list, sortedList);
-        Assert.assertEquals(
+        assertSame(this.list, sortedList);
+        assertEquals(
                 this.getNStrings(),
                 sortedList);
     }
@@ -113,7 +118,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisBy()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisBy(Functions.getStringToInteger()));
     }
@@ -122,7 +127,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByInt()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByInt(Integer::parseInt));
     }
@@ -132,14 +137,14 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         PartitionMutableList<String> partition = this.getNStrings().partition(s -> Integer.parseInt(s) % 2 == 0);
         MutableList<String> expected = FastList.newList(partition.getRejected()).withAll(partition.getSelected());
-        Assert.assertEquals(expected, this.list.sortThisByBoolean(s -> Integer.parseInt(s) % 2 == 0));
+        assertEquals(expected, this.list.sortThisByBoolean(s -> Integer.parseInt(s) % 2 == 0));
     }
 
     @Test
     public void sortThisByChar()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByChar(string -> string.charAt(0)));
     }
@@ -148,7 +153,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByByte()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByByte(Byte::parseByte));
     }
@@ -157,7 +162,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByShort()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByShort(Short::parseShort));
     }
@@ -166,7 +171,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByFloat()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByFloat(Float::parseFloat));
     }
@@ -175,7 +180,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByLong()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByLong(Long::parseLong));
     }
@@ -184,7 +189,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     public void sortThisByDouble()
     {
         this.list.shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 this.getNStrings(),
                 this.list.sortThisByDouble(Double::parseDouble));
     }
@@ -195,8 +200,8 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
         MutableList<String> expected = FastList.newList(this.list);
         MutableList<String> actual = this.list.reverseThis();
         Collections.reverse(expected);
-        Assert.assertEquals(actual, expected);
-        Assert.assertSame(this.list, actual);
+        assertEquals(actual, expected);
+        assertSame(this.list, actual);
     }
 
     @Test
@@ -204,8 +209,8 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         MutableList<String> actual = this.list.toReversed();
         MutableList<String> expected = FastList.newList(this.list).reverseThis();
-        Assert.assertEquals(actual, expected);
-        Assert.assertNotSame(this.list, actual);
+        assertEquals(actual, expected);
+        assertNotSame(this.list, actual);
     }
 
     @Test
@@ -214,7 +219,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
         MutableList<String> list = this.classUnderTest();
         Verify.assertNotContains("11", list);
         MutableList<String> listWith = list.with("11");
-        Assert.assertTrue(listWith.containsAll(list));
+        assertTrue(listWith.containsAll(list));
         Verify.assertContains("11", listWith);
         Verify.assertInstanceOf(FixedSizeList.class, listWith);
     }
@@ -225,10 +230,10 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
         MutableList<String> list = this.classUnderTest();
         Verify.assertContainsNone(list, "11", "12");
         MutableList<String> listWith = list.withAll(FastList.newListWith("11", "12"));
-        Assert.assertTrue(listWith.containsAll(list));
+        assertTrue(listWith.containsAll(list));
         Verify.assertContainsAll(listWith, "11", "12");
         Verify.assertInstanceOf(FixedSizeList.class, listWith);
-        Assert.assertSame(listWith, listWith.withAll(FastList.newList()));
+        assertSame(listWith, listWith.withAll(FastList.newList()));
     }
 
     @Test
@@ -236,17 +241,17 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
     {
         MutableList<String> list = this.classUnderTest().with("11").with("12");
         MutableList<String> listWithout = list.withoutAll(FastList.newListWith("11", "12"));
-        Assert.assertTrue(listWithout.containsAll(this.classUnderTest()));
+        assertTrue(listWithout.containsAll(this.classUnderTest()));
         Verify.assertContainsNone(listWithout, "11", "12");
         Verify.assertInstanceOf(FixedSizeList.class, listWithout);
-        Assert.assertSame(listWithout, listWithout.withoutAll(FastList.newList()));
+        assertSame(listWithout, listWithout.withoutAll(FastList.newList()));
     }
 
     @Test
     public void toStack()
     {
         MutableStack<String> stack = this.classUnderTest().toStack();
-        Assert.assertEquals(ArrayStack.newStack(this.classUnderTest()), stack);
+        assertEquals(ArrayStack.newStack(this.classUnderTest()), stack);
     }
 
     @Test
@@ -258,7 +263,7 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
                 this.classUnderTest().aggregateInPlaceBy(groupBy, Counter::new, sumAggregator);
         MapIterable<String, Counter> expected =
                 FastList.newList(this.classUnderTest()).aggregateInPlaceBy(groupBy, Counter::new, sumAggregator);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -270,112 +275,112 @@ public abstract class AbstractMemoryEfficientMutableListTestCase
                 this.classUnderTest().aggregateBy(groupBy, () -> 0, sumAggregator);
         MapIterable<String, Integer> expected =
                 FastList.newList(this.classUnderTest()).aggregateBy(groupBy, () -> 0, sumAggregator);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void add()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(""));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(""));
     }
 
     @Test
     public void addAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(0, ""));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().add(0, ""));
     }
 
     @Test
     public void addAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().addAll(Lists.mutable.empty()));
     }
 
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().addAll(0, Lists.mutable.empty()));
     }
 
     @Test
     public void addAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().addAllIterable(Lists.mutable.empty()));
     }
 
     @Test
     public void removeIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(0));
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().remove(null));
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().removeAll(Lists.fixedSize.empty()));
     }
 
     @Test
     public void removeAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().removeAllIterable(Lists.fixedSize.empty()));
     }
 
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().retainAll(Lists.fixedSize.empty()));
     }
 
     @Test
     public void retainAllIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().retainAllIterable(Lists.fixedSize.empty()));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, this.classUnderTest()::clear);
+        assertThrows(UnsupportedOperationException.class, this.classUnderTest()::clear);
     }
 
     @Test
     public void subList_methodsThrow()
     {
         MutableList<String> subList = this.classUnderTest().subList(0, this.getSize());
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.add(""));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.add(0, ""));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class, () -> subList.add(""));
+        assertThrows(UnsupportedOperationException.class, () -> subList.add(0, ""));
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.addAll(Lists.mutable.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.addAllIterable(Lists.mutable.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.remove(null));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> subList.remove(null));
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.removeAll(Lists.fixedSize.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.removeAllIterable(Lists.fixedSize.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.removeIf(each -> true));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.removeIfWith((argument1, argument2) -> true, null));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.retainAll(Lists.fixedSize.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> subList.retainAllIterable(Lists.fixedSize.empty()));
-        Assert.assertThrows(UnsupportedOperationException.class, subList::clear);
+        assertThrows(UnsupportedOperationException.class, subList::clear);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
@@ -33,10 +33,19 @@ import org.eclipse.collections.impl.list.mutable.UnmodifiableMutableList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ArrayAdapter}.
@@ -152,7 +161,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
     public void add()
     {
         MutableList<String> collection = ArrayAdapter.newArray();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> collection.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> collection.add(null));
     }
 
     @Override
@@ -161,8 +170,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.allSatisfy();
 
-        Assert.assertTrue(this.newWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(this.newWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
+        assertFalse(this.newWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Override
@@ -171,8 +180,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.anySatisfy();
 
-        Assert.assertFalse(this.newWith(1, 2, 3).anySatisfy(String.class::isInstance));
-        Assert.assertTrue(this.newWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
+        assertFalse(this.newWith(1, 2, 3).anySatisfy(String.class::isInstance));
+        assertTrue(this.newWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
     }
 
     @Override
@@ -181,8 +190,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.noneSatisfy();
 
-        Assert.assertTrue(this.newWith(1, 2, 3).noneSatisfy(String.class::isInstance));
-        Assert.assertFalse(this.newWith(1, 2, 3).noneSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newWith(1, 2, 3).noneSatisfy(String.class::isInstance));
+        assertFalse(this.newWith(1, 2, 3).noneSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Override
@@ -191,7 +200,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.count();
 
-        Assert.assertEquals(3, this.newWith(1, 2, 3).count(Integer.class::isInstance));
+        assertEquals(3, this.newWith(1, 2, 3).count(Integer.class::isInstance));
     }
 
     @Override
@@ -215,8 +224,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.getFirst();
 
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
-        Assert.assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
+        assertNotEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getFirst());
     }
 
     @Override
@@ -225,8 +234,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.getLast();
 
-        Assert.assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
+        assertNotEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
     }
 
     @Override
@@ -237,7 +246,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
 
         Verify.assertEmpty(this.newArray());
         Verify.assertNotEmpty(this.newWith(1, 2));
-        Assert.assertTrue(this.newWith(1, 2).notEmpty());
+        assertTrue(this.newWith(1, 2).notEmpty());
     }
 
     @Override
@@ -251,7 +260,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         for (int i = objects.size(); i-- > 0; )
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(3, integer.intValue() + i);
+            assertEquals(3, integer.intValue() + i);
         }
     }
 
@@ -263,7 +272,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
 
         MutableList<Integer> objects = this.newWith(1, 2, 3);
         Integer result = objects.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Override
@@ -280,9 +289,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
         Integer[] array3 = objects.toArray(new Integer[1]);
         Verify.assertSize(3, array3);
         Integer[] expected = {1, 2, 3};
-        Assert.assertArrayEquals(expected, array);
-        Assert.assertArrayEquals(expected, array2);
-        Assert.assertArrayEquals(expected, array3);
+        assertArrayEquals(expected, array);
+        assertArrayEquals(expected, array2);
+        assertArrayEquals(expected, array3);
     }
 
     @Override
@@ -301,21 +310,21 @@ public class ArrayAdapterTest extends AbstractListTestCase
     @Test
     public void removeIf()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).removeIf(Predicates.isNull()));
+        assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).removeIf(Predicates.isNull()));
     }
 
     @Override
     @Test
     public void removeIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).remove(0));
     }
 
     @Override
     @Test
     public void removeIfWith()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).removeIfWith((each, ignored) -> each == null, null));
+        assertThrows(UnsupportedOperationException.class, () -> ArrayAdapter.newArrayWith(1, 2, 3, null).removeIfWith((each, ignored) -> each == null, null));
     }
 
     @Override
@@ -325,7 +334,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         super.indexOf();
 
         MutableList<Integer> objects = ArrayAdapter.newArrayWith(1, 2, 3);
-        Assert.assertEquals(1, objects.indexOf(2));
+        assertEquals(1, objects.indexOf(2));
     }
 
     @Override
@@ -335,7 +344,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         super.lastIndexOf();
 
         MutableList<Integer> objects = ArrayAdapter.newArrayWith(1, 2, 3);
-        Assert.assertEquals(1, objects.lastIndexOf(2));
+        assertEquals(1, objects.lastIndexOf(2));
     }
 
     @Override
@@ -345,8 +354,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
         super.set();
 
         MutableList<Integer> objects = ArrayAdapter.newArrayWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(2), objects.set(1, 4));
-        Assert.assertEquals(FastList.newListWith(1, 4, 3), objects);
+        assertEquals(Integer.valueOf(2), objects.set(1, 4));
+        assertEquals(FastList.newListWith(1, 4, 3), objects);
     }
 
     @Override
@@ -359,15 +368,15 @@ public class ArrayAdapterTest extends AbstractListTestCase
         ArrayAdapter<Integer> array2 = ArrayAdapter.newArrayWith(1, 2, 3, 4);
         ArrayAdapter<Integer> array3 = ArrayAdapter.newArrayWith(2, 3, 4);
         ArrayAdapter<Integer> array4 = ArrayAdapter.newArrayWith(1, 2, 3, 5);
-        Assert.assertNotEquals(array1, null);
+        assertNotEquals(array1, null);
         Verify.assertEqualsAndHashCode(array1, array1);
         Verify.assertEqualsAndHashCode(array1, array2);
-        Assert.assertNotEquals(array2, array3);
+        assertNotEquals(array2, array3);
         Verify.assertEqualsAndHashCode(array1, new ArrayList<>(array1));
         Verify.assertEqualsAndHashCode(array1, new LinkedList<>(array1));
         Verify.assertEqualsAndHashCode(array1, ArrayListAdapter.<Integer>newList().with(1, 2, 3, 4));
         Verify.assertEqualsAndHashCode(array1, FastList.<Integer>newList().with(1, 2, 3, 4));
-        Assert.assertNotEquals(array1, new LinkedList<>(array4));
+        assertNotEquals(array1, new LinkedList<>(array4));
     }
 
     @Override
@@ -416,18 +425,18 @@ public class ArrayAdapterTest extends AbstractListTestCase
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 ArrayAdapter.newArrayWith(1, 2, 3, 4, 5).detectWith(Object::equals, 3));
-        Assert.assertNull(ArrayAdapter.newArrayWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
+        assertNull(ArrayAdapter.newArrayWith(1, 2, 3, 4, 5).detectWith(Object::equals, 6));
     }
 
     @Test
     public void detectWithIfNone()
     {
         MutableList<Integer> list = ArrayAdapter.newArrayWith(1, 2, 3, 4, 5);
-        Assert.assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
-        Assert.assertEquals(Integer.valueOf(10000), list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(Integer.valueOf(10000))));
+        assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
+        assertEquals(Integer.valueOf(10000), list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(Integer.valueOf(10000))));
     }
 
     @Override
@@ -436,9 +445,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.allSatisfyWith();
 
-        Assert.assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).allSatisfyWith(Predicates2.instanceOf(),
+        assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).allSatisfyWith(Predicates2.instanceOf(),
                 Integer.class));
-        Assert.assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).allSatisfyWith(Object::equals, 1));
+        assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).allSatisfyWith(Object::equals, 1));
     }
 
     @Override
@@ -446,9 +455,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     public void anySatisfyWith()
     {
         super.anySatisfyWith();
-        Assert.assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(),
+        assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(),
                 String.class));
-        Assert.assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(),
+        assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).anySatisfyWith(Predicates2.instanceOf(),
                 Integer.class));
     }
 
@@ -458,9 +467,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.noneSatisfyWith();
 
-        Assert.assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).noneSatisfyWith(Predicates2.instanceOf(),
+        assertTrue(ArrayAdapter.newArrayWith(1, 2, 3).noneSatisfyWith(Predicates2.instanceOf(),
                 String.class));
-        Assert.assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).noneSatisfyWith(Object::equals, 1));
+        assertFalse(ArrayAdapter.newArrayWith(1, 2, 3).noneSatisfyWith(Object::equals, 1));
     }
 
     @Override
@@ -469,7 +478,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         super.countWith();
 
-        Assert.assertEquals(
+        assertEquals(
                 3,
                 ArrayAdapter.newArrayWith(1, 2, 3).countWith(Predicates2.instanceOf(), Integer.class));
     }
@@ -481,10 +490,10 @@ public class ArrayAdapterTest extends AbstractListTestCase
         super.collectWith();
 
         Function2<Integer, Integer, Integer> addBlock = (each, parameter) -> each + parameter;
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4),
                 ArrayAdapter.newArrayWith(1, 2, 3).collectWith(addBlock, 1));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4),
                 ArrayAdapter.newArrayWith(1, 2, 3).collectWith(addBlock, 1, FastList.newList()));
     }
@@ -497,7 +506,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
 
         MutableList<Integer> objects = ArrayAdapter.newArrayWith(1, 2, 3);
         Integer result = objects.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Override
@@ -534,7 +543,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         // ArrayAdapter doesn't support add and cannot contain itself
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newList(this.newWith(1, 2, 3, 4)).toString(),
                 this.newWith(1, 2, 3, 4).toString());
     }
@@ -545,7 +554,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         // ArrayAdapter doesn't support add and cannot contain itself
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newList(this.newWith(1, 2, 3, 4)).makeString(),
                 this.newWith(1, 2, 3, 4).makeString());
     }
@@ -559,7 +568,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         StringBuilder stringBuilder = new StringBuilder();
         this.newWith(1, 2, 3, 4).appendString(stringBuilder);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newList(this.newWith(1, 2, 3, 4)).makeString(),
                 stringBuilder.toString());
     }
@@ -655,7 +664,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         this.validateForEachOnRange(list, 9, 9, FastList.newListWith(9));
         this.validateForEachOnRange(list, 0, 9, FastList.newListWith(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.validateForEachOnRange(list, 10, 10, FastList.newList()));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.validateForEachOnRange(list, 10, 10, FastList.newList()));
     }
 
     @Override
@@ -669,7 +678,7 @@ public class ArrayAdapterTest extends AbstractListTestCase
         this.validateForEachWithIndexOnRange(list, 4, 6, FastList.newListWith(4, 5, 6));
         this.validateForEachWithIndexOnRange(list, 9, 9, FastList.newListWith(9));
         this.validateForEachWithIndexOnRange(list, 0, 9, FastList.newListWith(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.validateForEachWithIndexOnRange(list, 10, 10, FastList.newList()));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.validateForEachWithIndexOnRange(list, 10, 10, FastList.newList()));
     }
 
     @Override
@@ -688,8 +697,8 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.with(4);
-        Assert.assertNotSame(coll, collWith);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), collWith);
+        assertNotSame(coll, collWith);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), collWith);
     }
 
     @Override
@@ -698,9 +707,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3);
         MutableCollection<Integer> collWith = coll.withAll(FastList.newListWith(4, 5));
-        Assert.assertNotSame(coll, collWith);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), collWith);
-        Assert.assertSame(collWith, collWith.withAll(FastList.newList()));
+        assertNotSame(coll, collWith);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), collWith);
+        assertSame(collWith, collWith.withAll(FastList.newList()));
     }
 
     @Override
@@ -709,9 +718,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 3, 2);
         MutableCollection<Integer> collWithout = coll.without(2);
-        Assert.assertNotSame(coll, collWithout);
-        Assert.assertEquals(FastList.newListWith(1, 3, 2), collWithout);
-        Assert.assertSame(collWithout, collWithout.without(9));
+        assertNotSame(coll, collWithout);
+        assertEquals(FastList.newListWith(1, 3, 2), collWithout);
+        assertSame(collWithout, collWithout.without(9));
     }
 
     @Override
@@ -720,9 +729,9 @@ public class ArrayAdapterTest extends AbstractListTestCase
     {
         MutableCollection<Integer> coll = this.newWith(1, 2, 4, 2, 3, 4, 5);
         MutableCollection<Integer> collWithout = coll.withoutAll(FastList.newListWith(2, 4));
-        Assert.assertNotSame(coll, collWithout);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), collWithout);
-        Assert.assertSame(collWithout, collWithout.withoutAll(FastList.newListWith(8, 9)));
-        Assert.assertSame(collWithout, collWithout.withoutAll(FastList.newList()));
+        assertNotSame(coll, collWithout);
+        assertEquals(FastList.newListWith(1, 3, 5), collWithout);
+        assertSame(collWithout, collWithout.withoutAll(FastList.newListWith(8, 9)));
+        assertSame(collWithout, collWithout.withoutAll(FastList.newList()));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/DoubletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/DoubletonListTest.java
@@ -21,8 +21,13 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link DoubletonList}.
@@ -52,27 +57,27 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void testContains()
     {
-        Assert.assertTrue(this.list.contains("1"));
-        Assert.assertTrue(this.list.contains("2"));
-        Assert.assertFalse(this.list.contains("3"));
+        assertTrue(this.list.contains("1"));
+        assertTrue(this.list.contains("2"));
+        assertFalse(this.list.contains("3"));
     }
 
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
     }
 
     @Test
     public void testAddAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
     }
 
     @Test
     public void testAdd()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
     }
 
     @Test
@@ -87,16 +92,16 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
     public void testGet()
     {
         Verify.assertStartsWith(this.list, "1", "2");
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(2));
     }
 
     @Test
     public void testSet()
     {
-        Assert.assertEquals("1", this.list.set(0, "2"));
-        Assert.assertEquals("2", this.list.set(1, "1"));
-        Assert.assertEquals(FastList.newListWith("2", "1"), this.list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.set(2, "0"));
+        assertEquals("1", this.list.set(0, "2"));
+        assertEquals("2", this.list.set(1, "1"));
+        assertEquals(FastList.newListWith("2", "1"), this.list);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.set(2, "0"));
     }
 
     @Test
@@ -126,7 +131,7 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = this.classUnderTest();
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(FastList.newListWith("1", "2"), result);
     }
 
     @Test
@@ -140,8 +145,8 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
-        Assert.assertEquals(1, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(1, indexSum[0]);
     }
 
     @Test
@@ -149,14 +154,14 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<String> result = Lists.mutable.of();
         this.list.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(FastList.newListWith("1", "2"), result);
     }
 
     @Test
     public void testGetFirstGetLast()
     {
-        Assert.assertEquals("1", this.list.getFirst());
-        Assert.assertEquals("2", this.list.getLast());
+        assertEquals("1", this.list.getFirst());
+        assertEquals("2", this.list.getLast());
     }
 
     @Test
@@ -180,21 +185,21 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
         {
             Verify.assertContains(each.toUpperCase(), upperList);
         }
-        Assert.assertEquals("one", subList.getFirst());
-        Assert.assertEquals("two", subList.getLast());
+        assertEquals("one", subList.getFirst());
+        assertEquals("two", subList.getLast());
         MutableList<String> subList2 = list.subList(1, 2);
-        Assert.assertEquals("two", subList2.getFirst());
-        Assert.assertEquals("two", subList2.getLast());
+        assertEquals("two", subList2.getFirst());
+        assertEquals("two", subList2.getLast());
         MutableList<String> subList3 = list.subList(0, 1);
-        Assert.assertEquals("one", subList3.getFirst());
-        Assert.assertEquals("one", subList3.getLast());
+        assertEquals("one", subList3.getFirst());
+        assertEquals("one", subList3.getLast());
     }
 
     @Test
     public void without()
     {
         MutableList<Integer> list = new DoubletonList<>(2, 2);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(FastList.newListWith(2), list);
         Verify.assertInstanceOf(SingletonList.class, list);
@@ -203,7 +208,7 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void testGetOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.list.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.list.getOnly());
     }
 
     @Override
@@ -213,9 +218,9 @@ public class DoubletonListTest extends AbstractMemoryEfficientMutableListTestCas
         super.sort();
         MutableList<String> strings = this.classUnderTest().reverseThis();
         strings.sort(Comparator.naturalOrder());
-        Assert.assertEquals(this.classUnderTest(), strings);
+        assertEquals(this.classUnderTest(), strings);
         MutableList<String> strings2 = this.classUnderTest().reverseThis();
         strings2.sort(null);
-        Assert.assertEquals(this.classUnderTest(), strings2);
+        assertEquals(this.classUnderTest(), strings2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/EmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/EmptyListTest.java
@@ -22,8 +22,13 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class EmptyListTest
 {
@@ -36,42 +41,42 @@ public class EmptyListTest
     @Test
     public void contains()
     {
-        Assert.assertFalse(new EmptyList<>().contains(null));
-        Assert.assertFalse(new EmptyList<>().contains(new Object()));
+        assertFalse(new EmptyList<>().contains(null));
+        assertFalse(new EmptyList<>().contains(new Object()));
     }
 
     @Test
     public void get()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().get(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().get(0));
     }
 
     @Test
     public void set()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().set(0, null));
+        assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().set(0, null));
     }
 
     @Test
     public void empty()
     {
         Verify.assertEmpty(new EmptyList<>());
-        Assert.assertFalse(new EmptyList<>().notEmpty());
+        assertFalse(new EmptyList<>().notEmpty());
         Verify.assertEmpty(Lists.fixedSize.of());
-        Assert.assertFalse(Lists.fixedSize.of().notEmpty());
+        assertFalse(Lists.fixedSize.of().notEmpty());
     }
 
     @Test
     public void getFirstLast()
     {
-        Assert.assertNull(new EmptyList<>().getFirst());
-        Assert.assertNull(new EmptyList<>().getLast());
+        assertNull(new EmptyList<>().getFirst());
+        assertNull(new EmptyList<>().getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> new EmptyList<>().getOnly());
+        assertThrows(IllegalStateException.class, () -> new EmptyList<>().getOnly());
     }
 
     @Test
@@ -84,49 +89,49 @@ public class EmptyListTest
     @Test
     public void testClone()
     {
-        Assert.assertSame(Lists.fixedSize.of().clone(), Lists.fixedSize.of());
+        assertSame(Lists.fixedSize.of().clone(), Lists.fixedSize.of());
     }
 
     @Test
     public void min()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().min(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().min(Comparators.naturalOrder()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().max(Comparators.naturalOrder()));
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().max(Comparators.naturalOrder()));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().min());
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().max());
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().max());
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().minBy(String::valueOf));
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().maxBy(String::valueOf));
+        assertThrows(NoSuchElementException.class, () -> Lists.fixedSize.of().maxBy(String::valueOf));
     }
 
     @Test
     public void zip()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.fixedSize.of(),
                 Lists.fixedSize.of().zip(FastList.newListWith(1, 2, 3)));
     }
@@ -134,7 +139,7 @@ public class EmptyListTest
     @Test
     public void zipWithIndex()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.fixedSize.of(),
                 Lists.fixedSize.of().zipWithIndex());
     }
@@ -142,7 +147,7 @@ public class EmptyListTest
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(Lists.fixedSize.of(), Lists.fixedSize.of().chunk(10));
+        assertEquals(Lists.fixedSize.of(), Lists.fixedSize.of().chunk(10));
     }
 
     @Test
@@ -151,8 +156,8 @@ public class EmptyListTest
         MutableList<Object> expected = Lists.fixedSize.of();
         MutableList<Object> list = Lists.fixedSize.of();
         MutableList<Object> sortedList = list.sortThis();
-        Assert.assertEquals(expected, sortedList);
-        Assert.assertSame(sortedList, list);
+        assertEquals(expected, sortedList);
+        assertSame(sortedList, list);
     }
 
     @Test
@@ -161,8 +166,8 @@ public class EmptyListTest
         MutableList<Object> expected = Lists.fixedSize.of();
         MutableList<Object> list = Lists.fixedSize.of();
         MutableList<Object> sortedList = list.sortThisBy(String::valueOf);
-        Assert.assertEquals(expected, sortedList);
-        Assert.assertSame(sortedList, list);
+        assertEquals(expected, sortedList);
+        assertSame(sortedList, list);
     }
 
     @Test
@@ -170,22 +175,22 @@ public class EmptyListTest
     {
         MutableList<Object> expected = Lists.fixedSize.of();
         MutableList<Object> list = Lists.fixedSize.of();
-        Assert.assertEquals(expected, list.sortThisByBoolean(anObject -> true));
-        Assert.assertSame(list, list.sortThisByBoolean(anObject -> true));
-        Assert.assertEquals(expected, list.sortThisByByte(anObject -> (byte) 0));
-        Assert.assertSame(list, list.sortThisByByte(anObject -> (byte) 0));
-        Assert.assertEquals(expected, list.sortThisByChar(anObject -> (char) 0));
-        Assert.assertSame(list, list.sortThisByChar(anObject -> (char) 0));
-        Assert.assertEquals(expected, list.sortThisByDouble(anObject -> 0.0));
-        Assert.assertSame(list, list.sortThisByDouble(anObject -> 0.0));
-        Assert.assertEquals(expected, list.sortThisByFloat(anObject -> 0.0f));
-        Assert.assertSame(list, list.sortThisByFloat(anObject -> 0.0f));
-        Assert.assertEquals(expected, list.sortThisByInt(anObject -> 0));
-        Assert.assertSame(list, list.sortThisByInt(anObject -> 0));
-        Assert.assertEquals(expected, list.sortThisByLong(anObject -> 0L));
-        Assert.assertSame(list, list.sortThisByLong(anObject -> 0L));
-        Assert.assertEquals(expected, list.sortThisByShort(anObject -> (short) 0));
-        Assert.assertSame(list, list.sortThisByShort(anObject -> (short) 0));
+        assertEquals(expected, list.sortThisByBoolean(anObject -> true));
+        assertSame(list, list.sortThisByBoolean(anObject -> true));
+        assertEquals(expected, list.sortThisByByte(anObject -> (byte) 0));
+        assertSame(list, list.sortThisByByte(anObject -> (byte) 0));
+        assertEquals(expected, list.sortThisByChar(anObject -> (char) 0));
+        assertSame(list, list.sortThisByChar(anObject -> (char) 0));
+        assertEquals(expected, list.sortThisByDouble(anObject -> 0.0));
+        assertSame(list, list.sortThisByDouble(anObject -> 0.0));
+        assertEquals(expected, list.sortThisByFloat(anObject -> 0.0f));
+        assertSame(list, list.sortThisByFloat(anObject -> 0.0f));
+        assertEquals(expected, list.sortThisByInt(anObject -> 0));
+        assertSame(list, list.sortThisByInt(anObject -> 0));
+        assertEquals(expected, list.sortThisByLong(anObject -> 0L));
+        assertSame(list, list.sortThisByLong(anObject -> 0L));
+        assertEquals(expected, list.sortThisByShort(anObject -> (short) 0));
+        assertSame(list, list.sortThisByShort(anObject -> (short) 0));
     }
 
     @Test
@@ -208,14 +213,14 @@ public class EmptyListTest
     public void without()
     {
         MutableList<Integer> list = new EmptyList<>();
-        Assert.assertSame(list, list.without(2));
+        assertSame(list, list.without(2));
     }
 
     @Test
     public void withoutAll()
     {
         MutableList<Integer> list = new EmptyList<>();
-        Assert.assertEquals(list, list.withoutAll(FastList.newListWith(1, 2)));
+        assertEquals(list, list.withoutAll(FastList.newListWith(1, 2)));
     }
 
     @Test
@@ -253,7 +258,7 @@ public class EmptyListTest
     {
         AtomicInteger integer = new AtomicInteger();
         new EmptyList<>().each(each -> integer.incrementAndGet());
-        Assert.assertEquals(0, integer.get());
+        assertEquals(0, integer.get());
     }
 
     @Test
@@ -261,41 +266,41 @@ public class EmptyListTest
     {
         AtomicInteger integer = new AtomicInteger();
         new EmptyList<>().forEachWith((argument1, argument2) -> integer.incrementAndGet(), null);
-        Assert.assertEquals(0, integer.get());
+        assertEquals(0, integer.get());
     }
 
     @Test
     public void iterator()
     {
         Iterator<Object> iterator = new EmptyList<>().iterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
     public void listIterator()
     {
         ListIterator<Object> iterator = new EmptyList<>().listIterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertFalse(iterator.hasPrevious());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(NoSuchElementException.class, iterator::previous);
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasPrevious());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::previous);
     }
 
     @Test
     public void listIteratorWithIndex()
     {
         ListIterator<Object> iterator = new EmptyList<>().listIterator(0);
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertFalse(iterator.hasPrevious());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertThrows(NoSuchElementException.class, iterator::previous);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().listIterator(1));
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasPrevious());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::previous);
+        assertThrows(IndexOutOfBoundsException.class, () -> new EmptyList<>().listIterator(1));
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertSame(Lists.immutable.empty(), new EmptyList<>().toImmutable());
+        assertSame(Lists.immutable.empty(), new EmptyList<>().toImmutable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
@@ -20,8 +20,15 @@ import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link FixedSizeListFactoryImpl}.
@@ -32,15 +39,15 @@ public class FixedSizeListFactoryTest
     public void createEmpty()
     {
         MutableList<String> list = Lists.fixedSize.of();
-        Assert.assertSame(list, Lists.fixedSize.of());
+        assertSame(list, Lists.fixedSize.of());
         Verify.assertInstanceOf(EmptyList.class, list);
         Verify.assertSize(0, list);
-        Assert.assertTrue(list.isEmpty());
-        Assert.assertFalse(list.notEmpty());
-        Assert.assertNull(list.getFirst());
-        Assert.assertNull(list.getLast());
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.get(0));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.set(0, "nope"));
+        assertTrue(list.isEmpty());
+        assertFalse(list.notEmpty());
+        assertNull(list.getFirst());
+        assertNull(list.getLast());
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.set(0, "nope"));
     }
 
     @Test
@@ -50,35 +57,35 @@ public class FixedSizeListFactoryTest
         Verify.assertEmpty(list0);
 
         MutableList<String> list1 = list0.with("1");
-        Assert.assertEquals(FastList.newListWith("1"), list1);
+        assertEquals(FastList.newListWith("1"), list1);
         Verify.assertInstanceOf(SingletonList.class, list1);
 
         MutableList<String> list2 = list1.with("2");
-        Assert.assertEquals(FastList.newListWith("1", "2"), list2);
+        assertEquals(FastList.newListWith("1", "2"), list2);
         Verify.assertInstanceOf(DoubletonList.class, list2);
 
         MutableList<String> list3 = list2.with("3");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), list3);
+        assertEquals(FastList.newListWith("1", "2", "3"), list3);
         Verify.assertInstanceOf(TripletonList.class, list3);
 
         MutableList<String> list4 = list3.with("4");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), list4);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), list4);
         Verify.assertInstanceOf(QuadrupletonList.class, list4);
 
         MutableList<String> list5 = list4.with("5");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), list5);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), list5);
         Verify.assertInstanceOf(QuintupletonList.class, list5);
 
         MutableList<String> list6 = list5.with("6");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), list6);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), list6);
         Verify.assertInstanceOf(SextupletonList.class, list6);
 
         MutableList<String> list7 = list6.with("7");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7"), list7);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7"), list7);
         Verify.assertInstanceOf(ArrayAdapter.class, list7);
 
         MutableList<String> list8 = list7.with("8");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8"), list8);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8"), list8);
         Verify.assertInstanceOf(ArrayAdapter.class, list8);
     }
 
@@ -118,7 +125,7 @@ public class FixedSizeListFactoryTest
     public void createList_singleton()
     {
         Verify.assertEmpty(Lists.fixedSize.of());
-        Assert.assertSame(Lists.fixedSize.of(), Lists.fixedSize.of());
+        assertSame(Lists.fixedSize.of(), Lists.fixedSize.of());
     }
 
     @Test
@@ -158,20 +165,20 @@ public class FixedSizeListFactoryTest
         threeA.add("3");
         Verify.assertEqualsAndHashCode(three, threeA);
 
-        Assert.assertNotEquals(three, twoA);
-        Assert.assertNotEquals(twoA, three);
+        assertNotEquals(three, twoA);
+        assertNotEquals(twoA, three);
 
         MutableList<String> differentThree = Lists.mutable.of();
         differentThree.add("1");
         differentThree.add("Two");
         differentThree.add("3");
-        Assert.assertNotEquals(three, differentThree);
-        Assert.assertNotEquals(differentThree, three);
+        assertNotEquals(three, differentThree);
+        assertNotEquals(differentThree, three);
 
-        Assert.assertEquals(new LinkedList<>(threeA), three);
-        Assert.assertNotEquals(new LinkedList<>(differentThree), three);
-        Assert.assertNotEquals(new LinkedList<>(FastList.newListWith("1", "2", "3", "4")), three);
-        Assert.assertNotEquals(new LinkedList<>(FastList.newListWith("1", "2")), three);
+        assertEquals(new LinkedList<>(threeA), three);
+        assertNotEquals(new LinkedList<>(differentThree), three);
+        assertNotEquals(new LinkedList<>(FastList.newListWith("1", "2", "3", "4")), three);
+        assertNotEquals(new LinkedList<>(FastList.newListWith("1", "2")), three);
     }
 
     @Test
@@ -179,7 +186,7 @@ public class FixedSizeListFactoryTest
     {
         Serializable list = (Serializable) Lists.fixedSize.of();
         Serializable list2 = (Serializable) Lists.fixedSize.of();
-        Assert.assertSame(list, list2);
+        assertSame(list, list2);
         Verify.assertPostSerializedIdentity(list);
     }
 
@@ -189,7 +196,7 @@ public class FixedSizeListFactoryTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
     }
 
     @Test
@@ -203,8 +210,8 @@ public class FixedSizeListFactoryTest
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
-        Assert.assertEquals(15, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(15, indexSum[0]);
     }
 
     @Test
@@ -213,29 +220,29 @@ public class FixedSizeListFactoryTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
     }
 
     @Test
     public void getFirstGetLast()
     {
         MutableList<String> list1 = Lists.fixedSize.of("1");
-        Assert.assertEquals("1", list1.getFirst());
-        Assert.assertEquals("1", list1.getLast());
+        assertEquals("1", list1.getFirst());
+        assertEquals("1", list1.getLast());
         MutableList<String> list2 = Lists.fixedSize.of("1", "2");
-        Assert.assertEquals("1", list2.getFirst());
-        Assert.assertEquals("2", list2.getLast());
+        assertEquals("1", list2.getFirst());
+        assertEquals("2", list2.getLast());
         MutableList<String> list3 = Lists.fixedSize.of("1", "2", "3");
-        Assert.assertEquals("1", list3.getFirst());
-        Assert.assertEquals("3", list3.getLast());
+        assertEquals("1", list3.getFirst());
+        assertEquals("3", list3.getLast());
         MutableList<String> list4 = Lists.fixedSize.of("1", "2", "3", "4");
-        Assert.assertEquals("1", list4.getFirst());
-        Assert.assertEquals("4", list4.getLast());
+        assertEquals("1", list4.getFirst());
+        assertEquals("4", list4.getLast());
         MutableList<String> list5 = Lists.fixedSize.of("1", "2", "3", "4", "5");
-        Assert.assertEquals("1", list5.getFirst());
-        Assert.assertEquals("5", list5.getLast());
+        assertEquals("1", list5.getFirst());
+        assertEquals("5", list5.getLast());
         MutableList<String> list6 = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
-        Assert.assertEquals("1", list6.getFirst());
-        Assert.assertEquals("6", list6.getLast());
+        assertEquals("1", list6.getFirst());
+        assertEquals("6", list6.getLast());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuadrupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuadrupletonListTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link QuadrupletonList}.
@@ -70,21 +74,21 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
         this.assertUnchanged();
     }
 
     @Test
     public void testAddAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
         this.assertUnchanged();
     }
 
     @Test
     public void testAdd()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
         this.assertUnchanged();
     }
 
@@ -100,26 +104,26 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
     public void testGet()
     {
         Verify.assertStartsWith(this.list, "1", "2", "3", "4");
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(4));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(4));
     }
 
     @Test
     public void testSet()
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3", "4");
-        Assert.assertEquals("1", list.set(0, "4"));
-        Assert.assertEquals("2", list.set(1, "3"));
-        Assert.assertEquals("3", list.set(2, "2"));
-        Assert.assertEquals("4", list.set(3, "1"));
-        Assert.assertEquals(FastList.newListWith("4", "3", "2", "1"), list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.set(4, "0"));
+        assertEquals("1", list.set(0, "4"));
+        assertEquals("2", list.set(1, "3"));
+        assertEquals("3", list.set(2, "2"));
+        assertEquals("4", list.set(3, "1"));
+        assertEquals(FastList.newListWith("4", "3", "2", "1"), list);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.set(4, "0"));
     }
 
     private void assertUnchanged()
     {
         Verify.assertSize(4, this.list);
         Verify.assertNotContains("5", this.list);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), this.list);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), this.list);
     }
 
     @Test
@@ -127,15 +131,15 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
     {
         Verify.assertPostSerializedEqualsAndHashCode(this.list);
         MutableList<String> copyOfList = SerializeTestHelper.serializeDeserialize(this.list);
-        Assert.assertNotSame(this.list, copyOfList);
+        assertNotSame(this.list, copyOfList);
     }
 
     @Test
     public void testGetFirstGetLast()
     {
         MutableList<String> list4 = Lists.fixedSize.of("1", "2", "3", "4");
-        Assert.assertEquals("1", list4.getFirst());
-        Assert.assertEquals("4", list4.getLast());
+        assertEquals("1", list4.getFirst());
+        assertEquals("4", list4.getLast());
     }
 
     @Test
@@ -144,7 +148,7 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
@@ -158,8 +162,8 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
-        Assert.assertEquals(6, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(6, indexSum[0]);
     }
 
     @Test
@@ -168,7 +172,7 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4");
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
@@ -198,7 +202,7 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
     public void without()
     {
         MutableList<Integer> list = new QuadrupletonList<>(1, 2, 3, 2);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(FastList.newListWith(1, 3, 2), list);
         Verify.assertInstanceOf(TripletonList.class, list);
@@ -207,6 +211,6 @@ public class QuadrupletonListTest extends AbstractMemoryEfficientMutableListTest
     @Test
     public void testGetOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.list.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.list.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuintupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuintupletonListTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTestCase
 {
@@ -68,21 +72,21 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
         this.assertUnchanged();
     }
 
     @Test
     public void testAddAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
         this.assertUnchanged();
     }
 
     @Test
     public void testAdd()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
         this.assertUnchanged();
     }
 
@@ -98,27 +102,27 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
     public void testGet()
     {
         Verify.assertStartsWith(this.list, "1", "2", "3", "4", "5");
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(5));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(5));
     }
 
     @Test
     public void testSet()
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3", "4", "5");
-        Assert.assertEquals("1", list.set(0, "5"));
-        Assert.assertEquals("2", list.set(1, "4"));
-        Assert.assertEquals("3", list.set(2, "3"));
-        Assert.assertEquals("4", list.set(3, "2"));
-        Assert.assertEquals("5", list.set(4, "1"));
-        Assert.assertEquals(FastList.newListWith("5", "4", "3", "2", "1"), list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.set(5, "0"));
+        assertEquals("1", list.set(0, "5"));
+        assertEquals("2", list.set(1, "4"));
+        assertEquals("3", list.set(2, "3"));
+        assertEquals("4", list.set(3, "2"));
+        assertEquals("5", list.set(4, "1"));
+        assertEquals(FastList.newListWith("5", "4", "3", "2", "1"), list);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.set(5, "0"));
     }
 
     private void assertUnchanged()
     {
         Verify.assertSize(5, this.list);
         Verify.assertNotContains("6", this.list);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), this.list);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), this.list);
     }
 
     @Test
@@ -126,15 +130,15 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
     {
         Verify.assertPostSerializedEqualsAndHashCode(this.list);
         MutableList<String> copyOfList = SerializeTestHelper.serializeDeserialize(this.list);
-        Assert.assertNotSame(this.list, copyOfList);
+        assertNotSame(this.list, copyOfList);
     }
 
     @Test
     public void testGetFirstGetLast()
     {
         MutableList<String> list5 = Lists.fixedSize.of("1", "2", "3", "4", "5");
-        Assert.assertEquals("1", list5.getFirst());
-        Assert.assertEquals("5", list5.getLast());
+        assertEquals("1", list5.getFirst());
+        assertEquals("5", list5.getLast());
     }
 
     @Test
@@ -143,7 +147,7 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
     }
 
     @Test
@@ -157,8 +161,8 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
-        Assert.assertEquals(10, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
+        assertEquals(10, indexSum[0]);
     }
 
     @Test
@@ -167,7 +171,7 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5");
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5"), result);
     }
 
     @Test
@@ -197,7 +201,7 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
     public void without()
     {
         MutableList<Integer> list = new QuintupletonList<>(1, 2, 3, 2, 4);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(FastList.newListWith(1, 3, 2, 4), list);
         Verify.assertInstanceOf(QuadrupletonList.class, list);
@@ -206,6 +210,6 @@ public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTest
     @Test
     public void testGetOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.list.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.list.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SextupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SextupletonListTest.java
@@ -20,8 +20,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestCase
 {
@@ -57,33 +63,33 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
     @Test
     public void testContains()
     {
-        Assert.assertTrue(this.list.contains("1"));
-        Assert.assertTrue(this.list.contains("2"));
-        Assert.assertTrue(this.list.contains("3"));
-        Assert.assertTrue(this.list.contains("4"));
-        Assert.assertTrue(this.list.contains("5"));
-        Assert.assertTrue(this.list.contains("6"));
-        Assert.assertFalse(this.list.contains("7"));
+        assertTrue(this.list.contains("1"));
+        assertTrue(this.list.contains("2"));
+        assertTrue(this.list.contains("3"));
+        assertTrue(this.list.contains("4"));
+        assertTrue(this.list.contains("5"));
+        assertTrue(this.list.contains("6"));
+        assertFalse(this.list.contains("7"));
     }
 
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
         this.assertUnchanged();
     }
 
     @Test
     public void testAddAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
         this.assertUnchanged();
     }
 
     @Test
     public void testAdd()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
         this.assertUnchanged();
     }
 
@@ -99,28 +105,28 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
     public void testGet()
     {
         Verify.assertStartsWith(this.list, "1", "2", "3", "4", "5", "6");
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(6));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(6));
     }
 
     @Test
     public void testSet()
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
-        Assert.assertEquals("1", list.set(0, "6"));
-        Assert.assertEquals("2", list.set(1, "5"));
-        Assert.assertEquals("3", list.set(2, "4"));
-        Assert.assertEquals("4", list.set(3, "3"));
-        Assert.assertEquals("5", list.set(4, "2"));
-        Assert.assertEquals("6", list.set(5, "1"));
-        Assert.assertEquals(FastList.newListWith("6", "5", "4", "3", "2", "1"), list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.set(6, "0"));
+        assertEquals("1", list.set(0, "6"));
+        assertEquals("2", list.set(1, "5"));
+        assertEquals("3", list.set(2, "4"));
+        assertEquals("4", list.set(3, "3"));
+        assertEquals("5", list.set(4, "2"));
+        assertEquals("6", list.set(5, "1"));
+        assertEquals(FastList.newListWith("6", "5", "4", "3", "2", "1"), list);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.set(6, "0"));
     }
 
     private void assertUnchanged()
     {
         Verify.assertSize(6, this.list);
         Verify.assertNotContains("7", this.list);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), this.list);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), this.list);
     }
 
     @Test
@@ -128,15 +134,15 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
     {
         Verify.assertPostSerializedEqualsAndHashCode(this.list);
         MutableList<String> copyOfList = SerializeTestHelper.serializeDeserialize(this.list);
-        Assert.assertNotSame(this.list, copyOfList);
+        assertNotSame(this.list, copyOfList);
     }
 
     @Test
     public void testGetFirstGetLast()
     {
         MutableList<String> list6 = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
-        Assert.assertEquals("1", list6.getFirst());
-        Assert.assertEquals("6", list6.getLast());
+        assertEquals("1", list6.getFirst());
+        assertEquals("6", list6.getLast());
     }
 
     @Test
@@ -145,7 +151,7 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
     }
 
     @Test
@@ -159,8 +165,8 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
-        Assert.assertEquals(15, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(15, indexSum[0]);
     }
 
     @Test
@@ -169,7 +175,7 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3", "4", "5", "6");
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6"), result);
     }
 
     @Test
@@ -199,7 +205,7 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
     public void without()
     {
         MutableList<Integer> list = new SextupletonList<>(1, 2, 3, 2, 3, 4);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(FastList.newListWith(1, 3, 2, 3, 4), list);
         Verify.assertInstanceOf(QuintupletonList.class, list);
@@ -208,6 +214,6 @@ public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestC
     @Test
     public void testGetOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.list.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.list.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SingletonListTest.java
@@ -31,8 +31,15 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.SynchronizedMutableList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SingletonList}.
@@ -75,8 +82,8 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.list.contains("1"));
-        Assert.assertFalse(this.list.contains("2"));
+        assertTrue(this.list.contains("1"));
+        assertFalse(this.list.contains("2"));
     }
 
     @Test
@@ -92,8 +99,8 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     public void get()
     {
         Verify.assertItemAtIndex("1", 0, this.list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(1));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(-1));
     }
 
     @Test
@@ -101,8 +108,8 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
         MutableList<Integer> collection = SingletonListTest.newWith(1);
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Test
@@ -111,7 +118,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<Integer> result = Lists.mutable.of();
         MutableList<Integer> collection = SingletonListTest.newWith(1);
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     private static <T> MutableList<T> newWith(T item)
@@ -125,7 +132,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<Integer> result = Lists.mutable.of();
         MutableList<Integer> collection = SingletonListTest.newWith(1);
         collection.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 0);
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     @Test
@@ -140,9 +147,9 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void set()
     {
-        Assert.assertEquals("1", this.list.set(0, "2"));
-        Assert.assertEquals(FastList.newListWith("2"), this.list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.set(1, "2"));
+        assertEquals("1", this.list.set(0, "2"));
+        assertEquals(FastList.newListWith("2"), this.list);
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.set(1, "2"));
     }
 
     @Test
@@ -199,87 +206,87 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detect(Integer.valueOf(1)::equals));
-        Assert.assertNull(SingletonListTest.newWith(1).detect(Integer.valueOf(6)::equals));
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detect(Integer.valueOf(1)::equals));
+        assertNull(SingletonListTest.newWith(1).detect(Integer.valueOf(6)::equals));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectWith(Object::equals, 1));
-        Assert.assertNull(SingletonListTest.newWith(1).detectWith(Object::equals, 6));
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectWith(Object::equals, 1));
+        assertNull(SingletonListTest.newWith(1).detectWith(Object::equals, 6));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectIfNone(Integer.valueOf(1)::equals, function));
-        Assert.assertEquals(Integer.valueOf(6), SingletonListTest.newWith(1).detectIfNone(Integer.valueOf(6)::equals, function));
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectIfNone(Integer.valueOf(1)::equals, function));
+        assertEquals(Integer.valueOf(6), SingletonListTest.newWith(1).detectIfNone(Integer.valueOf(6)::equals, function));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectWithIfNone(Object::equals, 1, function));
-        Assert.assertEquals(Integer.valueOf(6), SingletonListTest.newWith(1).detectWithIfNone(Object::equals, 6, function));
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).detectWithIfNone(Object::equals, 1, function));
+        assertEquals(Integer.valueOf(6), SingletonListTest.newWith(1).detectWithIfNone(Object::equals, 6, function));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(SingletonListTest.newWith(1).allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(SingletonListTest.newWith(1).allSatisfy(Integer.valueOf(2)::equals));
+        assertTrue(SingletonListTest.newWith(1).allSatisfy(Integer.class::isInstance));
+        assertFalse(SingletonListTest.newWith(1).allSatisfy(Integer.valueOf(2)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(SingletonListTest.newWith(1).allSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(SingletonListTest.newWith(1).allSatisfyWith(Object::equals, 2));
+        assertTrue(SingletonListTest.newWith(1).allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(SingletonListTest.newWith(1).allSatisfyWith(Object::equals, 2));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(SingletonListTest.newWith(1).anySatisfy(String.class::isInstance));
-        Assert.assertTrue(SingletonListTest.newWith(1).anySatisfy(Integer.class::isInstance));
+        assertFalse(SingletonListTest.newWith(1).anySatisfy(String.class::isInstance));
+        assertTrue(SingletonListTest.newWith(1).anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(SingletonListTest.newWith(1).anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertTrue(SingletonListTest.newWith(1).anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(SingletonListTest.newWith(1).anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(SingletonListTest.newWith(1).anySatisfyWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(SingletonListTest.newWith(1).noneSatisfy(String.class::isInstance));
-        Assert.assertFalse(SingletonListTest.newWith(1).noneSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(SingletonListTest.newWith(1).noneSatisfy(String.class::isInstance));
+        assertFalse(SingletonListTest.newWith(1).noneSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(SingletonListTest.newWith(1).noneSatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(SingletonListTest.newWith(1).noneSatisfyWith(Object::equals, 1));
+        assertTrue(SingletonListTest.newWith(1).noneSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(SingletonListTest.newWith(1).noneSatisfyWith(Object::equals, 1));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1, SingletonListTest.newWith(1).count(Integer.class::isInstance));
-        Assert.assertEquals(0, SingletonListTest.newWith(1).count(String.class::isInstance));
+        assertEquals(1, SingletonListTest.newWith(1).count(Integer.class::isInstance));
+        assertEquals(0, SingletonListTest.newWith(1).count(String.class::isInstance));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(1, SingletonListTest.newWith(1).countWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, SingletonListTest.newWith(1).countWith(Predicates2.instanceOf(), String.class));
+        assertEquals(1, SingletonListTest.newWith(1).countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, SingletonListTest.newWith(1).countWith(Predicates2.instanceOf(), String.class));
     }
 
     @Test
@@ -297,10 +304,10 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2),
                 SingletonListTest.newWith(1).collectWith(AddFunction.INTEGER, 1));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2),
                 SingletonListTest.newWith(1).collectWith(AddFunction.INTEGER, 1, FastList.newList()));
     }
@@ -308,26 +315,26 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getFirst());
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getLast());
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getOnly());
+        assertEquals(Integer.valueOf(1), SingletonListTest.newWith(1).getOnly());
     }
 
     @Test
     public void isEmpty()
     {
         Verify.assertNotEmpty(SingletonListTest.newWith(1));
-        Assert.assertTrue(SingletonListTest.newWith(1).notEmpty());
+        assertTrue(SingletonListTest.newWith(1).notEmpty());
     }
 
     @Test
@@ -338,7 +345,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
         for (int i = objects.size(); i-- > 0; )
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(1, integer.intValue() + i);
+            assertEquals(1, integer.intValue() + i);
         }
     }
 
@@ -347,7 +354,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<Integer> objects = SingletonListTest.newWith(1);
         Integer result = objects.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(2), result);
+        assertEquals(Integer.valueOf(2), result);
     }
 
     @Test
@@ -355,7 +362,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<Integer> objects = SingletonListTest.newWith(1);
         Integer result = objects.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(2), result);
+        assertEquals(Integer.valueOf(2), result);
     }
 
     @Test
@@ -381,14 +388,14 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     public void removeIf()
     {
         MutableList<Integer> objects = SingletonListTest.newWith(1);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> objects.removeIf(Predicates.isNull()));
+        assertThrows(UnsupportedOperationException.class, () -> objects.removeIf(Predicates.isNull()));
     }
 
     @Test
     public void removeIfWith()
     {
         MutableList<Integer> objects = SingletonListTest.newWith(1);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> objects.removeIfWith(Predicates2.isNull(), null));
+        assertThrows(UnsupportedOperationException.class, () -> objects.removeIfWith(Predicates2.isNull(), null));
     }
 
     @Test
@@ -407,10 +414,10 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<Integer> integers = SingletonListTest.newWith(1);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
         Verify.assertStartsWith(list, 1);
-        Assert.assertNotSame(integers, list);
+        assertNotSame(integers, list);
         MutableList<Integer> list2 = integers.toSortedList();
         Verify.assertStartsWith(list2, 1);
-        Assert.assertNotSame(integers, list2);
+        assertNotSame(integers, list2);
     }
 
     @Test
@@ -418,8 +425,8 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<Integer> integers = SingletonListTest.newWith(1);
         MutableList<Integer> list = integers.toSortedListBy(Functions.getIntegerPassThru());
-        Assert.assertEquals(FastList.newListWith(1), list);
-        Assert.assertNotSame(integers, list);
+        assertEquals(FastList.newListWith(1), list);
+        assertNotSame(integers, list);
     }
 
     @Test
@@ -461,8 +468,8 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
         {
             Verify.assertContains(each.toUpperCase(), upperList);
         }
-        Assert.assertEquals("one", subList.getFirst());
-        Assert.assertEquals("one", subList.getLast());
+        assertEquals("one", subList.getFirst());
+        assertEquals("one", subList.getLast());
     }
 
     @Test
@@ -470,7 +477,7 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<MutableList<?>> list = Lists.fixedSize.of(Lists.fixedSize.of());
         list.set(0, list);
-        Assert.assertEquals("[(this SingletonList)]", list.toString());
+        assertEquals("[(this SingletonList)]", list.toString());
     }
 
     private MutableList<Integer> newList()
@@ -500,13 +507,13 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newList().min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.newList().min(Integer::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newList().max(Comparators.reverse(Integer::compareTo)));
+        assertEquals(Integer.valueOf(1), this.newList().max(Comparators.reverse(Integer::compareTo)));
     }
 
     @Test
@@ -526,32 +533,32 @@ public class SingletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newList().min());
+        assertEquals(Integer.valueOf(1), this.newList().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(this.newList().size()), this.newList().max());
+        assertEquals(Integer.valueOf(this.newList().size()), this.newList().max());
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newList().minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.newList().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newList().maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.newList().maxBy(String::valueOf));
     }
 
     @Test
     public void without()
     {
         MutableList<Integer> list = new SingletonList<>(2);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(Lists.mutable.of(), list);
         Verify.assertInstanceOf(EmptyList.class, list);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/TripletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/TripletonListTest.java
@@ -19,8 +19,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link TripletonList}.
@@ -50,30 +56,30 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void testContains()
     {
-        Assert.assertTrue(this.list.contains("1"));
-        Assert.assertTrue(this.list.contains("2"));
-        Assert.assertTrue(this.list.contains("3"));
-        Assert.assertFalse(this.list.contains("4"));
+        assertTrue(this.list.contains("1"));
+        assertTrue(this.list.contains("2"));
+        assertTrue(this.list.contains("3"));
+        assertFalse(this.list.contains("4"));
     }
 
     @Test
     public void testRemove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.remove(0));
         this.assertUnchanged();
     }
 
     @Test
     public void testAddAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add(0, "1"));
         this.assertUnchanged();
     }
 
     @Test
     public void testAdd()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.list.add("1"));
         this.assertUnchanged();
     }
 
@@ -82,25 +88,25 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<String> newList = FastList.newList(this.list);
         newList.add("4");
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), newList);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), newList);
     }
 
     @Test
     public void testGet()
     {
         Verify.assertStartsWith(this.list, "1", "2", "3");
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(3));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.list.get(3));
     }
 
     @Test
     public void testSet()
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3");
-        Assert.assertEquals("1", list.set(0, "3"));
-        Assert.assertEquals("2", list.set(1, "2"));
-        Assert.assertEquals("3", list.set(2, "1"));
-        Assert.assertEquals(FastList.newListWith("3", "2", "1"), list);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.set(3, "0"));
+        assertEquals("1", list.set(0, "3"));
+        assertEquals("2", list.set(1, "2"));
+        assertEquals("3", list.set(2, "1"));
+        assertEquals(FastList.newListWith("3", "2", "1"), list);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.set(3, "0"));
     }
 
     private void assertUnchanged()
@@ -108,7 +114,7 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         Verify.assertInstanceOf(TripletonList.class, this.list);
         Verify.assertSize(3, this.list);
         Verify.assertNotContains("4", this.list);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), this.list);
+        assertEquals(FastList.newListWith("1", "2", "3"), this.list);
     }
 
     @Test
@@ -116,7 +122,7 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         Verify.assertPostSerializedEqualsAndHashCode(this.list);
         MutableList<String> copyOfList = SerializeTestHelper.serializeDeserialize(this.list);
-        Assert.assertNotSame(this.list, copyOfList);
+        assertNotSame(this.list, copyOfList);
     }
 
     @Test
@@ -142,7 +148,7 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
     }
 
     @Test
@@ -151,7 +157,7 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3");
         source.forEach(0, 2, result::add);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
     }
 
     @Test
@@ -165,8 +171,8 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
-        Assert.assertEquals(3, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(3, indexSum[0]);
     }
 
     @Test
@@ -180,8 +186,8 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
-        Assert.assertEquals(3, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(3, indexSum[0]);
     }
 
     @Test
@@ -190,15 +196,15 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> result = Lists.mutable.of();
         MutableList<String> source = Lists.fixedSize.of("1", "2", "3");
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
     }
 
     @Test
     public void testGetFirstGetLast()
     {
         MutableList<String> list3 = Lists.fixedSize.of("1", "2", "3");
-        Assert.assertEquals("1", list3.getFirst());
-        Assert.assertEquals("3", list3.getLast());
+        assertEquals("1", list3.getFirst());
+        assertEquals("3", list3.getLast());
     }
 
     @Test
@@ -222,17 +228,17 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         {
             Verify.assertContains(each.toUpperCase(), upperList);
         }
-        Assert.assertEquals("one", subList.getFirst());
-        Assert.assertEquals("three", subList.getLast());
+        assertEquals("one", subList.getFirst());
+        assertEquals("three", subList.getLast());
         MutableList<String> subList2 = list.subList(1, 2);
-        Assert.assertEquals("two", subList2.getFirst());
-        Assert.assertEquals("two", subList2.getLast());
+        assertEquals("two", subList2.getFirst());
+        assertEquals("two", subList2.getLast());
         MutableList<String> subList3 = list.subList(0, 1);
-        Assert.assertEquals("one", subList3.getFirst());
-        Assert.assertEquals("one", subList3.getLast());
+        assertEquals("one", subList3.getFirst());
+        assertEquals("one", subList3.getLast());
         MutableList<String> subList4 = subList.subList(1, 3);
-        Assert.assertEquals("two", subList4.getFirst());
-        Assert.assertEquals("three", subList4.getLast());
+        assertEquals("two", subList4.getFirst());
+        assertEquals("three", subList4.getLast());
     }
 
     @Test
@@ -240,18 +246,18 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<String> list = Lists.fixedSize.of("one", "two", "three");
         ListIterator<String> iterator = list.listIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.hasPrevious());
-        Assert.assertEquals("one", iterator.next());
-        Assert.assertEquals("two", iterator.next());
-        Assert.assertEquals("three", iterator.next());
-        Assert.assertTrue(iterator.hasPrevious());
-        Assert.assertEquals("three", iterator.previous());
-        Assert.assertEquals("two", iterator.previous());
-        Assert.assertEquals("one", iterator.previous());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.hasPrevious());
+        assertEquals("one", iterator.next());
+        assertEquals("two", iterator.next());
+        assertEquals("three", iterator.next());
+        assertTrue(iterator.hasPrevious());
+        assertEquals("three", iterator.previous());
+        assertEquals("two", iterator.previous());
+        assertEquals("one", iterator.previous());
         iterator.set("1");
-        Assert.assertEquals("1", iterator.next());
-        Assert.assertEquals("1", list.getFirst());
+        assertEquals("1", iterator.next());
+        assertEquals("1", list.getFirst());
         list.subList(1, 3);
     }
 
@@ -261,17 +267,17 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> list = Lists.fixedSize.of("one", "two", "three");
         MutableList<String> subList = list.subList(1, 3);
         ListIterator<String> iterator = subList.listIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.hasPrevious());
-        Assert.assertEquals("two", iterator.next());
-        Assert.assertEquals("three", iterator.next());
-        Assert.assertTrue(iterator.hasPrevious());
-        Assert.assertEquals("three", iterator.previous());
-        Assert.assertEquals("two", iterator.previous());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.hasPrevious());
+        assertEquals("two", iterator.next());
+        assertEquals("three", iterator.next());
+        assertTrue(iterator.hasPrevious());
+        assertEquals("three", iterator.previous());
+        assertEquals("two", iterator.previous());
         iterator.set("2");
-        Assert.assertEquals("2", iterator.next());
-        Assert.assertEquals("2", subList.getFirst());
-        Assert.assertEquals("2", list.get(1));
+        assertEquals("2", iterator.next());
+        assertEquals("2", subList.getFirst());
+        assertEquals("2", list.get(1));
     }
 
     @Test
@@ -279,9 +285,9 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     {
         MutableList<String> list = Lists.fixedSize.of("one", "two", "three");
         MutableList<String> subList = list.subList(1, 3);
-        Assert.assertEquals("two", subList.set(0, "2"));
-        Assert.assertEquals("2", subList.getFirst());
-        Assert.assertEquals("2", list.get(1));
+        assertEquals("two", subList.set(0, "2"));
+        assertEquals("2", subList.getFirst());
+        assertEquals("2", list.get(1));
     }
 
     @Test
@@ -298,7 +304,7 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> source = list.subList(1, 3);
         MutableList<String> result = Lists.mutable.of();
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("2", "3"), result);
+        assertEquals(FastList.newListWith("2", "3"), result);
     }
 
     @Test
@@ -313,8 +319,8 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("2", "3"), result);
-        Assert.assertEquals(1, indexSum[0]);
+        assertEquals(FastList.newListWith("2", "3"), result);
+        assertEquals(1, indexSum[0]);
     }
 
     @Test
@@ -324,33 +330,33 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
         MutableList<String> source = list.subList(1, 3);
         MutableList<String> result = Lists.mutable.of();
         source.forEachWith(Procedures2.fromProcedure(result::add), null);
-        Assert.assertEquals(FastList.newListWith("2", "3"), result);
+        assertEquals(FastList.newListWith("2", "3"), result);
     }
 
     @Test
     public void testIndexOf()
     {
         MutableList<String> list = Lists.fixedSize.of("1", null, "3");
-        Assert.assertEquals(0, list.indexOf("1"));
-        Assert.assertEquals(1, list.indexOf(null));
-        Assert.assertEquals(2, list.indexOf("3"));
-        Assert.assertEquals(-1, list.indexOf("4"));
+        assertEquals(0, list.indexOf("1"));
+        assertEquals(1, list.indexOf(null));
+        assertEquals(2, list.indexOf("3"));
+        assertEquals(-1, list.indexOf("4"));
     }
 
     @Test
     public void testLastIndexOf()
     {
         MutableList<String> list = Lists.fixedSize.of("1", null, "1");
-        Assert.assertEquals(2, list.lastIndexOf("1"));
-        Assert.assertEquals(1, list.lastIndexOf(null));
-        Assert.assertEquals(-1, list.lastIndexOf("4"));
+        assertEquals(2, list.lastIndexOf("1"));
+        assertEquals(1, list.lastIndexOf(null));
+        assertEquals(-1, list.lastIndexOf("4"));
     }
 
     @Test
     public void without()
     {
         MutableList<Integer> list = new TripletonList<>(2, 3, 2);
-        Assert.assertSame(list, list.without(9));
+        assertSame(list, list.without(9));
         list = list.without(2);
         Verify.assertListsEqual(FastList.newListWith(3, 2), list);
         Verify.assertInstanceOf(DoubletonList.class, list);
@@ -359,6 +365,6 @@ public class TripletonListTest extends AbstractMemoryEfficientMutableListTestCas
     @Test
     public void testGetOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.list.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.list.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/UnmodifiableMemoryEfficientListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/UnmodifiableMemoryEfficientListTestCase.java
@@ -17,8 +17,13 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test to check that {@link AbstractMemoryEfficientMutableList}s are Unmodifiable.
@@ -33,43 +38,43 @@ public abstract class UnmodifiableMemoryEfficientListTestCase<T> extends Unmodif
     {
         MutableList<T> collection = this.getCollection();
         ListIterator<T> it = collection.listIterator();
-        Assert.assertFalse(it.hasPrevious());
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(0, it.nextIndex());
+        assertFalse(it.hasPrevious());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(0, it.nextIndex());
         it.next();
-        Assert.assertEquals(1, it.nextIndex());
+        assertEquals(1, it.nextIndex());
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.add(null));
 
         it.set(null);
-        Assert.assertNotEquals(this.getCollection(), collection);
+        assertNotEquals(this.getCollection(), collection);
     }
 
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().addAll(0, FastList.<T>newList().with((T) null)));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().addAll(0, FastList.<T>newList().with((T) null)));
     }
 
     @Test
     public void addAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().add(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().add(0, null));
     }
 
     @Test
     public void removeFromIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().remove(0));
     }
 
     @Test
     public void subList()
     {
         MutableList<T> subList = this.getCollection().subList(0, 1);
-        Assert.assertThrows(UnsupportedOperationException.class, subList::clear);
+        assertThrows(UnsupportedOperationException.class, subList::clear);
     }
 
     @Override
@@ -86,27 +91,27 @@ public abstract class UnmodifiableMemoryEfficientListTestCase<T> extends Unmodif
     {
         MutableList<T> mutableList1 = this.getCollection();
         MutableList<Integer> mutableList2 = mutableList1.collect(element -> Integer.valueOf(element.toString()) + 1);
-        Assert.assertTrue(mutableList1.corresponds(mutableList2, (argument1, argument2) -> Integer.valueOf(argument1.toString()) < argument2));
-        Assert.assertFalse(mutableList1.corresponds(mutableList2, (argument1, argument2) -> Integer.valueOf(argument1.toString()) > argument2));
+        assertTrue(mutableList1.corresponds(mutableList2, (argument1, argument2) -> Integer.valueOf(argument1.toString()) < argument2));
+        assertFalse(mutableList1.corresponds(mutableList2, (argument1, argument2) -> Integer.valueOf(argument1.toString()) > argument2));
 
         MutableList<Integer> mutableList3 = this.getCollection().collect(element -> Integer.valueOf(element.toString()));
         mutableList3.add(0);
-        Assert.assertFalse(mutableList1.corresponds(mutableList3, Predicates2.alwaysTrue()));
+        assertFalse(mutableList1.corresponds(mutableList3, Predicates2.alwaysTrue()));
     }
 
     @Test
     public void detectIndex()
     {
         MutableList<T> mutableList = this.getCollection();
-        Assert.assertEquals(0, mutableList.detectIndex(element -> Integer.valueOf(element.toString()) == 1));
-        Assert.assertEquals(-1, mutableList.detectIndex(element -> Integer.valueOf(element.toString()) == 0));
+        assertEquals(0, mutableList.detectIndex(element -> Integer.valueOf(element.toString()) == 1));
+        assertEquals(-1, mutableList.detectIndex(element -> Integer.valueOf(element.toString()) == 0));
     }
 
     @Test
     public void detectLastIndex()
     {
         MutableList<T> mutableList = this.getCollection();
-        Assert.assertEquals(0, mutableList.detectLastIndex(element -> Integer.valueOf(element.toString()) == 1));
-        Assert.assertEquals(-1, mutableList.detectLastIndex(element -> Integer.valueOf(element.toString()) == 0));
+        assertEquals(0, mutableList.detectLastIndex(element -> Integer.valueOf(element.toString()) == 1));
+        assertEquals(-1, mutableList.detectLastIndex(element -> Integer.valueOf(element.toString()) == 0));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
@@ -59,10 +59,16 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableListTestCase extends AbstractImmutableCollectionTestCase
 {
@@ -88,13 +94,13 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         Verify.assertEqualsAndHashCode(mutable2, immutable);
         Verify.assertEqualsAndHashCode(mutable3, immutable);
         Verify.assertPostSerializedEqualsAndHashCode(immutable);
-        Assert.assertNotEquals(immutable, UnifiedSet.newSet(mutable1));
+        assertNotEquals(immutable, UnifiedSet.newSet(mutable1));
         mutable1.add(null);
         mutable2.add(null);
         mutable3.add(null);
-        Assert.assertNotEquals(mutable1, immutable);
-        Assert.assertNotEquals(mutable2, immutable);
-        Assert.assertNotEquals(mutable3, immutable);
+        assertNotEquals(mutable1, immutable);
+        assertNotEquals(mutable2, immutable);
+        assertNotEquals(mutable3, immutable);
         mutable1.remove(null);
         mutable2.remove(null);
         mutable3.remove(null);
@@ -106,15 +112,15 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
             mutable1.set(2, null);
             mutable2.set(2, null);
             mutable3.set(2, null);
-            Assert.assertNotEquals(mutable1, immutable);
-            Assert.assertNotEquals(mutable2, immutable);
-            Assert.assertNotEquals(mutable3, immutable);
+            assertNotEquals(mutable1, immutable);
+            assertNotEquals(mutable2, immutable);
+            assertNotEquals(mutable3, immutable);
             mutable1.remove(2);
             mutable2.remove(2);
             mutable3.remove(2);
-            Assert.assertNotEquals(mutable1, immutable);
-            Assert.assertNotEquals(mutable2, immutable);
-            Assert.assertNotEquals(mutable3, immutable);
+            assertNotEquals(mutable1, immutable);
+            assertNotEquals(mutable2, immutable);
+            assertNotEquals(mutable3, immutable);
         }
     }
 
@@ -124,56 +130,56 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         ImmutableList<Integer> list = this.classUnderTest();
         for (int i = 1; i <= list.size(); i++)
         {
-            Assert.assertTrue(list.contains(i));
+            assertTrue(list.contains(i));
         }
-        Assert.assertFalse(list.contains(list.size() + 1));
+        assertFalse(list.contains(list.size() + 1));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(this.classUnderTest().toList()));
+        assertTrue(this.classUnderTest().containsAll(this.classUnderTest().toList()));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllArguments(this.classUnderTest().toArray()));
+        assertTrue(this.classUnderTest().containsAllArguments(this.classUnderTest().toArray()));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(this.classUnderTest()));
+        assertTrue(this.classUnderTest().containsAllIterable(this.classUnderTest()));
     }
 
     @Test
     public void indexOf()
     {
-        Assert.assertEquals(0, this.classUnderTest().indexOf(1));
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(null));
+        assertEquals(0, this.classUnderTest().indexOf(1));
+        assertEquals(-1, this.classUnderTest().indexOf(null));
         ImmutableList<Integer> immutableList = this.classUnderTest().newWith(null);
-        Assert.assertEquals(immutableList.size() - 1, immutableList.indexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(Integer.MAX_VALUE));
+        assertEquals(immutableList.size() - 1, immutableList.indexOf(null));
+        assertEquals(-1, this.classUnderTest().indexOf(Integer.MAX_VALUE));
     }
 
     @Test
     public void lastIndexOf()
     {
-        Assert.assertEquals(0, this.classUnderTest().lastIndexOf(1));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(null));
+        assertEquals(0, this.classUnderTest().lastIndexOf(1));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(null));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(null));
         ImmutableList<Integer> immutableList = this.classUnderTest().newWith(null);
-        Assert.assertEquals(immutableList.size() - 1, immutableList.lastIndexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(Integer.MAX_VALUE));
+        assertEquals(immutableList.size() - 1, immutableList.lastIndexOf(null));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(Integer.MAX_VALUE));
     }
 
     @Test
     public void get()
     {
         ImmutableList<Integer> list = this.classUnderTest();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.get(list.size() + 1));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(list.size() + 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(-1));
     }
 
     @Test
@@ -182,7 +188,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableList<Integer> collection = this.classUnderTest();
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Test
@@ -191,7 +197,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableList<Integer> collection = this.classUnderTest();
         collection.each(result::add);
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Test
@@ -200,7 +206,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableList<Integer> list = this.classUnderTest();
         list.reverseForEach(result::add);
-        Assert.assertEquals(ListIterate.reverseThis(FastList.newList(list)), result);
+        assertEquals(ListIterate.reverseThis(FastList.newList(list)), result);
     }
 
     @Test
@@ -209,10 +215,10 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> expected = Lists.mutable.of();
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableList<Integer> list = this.classUnderTest();
-        list.reverseForEachWithIndex((each, index) -> Assert.assertEquals(each - 1, index));
+        list.reverseForEachWithIndex((each, index) -> assertEquals(each - 1, index));
         list.reverseForEachWithIndex((each, index) -> result.add(each + index));
         list.forEachWithIndex((each, index) -> expected.add(each + index));
-        Assert.assertEquals(expected.reverseThis(), result);
+        assertEquals(expected.reverseThis(), result);
     }
 
     @Test
@@ -220,11 +226,11 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         ImmutableList<Integer> integers1 = this.classUnderTest();
         ImmutableList<Integer> integers2 = this.classUnderTest().newWith(Integer.valueOf(1));
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.alwaysTrue()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.alwaysTrue()));
 
         ImmutableList<Integer> integers3 = integers1.collect(integer -> integer + 1);
-        Assert.assertTrue(integers1.corresponds(integers3, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers3, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers3, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers3, Predicates2.greaterThan()));
     }
 
     @Test
@@ -234,12 +240,12 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> reverseResult = Lists.mutable.of();
         ImmutableList<Integer> list = this.classUnderTest();
         list.forEach(0, list.size() - 1, result::add);
-        Assert.assertEquals(list, result);
+        assertEquals(list, result);
         list.forEach(list.size() - 1, 0, reverseResult::add);
-        Assert.assertEquals(ListIterate.reverseThis(FastList.newList(list)), reverseResult);
+        assertEquals(ListIterate.reverseThis(FastList.newList(list)), reverseResult);
 
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(-1, 0, result::add));
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(0, -1, result::add));
     }
 
     @Test
@@ -249,12 +255,12 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableList<Integer> reverseResult = Lists.mutable.of();
         ImmutableList<Integer> list = this.classUnderTest();
         list.forEachWithIndex(0, list.size() - 1, ObjectIntProcedures.fromProcedure(result::add));
-        Assert.assertEquals(list, result);
+        assertEquals(list, result);
         list.forEachWithIndex(list.size() - 1, 0, ObjectIntProcedures.fromProcedure(reverseResult::add));
-        Assert.assertEquals(ListIterate.reverseThis(FastList.newList(list)), reverseResult);
+        assertEquals(ListIterate.reverseThis(FastList.newList(list)), reverseResult);
 
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(-1, 0, result::add));
-        Verify.assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(0, -1, result::add));
     }
 
     @Test
@@ -262,7 +268,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         MutableCollection<Integer> result = Lists.mutable.of();
         this.classUnderTest().forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 0);
-        Assert.assertEquals(this.classUnderTest(), result);
+        assertEquals(this.classUnderTest(), result);
     }
 
     @Test
@@ -271,29 +277,29 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         ImmutableList<Integer> list = this.classUnderTest();
         MutableList<Integer> result = Lists.mutable.of();
         list.forEachWithIndex((object, index) -> result.add(object + index));
-        result.forEachWithIndex((object, index) -> Assert.assertEquals(object, result.set(index, object - index)));
-        Assert.assertEquals(list, result);
+        result.forEachWithIndex((object, index) -> assertEquals(object, result.set(index, object - index)));
+        assertEquals(list, result);
     }
 
     @Test
     public void detectIndex()
     {
-        Assert.assertEquals(0, this.classUnderTest().detectIndex(integer -> integer == 1));
-        Assert.assertEquals(-1, this.classUnderTest().detectIndex(integer -> integer == 0));
+        assertEquals(0, this.classUnderTest().detectIndex(integer -> integer == 1));
+        assertEquals(-1, this.classUnderTest().detectIndex(integer -> integer == 0));
     }
 
     @Test
     public void detectLastIndex()
     {
-        Assert.assertEquals(0, this.classUnderTest().detectLastIndex(integer -> integer == 1));
-        Assert.assertEquals(-1, this.classUnderTest().detectLastIndex(integer -> integer == 0));
+        assertEquals(0, this.classUnderTest().detectLastIndex(integer -> integer == 1));
+        assertEquals(-1, this.classUnderTest().detectLastIndex(integer -> integer == 0));
     }
 
     @Test
     public void select_target()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1), FastList.newList()));
+        assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1), FastList.newList()));
         Verify.assertEmpty(integers.select(Predicates.greaterThan(integers.size()), FastList.newList()));
     }
 
@@ -302,7 +308,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Verify.assertEmpty(integers.reject(Predicates.lessThan(integers.size() + 1), FastList.newList()));
-        Assert.assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size()), FastList.newList()));
+        assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size()), FastList.newList()));
     }
 
     @Test
@@ -312,15 +318,15 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
 
         ImmutableCollection<String> expected = this.classUnderTest().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void distinct()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.newWith(1).distinct());
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().distinct());
+        assertEquals(integers, integers.newWith(1).distinct());
+        assertEquals(this.classUnderTest(), this.classUnderTest().distinct());
     }
 
     @Test
@@ -330,15 +336,15 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         HashingStrategy<Integer> hashingStrategy = HashingStrategies.fromFunction(e -> e % 2);
         if (integers.size() > 1)
         {
-            Assert.assertEquals(Lists.immutable.with(1, 2), integers.distinct(hashingStrategy));
+            assertEquals(Lists.immutable.with(1, 2), integers.distinct(hashingStrategy));
         }
         else if (integers.size() == 1)
         {
-            Assert.assertEquals(Lists.immutable.with(1), integers.distinct(hashingStrategy));
+            assertEquals(Lists.immutable.with(1), integers.distinct(hashingStrategy));
         }
         else
         {
-            Assert.assertEquals(Lists.immutable.empty(), integers.distinct(hashingStrategy));
+            assertEquals(Lists.immutable.empty(), integers.distinct(hashingStrategy));
         }
     }
 
@@ -351,15 +357,15 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         ImmutableList<Integer> integers = this.classUnderTest();
         if (integers.size() > 1)
         {
-            Assert.assertEquals(Lists.immutable.with(1, 2), integers.distinctBy(e -> e % 2));
+            assertEquals(Lists.immutable.with(1, 2), integers.distinctBy(e -> e % 2));
         }
         else if (integers.size() == 1)
         {
-            Assert.assertEquals(Lists.immutable.with(1), integers.distinctBy(e -> e % 2));
+            assertEquals(Lists.immutable.with(1), integers.distinctBy(e -> e % 2));
         }
         else
         {
-            Assert.assertEquals(Lists.immutable.empty(), integers.distinctBy(e -> e % 2));
+            assertEquals(Lists.immutable.empty(), integers.distinctBy(e -> e % 2));
         }
     }
 
@@ -372,18 +378,18 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         List<Object> nullsMinusOne = Collections.nCopies(immutableCollection.size() - 1, null);
 
         ImmutableCollection<Pair<Integer, Object>> pairs = immutableCollection.zip(nulls);
-        Assert.assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableCollection<Pair<Integer, Object>> pairsPlusOne = immutableCollection.zip(nullsPlusOne);
-        Assert.assertEquals(immutableCollection, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableCollection, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableCollection<Pair<Integer, Object>> pairsMinusOne = immutableCollection.zip(nullsMinusOne);
-        Assert.assertEquals(immutableCollection.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(immutableCollection.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
+        assertEquals(immutableCollection.size() - 1, pairsMinusOne.size());
+        assertTrue(immutableCollection.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
 
-        Assert.assertEquals(immutableCollection.zip(nulls), immutableCollection.zip(nulls, FastList.newList()));
+        assertEquals(immutableCollection.zip(nulls), immutableCollection.zip(nulls, FastList.newList()));
     }
 
     @Test
@@ -392,16 +398,16 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         ImmutableCollection<Integer> immutableCollection = this.classUnderTest();
         ImmutableCollection<Pair<Integer, Integer>> pairs = immutableCollection.zipWithIndex();
 
-        Assert.assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(Interval.zeroTo(immutableCollection.size() - 1), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
+        assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(Interval.zeroTo(immutableCollection.size() - 1), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(immutableCollection.zipWithIndex(), immutableCollection.zipWithIndex(FastList.newList()));
+        assertEquals(immutableCollection.zipWithIndex(), immutableCollection.zipWithIndex(FastList.newList()));
     }
 
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
+        assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
         Verify.assertInstanceOf(ImmutableList.class, this.classUnderTest().chunk(10).getFirst());
     }
 
@@ -409,7 +415,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void collectIfWithTarget()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), FastList.newList()));
+        assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), FastList.newList()));
     }
 
     @Test
@@ -418,7 +424,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         ImmutableCollection<Integer> integers = this.classUnderTest();
         MutableList<Integer> list = integers.toList();
         Verify.assertEqualsAndHashCode(integers, list);
-        Assert.assertNotSame(integers, list);
+        assertNotSame(integers, list);
     }
 
     @Test
@@ -428,45 +434,45 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         mutableList.shuffleThis();
         ImmutableList<Integer> immutableList = mutableList.toImmutable();
         MutableList<Integer> sortedList = immutableList.toSortedListBy(Functions.getIntegerPassThru());
-        Assert.assertEquals(this.classUnderTest(), sortedList);
+        assertEquals(this.classUnderTest(), sortedList);
     }
 
     @Test
     public void removeAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().remove(1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().remove(1));
     }
 
     @Test
     public void set()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().set(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().set(0, 1));
     }
 
     @Test
     public void addAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().add(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> this.classUnderTest().castToList().add(0, 1));
     }
 
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().castToList().addAll(0, Lists.fixedSize.of()));
     }
 
     @Test
     public void sort()
     {
-        Assert.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().castToList().sort(Comparator.naturalOrder()));
     }
 
     @Test
     public void replaceAll()
     {
-        Verify.assertThrows(UnsupportedOperationException.class,
+        assertThrows(UnsupportedOperationException.class,
                 () -> this.classUnderTest().castToList().replaceAll(i -> i * 2));
     }
 
@@ -481,21 +487,21 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     @Test
     public void subListFromNegative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class,
+        assertThrows(IndexOutOfBoundsException.class,
                 () -> this.classUnderTest().castToList().subList(-1, 1));
     }
 
     @Test
     public void subListFromGreaterThanTO()
     {
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> this.classUnderTest().castToList().subList(1, 0));
     }
 
     @Test
     public void subListToGreaterThanSize()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class,
+        assertThrows(IndexOutOfBoundsException.class,
                 () -> this.classUnderTest().castToList().subList(0, 100));
     }
 
@@ -503,33 +509,33 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void listIterator()
     {
         ListIterator<Integer> it = this.classUnderTest().listIterator();
-        Assert.assertFalse(it.hasPrevious());
+        assertFalse(it.hasPrevious());
 
-        Assert.assertThrows(NoSuchElementException.class, it::previous);
+        assertThrows(NoSuchElementException.class, it::previous);
 
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(0, it.nextIndex());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(0, it.nextIndex());
         it.next();
-        Assert.assertEquals(1, it.nextIndex());
+        assertEquals(1, it.nextIndex());
 
-        Verify.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Verify.assertThrows(UnsupportedOperationException.class, () -> it.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.add(null));
 
-        Verify.assertThrows(UnsupportedOperationException.class, () -> it.set(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.set(null));
     }
 
     @Test
     public void listIterator_throwsNegative()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class,
+        assertThrows(IndexOutOfBoundsException.class,
                 () -> this.classUnderTest().listIterator(-1));
     }
 
     @Test
     public void listIterator_throwsGreaterThanSize()
     {
-        Assert.assertThrows(IndexOutOfBoundsException.class,
+        assertThrows(IndexOutOfBoundsException.class,
                 () -> this.classUnderTest().listIterator(100));
     }
 
@@ -537,35 +543,35 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void toStack()
     {
         MutableStack<Integer> stack = this.classUnderTest().toStack();
-        Assert.assertEquals(stack.toSortedList().toReversed(), stack.toList());
+        assertEquals(stack.toSortedList().toReversed(), stack.toList());
     }
 
     @Test
     public void take()
     {
         ImmutableList<Integer> immutableList = this.classUnderTest();
-        Assert.assertEquals(Lists.immutable.of(), immutableList.take(0));
-        Assert.assertEquals(iList(1), immutableList.take(1));
-        Assert.assertEquals(immutableList, immutableList.take(10));
+        assertEquals(Lists.immutable.of(), immutableList.take(0));
+        assertEquals(iList(1), immutableList.take(1));
+        assertEquals(immutableList, immutableList.take(10));
         MutableList<Integer> mutableList = Lists.mutable.ofAll(immutableList);
-        Assert.assertEquals(
+        assertEquals(
                 mutableList.take(mutableList.size() - 1),
                 immutableList.take(immutableList.size() - 1));
 
-        Assert.assertSame(immutableList, immutableList.take(immutableList.size()));
-        Assert.assertSame(immutableList, immutableList.take(Integer.MAX_VALUE));
+        assertSame(immutableList, immutableList.take(immutableList.size()));
+        assertSame(immutableList, immutableList.take(Integer.MAX_VALUE));
     }
 
     @Test
     public void take_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().take(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().take(-1));
     }
 
     @Test
     public void takeWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(1),
                 this.classUnderTest().takeWhile(Predicates.lessThan(2)));
     }
@@ -574,34 +580,34 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void drop()
     {
         ImmutableList<Integer> immutableList = this.classUnderTest();
-        Assert.assertSame(immutableList, immutableList.drop(0));
+        assertSame(immutableList, immutableList.drop(0));
         MutableList<Integer> mutableList = Lists.mutable.ofAll(immutableList);
-        Assert.assertEquals(mutableList.drop(1), immutableList.drop(1));
+        assertEquals(mutableList.drop(1), immutableList.drop(1));
 
         if (mutableList.notEmpty())
         {
-            Assert.assertEquals(
+            assertEquals(
                     mutableList.drop(mutableList.size() - 1),
                     immutableList.drop(immutableList.size() - 1));
         }
-        Assert.assertEquals(Lists.immutable.of(), immutableList.drop(10));
-        Assert.assertEquals(Lists.immutable.of(), immutableList.drop(immutableList.size()));
-        Assert.assertEquals(Lists.immutable.of(), immutableList.drop(Integer.MAX_VALUE));
+        assertEquals(Lists.immutable.of(), immutableList.drop(10));
+        assertEquals(Lists.immutable.of(), immutableList.drop(immutableList.size()));
+        assertEquals(Lists.immutable.of(), immutableList.drop(Integer.MAX_VALUE));
     }
 
     @Test
     public void drop_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().drop(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().drop(-1));
     }
 
     @Test
     public void dropWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest(),
                 this.classUnderTest().dropWhile(Predicates.lessThan(0)));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.of(),
                 this.classUnderTest().dropWhile(Predicates.greaterThan(0)));
     }
@@ -610,12 +616,12 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void partitionWhile()
     {
         PartitionImmutableList<Integer> partitionAll = this.classUnderTest().partitionWhile(Predicates.greaterThan(0));
-        Assert.assertEquals(this.classUnderTest(), partitionAll.getSelected());
-        Assert.assertEquals(Lists.immutable.of(), partitionAll.getRejected());
+        assertEquals(this.classUnderTest(), partitionAll.getSelected());
+        assertEquals(Lists.immutable.of(), partitionAll.getRejected());
 
         PartitionImmutableList<Integer> partitionNone = this.classUnderTest().partitionWhile(Predicates.lessThan(0));
-        Assert.assertEquals(Lists.immutable.of(), partitionNone.getSelected());
-        Assert.assertEquals(this.classUnderTest(), partitionNone.getRejected());
+        assertEquals(Lists.immutable.of(), partitionNone.getSelected());
+        assertEquals(this.classUnderTest(), partitionNone.getRejected());
     }
 
     @Override
@@ -635,10 +641,10 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         RichIterable<ObjectIntPair<Integer>> pairs = this.classUnderTest()
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.withAll(IntInterval.zeroTo(pairs.size() - 1)),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.withAll(Interval.oneTo(pairs.size())),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
     }
@@ -651,19 +657,19 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         RichIterable<ObjectIntPair<Integer>> pairs =
                 this.classUnderTest().collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.withAll(IntInterval.zeroTo(pairs.size() - 1)),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.withAll(Interval.oneTo(pairs.size())),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
 
         RichIterable<ObjectIntPair<Integer>> setOfPairs =
                 this.classUnderTest().collectWithIndex(PrimitiveTuples::pair, Sets.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.withAll(IntInterval.zeroTo(pairs.size() - 1)),
                 setOfPairs.collectInt(ObjectIntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.withAll(Interval.oneTo(pairs.size())),
                 setOfPairs.collect(ObjectIntPair::getOne, Sets.mutable.empty()));
     }
@@ -676,8 +682,8 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         ImmutableList<Integer> selected1 = this.classUnderTest().selectWithIndex((each, index) -> index < each);
         ImmutableList<Integer> selected2 = this.classUnderTest().selectWithIndex((each, index) -> index > each);
-        Assert.assertEquals(this.classUnderTest(), selected1);
-        Assert.assertEquals(Lists.immutable.empty(), selected2);
+        assertEquals(this.classUnderTest(), selected1);
+        assertEquals(Lists.immutable.empty(), selected2);
     }
 
     /**
@@ -690,8 +696,8 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
                 .selectWithIndex((each, index) -> index < each, Sets.mutable.empty());
         MutableSet<Integer> selected2 = this.classUnderTest()
                 .selectWithIndex((each, index) -> index > each, Sets.mutable.empty());
-        Assert.assertEquals(this.classUnderTest().toSet(), selected1);
-        Assert.assertEquals(Sets.immutable.empty(), selected2);
+        assertEquals(this.classUnderTest().toSet(), selected1);
+        assertEquals(Sets.immutable.empty(), selected2);
     }
 
     /**
@@ -702,8 +708,8 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         ImmutableList<Integer> rejected1 = this.classUnderTest().rejectWithIndex((each, index) -> index < each);
         ImmutableList<Integer> rejected2 = this.classUnderTest().rejectWithIndex((each, index) -> index > each);
-        Assert.assertEquals(Lists.immutable.empty(), rejected1);
-        Assert.assertEquals(this.classUnderTest(), rejected2);
+        assertEquals(Lists.immutable.empty(), rejected1);
+        assertEquals(this.classUnderTest(), rejected2);
     }
 
     /**
@@ -716,8 +722,8 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
                 .rejectWithIndex((each, index) -> index < each, Sets.mutable.empty());
         MutableSet<Integer> rejected2 = this.classUnderTest()
                 .rejectWithIndex((each, index) -> index > each, Sets.mutable.empty());
-        Assert.assertEquals(Sets.immutable.empty(), rejected1);
-        Assert.assertEquals(this.classUnderTest().toSet(), rejected2);
+        assertEquals(Sets.immutable.empty(), rejected1);
+        assertEquals(this.classUnderTest().toSet(), rejected2);
     }
 
     @Test
@@ -730,8 +736,8 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         MutableMap<Boolean, RichIterable<Integer>> actualMap = multimap.toMap();
         int halfSize = this.classUnderTest().size() / 2;
         boolean odd = this.classUnderTest().size() % 2 != 0;
-        Assert.assertEquals(halfSize, Iterate.sizeOf(actualMap.getIfAbsent(false, FastList::new)));
-        Assert.assertEquals(halfSize + (odd ? 1 : 0), Iterate.sizeOf(actualMap.getIfAbsent(true, FastList::new)));
+        assertEquals(halfSize, Iterate.sizeOf(actualMap.getIfAbsent(false, FastList::new)));
+        assertEquals(halfSize + (odd ? 1 : 0), Iterate.sizeOf(actualMap.getIfAbsent(true, FastList::new)));
     }
 
     @Test
@@ -743,11 +749,11 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
         list.forEach(Procedures.cast(value -> expected.putAll(-value, Interval.fromTo(value, list.size()))));
 
         Multimap<Integer, Integer> actual = list.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 list.groupByEach(new NegativeIntervalFunction(), FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
@@ -760,14 +766,14 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     public void toReversed()
     {
         ImmutableList<Integer> immutableList = this.classUnderTest();
-        Assert.assertEquals(immutableList.toReversed().toReversed(), immutableList);
+        assertEquals(immutableList.toReversed().toReversed(), immutableList);
         if (immutableList.size() <= 1)
         {
-            Assert.assertSame(immutableList.toReversed(), immutableList);
+            assertSame(immutableList.toReversed(), immutableList);
         }
         else
         {
-            Assert.assertNotEquals(immutableList.toReversed(), immutableList);
+            assertNotEquals(immutableList.toReversed(), immutableList);
         }
     }
 
@@ -776,7 +782,7 @@ public abstract class AbstractImmutableListTestCase extends AbstractImmutableCol
     {
         ImmutableList<Integer> integers = this.classUnderTest();
         ImmutableList<Integer> actual = integers.toImmutable();
-        Assert.assertEquals(integers, actual);
-        Assert.assertSame(integers, actual);
+        assertEquals(integers, actual);
+        assertSame(integers, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayListTest.java
@@ -24,8 +24,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link ImmutableArrayList}.
@@ -43,8 +49,8 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> list = this.newList(1, 2, 3);
         ImmutableList<Integer> with = list.newWith(4);
-        Assert.assertNotEquals(list, with);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), with);
+        assertNotEquals(list, with);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), with);
     }
 
     @Test
@@ -52,8 +58,8 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> list = this.newList(1, 2, 3);
         ImmutableList<Integer> withAll = list.newWithAll(FastList.newListWith(4, 5));
-        Assert.assertNotEquals(list, withAll);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), withAll);
+        assertNotEquals(list, withAll);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), withAll);
     }
 
     @Test
@@ -61,18 +67,18 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> list = this.newList(1, 2, 3, 4);
         ImmutableList<Integer> without4 = list.newWithout(4);
-        Assert.assertNotEquals(list, without4);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), without4);
+        assertNotEquals(list, without4);
+        assertEquals(FastList.newListWith(1, 2, 3), without4);
 
         ImmutableList<Integer> without1 = list.newWithout(1);
-        Assert.assertNotEquals(list, without1);
-        Assert.assertEquals(FastList.newListWith(2, 3, 4), without1);
+        assertNotEquals(list, without1);
+        assertEquals(FastList.newListWith(2, 3, 4), without1);
 
         ImmutableList<Integer> without0 = list.newWithout(0);
-        Assert.assertSame(list, without0);
+        assertSame(list, without0);
 
         ImmutableList<Integer> without5 = list.newWithout(5);
-        Assert.assertSame(list, without5);
+        assertSame(list, without5);
     }
 
     @Test
@@ -80,17 +86,17 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> list = this.newList(1, 2, 3, 4, 5);
         ImmutableList<Integer> withoutAll = list.newWithoutAll(FastList.newListWith(4, 5));
-        Assert.assertNotEquals(list, withoutAll);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), withoutAll);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), list.newWithoutAll(HashBag.newBagWith(4, 4, 5)));
+        assertNotEquals(list, withoutAll);
+        assertEquals(FastList.newListWith(1, 2, 3), withoutAll);
+        assertEquals(FastList.newListWith(1, 2, 3), list.newWithoutAll(HashBag.newBagWith(4, 4, 5)));
         ImmutableList<Integer> largeList = this.newList(Interval.oneTo(20).toArray());
         ImmutableList<Integer> largeWithoutAll = largeList.newWithoutAll(FastList.newList(Interval.oneTo(10)));
-        Assert.assertEquals(FastList.newList(Interval.fromTo(11, 20)), largeWithoutAll);
+        assertEquals(FastList.newList(Interval.fromTo(11, 20)), largeWithoutAll);
         ImmutableList<Integer> largeWithoutAll2 = largeWithoutAll.newWithoutAll(Interval.fromTo(11, 15));
-        Assert.assertEquals(FastList.newList(Interval.fromTo(16, 20)), largeWithoutAll2);
+        assertEquals(FastList.newList(Interval.fromTo(16, 20)), largeWithoutAll2);
         ImmutableList<Integer> largeWithoutAll3 =
                 largeWithoutAll2.newWithoutAll(UnifiedSet.newSet(Interval.fromTo(16, 19)));
-        Assert.assertEquals(FastList.newListWith(20), largeWithoutAll3);
+        assertEquals(FastList.newListWith(20), largeWithoutAll3);
     }
 
     private ImmutableArrayList<Integer> newList(Integer... elements)
@@ -122,19 +128,19 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     public void newListWith()
     {
         ImmutableList<Integer> collection = ImmutableArrayList.newListWith(1);
-        Assert.assertTrue(collection.notEmpty());
-        Assert.assertEquals(1, collection.size());
-        Assert.assertTrue(collection.contains(1));
+        assertTrue(collection.notEmpty());
+        assertEquals(1, collection.size());
+        assertTrue(collection.contains(1));
     }
 
     @Test
     public void newListWithVarArgs()
     {
         ImmutableList<Integer> collection = this.newListWith(1, 2, 3, 4);
-        Assert.assertTrue(collection.notEmpty());
-        Assert.assertEquals(4, collection.size());
-        Assert.assertTrue(collection.containsAllArguments(1, 2, 3, 4));
-        Assert.assertTrue(collection.containsAllIterable(Interval.oneTo(4)));
+        assertTrue(collection.notEmpty());
+        assertEquals(4, collection.size());
+        assertTrue(collection.containsAllArguments(1, 2, 3, 4));
+        assertTrue(collection.containsAllIterable(Interval.oneTo(4)));
     }
 
     @Test
@@ -151,7 +157,7 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
         ImmutableArrayList<Integer> integers = ImmutableArrayList.newListWith(1, 2, 3, 4);
         MutableMap<String, String> map =
                 integers.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -159,8 +165,8 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> collection = ImmutableArrayList.newListWith(1, 2, 3, 4, 5);
         ImmutableList<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
-        Assert.assertEquals(5, deserializedCollection.size());
-        Assert.assertTrue(deserializedCollection.containsAllArguments(1, 2, 3, 4, 5));
+        assertEquals(5, deserializedCollection.size());
+        assertTrue(deserializedCollection.containsAllArguments(1, 2, 3, 4, 5));
         Verify.assertEqualsAndHashCode(collection, deserializedCollection);
     }
 
@@ -183,8 +189,8 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     public void get()
     {
         ImmutableList<Integer> list = this.classUnderTest();
-        Assert.assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(list.size() + 1));
-        Assert.assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(-1));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(list.size() + 1));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(-1));
     }
 
     @Test
@@ -194,18 +200,18 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
         try
         {
             this.classUnderTest().iterator().remove();
-            Assert.fail("Should not reach here! Exception should be thrown on previous line.");
+            fail("Should not reach here! Exception should be thrown on previous line.");
         }
         catch (Exception e)
         {
-            Assert.assertTrue(e instanceof IllegalStateException || e instanceof UnsupportedOperationException);
+            assertTrue(e instanceof IllegalStateException || e instanceof UnsupportedOperationException);
         }
     }
 
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3),
                 this.classUnderTest().groupByUniqueKey(id -> id));
     }
@@ -221,7 +227,7 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     {
         MutableMap<Integer, Integer> integers =
                 this.classUnderTest().groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -234,7 +240,7 @@ public class ImmutableArrayListTest extends AbstractImmutableListTestCase
     public void getOnly()
     {
         ImmutableList<Integer> list = this.newList(2);
-        Assert.assertEquals(Integer.valueOf(2), list.getOnly());
+        assertEquals(Integer.valueOf(2), list.getOnly());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDecapletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDecapletonListTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableDecapletonListTest extends AbstractImmutableListTestCase
 {
@@ -40,7 +40,7 @@ public class ImmutableDecapletonListTest extends AbstractImmutableListTestCase
     public void selectInstanceOf()
     {
         ImmutableList<Number> numbers = new ImmutableDecapletonList<>(1, 2.0, 3, 4.0, 5, 6.0, 7, 8.0, 9, 10.0);
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 3, 5, 7, 9),
                 numbers.selectInstancesOf(Integer.class));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyListTest.java
@@ -34,9 +34,16 @@ import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
@@ -51,30 +58,30 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     @Test
     public void indexOf()
     {
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(1));
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(null));
+        assertEquals(-1, this.classUnderTest().indexOf(1));
+        assertEquals(-1, this.classUnderTest().indexOf(null));
         ImmutableList<Integer> immutableList = this.classUnderTest().newWith(null);
-        Assert.assertEquals(immutableList.size() - 1, immutableList.indexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().indexOf(Integer.MAX_VALUE));
+        assertEquals(immutableList.size() - 1, immutableList.indexOf(null));
+        assertEquals(-1, this.classUnderTest().indexOf(Integer.MAX_VALUE));
     }
 
     @Override
     @Test
     public void lastIndexOf()
     {
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(1));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(null));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(1));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(null));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(null));
         ImmutableList<Integer> immutableList = this.classUnderTest().newWith(null);
-        Assert.assertEquals(immutableList.size() - 1, immutableList.lastIndexOf(null));
-        Assert.assertEquals(-1, this.classUnderTest().lastIndexOf(Integer.MAX_VALUE));
+        assertEquals(immutableList.size() - 1, immutableList.lastIndexOf(null));
+        assertEquals(-1, this.classUnderTest().lastIndexOf(Integer.MAX_VALUE));
     }
 
     @Test
     public void newWithout()
     {
-        Assert.assertSame(Lists.immutable.empty(), Lists.immutable.empty().newWithout(1));
-        Assert.assertSame(Lists.immutable.empty(), Lists.immutable.empty().newWithoutAll(Interval.oneTo(3)));
+        assertSame(Lists.immutable.empty(), Lists.immutable.empty().newWithout(1));
+        assertSame(Lists.immutable.empty(), Lists.immutable.empty().newWithoutAll(Interval.oneTo(3)));
     }
 
     @Override
@@ -84,7 +91,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         ImmutableList<Integer> list = Lists.immutable.empty();
         MutableList<Integer> result = Lists.mutable.empty();
         list.reverseForEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(list, result);
+        assertEquals(list, result);
     }
 
     @Override
@@ -102,8 +109,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         MutableList<Integer> result = Lists.mutable.empty();
         MutableList<Integer> reverseResult = Lists.mutable.empty();
         ImmutableList<Integer> list = this.classUnderTest();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(0, list.size() - 1, CollectionAddProcedure.on(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(list.size() - 1, 0, CollectionAddProcedure.on(reverseResult)));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(0, list.size() - 1, CollectionAddProcedure.on(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEach(list.size() - 1, 0, CollectionAddProcedure.on(reverseResult)));
     }
 
     @Override
@@ -113,8 +120,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         MutableList<Integer> result = Lists.mutable.empty();
         MutableList<Integer> reverseResult = Lists.mutable.empty();
         ImmutableList<Integer> list = this.classUnderTest();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(0, list.size() - 1, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(result))));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(list.size() - 1, 0, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(reverseResult))));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(0, list.size() - 1, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(result))));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.forEachWithIndex(list.size() - 1, 0, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(reverseResult))));
     }
 
     @Override
@@ -122,7 +129,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void detect()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.detect(Integer.valueOf(1)::equals));
+        assertNull(integers.detect(Integer.valueOf(1)::equals));
     }
 
     @Override
@@ -130,7 +137,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void detectWith()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(integers.detectWith(Object::equals, Integer.valueOf(1)));
     }
 
     @Override
@@ -138,8 +145,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void distinct()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertNotNull(integers.distinct());
-        Assert.assertTrue(integers.isEmpty());
+        assertNotNull(integers.distinct());
+        assertTrue(integers.isEmpty());
     }
 
     @Override
@@ -147,7 +154,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void countWith()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(0, integers.countWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertEquals(0, integers.countWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -156,10 +163,10 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     {
         //Evaluates true for all empty lists and false for all non-empty lists
 
-        Assert.assertTrue(this.classUnderTest().corresponds(Lists.mutable.empty(), Predicates2.alwaysFalse()));
+        assertTrue(this.classUnderTest().corresponds(Lists.mutable.empty(), Predicates2.alwaysFalse()));
 
         ImmutableList<Integer> integers = this.classUnderTest().newWith(Integer.valueOf(1));
-        Assert.assertFalse(this.classUnderTest().corresponds(integers, Predicates2.alwaysTrue()));
+        assertFalse(this.classUnderTest().corresponds(integers, Predicates2.alwaysTrue()));
     }
 
     @Override
@@ -167,28 +174,28 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void allSatisfy()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(integers.allSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void allSatisfyWith()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(integers.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
     public void noneSatisfy()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(integers.noneSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void noneSatisfyWith()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(integers.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -196,14 +203,14 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void anySatisfy()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfy(ERROR_THROWING_PREDICATE));
+        assertFalse(integers.anySatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void anySatisfyWith()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertFalse(integers.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -211,7 +218,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void getFirst()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.getFirst());
+        assertNull(integers.getFirst());
     }
 
     @Override
@@ -219,7 +226,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void getLast()
     {
         ImmutableList<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.getLast());
+        assertNull(integers.getLast());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -234,8 +241,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void isEmpty()
     {
         ImmutableList<Integer> list = this.classUnderTest();
-        Assert.assertTrue(list.isEmpty());
-        Assert.assertFalse(list.notEmpty());
+        assertTrue(list.isEmpty());
+        assertFalse(list.notEmpty());
     }
 
     @Override
@@ -328,14 +335,14 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         List<Object> nullsPlusOne = Collections.nCopies(immutableList.size() + 1, null);
 
         ImmutableList<Pair<Integer, Object>> pairs = immutableList.zip(nulls);
-        Assert.assertEquals(immutableList, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableList, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableList<Pair<Integer, Object>> pairsPlusOne = immutableList.zip(nullsPlusOne);
-        Assert.assertEquals(immutableList, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableList, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
-        Assert.assertEquals(immutableList.zip(nulls), immutableList.zip(nulls, FastList.newList()));
+        assertEquals(immutableList.zip(nulls), immutableList.zip(nulls, FastList.newList()));
     }
 
     @Override
@@ -345,16 +352,16 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         ImmutableList<Integer> immutableList = this.classUnderTest();
         ImmutableList<Pair<Integer, Integer>> pairs = immutableList.zipWithIndex();
 
-        Assert.assertEquals(immutableList, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(FastList.<Integer>newList(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
+        assertEquals(immutableList, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(FastList.<Integer>newList(), pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(immutableList.zipWithIndex(), immutableList.zipWithIndex(FastList.newList()));
+        assertEquals(immutableList.zipWithIndex(), immutableList.zipWithIndex(FastList.newList()));
     }
 
     @Test
     public void chunk()
     {
-        Assert.assertEquals(Lists.mutable.empty(), this.classUnderTest().chunk(2));
+        assertEquals(Lists.mutable.empty(), this.classUnderTest().chunk(2));
     }
 
     @Override
@@ -368,7 +375,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10));
+        assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10));
         Verify.assertInstanceOf(ImmutableList.class, this.classUnderTest().chunk(10));
     }
 
@@ -380,7 +387,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         MutableList<Integer> mutable = FastList.newList(immutable);
         Verify.assertEqualsAndHashCode(immutable, mutable);
         Verify.assertPostSerializedIdentity(immutable);
-        Assert.assertNotEquals(immutable, UnifiedSet.newSet(mutable));
+        assertNotEquals(immutable, UnifiedSet.newSet(mutable));
     }
 
     @Override
@@ -388,17 +395,17 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void take()
     {
         ImmutableList<Integer> immutableList = this.classUnderTest();
-        Assert.assertSame(immutableList, immutableList.take(0));
-        Assert.assertSame(immutableList, immutableList.take(10));
-        Assert.assertSame(immutableList, immutableList.take(Integer.MAX_VALUE));
+        assertSame(immutableList, immutableList.take(0));
+        assertSame(immutableList, immutableList.take(10));
+        assertSame(immutableList, immutableList.take(Integer.MAX_VALUE));
     }
 
     @Override
     @Test
     public void takeWhile()
     {
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().takeWhile(ignored -> true));
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().takeWhile(ignored -> false));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().takeWhile(ignored -> true));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().takeWhile(ignored -> false));
     }
 
     @Override
@@ -408,9 +415,9 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         super.drop();
 
         ImmutableList<Integer> immutableList = this.classUnderTest();
-        Assert.assertSame(immutableList, immutableList.drop(10));
-        Assert.assertSame(immutableList, immutableList.drop(0));
-        Assert.assertSame(immutableList, immutableList.drop(Integer.MAX_VALUE));
+        assertSame(immutableList, immutableList.drop(10));
+        assertSame(immutableList, immutableList.drop(0));
+        assertSame(immutableList, immutableList.drop(Integer.MAX_VALUE));
     }
 
     @Override
@@ -419,8 +426,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     {
         super.dropWhile();
 
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().dropWhile(ignored -> true));
-        Assert.assertEquals(Lists.immutable.empty(), this.classUnderTest().dropWhile(ignored -> false));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().dropWhile(ignored -> true));
+        assertEquals(Lists.immutable.empty(), this.classUnderTest().dropWhile(ignored -> false));
     }
 
     @Override
@@ -430,12 +437,12 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         super.partitionWhile();
 
         PartitionImmutableList<Integer> partition1 = this.classUnderTest().partitionWhile(ignored -> true);
-        Assert.assertEquals(Lists.immutable.empty(), partition1.getSelected());
-        Assert.assertEquals(Lists.immutable.empty(), partition1.getRejected());
+        assertEquals(Lists.immutable.empty(), partition1.getSelected());
+        assertEquals(Lists.immutable.empty(), partition1.getRejected());
 
         PartitionImmutableList<Integer> partiton2 = this.classUnderTest().partitionWhile(ignored -> false);
-        Assert.assertEquals(Lists.immutable.empty(), partiton2.getSelected());
-        Assert.assertEquals(Lists.immutable.empty(), partiton2.getRejected());
+        assertEquals(Lists.immutable.empty(), partiton2.getSelected());
+        assertEquals(Lists.immutable.empty(), partiton2.getRejected());
     }
 
     @Override
@@ -443,15 +450,15 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void listIterator()
     {
         ListIterator<Integer> it = this.classUnderTest().listIterator();
-        Assert.assertFalse(it.hasPrevious());
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(0, it.nextIndex());
+        assertFalse(it.hasPrevious());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(0, it.nextIndex());
 
-        Assert.assertThrows(NoSuchElementException.class, it::next);
+        assertThrows(NoSuchElementException.class, it::next);
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.add(null));
     }
 
     @Override
@@ -463,8 +470,8 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         {
             throw new AssertionError();
         }, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Override
@@ -476,22 +483,22 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
         {
             throw new AssertionError();
         }, 1, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Test
     public void binarySearch()
     {
         ListIterable<Integer> sortedList = this.classUnderTest();
-        Assert.assertEquals(-1, sortedList.binarySearch(1));
+        assertEquals(-1, sortedList.binarySearch(1));
     }
 
     @Test
     public void binarySearchWithComparator()
     {
         ListIterable<Integer> sortedList = this.classUnderTest();
-        Assert.assertEquals(-1, sortedList.binarySearch(1, Integer::compareTo));
+        assertEquals(-1, sortedList.binarySearch(1, Integer::compareTo));
     }
 
     @Override
@@ -499,7 +506,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void detectIndex()
     {
         // any predicate will result in -1
-        Assert.assertEquals(-1, this.classUnderTest().detectIndex(Predicates.alwaysTrue()));
+        assertEquals(-1, this.classUnderTest().detectIndex(Predicates.alwaysTrue()));
     }
 
     @Override
@@ -507,7 +514,7 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     public void detectLastIndex()
     {
         // any predicate will result in -1
-        Assert.assertEquals(-1, this.classUnderTest().detectLastIndex(Predicates.alwaysTrue()));
+        assertEquals(-1, this.classUnderTest().detectLastIndex(Predicates.alwaysTrue()));
     }
 
     /**
@@ -533,13 +540,13 @@ public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
     @Test
     public void countByEach()
     {
-        Assert.assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
+        assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
     }
 
     @Test
     public void countByEach_target()
     {
         MutableBag<Integer> target = Bags.mutable.empty();
-        Assert.assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
+        assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuadrupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuadrupletonListTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ImmutableQuadrupletonListTest extends AbstractImmutableListTestCase
 {
@@ -32,9 +34,9 @@ public class ImmutableQuadrupletonListTest extends AbstractImmutableListTestCase
         super.distinct();
         ImmutableList<Integer> list = new ImmutableQuadrupletonList<>(2, 1, 1, 2);
         ImmutableList<Integer> distinctList = list.distinct();
-        Assert.assertFalse(distinctList.isEmpty());
+        assertFalse(distinctList.isEmpty());
         Verify.assertInstanceOf(ImmutableDoubletonList.class, distinctList);
-        Assert.assertEquals(FastList.newListWith(2, 1), distinctList);
+        assertEquals(FastList.newListWith(2, 1), distinctList);
     }
 
     @Test
@@ -42,8 +44,8 @@ public class ImmutableQuadrupletonListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<String> list = new ImmutableQuadrupletonList<>("a", "a", "B", "c");
         ImmutableList<String> distinctList = list.distinct(HashingStrategies.fromFunction(String::toLowerCase));
-        Assert.assertFalse(distinctList.isEmpty());
-        Assert.assertEquals(FastList.newListWith("a", "B", "c"), distinctList);
+        assertFalse(distinctList.isEmpty());
+        assertEquals(FastList.newListWith("a", "B", "c"), distinctList);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonListTest.java
@@ -11,8 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableSingletonListTest extends AbstractImmutableListTestCase
 {
@@ -58,6 +59,6 @@ public class ImmutableSingletonListTest extends AbstractImmutableListTestCase
     public void getOnly()
     {
         ImmutableList<Integer> list = new ImmutableSingletonList<>(3);
-        Assert.assertEquals(Integer.valueOf(3), list.getOnly());
+        assertEquals(Integer.valueOf(3), list.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSubListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSubListTest.java
@@ -14,8 +14,11 @@ import java.util.ListIterator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableSubListTest extends AbstractImmutableListTestCase
 {
@@ -30,15 +33,15 @@ public class ImmutableSubListTest extends AbstractImmutableListTestCase
     {
         ImmutableList<Integer> subList = this.classUnderTest();
         ListIterator<Integer> iterator = subList.listIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.hasPrevious());
-        Assert.assertEquals(Integer.valueOf(1), iterator.next());
-        Assert.assertEquals(Integer.valueOf(2), iterator.next());
-        Assert.assertEquals(Integer.valueOf(3), iterator.next());
-        Assert.assertTrue(iterator.hasPrevious());
-        Assert.assertEquals(Integer.valueOf(3), iterator.previous());
-        Assert.assertEquals(Integer.valueOf(2), iterator.previous());
-        Assert.assertEquals(Integer.valueOf(1), iterator.previous());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.hasPrevious());
+        assertEquals(Integer.valueOf(1), iterator.next());
+        assertEquals(Integer.valueOf(2), iterator.next());
+        assertEquals(Integer.valueOf(3), iterator.next());
+        assertTrue(iterator.hasPrevious());
+        assertEquals(Integer.valueOf(3), iterator.previous());
+        assertEquals(Integer.valueOf(2), iterator.previous());
+        assertEquals(Integer.valueOf(1), iterator.previous());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -69,7 +72,7 @@ public class ImmutableSubListTest extends AbstractImmutableListTestCase
     public void getOnly()
     {
         ImmutableList<Integer> list = Lists.immutable.of(1, 2, 3, 4, 5).subList(1, 2);
-        Assert.assertEquals(Integer.valueOf(2), list.getOnly());
+        assertEquals(Integer.valueOf(2), list.getOnly());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/AbstractImmutableBooleanListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/AbstractImmutableBooleanListTestCase.java
@@ -22,8 +22,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanList}.
@@ -60,11 +66,11 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
             sixtyFourElementCollection.add(true);
         }
         ImmutableBooleanList immutableBooleanList = sixtyFourElementCollection.toImmutable();
-        Assert.assertEquals(sixtyFourElementCollection, immutableBooleanList);
+        assertEquals(sixtyFourElementCollection, immutableBooleanList);
         ImmutableBooleanList newImmutableBooleanList = immutableBooleanList.newWith(false);
-        Assert.assertFalse(newImmutableBooleanList.get(64));
+        assertFalse(newImmutableBooleanList.get(64));
         ImmutableBooleanList newImmutableBooleanList1 = immutableBooleanList.newWith(true);
-        Assert.assertTrue(newImmutableBooleanList1.get(64));
+        assertTrue(newImmutableBooleanList1.get(64));
     }
 
     @Test
@@ -73,7 +79,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         ImmutableBooleanList list = this.classUnderTest();
         for (int i = 0; i < list.size(); i++)
         {
-            Assert.assertEquals((i & 1) == 0, list.get(i));
+            assertEquals((i & 1) == 0, list.get(i));
         }
     }
 
@@ -99,28 +105,28 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
     @Test
     public void getFirst()
     {
-        Assert.assertTrue(this.classUnderTest().getFirst());
+        assertTrue(this.classUnderTest().getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().getLast());
+        assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().getLast());
     }
 
     @Test
     public void indexOf()
     {
         ImmutableBooleanList list = this.classUnderTest();
-        Assert.assertEquals(0L, list.indexOf(true));
-        Assert.assertEquals(list.size() > 2 ? 1L : -1L, list.indexOf(false));
+        assertEquals(0L, list.indexOf(true));
+        assertEquals(list.size() > 2 ? 1L : -1L, list.indexOf(false));
 
         MutableBooleanList mutableList = this.newMutableCollectionWith();
         for (int i = 0; i < list.size(); i++)
         {
             mutableList.add(false);
         }
-        Assert.assertEquals(-1L, mutableList.toImmutable().indexOf(true));
+        assertEquals(-1L, mutableList.toImmutable().indexOf(true));
     }
 
     @Test
@@ -128,15 +134,15 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
     {
         ImmutableBooleanList list = this.classUnderTest();
         int size = list.size();
-        Assert.assertEquals((size & 1) == 0 ? size - 2 : size - 1, list.lastIndexOf(true));
-        Assert.assertEquals((size & 1) == 0 ? size - 1 : size - 2, list.lastIndexOf(false));
+        assertEquals((size & 1) == 0 ? size - 2 : size - 1, list.lastIndexOf(true));
+        assertEquals((size & 1) == 0 ? size - 1 : size - 2, list.lastIndexOf(false));
 
         MutableBooleanList mutableList = this.newMutableCollectionWith();
         for (int i = 0; i < list.size(); i++)
         {
             mutableList.add(false);
         }
-        Assert.assertEquals(-1L, mutableList.toImmutable().lastIndexOf(true));
+        assertEquals(-1L, mutableList.toImmutable().lastIndexOf(true));
     }
 
     @Override
@@ -146,9 +152,9 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
         for (int i = 0; iterator.hasNext(); i++)
         {
-            Assert.assertEquals(i % 2 == 0, iterator.next());
+            assertEquals(i % 2 == 0, iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -165,7 +171,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         {
             expectedString.append((i & 1) == 0);
         }
-        Assert.assertEquals(expectedString.toString(), sum[0]);
+        assertEquals(expectedString.toString(), sum[0]);
     }
 
     @Test
@@ -176,16 +182,16 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         sum[1] = "";
         this.classUnderTest().forEachWithIndex((each, index) -> sum[0] += index + ":" + each);
         this.newWith().forEachWithIndex((each, index) -> sum[1] += index + ":" + each);
-        Assert.assertEquals("0:true1:false2:true", sum[0]);
-        Assert.assertEquals("", sum[1]);
+        assertEquals("0:true1:false2:true", sum[0]);
+        assertEquals("", sum[1]);
     }
 
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).toReversed());
+        assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).toReversed());
         ImmutableBooleanList originalList = this.newWith(true, true, false, false);
-        Assert.assertNotSame(originalList, originalList.toReversed());
+        assertNotSame(originalList, originalList.toReversed());
     }
 
     @Override
@@ -194,10 +200,10 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
     {
         super.toArray();
         ImmutableBooleanList list = this.classUnderTest();
-        Assert.assertEquals(this.classUnderTest().size(), list.toArray().length);
+        assertEquals(this.classUnderTest().size(), list.toArray().length);
         for (int i = 0; i < this.classUnderTest().size(); i++)
         {
-            Assert.assertEquals((i & 1) == 0, list.toArray()[i]);
+            assertEquals((i & 1) == 0, list.toArray()[i]);
         }
     }
 
@@ -206,7 +212,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
     {
         ImmutableBooleanList list = this.newWith(true, false, true);
         MutableInteger result = list.injectIntoWithIndex(new MutableInteger(0), (object, value, index) -> object.add((value ? 1 : 0) + index));
-        Assert.assertEquals(new MutableInteger(5), result);
+        assertEquals(new MutableInteger(5), result);
     }
 
     @Override
@@ -216,7 +222,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         super.testEquals();
         ImmutableBooleanList list1 = this.newWith(true, false, true, true);
         ImmutableBooleanList list2 = this.newWith(true, true, false, true);
-        Assert.assertNotEquals(list1, list2);
+        assertNotEquals(list1, list2);
     }
 
     @Override
@@ -232,7 +238,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
             expectedString.append(i == size - 1 ? "" : ", ");
         }
         expectedString.append(']');
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Override
@@ -251,9 +257,9 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
             expectedString.append(i == size - 1 ? "" : ", ");
             expectedString1.append(i == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().makeString());
-        Assert.assertEquals(expectedString1.toString(), this.classUnderTest().makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals(expectedString.toString(), this.classUnderTest().makeString());
+        assertEquals(expectedString1.toString(), this.classUnderTest().makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
     }
 
     @Override
@@ -274,13 +280,13 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         }
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -290,7 +296,7 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         super.toList();
         MutableBooleanList list = this.classUnderTest().toList();
         Verify.assertEqualsAndHashCode(this.classUnderTest(), list);
-        Assert.assertNotSame(this.classUnderTest(), list);
+        assertNotSame(this.classUnderTest(), list);
     }
 
     @Override
@@ -305,14 +311,14 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         ImmutableBooleanCollection collection2 = booleanCollection.newWith(true).newWith(false).newWith(true).newWith(false);
         ImmutableBooleanCollection collection3 = booleanCollection.newWith(true).newWith(false).newWith(true).newWith(false).newWith(true);
         ImmutableBooleanCollection collection4 = collection3.newWith(true).newWith(false).newWith(true).newWith(false).newWith(true);
-        Assert.assertEquals(list, booleanCollection);
-        Assert.assertEquals(list.with(true), collection);
-        Assert.assertEquals(list.with(false), collection0);
-        Assert.assertEquals(list.with(true), collection1);
-        Assert.assertEquals(list.with(false), collection2);
-        Assert.assertEquals(list.with(true), collection3);
+        assertEquals(list, booleanCollection);
+        assertEquals(list.with(true), collection);
+        assertEquals(list.with(false), collection0);
+        assertEquals(list.with(true), collection1);
+        assertEquals(list.with(false), collection2);
+        assertEquals(list.with(true), collection3);
         list.addAll(true, false, true, false, true);
-        Assert.assertEquals(list, collection4);
+        assertEquals(list, collection4);
     }
 
     @Override
@@ -327,14 +333,14 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         ImmutableBooleanCollection collection2 = booleanCollection.newWithAll(this.newMutableCollectionWith(true, false, true, false));
         ImmutableBooleanCollection collection3 = booleanCollection.newWithAll(this.newMutableCollectionWith(true, false, true, false, true));
         ImmutableBooleanCollection collection4 = collection3.newWithAll(this.newMutableCollectionWith(true, false, true, false, true));
-        Assert.assertEquals(list, booleanCollection);
-        Assert.assertEquals(list.with(true), collection);
-        Assert.assertEquals(list.with(false), collection0);
-        Assert.assertEquals(list.with(true), collection1);
-        Assert.assertEquals(list.with(false), collection2);
-        Assert.assertEquals(list.with(true), collection3);
+        assertEquals(list, booleanCollection);
+        assertEquals(list.with(true), collection);
+        assertEquals(list.with(false), collection0);
+        assertEquals(list.with(true), collection1);
+        assertEquals(list.with(false), collection2);
+        assertEquals(list.with(true), collection3);
         list.addAll(true, false, true, false, true);
-        Assert.assertEquals(list, collection4);
+        assertEquals(list, collection4);
     }
 
     @Override
@@ -342,15 +348,15 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
     public void newWithout()
     {
         ImmutableBooleanCollection trueCollection = this.getTrueCollection(this.classUnderTest()).toImmutable();
-        Assert.assertSame(trueCollection, trueCollection.newWithout(false));
-        Assert.assertNotSame(trueCollection, trueCollection.newWithout(true));
+        assertSame(trueCollection, trueCollection.newWithout(false));
+        assertNotSame(trueCollection, trueCollection.newWithout(true));
 
         ImmutableBooleanCollection collection = this.classUnderTest();
         MutableBooleanList list = collection.toList();
-        Assert.assertEquals(list.without(true), collection.newWithout(true));
+        assertEquals(list.without(true), collection.newWithout(true));
         MutableBooleanList list1 = collection.toList();
-        Assert.assertEquals(list1.without(false), collection.newWithout(false));
-        Assert.assertEquals(this.classUnderTest(), collection);
+        assertEquals(list1.without(false), collection.newWithout(false));
+        assertEquals(this.classUnderTest(), collection);
     }
 
     @Override
@@ -360,17 +366,17 @@ public abstract class AbstractImmutableBooleanListTestCase extends AbstractImmut
         ImmutableBooleanCollection immutableBooleanCollection = this.classUnderTest();
         MutableBooleanCollection mutableTrueCollection = this.getTrueCollection(immutableBooleanCollection);
         ImmutableBooleanCollection trueCollection = mutableTrueCollection.toImmutable();
-        Assert.assertEquals(this.newMutableCollectionWith(), trueCollection.newWithoutAll(this.newMutableCollectionWith(true, false)));
-        Assert.assertEquals(mutableTrueCollection, trueCollection);
+        assertEquals(this.newMutableCollectionWith(), trueCollection.newWithoutAll(this.newMutableCollectionWith(true, false)));
+        assertEquals(mutableTrueCollection, trueCollection);
 
         MutableBooleanList list = immutableBooleanCollection.toList();
         list.removeAll(true);
-        Assert.assertEquals(list, immutableBooleanCollection.newWithoutAll(this.newMutableCollectionWith(true)));
-        Assert.assertEquals(this.newMutableCollectionWith(), immutableBooleanCollection.newWithoutAll(this.newMutableCollectionWith(true, false)));
+        assertEquals(list, immutableBooleanCollection.newWithoutAll(this.newMutableCollectionWith(true)));
+        assertEquals(this.newMutableCollectionWith(), immutableBooleanCollection.newWithoutAll(this.newMutableCollectionWith(true, false)));
 
         ImmutableBooleanCollection collection = this.newWith(true, false, true, false, true);
-        Assert.assertEquals(this.newMutableCollectionWith(false, false), collection.newWithoutAll(this.newMutableCollectionWith(true, true)));
-        Assert.assertEquals(this.newMutableCollectionWith(), collection.newWithoutAll(this.newMutableCollectionWith(true, false)));
+        assertEquals(this.newMutableCollectionWith(false, false), collection.newWithoutAll(this.newMutableCollectionWith(true, true)));
+        assertEquals(this.newMutableCollectionWith(), collection.newWithoutAll(this.newMutableCollectionWith(true, false)));
     }
 
     private MutableBooleanCollection getTrueCollection(ImmutableBooleanCollection collection)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayListTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link ImmutableBooleanArrayList}.
@@ -45,7 +46,7 @@ public class ImmutableBooleanArrayListTest extends AbstractImmutableBooleanListT
     public void newCollection()
     {
         super.newCollection();
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), ImmutableBooleanArrayList.newList(BooleanArrayList.newListWith(true, false, true)));
+        assertEquals(BooleanArrayList.newListWith(true, false, true), ImmutableBooleanArrayList.newList(BooleanArrayList.newListWith(true, false, true)));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanEmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanEmptyListTest.java
@@ -14,8 +14,12 @@ import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListTestCase
 {
@@ -31,9 +35,9 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
     {
         ImmutableBooleanList emptyList = this.newWith();
         ImmutableBooleanList newList = emptyList.newWithout(true);
-        Assert.assertEquals(this.newWith(), newList);
-        Assert.assertSame(emptyList, newList);
-        Assert.assertEquals(this.newMutableCollectionWith(), emptyList);
+        assertEquals(this.newWith(), newList);
+        assertSame(emptyList, newList);
+        assertEquals(this.newMutableCollectionWith(), emptyList);
     }
 
     @Override
@@ -61,16 +65,16 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
     @Test
     public void indexOf()
     {
-        Assert.assertEquals(-1L, this.classUnderTest().indexOf(true));
-        Assert.assertEquals(-1L, this.classUnderTest().indexOf(false));
+        assertEquals(-1L, this.classUnderTest().indexOf(true));
+        assertEquals(-1L, this.classUnderTest().indexOf(false));
     }
 
     @Override
     @Test
     public void lastIndexOf()
     {
-        Assert.assertEquals(-1L, this.classUnderTest().lastIndexOf(true));
-        Assert.assertEquals(-1L, this.classUnderTest().lastIndexOf(false));
+        assertEquals(-1L, this.classUnderTest().lastIndexOf(true));
+        assertEquals(-1L, this.classUnderTest().lastIndexOf(false));
     }
 
     @Override
@@ -80,14 +84,14 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
         String[] sum = new String[2];
         sum[0] = "";
         this.classUnderTest().forEachWithIndex((each, index) -> sum[0] += index + ":" + each);
-        Assert.assertEquals("", sum[0]);
+        assertEquals("", sum[0]);
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toReversed());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -101,7 +105,7 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -113,7 +117,7 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
         Verify.assertEmpty(iterable.select(BooleanPredicates.isTrue()));
         BooleanIterable booleanIterable = iterable.select(BooleanPredicates.isFalse());
         Verify.assertEmpty(booleanIterable);
-        Assert.assertSame(iterable, booleanIterable);
+        assertSame(iterable, booleanIterable);
     }
 
     @Override
@@ -125,7 +129,7 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
         Verify.assertEmpty(iterable.reject(BooleanPredicates.isTrue()));
         BooleanIterable booleanIterable = iterable.reject(BooleanPredicates.isFalse());
         Verify.assertEmpty(booleanIterable);
-        Assert.assertSame(iterable, booleanIterable);
+        assertSame(iterable, booleanIterable);
     }
 
     @Override
@@ -134,7 +138,7 @@ public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListT
     {
         Verify.assertEqualsAndHashCode(this.newMutableCollectionWith(), this.classUnderTest());
         Verify.assertPostSerializedIdentity(this.newWith());
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(false, false, false, true));
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(true));
+        assertNotEquals(this.classUnderTest(), this.newWith(false, false, false, true));
+        assertNotEquals(this.classUnderTest(), this.newWith(true));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanSingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanSingletonListTest.java
@@ -12,8 +12,10 @@ package org.eclipse.collections.impl.list.immutable.primitive;
 
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ImmutableBooleanSingletonListTest extends AbstractImmutableBooleanListTestCase
 {
@@ -28,14 +30,14 @@ public class ImmutableBooleanSingletonListTest extends AbstractImmutableBooleanL
     public void testEquals()
     {
         super.testEquals();
-        Assert.assertNotEquals(this.newWith(true), this.newWith());
+        assertNotEquals(this.newWith(true), this.newWith());
     }
 
     @Override
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toReversed());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toReversed());
     }
 
     @Override
@@ -45,6 +47,6 @@ public class ImmutableBooleanSingletonListTest extends AbstractImmutableBooleanL
         String[] sum = new String[2];
         sum[0] = "";
         this.classUnderTest().forEachWithIndex((each, index) -> sum[0] += index + ":" + each);
-        Assert.assertEquals("0:true", sum[0]);
+        assertEquals("0:true", sum[0]);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
@@ -65,10 +65,16 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -83,45 +89,45 @@ public abstract class AbstractListTestCase
     @Test
     public void randomAccess_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new ListAdapter<>(FastList.newListWith(1, 2, 3)));
+        assertThrows(IllegalArgumentException.class, () -> new ListAdapter<>(FastList.newListWith(1, 2, 3)));
     }
 
     @Test
     public void getFirstOptional()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirstOptional().get());
-        Assert.assertTrue(this.newWith(1, 2, 3).getFirstOptional().isPresent());
-        Assert.assertFalse(this.newWith().getFirstOptional().isPresent());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirstOptional().get());
+        assertTrue(this.newWith(1, 2, 3).getFirstOptional().isPresent());
+        assertFalse(this.newWith().getFirstOptional().isPresent());
     }
 
     @Test
     public void getLastOptional()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLastOptional().get());
-        Assert.assertTrue(this.newWith(1, 2, 3).getLastOptional().isPresent());
-        Assert.assertFalse(this.newWith().getLastOptional().isPresent());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLastOptional().get());
+        assertTrue(this.newWith(1, 2, 3).getLastOptional().isPresent());
+        assertFalse(this.newWith().getLastOptional().isPresent());
     }
 
     @Test
     public void detectIndex()
     {
-        Assert.assertEquals(1, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(0, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 5 == 0));
-        Assert.assertEquals(2, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer == 2));
-        Assert.assertEquals(0, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer != 2));
-        Assert.assertEquals(-1, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer == 5));
+        assertEquals(1, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 2 == 0));
+        assertEquals(0, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, this.newWith(1, 2, 3, 4).detectIndex(integer -> integer % 5 == 0));
+        assertEquals(2, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer == 2));
+        assertEquals(0, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer != 2));
+        assertEquals(-1, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectIndex(integer -> integer == 5));
     }
 
     @Test
     public void detectLastIndex()
     {
-        Assert.assertEquals(3, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(2, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 5 == 0));
-        Assert.assertEquals(8, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer == 2));
-        Assert.assertEquals(7, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer != 2));
-        Assert.assertEquals(-1, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer == 5));
+        assertEquals(3, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 2 == 0));
+        assertEquals(2, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, this.newWith(1, 2, 3, 4).detectLastIndex(integer -> integer % 5 == 0));
+        assertEquals(8, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer == 2));
+        assertEquals(7, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer != 2));
+        assertEquals(-1, this.newWith(1, 1, 2, 2, 3, 3, 3, 4, 2).detectLastIndex(integer -> integer == 5));
     }
 
     /**
@@ -132,10 +138,10 @@ public abstract class AbstractListTestCase
     {
         RichIterable<ObjectIntPair<Integer>> pairs =
                 this.newWith(3, 2, 1, 0).collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(3, 2, 1, 0),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
     }
@@ -148,19 +154,19 @@ public abstract class AbstractListTestCase
     {
         RichIterable<ObjectIntPair<Integer>> pairs =
                 this.newWith(3, 2, 1, 0).collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(3, 2, 1, 0),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
 
         RichIterable<ObjectIntPair<Integer>> setOfPairs =
                 this.newWith(3, 2, 1, 0).collectWithIndex(PrimitiveTuples::pair, Sets.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 setOfPairs.collectInt(ObjectIntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.with(3, 2, 1, 0),
                 setOfPairs.collect(ObjectIntPair::getOne, Sets.mutable.empty()));
     }
@@ -174,8 +180,8 @@ public abstract class AbstractListTestCase
         MutableList<Integer> integers = this.newWith(0, 1, 2, 3);
         MutableList<Integer> selected1 = integers.selectWithIndex((each, index) -> (each + index) % 2 == 0);
         MutableList<Integer> selected2 = integers.selectWithIndex((each, index) -> index % 2 == 0);
-        Assert.assertEquals(this.newWith(0, 1, 2, 3), selected1);
-        Assert.assertEquals(this.newWith(0, 2), selected2);
+        assertEquals(this.newWith(0, 1, 2, 3), selected1);
+        assertEquals(this.newWith(0, 2), selected2);
     }
 
     /**
@@ -189,8 +195,8 @@ public abstract class AbstractListTestCase
                 integers.selectWithIndex((each, index) -> (each + index) % 2 == 0, Sets.mutable.empty());
         MutableSet<Integer> selected2 =
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Sets.mutable.empty());
-        Assert.assertEquals(Sets.mutable.with(0, 1, 2, 3), selected1);
-        Assert.assertEquals(Sets.mutable.with(0, 2), selected2);
+        assertEquals(Sets.mutable.with(0, 1, 2, 3), selected1);
+        assertEquals(Sets.mutable.with(0, 2), selected2);
     }
 
     /**
@@ -202,8 +208,8 @@ public abstract class AbstractListTestCase
         MutableList<Integer> integers = this.newWith(0, 1, 2, 3);
         MutableList<Integer> rejected1 = integers.rejectWithIndex((each, index) -> (each + index) % 2 == 0);
         MutableList<Integer> rejected2 = integers.rejectWithIndex((each, index) -> index % 2 == 0);
-        Assert.assertEquals(this.newWith(), rejected1);
-        Assert.assertEquals(this.newWith(1, 3), rejected2);
+        assertEquals(this.newWith(), rejected1);
+        assertEquals(this.newWith(1, 3), rejected2);
     }
 
     /**
@@ -217,8 +223,8 @@ public abstract class AbstractListTestCase
                 integers.rejectWithIndex((each, index) -> (each + index) % 2 == 0, Sets.mutable.empty());
         MutableSet<Integer> rejected2 =
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Sets.mutable.empty());
-        Assert.assertEquals(Sets.mutable.empty(), rejected1);
-        Assert.assertEquals(Sets.mutable.with(1, 3), rejected2);
+        assertEquals(Sets.mutable.empty(), rejected1);
+        assertEquals(Sets.mutable.with(1, 3), rejected2);
     }
 
     @Override
@@ -226,7 +232,7 @@ public abstract class AbstractListTestCase
     {
         super.collectBoolean();
         MutableBooleanList result = this.newWith(-1, 0, 1, 4).collectBoolean(PrimitiveFunctions.integerIsPositive());
-        Assert.assertEquals(BooleanLists.mutable.of(false, false, true, true), result);
+        assertEquals(BooleanLists.mutable.of(false, false, true, true), result);
     }
 
     @Override
@@ -234,7 +240,7 @@ public abstract class AbstractListTestCase
     {
         super.collectByte();
         MutableByteList result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte());
-        Assert.assertEquals(ByteLists.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), result);
+        assertEquals(ByteLists.mutable.of((byte) 1, (byte) 2, (byte) 3, (byte) 4), result);
     }
 
     @Override
@@ -242,7 +248,7 @@ public abstract class AbstractListTestCase
     {
         super.collectChar();
         MutableCharList result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar());
-        Assert.assertEquals(CharLists.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), result);
+        assertEquals(CharLists.mutable.of((char) 1, (char) 2, (char) 3, (char) 4), result);
     }
 
     @Override
@@ -250,7 +256,7 @@ public abstract class AbstractListTestCase
     {
         super.collectDouble();
         MutableDoubleList result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble());
-        Assert.assertEquals(DoubleLists.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), result);
+        assertEquals(DoubleLists.mutable.of(1.0d, 2.0d, 3.0d, 4.0d), result);
     }
 
     @Override
@@ -258,7 +264,7 @@ public abstract class AbstractListTestCase
     {
         super.collectFloat();
         MutableFloatList result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat());
-        Assert.assertEquals(FloatLists.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), result);
+        assertEquals(FloatLists.mutable.of(1.0f, 2.0f, 3.0f, 4.0f), result);
     }
 
     @Override
@@ -266,7 +272,7 @@ public abstract class AbstractListTestCase
     {
         super.collectInt();
         MutableIntList result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt());
-        Assert.assertEquals(IntLists.mutable.of(1, 2, 3, 4), result);
+        assertEquals(IntLists.mutable.of(1, 2, 3, 4), result);
     }
 
     @Override
@@ -274,7 +280,7 @@ public abstract class AbstractListTestCase
     {
         super.collectLong();
         MutableLongList result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong());
-        Assert.assertEquals(LongLists.mutable.of(1L, 2L, 3L, 4L), result);
+        assertEquals(LongLists.mutable.of(1L, 2L, 3L, 4L), result);
     }
 
     @Override
@@ -282,7 +288,7 @@ public abstract class AbstractListTestCase
     {
         super.collectShort();
         MutableShortList result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort());
-        Assert.assertEquals(ShortLists.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), result);
+        assertEquals(ShortLists.mutable.of((short) 1, (short) 2, (short) 3, (short) 4), result);
     }
 
     @Override
@@ -298,7 +304,7 @@ public abstract class AbstractListTestCase
     {
         super.toImmutable();
         Verify.assertInstanceOf(ImmutableList.class, this.newWith().toImmutable());
-        Assert.assertSame(this.newWith().toImmutable(), this.newWith().toImmutable());
+        assertSame(this.newWith().toImmutable(), this.newWith().toImmutable());
     }
 
     @Override
@@ -336,29 +342,29 @@ public abstract class AbstractListTestCase
         MutableCollection<Integer> list2 = this.newWith(1, 2, 3);
         MutableCollection<Integer> list3 = this.newWith(2, 3, 4);
         MutableCollection<Integer> list4 = this.newWith(1, 2, 3, 4);
-        Assert.assertNotEquals(list1, null);
+        assertNotEquals(list1, null);
         Verify.assertEqualsAndHashCode(list1, list1);
         Verify.assertEqualsAndHashCode(list1, list2);
         Verify.assertEqualsAndHashCode(new LinkedList<>(Arrays.asList(1, 2, 3)), list1);
         Verify.assertEqualsAndHashCode(new ArrayList<>(Arrays.asList(1, 2, 3)), list1);
         Verify.assertEqualsAndHashCode(ArrayAdapter.newArrayWith(1, 2, 3), list1);
-        Assert.assertNotEquals(list2, list3);
-        Assert.assertNotEquals(list2, list4);
-        Assert.assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3)), list4);
-        Assert.assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3, 3)), list4);
-        Assert.assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3)), list4);
-        Assert.assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3, 3)), list4);
-        Assert.assertNotEquals(list4, new LinkedList<>(Arrays.asList(1, 2, 3)));
-        Assert.assertNotEquals(list4, new LinkedList<>(Arrays.asList(1, 2, 3, 3)));
-        Assert.assertNotEquals(list4, new ArrayList<>(Arrays.asList(1, 2, 3)));
-        Assert.assertNotEquals(list4, new ArrayList<>(Arrays.asList(1, 2, 3, 3)));
-        Assert.assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3, 4)), list1);
-        Assert.assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, null)), list1);
-        Assert.assertNotEquals(new LinkedList<>(Arrays.asList(1, 2)), list1);
-        Assert.assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3, 4)), list1);
-        Assert.assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, null)), list1);
-        Assert.assertNotEquals(new ArrayList<>(Arrays.asList(1, 2)), list1);
-        Assert.assertNotEquals(ArrayAdapter.newArrayWith(1, 2, 3, 4), list1);
+        assertNotEquals(list2, list3);
+        assertNotEquals(list2, list4);
+        assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3)), list4);
+        assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3, 3)), list4);
+        assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3)), list4);
+        assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3, 3)), list4);
+        assertNotEquals(list4, new LinkedList<>(Arrays.asList(1, 2, 3)));
+        assertNotEquals(list4, new LinkedList<>(Arrays.asList(1, 2, 3, 3)));
+        assertNotEquals(list4, new ArrayList<>(Arrays.asList(1, 2, 3)));
+        assertNotEquals(list4, new ArrayList<>(Arrays.asList(1, 2, 3, 3)));
+        assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, 3, 4)), list1);
+        assertNotEquals(new LinkedList<>(Arrays.asList(1, 2, null)), list1);
+        assertNotEquals(new LinkedList<>(Arrays.asList(1, 2)), list1);
+        assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, 3, 4)), list1);
+        assertNotEquals(new ArrayList<>(Arrays.asList(1, 2, null)), list1);
+        assertNotEquals(new ArrayList<>(Arrays.asList(1, 2)), list1);
+        assertNotEquals(ArrayAdapter.newArrayWith(1, 2, 3, 4), list1);
     }
 
     @Test
@@ -375,7 +381,7 @@ public abstract class AbstractListTestCase
         MutableList<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
         Verify.assertContainsAll(deserializedCollection, 1, 2, 3, 4, 5);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     @Test
@@ -383,22 +389,22 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> integers1 = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         MutableList<Integer> integers2 = this.newWith(1, 2, 3, 4);
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.alwaysTrue()));
-        Assert.assertFalse(integers2.corresponds(integers1, Predicates2.alwaysTrue()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.alwaysTrue()));
+        assertFalse(integers2.corresponds(integers1, Predicates2.alwaysTrue()));
 
         MutableList<Integer> integers3 = this.newWith(2, 3, 3, 4, 4, 4, 5, 5, 5, 5);
-        Assert.assertTrue(integers1.corresponds(integers3, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers3, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers3, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers3, Predicates2.greaterThan()));
 
         MutableList<Integer> nonRandomAccess = ListAdapter.adapt(new LinkedList<>(integers3));
-        Assert.assertTrue(integers1.corresponds(nonRandomAccess, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(nonRandomAccess, Predicates2.greaterThan()));
-        Assert.assertTrue(nonRandomAccess.corresponds(integers1, Predicates2.greaterThan()));
-        Assert.assertFalse(nonRandomAccess.corresponds(integers1, Predicates2.lessThan()));
+        assertTrue(integers1.corresponds(nonRandomAccess, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(nonRandomAccess, Predicates2.greaterThan()));
+        assertTrue(nonRandomAccess.corresponds(integers1, Predicates2.greaterThan()));
+        assertFalse(nonRandomAccess.corresponds(integers1, Predicates2.lessThan()));
 
         MutableList<String> nullBlanks = this.newWith(null, "", " ", null);
-        Assert.assertTrue(nullBlanks.corresponds(FastList.newListWith(null, "", " ", null), Objects::equals));
-        Assert.assertFalse(nullBlanks.corresponds(FastList.newListWith("", null, " ", ""), Objects::equals));
+        assertTrue(nullBlanks.corresponds(FastList.newListWith(null, "", " ", null), Objects::equals));
+        assertFalse(nullBlanks.corresponds(FastList.newListWith("", null, " ", ""), Objects::equals));
     }
 
     @Test
@@ -407,22 +413,22 @@ public abstract class AbstractListTestCase
         MutableList<Integer> result = FastList.newList();
         MutableList<Integer> collection = FastList.newListWith(1, 2, 3, 4);
         collection.forEach(2, 3, result::add);
-        Assert.assertEquals(this.newWith(3, 4), result);
+        assertEquals(this.newWith(3, 4), result);
 
         MutableList<Integer> result2 = FastList.newList();
         collection.forEach(3, 2, CollectionAddProcedure.on(result2));
-        Assert.assertEquals(this.newWith(4, 3), result2);
+        assertEquals(this.newWith(4, 3), result2);
 
         MutableList<Integer> result3 = FastList.newList();
         collection.forEach(0, 3, CollectionAddProcedure.on(result3));
-        Assert.assertEquals(this.newWith(1, 2, 3, 4), result3);
+        assertEquals(this.newWith(1, 2, 3, 4), result3);
 
         MutableList<Integer> result4 = FastList.newList();
         collection.forEach(3, 0, CollectionAddProcedure.on(result4));
-        Assert.assertEquals(this.newWith(4, 3, 2, 1), result4);
+        assertEquals(this.newWith(4, 3, 2, 1), result4);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> collection.forEach(-1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> collection.forEach(0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> collection.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> collection.forEach(0, -1, result::add));
     }
 
     @Test
@@ -430,7 +436,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> result = Lists.mutable.empty();
         this.newWith(1, 2, 3, 4).forEach(3, 2, result::add);
-        Assert.assertEquals(FastList.newListWith(4, 3), result);
+        assertEquals(FastList.newListWith(4, 3), result);
     }
 
     @Test
@@ -439,7 +445,7 @@ public abstract class AbstractListTestCase
         MutableList<Integer> result = Lists.mutable.empty();
         MutableList<Integer> collection = this.newWith(1, 2, 3, 4);
         collection.reverseForEach(result::add);
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), result);
+        assertEquals(FastList.newListWith(4, 3, 2, 1), result);
     }
 
     @Test
@@ -448,7 +454,7 @@ public abstract class AbstractListTestCase
         MutableList<Integer> integers = Lists.mutable.empty();
         MutableList<Integer> results = Lists.mutable.empty();
         integers.reverseForEach(results::add);
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
     }
 
     @Test
@@ -457,7 +463,7 @@ public abstract class AbstractListTestCase
         MutableList<Integer> result = Lists.mutable.empty();
         MutableList<Integer> collection = this.newWith(1, 2, 3, 4);
         collection.reverseForEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(FastList.newListWith(7, 5, 3, 1), result);
+        assertEquals(FastList.newListWith(7, 5, 3, 1), result);
     }
 
     @Test
@@ -472,8 +478,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> original = this.newWith(1, 2, 3, 4);
         MutableList<Integer> reversed = original.reverseThis();
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), reversed);
-        Assert.assertSame(original, reversed);
+        assertEquals(FastList.newListWith(4, 3, 2, 1), reversed);
+        assertSame(original, reversed);
     }
 
     @Test
@@ -482,8 +488,8 @@ public abstract class AbstractListTestCase
         MutableList<Integer> original = this.newWith(1, 2, 3, 4);
         MutableList<Integer> actual = original.toReversed();
         MutableList<Integer> expected = this.newWith(4, 3, 2, 1);
-        Assert.assertEquals(expected, actual);
-        Assert.assertNotSame(original, actual);
+        assertEquals(expected, actual);
+        assertNotSame(original, actual);
     }
 
     @Test
@@ -491,7 +497,7 @@ public abstract class AbstractListTestCase
     {
         ListIterable<Integer> list = this.newWith(1, 4, 3, 2, 1, 4, 1);
         ListIterable<Integer> actual = list.distinct();
-        Assert.assertEquals(Lists.mutable.with(1, 4, 3, 2), actual);
+        assertEquals(Lists.mutable.with(1, 4, 3, 2), actual);
     }
 
     @Test
@@ -499,7 +505,7 @@ public abstract class AbstractListTestCase
     {
         ListIterable<String> list = this.newWith("a", "A", "b", "C", "b", "D", "E", "e");
         ListIterable<String> actual = list.distinct(HashingStrategies.fromFunction(String::toLowerCase));
-        Assert.assertEquals(Lists.mutable.with("a", "b", "C", "D", "E"), actual);
+        assertEquals(Lists.mutable.with("a", "b", "C", "D", "E"), actual);
     }
 
     /**
@@ -510,7 +516,7 @@ public abstract class AbstractListTestCase
     {
         ListIterable<String> list = this.newWith("a", "A", "b", "C", "b", "D", "E", "e");
         ListIterable<String> actual = list.distinctBy(String::toLowerCase);
-        Assert.assertEquals(Lists.mutable.with("a", "b", "C", "D", "E"), actual);
+        assertEquals(Lists.mutable.with("a", "b", "C", "D", "E"), actual);
     }
 
     @Override
@@ -519,7 +525,7 @@ public abstract class AbstractListTestCase
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3, null);
         objects.removeIf(Predicates.isNull());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), objects);
+        assertEquals(FastList.newListWith(1, 2, 3), objects);
     }
 
     @Test
@@ -527,33 +533,33 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> objects = this.newWith(1, 2, 3);
         objects.remove(2);
-        Assert.assertEquals(FastList.newListWith(1, 2), objects);
+        assertEquals(FastList.newListWith(1, 2), objects);
     }
 
     @Test
     public void indexOf()
     {
         MutableList<Integer> objects = this.newWith(1, 2, 2);
-        Assert.assertEquals(1, objects.indexOf(2));
-        Assert.assertEquals(0, objects.indexOf(1));
-        Assert.assertEquals(-1, objects.indexOf(3));
+        assertEquals(1, objects.indexOf(2));
+        assertEquals(0, objects.indexOf(1));
+        assertEquals(-1, objects.indexOf(3));
     }
 
     @Test
     public void lastIndexOf()
     {
         MutableList<Integer> objects = this.newWith(2, 2, 3);
-        Assert.assertEquals(1, objects.lastIndexOf(2));
-        Assert.assertEquals(2, objects.lastIndexOf(3));
-        Assert.assertEquals(-1, objects.lastIndexOf(1));
+        assertEquals(1, objects.lastIndexOf(2));
+        assertEquals(2, objects.lastIndexOf(3));
+        assertEquals(-1, objects.lastIndexOf(1));
     }
 
     @Test
     public void set()
     {
         MutableList<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(2), objects.set(1, 4));
-        Assert.assertEquals(FastList.newListWith(1, 4, 3), objects);
+        assertEquals(Integer.valueOf(2), objects.set(1, 4));
+        assertEquals(FastList.newListWith(1, 4, 3), objects);
     }
 
     @Test
@@ -561,7 +567,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> objects = this.newWith(1, 2, 3);
         objects.add(0, 0);
-        Assert.assertEquals(FastList.newListWith(0, 1, 2, 3), objects);
+        assertEquals(FastList.newListWith(0, 1, 2, 3), objects);
     }
 
     @Test
@@ -573,7 +579,7 @@ public abstract class AbstractListTestCase
         objects.addAll(0, new ArrayList<>(Lists.fixedSize.of(one)));
         objects.addAll(0, FastList.newListWith(-2));
         objects.addAll(0, UnifiedSet.newSetWith(-3));
-        Assert.assertEquals(FastList.newListWith(-3, -2, -1, 0, 1, 2, 3), objects);
+        assertEquals(FastList.newListWith(-3, -2, -1, 0, 1, 2, 3), objects);
     }
 
     @Test
@@ -596,8 +602,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis();
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(1, 2, 3), actual);
     }
 
     @Test
@@ -605,8 +611,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis();
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), actual);
     }
 
     @Test
@@ -614,8 +620,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(Interval.oneTo(1000).toArray()).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis();
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(Interval.oneTo(1000).toList(), actual);
+        assertSame(actual, sorted);
+        assertEquals(Interval.oneTo(1000).toList(), actual);
     }
 
     @Test
@@ -623,8 +629,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis(Collections.reverseOrder());
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(3, 2, 1), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(3, 2, 1), actual);
     }
 
     @Test
@@ -632,8 +638,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis(Collections.reverseOrder());
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(10, 9, 8, 7, 6, 5, 4, 3, 2, 1), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(10, 9, 8, 7, 6, 5, 4, 3, 2, 1), actual);
     }
 
     @Test
@@ -641,8 +647,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(Interval.oneTo(1000).toArray()).shuffleThis();
         MutableList<Integer> sorted = actual.sortThis(Collections.reverseOrder());
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(Interval.fromToBy(1000, 1, -1).toList(), actual);
+        assertSame(actual, sorted);
+        assertEquals(Interval.fromToBy(1000, 1, -1).toList(), actual);
     }
 
     @Test
@@ -650,8 +656,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).shuffleThis();
         MutableList<Integer> sorted = actual.sortThisBy(String::valueOf);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(1, 10, 2, 3, 4, 5, 6, 7, 8, 9), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(1, 10, 2, 3, 4, 5, 6, 7, 8, 9), actual);
     }
 
     @Test
@@ -659,8 +665,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> actual = this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         MutableList<Integer> sorted = actual.sortThisByBoolean(i -> i % 2 == 0);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5, 7, 9, 2, 4, 6, 8, 10), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith(1, 3, 5, 7, 9, 2, 4, 6, 8, 10), actual);
     }
 
     @Test
@@ -668,8 +674,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByInt(Integer::parseInt);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Test
@@ -677,8 +683,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9").shuffleThis();
         MutableList<String> sorted = actual.sortThisByChar(s -> s.charAt(0));
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9"), actual);
     }
 
     @Test
@@ -686,8 +692,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByByte(Byte::parseByte);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Test
@@ -695,8 +701,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByShort(Short::parseShort);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Test
@@ -704,8 +710,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByFloat(Float::parseFloat);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Test
@@ -713,8 +719,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByLong(Long::parseLong);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Test
@@ -722,8 +728,8 @@ public abstract class AbstractListTestCase
     {
         MutableList<String> actual = this.newWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10").shuffleThis();
         MutableList<String> sorted = actual.sortThisByDouble(Double::parseDouble);
-        Assert.assertSame(actual, sorted);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
+        assertSame(actual, sorted);
+        assertEquals(FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), actual);
     }
 
     @Override
@@ -739,7 +745,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Object> list = this.newWith(1, 2, 3);
         list.add(list);
-        Assert.assertEquals("[1, 2, 3, (this " + list.getClass().getSimpleName() + ")]", list.toString());
+        assertEquals("[1, 2, 3, (this " + list.getClass().getSimpleName() + ")]", list.toString());
     }
 
     @Override
@@ -748,7 +754,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Object> list = this.newWith(1, 2, 3);
         list.add(list);
-        Assert.assertEquals("1, 2, 3, (this " + list.getClass().getSimpleName() + ')', list.makeString());
+        assertEquals("1, 2, 3, (this " + list.getClass().getSimpleName() + ')', list.makeString());
     }
 
     @Override
@@ -756,7 +762,7 @@ public abstract class AbstractListTestCase
     public void makeStringWithSeparator()
     {
         MutableList<Object> list = this.newWith(1, 2, 3);
-        Assert.assertEquals("1/2/3", list.makeString("/"));
+        assertEquals("1/2/3", list.makeString("/"));
     }
 
     @Override
@@ -764,7 +770,7 @@ public abstract class AbstractListTestCase
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         MutableList<Object> list = this.newWith(1, 2, 3);
-        Assert.assertEquals("[1/2/3]", list.makeString("[", "/", "]"));
+        assertEquals("[1/2/3]", list.makeString("[", "/", "]"));
     }
 
     @Override
@@ -776,7 +782,7 @@ public abstract class AbstractListTestCase
 
         Appendable builder = new StringBuilder();
         list.appendString(builder);
-        Assert.assertEquals("1, 2, 3, (this " + list.getClass().getSimpleName() + ')', builder.toString());
+        assertEquals("1, 2, 3, (this " + list.getClass().getSimpleName() + ')', builder.toString());
     }
 
     @Override
@@ -787,7 +793,7 @@ public abstract class AbstractListTestCase
 
         Appendable builder = new StringBuilder();
         list.appendString(builder, "/");
-        Assert.assertEquals("1/2/3", builder.toString());
+        assertEquals("1/2/3", builder.toString());
     }
 
     @Override
@@ -798,7 +804,7 @@ public abstract class AbstractListTestCase
 
         Appendable builder = new StringBuilder();
         list.appendString(builder, "[", "/", "]");
-        Assert.assertEquals("[1/2/3]", builder.toString());
+        assertEquals("[1/2/3]", builder.toString());
     }
 
     @Test
@@ -807,29 +813,29 @@ public abstract class AbstractListTestCase
         MutableList<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         StringBuilder builder = new StringBuilder();
         integers.forEachWithIndex(5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("353627", builder.toString());
+        assertEquals("353627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         integers.forEachWithIndex(5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("35", builder2.toString());
+        assertEquals("35", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         integers.forEachWithIndex(0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("40414243343536272819", builder3.toString());
+        assertEquals("40414243343536272819", builder3.toString());
 
         StringBuilder builder4 = new StringBuilder();
         integers.forEachWithIndex(7, 5, (each, index) -> builder4.append(each).append(index));
-        Assert.assertEquals("273635", builder4.toString());
+        assertEquals("273635", builder4.toString());
 
         StringBuilder builder5 = new StringBuilder();
         integers.forEachWithIndex(9, 0, (each, index) -> builder5.append(each).append(index));
-        Assert.assertEquals("19282736353443424140", builder5.toString());
+        assertEquals("19282736353443424140", builder5.toString());
 
         MutableList<Integer> result = Lists.mutable.empty();
-        Assert.assertThrows(
+        assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
-        Assert.assertThrows(
+        assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
     }
@@ -839,7 +845,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> result = Lists.mutable.empty();
         this.newWith(1, 2, 3).forEachWithIndex(2, 1, new AddToList(result));
-        Assert.assertEquals(FastList.newListWith(3, 2), result);
+        assertEquals(FastList.newListWith(3, 2), result);
     }
 
     @Test(expected = NullPointerException.class)
@@ -886,7 +892,7 @@ public abstract class AbstractListTestCase
         this.validateForEachOnRange(list, 9, 9, FastList.newListWith(9));
         this.validateForEachOnRange(list, 0, 9, FastList.newListWith(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
-        Assert.assertThrows(
+        assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> this.validateForEachOnRange(list, 10, 10, FastList.newList()));
     }
@@ -896,7 +902,7 @@ public abstract class AbstractListTestCase
         List<Integer> outputList = Lists.mutable.empty();
         list.forEach(from, to, outputList::add);
 
-        Assert.assertEquals(expectedOutput, outputList);
+        assertEquals(expectedOutput, outputList);
     }
 
     @Test
@@ -914,7 +920,7 @@ public abstract class AbstractListTestCase
         this.validateForEachWithIndexOnRange(list, 4, 6, FastList.newListWith(4, 5, 6));
         this.validateForEachWithIndexOnRange(list, 9, 9, FastList.newListWith(9));
         this.validateForEachWithIndexOnRange(list, 0, 9, FastList.newListWith(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-        Assert.assertThrows(
+        assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> this.validateForEachWithIndexOnRange(list, 10, 10, FastList.newList()));
     }
@@ -928,7 +934,7 @@ public abstract class AbstractListTestCase
         MutableList<Integer> outputList = Lists.mutable.empty();
         list.forEachWithIndex(from, to, (each, index) -> outputList.add(each));
 
-        Assert.assertEquals(expectedOutput, outputList);
+        assertEquals(expectedOutput, outputList);
     }
 
     @Test
@@ -947,7 +953,7 @@ public abstract class AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -955,7 +961,7 @@ public abstract class AbstractListTestCase
         Verify.assertContainsAll(list, "A", "B", "R", "W", "G", "D");
         sublist.clear();
         Verify.assertEmpty(sublist);
-        Assert.assertFalse(sublist.remove("X"));
+        assertFalse(sublist.remove("X"));
         Verify.assertEmpty(sublist);
         Verify.assertContainsAll(list, "A", "D");
     }
@@ -983,7 +989,7 @@ public abstract class AbstractListTestCase
     {
         Object item = new Object();
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(item).get(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(item).get(1));
     }
 
     @Test
@@ -998,7 +1004,7 @@ public abstract class AbstractListTestCase
         }
         catch (Exception e)
         {
-            Assert.assertTrue((e instanceof ArrayIndexOutOfBoundsException)
+            assertTrue((e instanceof ArrayIndexOutOfBoundsException)
                     || (e instanceof IndexOutOfBoundsException));
         }
     }
@@ -1017,7 +1023,7 @@ public abstract class AbstractListTestCase
             Integer each = iterator.previous();
             sum += each.intValue();
         }
-        Assert.assertEquals(20, sum);
+        assertEquals(20, sum);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -1040,7 +1046,7 @@ public abstract class AbstractListTestCase
 
         MutableCollection<String> collection = this.newWith("1", "2", "3", "4", "5", "6", "7");
         RichIterable<RichIterable<String>> groups = collection.chunk(2);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.<RichIterable<String>>newListWith(
                         FastList.newListWith("1", "2"),
                         FastList.newListWith("3", "4"),
@@ -1053,22 +1059,22 @@ public abstract class AbstractListTestCase
     public void toStack()
     {
         MutableStack<Integer> stack = this.newWith(1, 2, 3, 4).toStack();
-        Assert.assertEquals(Stacks.mutable.of(1, 2, 3, 4), stack);
+        assertEquals(Stacks.mutable.of(1, 2, 3, 4), stack);
     }
 
     @Test
     public void take()
     {
         MutableList<Integer> mutableList = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertEquals(iList(), mutableList.take(0));
-        Assert.assertEquals(iList(1, 2, 3), mutableList.take(3));
-        Assert.assertEquals(iList(1, 2, 3, 4), mutableList.take(mutableList.size() - 1));
+        assertEquals(iList(), mutableList.take(0));
+        assertEquals(iList(1, 2, 3), mutableList.take(3));
+        assertEquals(iList(1, 2, 3, 4), mutableList.take(mutableList.size() - 1));
 
         ImmutableList<Integer> expectedList = iList(1, 2, 3, 4, 5);
-        Assert.assertEquals(expectedList, mutableList.take(mutableList.size()));
-        Assert.assertEquals(expectedList, mutableList.take(10));
-        Assert.assertEquals(expectedList, mutableList.take(Integer.MAX_VALUE));
-        Assert.assertNotSame(mutableList, mutableList.take(Integer.MAX_VALUE));
+        assertEquals(expectedList, mutableList.take(mutableList.size()));
+        assertEquals(expectedList, mutableList.take(10));
+        assertEquals(expectedList, mutableList.take(Integer.MAX_VALUE));
+        assertNotSame(mutableList, mutableList.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1080,15 +1086,15 @@ public abstract class AbstractListTestCase
     @Test
     public void takeWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3),
                 this.newWith(1, 2, 3, 4, 5).takeWhile(Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3, 4, 5),
                 this.newWith(1, 2, 3, 4, 5).takeWhile(Predicates.lessThan(10)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 this.newWith(1, 2, 3, 4, 5).takeWhile(Predicates.lessThan(0)));
     }
@@ -1097,13 +1103,13 @@ public abstract class AbstractListTestCase
     public void drop()
     {
         MutableList<Integer> mutableList = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), mutableList.drop(0));
-        Assert.assertNotSame(mutableList, mutableList.drop(0));
-        Assert.assertEquals(iList(4, 5), mutableList.drop(3));
-        Assert.assertEquals(iList(5), mutableList.drop(mutableList.size() - 1));
-        Assert.assertEquals(iList(), mutableList.drop(mutableList.size()));
-        Assert.assertEquals(iList(), mutableList.drop(10));
-        Assert.assertEquals(iList(), mutableList.drop(Integer.MAX_VALUE));
+        assertEquals(iList(1, 2, 3, 4, 5), mutableList.drop(0));
+        assertNotSame(mutableList, mutableList.drop(0));
+        assertEquals(iList(4, 5), mutableList.drop(3));
+        assertEquals(iList(5), mutableList.drop(mutableList.size() - 1));
+        assertEquals(iList(), mutableList.drop(mutableList.size()));
+        assertEquals(iList(), mutableList.drop(10));
+        assertEquals(iList(), mutableList.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1115,15 +1121,15 @@ public abstract class AbstractListTestCase
     @Test
     public void dropWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(4, 5),
                 this.newWith(1, 2, 3, 4, 5).dropWhile(Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 this.newWith(1, 2, 3, 4, 5).dropWhile(Predicates.lessThan(10)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3, 4, 5),
                 this.newWith(1, 2, 3, 4, 5).dropWhile(Predicates.lessThan(0)));
     }
@@ -1132,16 +1138,16 @@ public abstract class AbstractListTestCase
     public void partitionWhile()
     {
         PartitionMutableList<Integer> partition1 = this.newWith(1, 2, 3, 4, 5).partitionWhile(Predicates.lessThan(4));
-        Assert.assertEquals(iList(1, 2, 3), partition1.getSelected());
-        Assert.assertEquals(iList(4, 5), partition1.getRejected());
+        assertEquals(iList(1, 2, 3), partition1.getSelected());
+        assertEquals(iList(4, 5), partition1.getRejected());
 
         PartitionMutableList<Integer> partition2 = this.newWith(1, 2, 3, 4, 5).partitionWhile(Predicates.lessThan(0));
-        Assert.assertEquals(iList(), partition2.getSelected());
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), partition2.getRejected());
+        assertEquals(iList(), partition2.getSelected());
+        assertEquals(iList(1, 2, 3, 4, 5), partition2.getRejected());
 
         PartitionMutableList<Integer> partition3 = this.newWith(1, 2, 3, 4, 5).partitionWhile(Predicates.lessThan(10));
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), partition3.getSelected());
-        Assert.assertEquals(iList(), partition3.getRejected());
+        assertEquals(iList(1, 2, 3, 4, 5), partition3.getSelected());
+        assertEquals(iList(), partition3.getRejected());
     }
 
     @Test
@@ -1156,11 +1162,11 @@ public abstract class AbstractListTestCase
     public void binarySearch()
     {
         MutableList<Integer> sortedList = this.newWith(1, 2, 3, 4, 5, 7);
-        Assert.assertEquals(1, sortedList.binarySearch(2));
-        Assert.assertEquals(-6, sortedList.binarySearch(6));
+        assertEquals(1, sortedList.binarySearch(2));
+        assertEquals(-6, sortedList.binarySearch(6));
         for (Integer integer : sortedList)
         {
-            Assert.assertEquals(
+            assertEquals(
                     Collections.binarySearch(sortedList, integer),
                     sortedList.binarySearch(integer));
         }
@@ -1170,11 +1176,11 @@ public abstract class AbstractListTestCase
     public void binarySearchWithComparator()
     {
         MutableList<Integer> sortedList = this.newWith(7, 5, 4, 3, 2, 1);
-        Assert.assertEquals(4, sortedList.binarySearch(2, Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(-2, sortedList.binarySearch(6, Comparators.reverseNaturalOrder()));
+        assertEquals(4, sortedList.binarySearch(2, Comparators.reverseNaturalOrder()));
+        assertEquals(-2, sortedList.binarySearch(6, Comparators.reverseNaturalOrder()));
         for (Integer integer : sortedList)
         {
-            Assert.assertEquals(
+            assertEquals(
                     Collections.binarySearch(sortedList, integer, Comparators.reverseNaturalOrder()),
                     sortedList.binarySearch(integer, Comparators.reverseNaturalOrder()));
         }
@@ -1194,8 +1200,8 @@ public abstract class AbstractListTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), elements);
-        Assert.assertEquals(IntArrayList.newListWith(0, 1, 2, 3), indexes);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), elements);
+        assertEquals(IntArrayList.newListWith(0, 1, 2, 3), indexes);
     }
 
     @Test
@@ -1205,7 +1211,7 @@ public abstract class AbstractListTestCase
         ListIterable<Integer> integers = this.newWith(1, 2, 3);
         ImmutableList<String> strings = this.newWith("1", "2", "3").toImmutable();
         integers.forEachInBoth(strings, (integer, string) -> result.add(Tuples.pair(integer, string)));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(Tuples.pair(1, "1"), Tuples.pair(2, "2"), Tuples.pair(3, "3")),
                 result);
     }
@@ -1234,7 +1240,7 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.replaceAll(i -> i * 2);
-        Assert.assertEquals(Lists.mutable.with(2, 4, 6, 8), integers);
+        assertEquals(Lists.mutable.with(2, 4, 6, 8), integers);
     }
 
     @Test
@@ -1242,6 +1248,6 @@ public abstract class AbstractListTestCase
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.sort(Comparator.reverseOrder());
-        Assert.assertEquals(Lists.mutable.with(4, 3, 2, 1), integers);
+        assertEquals(Lists.mutable.with(4, 3, 2, 1), integers);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ArrayListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ArrayListAdapterTest.java
@@ -22,10 +22,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ArrayListAdapter}.
@@ -58,7 +62,7 @@ public class ArrayListAdapterTest extends AbstractListTestCase
         super.newListWithSize();
 
         MutableList<Integer> objects = ArrayListAdapter.<Integer>newList(4).with(1, 2, 3);
-        Assert.assertEquals(1, objects.indexOf(2));
+        assertEquals(1, objects.indexOf(2));
     }
 
     @Override
@@ -81,13 +85,13 @@ public class ArrayListAdapterTest extends AbstractListTestCase
         ByteArrayOutputStream stream1 = SerializeTestHelper.getByteArrayOutputStream(mutableArrayList);
         LOGGER.info("ArrayListAdapter size: {}", stream1.size());
         LOGGER.info("{}", stream1);
-        Assert.assertTrue(stream1.size() > 0);
+        assertTrue(stream1.size() > 0);
 
         List<Integer> arrayList = new ArrayList<>();
         ByteArrayOutputStream stream2 = SerializeTestHelper.getByteArrayOutputStream(arrayList);
         LOGGER.info("ArrayList size: {}", stream2.size());
         LOGGER.info("{}", stream2);
-        Assert.assertTrue(stream2.size() > 0);
+        assertTrue(stream2.size() > 0);
     }
 
     @Test
@@ -142,7 +146,7 @@ public class ArrayListAdapterTest extends AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -150,7 +154,7 @@ public class ArrayListAdapterTest extends AbstractListTestCase
         Verify.assertContainsAll(list, "A", "B", "R", "W", "G", "D");
         sublist.clear();
         Verify.assertEmpty(sublist);
-        Assert.assertFalse(sublist.remove("X"));
+        assertFalse(sublist.remove("X"));
         Verify.assertEmpty(sublist);
         Verify.assertContainsAll(list, "A", "D");
     }
@@ -158,6 +162,6 @@ public class ArrayListAdapterTest extends AbstractListTestCase
     @Test
     public void adapt_null()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> ArrayListAdapter.adapt(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/CompositeFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/CompositeFastListTest.java
@@ -24,8 +24,15 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class CompositeFastListTest extends AbstractListTestCase
 {
@@ -44,7 +51,7 @@ public class CompositeFastListTest extends AbstractListTestCase
     @Test
     public void testClone()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().clone());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().clone());
     }
 
     @Test
@@ -108,7 +115,7 @@ public class CompositeFastListTest extends AbstractListTestCase
         Collection<String> evenStrings = ParallelIterate.collect(evens2, Object::toString);
         Verify.assertInstanceOf(CompositeFastList.class, evenStrings);
         Verify.assertSize(50_000, evenStrings);
-        Assert.assertEquals(integers.select(e -> e <= 100_000).select(IntegerPredicates.isEven()).collect(Object::toString).toList(), evenStrings);
+        assertEquals(integers.select(e -> e <= 100_000).select(IntegerPredicates.isEven()).collect(Object::toString).toList(), evenStrings);
 
         Collection<Integer> odds = ParallelIterate.select(integers, IntegerPredicates.isOdd());
         Verify.assertInstanceOf(CompositeFastList.class, odds);
@@ -118,7 +125,7 @@ public class CompositeFastListTest extends AbstractListTestCase
         Collection<String> oddStrings = ParallelIterate.collect(odds2, Object::toString);
         Verify.assertInstanceOf(CompositeFastList.class, oddStrings);
         Verify.assertSize(50_000, oddStrings);
-        Assert.assertEquals(integers.select(e -> e <= 100_000).select(IntegerPredicates.isOdd()).collect(Object::toString).toList(), oddStrings);
+        assertEquals(integers.select(e -> e <= 100_000).select(IntegerPredicates.isOdd()).collect(Object::toString).toList(), oddStrings);
 
         MutableList<Integer> range = Interval.fromTo(-1_234_567, 1_234_567).toList().shuffleThis();
         Collection<Integer> positives = ParallelIterate.select(range, IntegerPredicates.isPositive());
@@ -126,20 +133,20 @@ public class CompositeFastListTest extends AbstractListTestCase
         Verify.assertSize(1_234_567, positives);
         Collection<Integer> evenPositives = ParallelIterate.select(positives, IntegerPredicates.isEven());
         Verify.assertSize(617_283, evenPositives);
-        Assert.assertEquals(2000, ParallelIterate.count(evenPositives, e -> e <= 4000));
+        assertEquals(2000, ParallelIterate.count(evenPositives, e -> e <= 4000));
         Collection<Integer> oddPositives = ParallelIterate.select(positives, IntegerPredicates.isOdd());
         Verify.assertSize(617_284, oddPositives);
-        Assert.assertEquals(2000, ParallelIterate.count(oddPositives, e -> e <= 4000));
+        assertEquals(2000, ParallelIterate.count(oddPositives, e -> e <= 4000));
 
         Collection<Integer> negatives = ParallelIterate.select(range, IntegerPredicates.isNegative());
         Verify.assertInstanceOf(CompositeFastList.class, negatives);
         Verify.assertSize(1_234_567, negatives);
         Collection<Integer> evenNegatives = ParallelIterate.select(negatives, IntegerPredicates.isEven());
         Verify.assertSize(617_283, evenNegatives);
-        Assert.assertEquals(2000, ParallelIterate.count(evenNegatives, e -> e >= -4000));
+        assertEquals(2000, ParallelIterate.count(evenNegatives, e -> e >= -4000));
         Collection<Integer> oddNegatives = ParallelIterate.select(negatives, IntegerPredicates.isOdd());
         Verify.assertSize(617_284, oddNegatives);
-        Assert.assertEquals(2000, ParallelIterate.count(oddNegatives, e -> e >= -4000));
+        assertEquals(2000, ParallelIterate.count(oddNegatives, e -> e >= -4000));
     }
 
     @Test
@@ -149,13 +156,13 @@ public class CompositeFastListTest extends AbstractListTestCase
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("A", "B", "C", "B"));
         list.addAll(FastList.newListWith("Cat", "Dog", "Mouse", "Bird"));
-        Assert.assertEquals("1", list.get(0));
-        Assert.assertEquals("2", list.get(1));
-        Assert.assertEquals("A", list.get(4));
-        Assert.assertEquals("4", list.get(3));
-        Assert.assertEquals("Cat", list.get(8));
-        Assert.assertEquals("Bird", list.get(11));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> list.get(12));
+        assertEquals("1", list.get(0));
+        assertEquals("2", list.get(1));
+        assertEquals("A", list.get(4));
+        assertEquals("4", list.get(3));
+        assertEquals("Cat", list.get(8));
+        assertEquals("Bird", list.get(11));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(12));
     }
 
     @Test
@@ -166,14 +173,14 @@ public class CompositeFastListTest extends AbstractListTestCase
         list.addAll(FastList.newListWith("A", "B", "C", "B"));
         list.add(3, "NEW");
         Verify.assertSize(9, list);
-        Assert.assertEquals("NEW", list.get(3));
-        Assert.assertEquals("4", list.get(4));
+        assertEquals("NEW", list.get(3));
+        assertEquals("4", list.get(4));
         list.add(0, "START");
         Verify.assertSize(10, list);
-        Assert.assertEquals("START", list.getFirst());
+        assertEquals("START", list.getFirst());
         list.add(10, "END");
         Verify.assertSize(11, list);
-        Assert.assertEquals("END", list.getLast());
+        assertEquals("END", list.getLast());
     }
 
     @Override
@@ -186,15 +193,15 @@ public class CompositeFastListTest extends AbstractListTestCase
         composite.addAll(FastList.newListWith(6, 5, 4));
         composite.addAll(FastList.newListWith(3, 2, 1));
         CompositeFastList<Integer> reversed = composite.reverseThis();
-        Assert.assertSame(composite, reversed);
-        Assert.assertEquals(Interval.oneTo(9), reversed);
+        assertSame(composite, reversed);
+        assertEquals(Interval.oneTo(9), reversed);
     }
 
     @Override
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, super::addAllAtIndex);
+        assertThrows(UnsupportedOperationException.class, super::addAllAtIndex);
     }
 
     @Override
@@ -205,13 +212,13 @@ public class CompositeFastListTest extends AbstractListTestCase
         MutableList<String> list = new CompositeFastList<>();
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("A", "B", "C", "B"));
-        Assert.assertEquals("1", list.set(0, "NEW"));
+        assertEquals("1", list.set(0, "NEW"));
         Verify.assertSize(8, list);
-        Assert.assertEquals("NEW", list.getFirst());
-        Assert.assertEquals("2", list.get(1));
-        Assert.assertEquals("B", list.set(7, "END"));
+        assertEquals("NEW", list.getFirst());
+        assertEquals("2", list.get(1));
+        assertEquals("B", list.set(7, "END"));
         Verify.assertSize(8, list);
-        Assert.assertEquals("END", list.getLast());
+        assertEquals("END", list.getLast());
     }
 
     @Test
@@ -226,9 +233,9 @@ public class CompositeFastListTest extends AbstractListTestCase
         compositeList.addAll(list2);
         compositeList.addAll(list3);
 
-        Assert.assertEquals(Integer.valueOf(4), compositeList.get(3));
-        Assert.assertEquals(Integer.valueOf(4), compositeList.set(3, 99));
-        Assert.assertEquals(Integer.valueOf(99), compositeList.get(3));
+        assertEquals(Integer.valueOf(4), compositeList.get(3));
+        assertEquals(Integer.valueOf(4), compositeList.set(3, 99));
+        assertEquals(Integer.valueOf(99), compositeList.get(3));
     }
 
     @Override
@@ -241,11 +248,11 @@ public class CompositeFastListTest extends AbstractListTestCase
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
         list.addAll(FastList.newListWith("3", "B", "3", "X"));
 
-        Assert.assertEquals(2, list.indexOf("3"));
-        Assert.assertEquals(5, list.indexOf("B"));
-        Assert.assertEquals(11, list.indexOf("X"));
+        assertEquals(2, list.indexOf("3"));
+        assertEquals(5, list.indexOf("B"));
+        assertEquals(11, list.indexOf("X"));
 
-        Assert.assertEquals(-1, list.indexOf("missing"));
+        assertEquals(-1, list.indexOf("missing"));
     }
 
     @Override
@@ -256,9 +263,9 @@ public class CompositeFastListTest extends AbstractListTestCase
         MutableList<String> list = new CompositeFastList<>();
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
-        Assert.assertEquals(6, list.lastIndexOf("3"));
-        Assert.assertEquals(3, list.lastIndexOf("4"));
-        Assert.assertEquals(-1, list.lastIndexOf("missing"));
+        assertEquals(6, list.lastIndexOf("3"));
+        assertEquals(3, list.lastIndexOf("4"));
+        assertEquals(-1, list.lastIndexOf("missing"));
     }
 
     @Test
@@ -267,12 +274,12 @@ public class CompositeFastListTest extends AbstractListTestCase
         MutableList<String> list = new CompositeFastList<>();
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
-        Assert.assertEquals("1", list.remove(0));
+        assertEquals("1", list.remove(0));
         Verify.assertSize(7, list);
-        Assert.assertEquals("2", list.getFirst());
-        Assert.assertEquals("B", list.remove(6));
+        assertEquals("2", list.getFirst());
+        assertEquals("B", list.remove(6));
         Verify.assertSize(6, list);
-        Assert.assertEquals("3", list.getLast());
+        assertEquals("3", list.getLast());
     }
 
     @Override
@@ -285,13 +292,13 @@ public class CompositeFastListTest extends AbstractListTestCase
         list.addAll(Lists.mutable.of());
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
         list.addAll(Lists.mutable.of());
-        Assert.assertArrayEquals(new String[]{"1", "2", "3", "4", "3", "B", "3", "B"}, list.toArray());
+        assertArrayEquals(new String[]{"1", "2", "3", "4", "3", "B", "3", "B"}, list.toArray());
     }
 
     @Test
     public void testEmptyIterator()
     {
-        Assert.assertFalse(new CompositeFastList<String>().iterator().hasNext());
+        assertFalse(new CompositeFastList<String>().iterator().hasNext());
     }
 
     @Override
@@ -303,8 +310,8 @@ public class CompositeFastListTest extends AbstractListTestCase
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
         list.clear();
-        Assert.assertTrue(list.isEmpty());
-        Assert.assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+        assertEquals(0, list.size());
     }
 
     @Test
@@ -313,7 +320,7 @@ public class CompositeFastListTest extends AbstractListTestCase
         MutableList<String> list = new CompositeFastList<>();
         list.addAll(FastList.newListWith("1", "2", "3", "4"));
         list.addAll(FastList.newListWith("3", "B", "3", "B"));
-        Assert.assertTrue(list.containsAll(FastList.newList().with("2", "B")));
+        assertTrue(list.containsAll(FastList.newList().with("2", "B")));
     }
 
     @Override
@@ -391,8 +398,8 @@ public class CompositeFastListTest extends AbstractListTestCase
 
         Verify.assertEqualsAndHashCode(list2, composite2);
 
-        Assert.assertNotEquals(firstBit, composite2);
-        Assert.assertNotEquals(composite2, firstBit);
+        assertNotEquals(firstBit, composite2);
+        assertNotEquals(composite2, firstBit);
 
         MutableList<String> list1 = FastList.newListWith("one", null, "three");
 
@@ -447,21 +454,21 @@ public class CompositeFastListTest extends AbstractListTestCase
         ListIterator<String> listIterator = composite.listIterator();
         listIterator.add("four");
         Verify.assertSize(4, composite);
-        Assert.assertTrue(listIterator.hasNext());
+        assertTrue(listIterator.hasNext());
         String element = listIterator.next();
 
-        Assert.assertEquals("one", element);
+        assertEquals("one", element);
 
         String element3 = listIterator.next();
 
-        Assert.assertEquals("two", element3);
+        assertEquals("two", element3);
 
         String element2 = listIterator.previous();
-        Assert.assertEquals("two", element2);
+        assertEquals("two", element2);
 
         String element1 = listIterator.next();
 
-        Assert.assertEquals("two", element1);
+        assertEquals("two", element1);
 
         listIterator.remove();
 
@@ -485,7 +492,7 @@ public class CompositeFastListTest extends AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.clear();
@@ -496,7 +503,7 @@ public class CompositeFastListTest extends AbstractListTestCase
     @Test
     public void notRandomAccess()
     {
-        Assert.assertFalse(this.newWith() instanceof RandomAccess);
+        assertFalse(this.newWith() instanceof RandomAccess);
     }
 
     @Test
@@ -511,22 +518,22 @@ public class CompositeFastListTest extends AbstractListTestCase
         iterator1.next();
         iterator1.next();
         iterator1.remove();
-        Assert.assertEquals("d", iterator1.next());
-        Assert.assertEquals(FastList.newListWith("a", "b", "d"), undertest);
+        assertEquals("d", iterator1.next());
+        assertEquals(FastList.newListWith("a", "b", "d"), undertest);
 
         Iterator<String> iterator2 = undertest.iterator();
         iterator2.next();
         iterator2.next();
         iterator2.remove();
-        Assert.assertEquals(FastList.newListWith("a", "d"), undertest);
+        assertEquals(FastList.newListWith("a", "d"), undertest);
 
         Iterator<String> iterator3 = undertest.iterator();
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(FastList.newListWith("d"), undertest);
+        assertEquals(FastList.newListWith("d"), undertest);
         iterator3.next();
         iterator3.remove();
-        Assert.assertEquals(FastList.newList(), undertest);
+        assertEquals(FastList.newList(), undertest);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -551,6 +558,6 @@ public class CompositeFastListTest extends AbstractListTestCase
 
         List<Integer> result = Lists.mutable.empty();
         compositeFastList.reverseForEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(Lists.mutable.with(21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1), result);
+        assertEquals(Lists.mutable.with(21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1), result);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -52,12 +52,20 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link FastList}.
@@ -80,9 +88,9 @@ public class FastListTest extends AbstractListTestCase
     @Test
     public void withNValues()
     {
-        Assert.assertEquals(FastList.newListWith(1, 1, 1, 1, 1), FastList.newWithNValues(5, () -> 1));
-        Assert.assertEquals(FastList.newListWith(null, null, null, null, null), FastList.newWithNValues(5, () -> null));
-        Assert.assertEquals(
+        assertEquals(FastList.newListWith(1, 1, 1, 1, 1), FastList.newWithNValues(5, () -> 1));
+        assertEquals(FastList.newListWith(null, null, null, null, null), FastList.newWithNValues(5, () -> null));
+        assertEquals(
                 FastList.newListWith(
                         Lists.mutable.with(),
                         Lists.mutable.with(),
@@ -97,13 +105,13 @@ public class FastListTest extends AbstractListTestCase
     {
         List<Integer> expected = new ArrayList<>(Interval.oneTo(20));
         FastList<Integer> actual = new FastList<>(expected);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testFastListNewWithContainsAllItems()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("Alice", "Bob", "Cooper", "Dio"),
                 this.newWith("Alice", "Bob", "Cooper", "Dio").toBag());
     }
@@ -112,32 +120,32 @@ public class FastListTest extends AbstractListTestCase
     public void testAddWithZeroBasedConstructor()
     {
         MutableList<String> strings = FastList.newList(0);
-        Assert.assertEquals(new ArrayList<String>(0), strings);
+        assertEquals(new ArrayList<String>(0), strings);
         strings.add("1");
-        Assert.assertEquals(this.newWith("1"), strings);
+        assertEquals(this.newWith("1"), strings);
     }
 
     @Test
     public void getBatchCount()
     {
         FastList<String> strings = FastList.newList(0);
-        Assert.assertEquals(1, strings.getBatchCount(10));
+        assertEquals(1, strings.getBatchCount(10));
         strings.with("a", "b", "c");
-        Assert.assertEquals(3, strings.getBatchCount(1));
-        Assert.assertEquals(1, strings.getBatchCount(2));
-        Assert.assertEquals(1, strings.getBatchCount(200));
+        assertEquals(3, strings.getBatchCount(1));
+        assertEquals(1, strings.getBatchCount(2));
+        assertEquals(1, strings.getBatchCount(200));
     }
 
     @Test
     public void remove()
     {
         MutableList<String> strings = Lists.mutable.of("a", "b", "c");
-        Assert.assertTrue(strings.remove("a"));
+        assertTrue(strings.remove("a"));
         Verify.assertSize(2, strings);
-        Assert.assertFalse(strings.remove("a"));
-        Assert.assertFalse(strings.remove("z"));
+        assertFalse(strings.remove("a"));
+        assertFalse(strings.remove("z"));
         Verify.assertSize(2, strings);
-        Assert.assertTrue(strings.remove("c"));
+        assertTrue(strings.remove("c"));
         Verify.assertSize(1, strings);
     }
 
@@ -148,13 +156,13 @@ public class FastListTest extends AbstractListTestCase
         FastList<Integer> actual = FastList.wrapCopy(integers);
         FastList<Integer> expected = this.newWith(1, 2, 3, 4);
         integers[0] = Integer.valueOf(4);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void fastListProperSuperSetOfArrayList()
     {
-        Assert.assertTrue(ClassComparer.isProperSupersetOf(FastList.class, ArrayList.class));
+        assertTrue(ClassComparer.isProperSupersetOf(FastList.class, ArrayList.class));
     }
 
     @Override
@@ -164,7 +172,7 @@ public class FastListTest extends AbstractListTestCase
         MutableList<Integer> result = FastList.newList();
         MutableList<Integer> collection = FastList.newListWith(1, 2, 3, 4);
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(this.newWith(1, 2, 3, 4), result);
+        assertEquals(this.newWith(1, 2, 3, 4), result);
     }
 
     @Override
@@ -172,42 +180,42 @@ public class FastListTest extends AbstractListTestCase
     public void injectInto()
     {
         FastList<Integer> list = this.newWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(1 + 1 + 2 + 3), list.injectInto(1, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(1 + 1 + 2 + 3), list.injectInto(1, AddFunction.INTEGER));
     }
 
     @Test
     public void testInjectIntoDouble()
     {
         FastList<Double> list = this.newWith(1.0, 2.0, 3.0);
-        Assert.assertEquals(new Double(1.0 + 1.0 + 2.0 + 3.0), list.injectInto(new Double(1.0d), AddFunction.DOUBLE));
+        assertEquals(new Double(1.0 + 1.0 + 2.0 + 3.0), list.injectInto(new Double(1.0d), AddFunction.DOUBLE));
     }
 
     @Test
     public void testInjectIntoFloat()
     {
         FastList<Float> list = this.newWith(1.0f, 2.0f, 3.0f);
-        Assert.assertEquals(new Float(7.0f), list.injectInto(new Float(1.0f), AddFunction.FLOAT));
+        assertEquals(new Float(7.0f), list.injectInto(new Float(1.0f), AddFunction.FLOAT));
     }
 
     @Test
     public void testInjectIntoString()
     {
         FastList<String> list = FastList.<String>newList().with("1", "2", "3");
-        Assert.assertEquals("0123", list.injectInto("0", AddFunction.STRING));
+        assertEquals("0123", list.injectInto("0", AddFunction.STRING));
     }
 
     @Test
     public void testInjectIntoMaxString()
     {
         FastList<String> list = FastList.<String>newList().with("1", "12", "123");
-        Assert.assertEquals(Integer.valueOf(3), list.injectInto(Integer.MIN_VALUE, MaxSizeFunction.STRING));
+        assertEquals(Integer.valueOf(3), list.injectInto(Integer.MIN_VALUE, MaxSizeFunction.STRING));
     }
 
     @Test
     public void testInjectIntoMinString()
     {
         FastList<String> list = FastList.<String>newList().with("1", "12", "123");
-        Assert.assertEquals(Integer.valueOf(1), list.injectInto(Integer.MAX_VALUE, MinSizeFunction.STRING));
+        assertEquals(Integer.valueOf(1), list.injectInto(Integer.MAX_VALUE, MinSizeFunction.STRING));
     }
 
     @Override
@@ -216,7 +224,7 @@ public class FastListTest extends AbstractListTestCase
     {
         FastList<Boolean> list = this.newWith(Boolean.TRUE, Boolean.FALSE, null);
         MutableList<String> newCollection = list.collect(String::valueOf);
-        Assert.assertEquals(this.newWith("true", "false", "null"), newCollection);
+        assertEquals(this.newWith("true", "false", "null"), newCollection);
     }
 
     @Override
@@ -226,7 +234,7 @@ public class FastListTest extends AbstractListTestCase
         super.forEachWithIndex();
 
         MutableList<Integer> list = FastList.newList(Interval.oneTo(5));
-        list.forEachWithIndex((object, index) -> Assert.assertEquals(index, object - 1));
+        list.forEachWithIndex((object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -236,7 +244,7 @@ public class FastListTest extends AbstractListTestCase
         MutableList<String> list1 = this.newWith("1", "2");
         MutableList<String> list2 = this.newWith("a", "b");
         ListIterate.forEachInBoth(list1, list2, (argument1, argument2) -> list.add(Tuples.twin(argument1, argument2)));
-        Assert.assertEquals(this.newWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
+        assertEquals(this.newWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
     }
 
     @Override
@@ -244,9 +252,9 @@ public class FastListTest extends AbstractListTestCase
     public void detect()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(Integer.valueOf(1), list.detect(Integer.valueOf(1)::equals));
+        assertEquals(Integer.valueOf(1), list.detect(Integer.valueOf(1)::equals));
         FastList<Integer> list2 = FastList.newListWith(1, 2, 2);
-        Assert.assertSame(list2.get(1), list2.detect(Integer.valueOf(2)::equals));
+        assertSame(list2.get(1), list2.detect(Integer.valueOf(2)::equals));
     }
 
     @Override
@@ -254,16 +262,16 @@ public class FastListTest extends AbstractListTestCase
     public void detectWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(Integer.valueOf(1), list.detectWith(Object::equals, 1));
+        assertEquals(Integer.valueOf(1), list.detectWith(Object::equals, 1));
         FastList<Integer> list2 = FastList.newListWith(1, 2, 2);
-        Assert.assertSame(list2.get(1), list2.detectWith(Object::equals, 2));
+        assertSame(list2.get(1), list2.detectWith(Object::equals, 2));
     }
 
     @Test
     public void testDetectWithIfNone()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
+        assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
     }
 
     @Override
@@ -309,8 +317,8 @@ public class FastListTest extends AbstractListTestCase
     public void anySatisfyWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(list.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(list.anySatisfyWith(Predicates2.instanceOf(), Double.class));
+        assertTrue(list.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(list.anySatisfyWith(Predicates2.instanceOf(), Double.class));
     }
 
     @Override
@@ -318,8 +326,8 @@ public class FastListTest extends AbstractListTestCase
     public void anySatisfy()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(Predicates.<Integer>anySatisfy(Integer.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.<Integer>anySatisfy(Double.class::isInstance).accept(list));
+        assertTrue(Predicates.<Integer>anySatisfy(Integer.class::isInstance).accept(list));
+        assertFalse(Predicates.<Integer>anySatisfy(Double.class::isInstance).accept(list));
     }
 
     @Override
@@ -327,9 +335,9 @@ public class FastListTest extends AbstractListTestCase
     public void allSatisfyWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(list.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertTrue(list.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(list.allSatisfyWith(greaterThanPredicate, 2));
+        assertFalse(list.allSatisfyWith(greaterThanPredicate, 2));
     }
 
     @Override
@@ -337,8 +345,8 @@ public class FastListTest extends AbstractListTestCase
     public void allSatisfy()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(Predicates.<Integer>allSatisfy(Integer.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.allSatisfy(Predicates.greaterThan(2)).accept(list));
+        assertTrue(Predicates.<Integer>allSatisfy(Integer.class::isInstance).accept(list));
+        assertFalse(Predicates.allSatisfy(Predicates.greaterThan(2)).accept(list));
     }
 
     @Override
@@ -346,8 +354,8 @@ public class FastListTest extends AbstractListTestCase
     public void noneSatisfy()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(Predicates.<Integer>noneSatisfy(String.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.noneSatisfy(Predicates.greaterThan(0)).accept(list));
+        assertTrue(Predicates.<Integer>noneSatisfy(String.class::isInstance).accept(list));
+        assertFalse(Predicates.noneSatisfy(Predicates.greaterThan(0)).accept(list));
     }
 
     @Override
@@ -355,9 +363,9 @@ public class FastListTest extends AbstractListTestCase
     public void noneSatisfyWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertTrue(list.noneSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(list.noneSatisfyWith(Predicates2.instanceOf(), String.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(list.noneSatisfyWith(greaterThanPredicate, 0));
+        assertFalse(list.noneSatisfyWith(greaterThanPredicate, 0));
     }
 
     @Override
@@ -365,8 +373,8 @@ public class FastListTest extends AbstractListTestCase
     public void count()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(5, list.count(Integer.class::isInstance));
-        Assert.assertEquals(0, list.count(Double.class::isInstance));
+        assertEquals(5, list.count(Integer.class::isInstance));
+        assertEquals(0, list.count(Double.class::isInstance));
     }
 
     @Override
@@ -374,8 +382,8 @@ public class FastListTest extends AbstractListTestCase
     public void countWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(5, list.countWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, list.countWith(Predicates2.instanceOf(), Double.class));
+        assertEquals(5, list.countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, list.countWith(Predicates2.instanceOf(), Double.class));
     }
 
     @Override
@@ -383,10 +391,10 @@ public class FastListTest extends AbstractListTestCase
     public void detectIfNone()
     {
         Function0<Integer> defaultResultFunction = new PassThruFunction0<>(6);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 FastList.newListWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, defaultResultFunction));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(6),
                 FastList.newListWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, defaultResultFunction));
     }
@@ -408,25 +416,25 @@ public class FastListTest extends AbstractListTestCase
         FastList<Integer> collection = FastList.newListWith(1, 2, 3, 4);
         CountProcedure<Integer> countProcedure = new CountProcedure<>(ignored -> true);
         collection.forEachIf(Predicates.lessThan(4), countProcedure);
-        Assert.assertEquals(3, countProcedure.getCount());
+        assertEquals(3, countProcedure.getCount());
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNull(FastList.<Integer>newList().getFirst());
-        Assert.assertEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getFirst());
-        Assert.assertNotEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getFirst());
+        assertNull(FastList.<Integer>newList().getFirst());
+        assertEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getFirst());
+        assertNotEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNull(FastList.<Integer>newList().getLast());
-        Assert.assertNotEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getLast());
+        assertNull(FastList.<Integer>newList().getLast());
+        assertNotEquals(Integer.valueOf(1), FastList.newListWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), FastList.newListWith(1, 2, 3).getLast());
     }
 
     @Override
@@ -435,7 +443,7 @@ public class FastListTest extends AbstractListTestCase
     {
         Verify.assertEmpty(FastList.<Integer>newList());
         Verify.assertNotEmpty(FastList.newListWith(1, 2));
-        Assert.assertTrue(FastList.newListWith(1, 2).notEmpty());
+        assertTrue(FastList.newListWith(1, 2).notEmpty());
     }
 
     @Override
@@ -455,10 +463,10 @@ public class FastListTest extends AbstractListTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4),
                 FastList.newListWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2, 3, 4),
                 FastList.newListWith(1, 2, 3).collectWith(AddFunction.INTEGER, 1, FastList.newList()));
     }
@@ -469,14 +477,14 @@ public class FastListTest extends AbstractListTestCase
     {
         MutableList<Integer> objects = FastList.newListWith(1, 2, 3);
         Integer result = objects.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Test
     public void testRemoveUsingPredicate()
     {
         MutableList<Integer> objects = FastList.newListWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIf(Predicates.isNull()));
+        assertTrue(objects.removeIf(Predicates.isNull()));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -529,7 +537,7 @@ public class FastListTest extends AbstractListTestCase
         Thread.yield();
         System.gc();
         Thread.yield();
-        Assert.assertNull(ref.get());
+        assertNull(ref.get());
     }
 
     @Override
@@ -675,10 +683,10 @@ public class FastListTest extends AbstractListTestCase
         List<List<Object>> arrayList = new ArrayList<>();
         Interval.oneTo(8).forEach(Procedures.cast(object -> arrayList.add(new ArrayList<>())));
         ByteArrayOutputStream stream2 = SerializeTestHelper.getByteArrayOutputStream(arrayList);
-        Assert.assertEquals(194L, stream2.size());
+        assertEquals(194L, stream2.size());
 
         ByteArrayOutputStream stream1 = SerializeTestHelper.getByteArrayOutputStream(mutableArrayList);
-        Assert.assertEquals(182L, stream1.size());
+        assertEquals(182L, stream1.size());
     }
 
     @Override
@@ -688,22 +696,22 @@ public class FastListTest extends AbstractListTestCase
         super.addAll();
 
         MutableList<Integer> integers1 = FastList.newList();
-        Assert.assertTrue(integers1.addAll(mList(1, 2, 3, 4)));
+        assertTrue(integers1.addAll(mList(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4), integers1);
-        Assert.assertTrue(integers1.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
+        assertTrue(integers1.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4, 1, 2, 3, 4), integers1);
-        Assert.assertTrue(integers1.addAll(mSet(5)));
+        assertTrue(integers1.addAll(mSet(5)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4, 1, 2, 3, 4, 5), integers1);
 
         MutableList<Integer> integers2 = FastList.newListWith(0);
-        Assert.assertTrue(integers2.addAll(mList(1, 2, 3, 4)));
+        assertTrue(integers2.addAll(mList(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(0, 1, 2, 3, 4), integers2);
-        Assert.assertTrue(integers2.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
+        assertTrue(integers2.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(0, 1, 2, 3, 4, 1, 2, 3, 4), integers2);
-        Assert.assertTrue(integers2.addAll(mSet(5)));
+        assertTrue(integers2.addAll(mSet(5)));
         Verify.assertListsEqual(FastList.newListWith(0, 1, 2, 3, 4, 1, 2, 3, 4, 5), integers2);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> FastList.newList().addAll(1, null));
+        assertThrows(IndexOutOfBoundsException.class, () -> FastList.newList().addAll(1, null));
     }
 
     @Override
@@ -713,11 +721,11 @@ public class FastListTest extends AbstractListTestCase
         super.addAllIterable();
 
         FastList<Integer> integers = FastList.newList();
-        Assert.assertTrue(integers.addAllIterable(iList(1, 2, 3, 4)));
+        assertTrue(integers.addAllIterable(iList(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4), integers);
-        Assert.assertTrue(integers.addAllIterable(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
+        assertTrue(integers.addAllIterable(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4, 1, 2, 3, 4), integers);
-        Assert.assertTrue(integers.addAllIterable(mSet(5)));
+        assertTrue(integers.addAllIterable(mSet(5)));
         Verify.assertListsEqual(FastList.newListWith(1, 2, 3, 4, 1, 2, 3, 4, 5), integers);
     }
 
@@ -743,8 +751,8 @@ public class FastListTest extends AbstractListTestCase
         list.addAll(mSet(5, 6));
         list.addAll(new ArrayList<>(mList(7, 8)));
         list.addAll(this.newWith(9, 10));
-        Assert.assertFalse(list.addAll(Lists.mutable.of()));
-        Assert.assertEquals(this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), list);
+        assertFalse(list.addAll(Lists.mutable.of()));
+        assertEquals(this.newWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), list);
     }
 
     @Override
@@ -797,7 +805,7 @@ public class FastListTest extends AbstractListTestCase
         FastList<Integer> midList = FastList.<Integer>newList(2).with(1, 3);
         midList.add(1, 2);
         Verify.assertStartsWith(midList, 1, 2, 3);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> midList.add(-1, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> midList.add(-1, -1));
     }
 
     @Test
@@ -820,7 +828,7 @@ public class FastListTest extends AbstractListTestCase
         Verify.assertSize(3, sublist2);
         Verify.assertStartsWith(sublist2, "A", "B", "X");
         Verify.assertContainsAll(sublist, "A", "B", "C", "X");
-        Assert.assertEquals("X", sublist2.remove(2));
+        assertEquals("X", sublist2.remove(2));
         Verify.assertSize(2, sublist2);
         Verify.assertContainsNone(sublist, "X");
         Verify.assertContainsNone(sublist2, "X");
@@ -851,7 +859,7 @@ public class FastListTest extends AbstractListTestCase
     public void testSetAtIndex()
     {
         FastList<Integer> integers = this.newWith(1, 2, 3, 5);
-        Assert.assertEquals(Integer.valueOf(5), integers.set(3, 4));
+        assertEquals(Integer.valueOf(5), integers.set(3, 4));
         Verify.assertStartsWith(integers, 1, 2, 3, 4);
     }
 
@@ -860,11 +868,11 @@ public class FastListTest extends AbstractListTestCase
     public void indexOf()
     {
         FastList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(2, integers.indexOf(3));
-        Assert.assertEquals(-1, integers.indexOf(0));
-        Assert.assertEquals(-1, integers.indexOf(null));
+        assertEquals(2, integers.indexOf(3));
+        assertEquals(-1, integers.indexOf(0));
+        assertEquals(-1, integers.indexOf(null));
         FastList<Integer> integers2 = FastList.<Integer>newList(4).with(null, 2, 3, 4);
-        Assert.assertEquals(0, integers2.indexOf(null));
+        assertEquals(0, integers2.indexOf(null));
     }
 
     @Override
@@ -872,18 +880,18 @@ public class FastListTest extends AbstractListTestCase
     public void lastIndexOf()
     {
         FastList<Integer> integers = FastList.<Integer>newList(4).with(1, 2, 3, 4);
-        Assert.assertEquals(2, integers.lastIndexOf(3));
-        Assert.assertEquals(-1, integers.lastIndexOf(0));
-        Assert.assertEquals(-1, integers.lastIndexOf(null));
+        assertEquals(2, integers.lastIndexOf(3));
+        assertEquals(-1, integers.lastIndexOf(0));
+        assertEquals(-1, integers.lastIndexOf(null));
         FastList<Integer> integers2 = FastList.<Integer>newList(4).with(null, 2, 3, 4);
-        Assert.assertEquals(0, integers2.lastIndexOf(null));
+        assertEquals(0, integers2.lastIndexOf(null));
     }
 
     @Test
     public void testOutOfBoundsCondition()
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.get(4));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.get(4));
     }
 
     @Override
@@ -904,8 +912,8 @@ public class FastListTest extends AbstractListTestCase
         MutableList<Integer> clone = integers.clone();
         Verify.assertListsEqual(integers, clone);
         Verify.assertInstanceOf(FastList.class, clone);
-        Assert.assertEquals(FastList.newList(), FastList.newList().clone());
-        Assert.assertEquals(FastList.newList(0), FastList.newList().clone());
+        assertEquals(FastList.newList(), FastList.newList().clone());
+        assertEquals(FastList.newList(0), FastList.newList().clone());
     }
 
     @Override
@@ -913,13 +921,13 @@ public class FastListTest extends AbstractListTestCase
     public void toArray()
     {
         Object[] typelessArray = this.newWith(1, 2, 3, 4).toArray();
-        Assert.assertArrayEquals(typelessArray, new Object[]{1, 2, 3, 4});
+        assertArrayEquals(typelessArray, new Object[]{1, 2, 3, 4});
         Integer[] typedArray = this.newWith(1, 2, 3, 4).toArray(new Integer[0]);
-        Assert.assertArrayEquals(typedArray, new Integer[]{1, 2, 3, 4});
+        assertArrayEquals(typedArray, new Integer[]{1, 2, 3, 4});
         Integer[] typedArray2 = this.newWith(1, 2, 3, 4).toArray(new Integer[5]);
-        Assert.assertArrayEquals(typedArray2, new Integer[]{1, 2, 3, 4, null});
+        assertArrayEquals(typedArray2, new Integer[]{1, 2, 3, 4, null});
         Integer[] typedArray3 = this.newWith(1, 2, 3, 4).toTypedArray(Integer.class);
-        Assert.assertArrayEquals(typedArray3, new Integer[]{1, 2, 3, 4});
+        assertArrayEquals(typedArray3, new Integer[]{1, 2, 3, 4});
     }
 
     @Override
@@ -927,8 +935,8 @@ public class FastListTest extends AbstractListTestCase
     public void testToString()
     {
         FastList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertNotNull(integers.toString());
-        Assert.assertEquals("[1, 2, 3, 4]", integers.toString());
+        assertNotNull(integers.toString());
+        assertEquals("[1, 2, 3, 4]", integers.toString());
     }
 
     @Test
@@ -936,7 +944,7 @@ public class FastListTest extends AbstractListTestCase
     {
         MutableList<Object> list = FastList.newListWith(1, 2, 3);
         list.add(list);
-        Assert.assertEquals("[1, 2, 3, (this FastList)]", list.toString());
+        assertEquals("[1, 2, 3, (this FastList)]", list.toString());
     }
 
     @Test
@@ -944,7 +952,7 @@ public class FastListTest extends AbstractListTestCase
     {
         MutableList<Object> list = FastList.newListWith(1, 2, 3);
         list.add(list);
-        Assert.assertEquals("1, 2, 3, (this FastList)", list.makeString());
+        assertEquals("1, 2, 3, (this FastList)", list.makeString());
     }
 
     @Test
@@ -952,16 +960,16 @@ public class FastListTest extends AbstractListTestCase
     {
         FastList<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.trimToSize();
-        Assert.assertEquals("[1, 2, 3, 4]", integers.toString());
+        assertEquals("[1, 2, 3, 4]", integers.toString());
     }
 
     @Test
     public void testTrimToSizeWithLoadFactory()
     {
         FastList<Integer> integers = FastList.<Integer>newList(10).with(1, 2, 3, 4);
-        Assert.assertFalse(integers.trimToSizeIfGreaterThanPercent(0.70));
-        Assert.assertTrue(integers.trimToSizeIfGreaterThanPercent(0.10));
-        Assert.assertEquals("[1, 2, 3, 4]", integers.toString());
+        assertFalse(integers.trimToSizeIfGreaterThanPercent(0.70));
+        assertTrue(integers.trimToSizeIfGreaterThanPercent(0.10));
+        assertEquals("[1, 2, 3, 4]", integers.toString());
     }
 
     @Override
@@ -981,20 +989,20 @@ public class FastListTest extends AbstractListTestCase
         Verify.assertEqualsAndHashCode(integers, integers2);
         Verify.assertEqualsAndHashCode(integers, iList(1, 2, 3));
         Verify.assertEqualsAndHashCode(integers, linkedList);
-        Assert.assertNotEquals(integers, integers3);
-        Assert.assertNotEquals(integers, integers5);
-        Assert.assertNotEquals(integers, iList(2, 3, 4));
-        Assert.assertNotEquals(integers, linkedList2);
-        Assert.assertNotEquals(integers, linkedList3);
-        Assert.assertNotEquals(integers, mSet());
+        assertNotEquals(integers, integers3);
+        assertNotEquals(integers, integers5);
+        assertNotEquals(integers, iList(2, 3, 4));
+        assertNotEquals(integers, linkedList2);
+        assertNotEquals(integers, linkedList3);
+        assertNotEquals(integers, mSet());
         Verify.assertEqualsAndHashCode(integers3, integers4);
         Verify.assertEqualsAndHashCode(integers3, new ArrayList<>(integers3));
         Verify.assertEqualsAndHashCode(integers3, new LinkedList<>(integers3));
         Verify.assertEqualsAndHashCode(integers3, ArrayAdapter.newArrayWith(1, null, 3, 4, 5));
-        Assert.assertNotEquals(integers3, ArrayAdapter.newArrayWith(1, null, 3, 4, 6));
+        assertNotEquals(integers3, ArrayAdapter.newArrayWith(1, null, 3, 4, 6));
         Verify.assertEqualsAndHashCode(integers3, ArrayListAdapter.<Integer>newList().with(1, null, 3, 4, 5));
-        Assert.assertEquals(integers, integers2);
-        Assert.assertNotEquals(integers, integers3);
+        assertEquals(integers, integers2);
+        assertNotEquals(integers, integers3);
     }
 
     @Override
@@ -1007,7 +1015,7 @@ public class FastListTest extends AbstractListTestCase
         {
             sum += each.intValue();
         }
-        Assert.assertEquals(10, sum);
+        assertEquals(10, sum);
     }
 
     @Override
@@ -1019,7 +1027,7 @@ public class FastListTest extends AbstractListTestCase
         FastList<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.remove(Integer.valueOf(1));
         Verify.assertStartsWith(integers, 2, 3, 4);
-        Assert.assertFalse(integers.remove(Integer.valueOf(5)));
+        assertFalse(integers.remove(Integer.valueOf(5)));
     }
 
     @Test
@@ -1070,8 +1078,8 @@ public class FastListTest extends AbstractListTestCase
             for (int j = 0; j < 3; j++)
             {
                 actual.shuffleThis();
-                Assert.assertEquals(Interval.oneTo(i), actual.sortThis());
-                Assert.assertEquals(Interval.oneTo(i).reverseThis(), actual.sortThis(Collections.reverseOrder()));
+                assertEquals(Interval.oneTo(i), actual.sortThis());
+                assertEquals(Interval.oneTo(i).reverseThis(), actual.sortThis(Collections.reverseOrder()));
             }
         }
     }
@@ -1104,24 +1112,24 @@ public class FastListTest extends AbstractListTestCase
     public void testNewListWithIterable()
     {
         FastList<Integer> integers = FastList.newList(Interval.oneTo(3));
-        Assert.assertEquals(this.newWith(1, 2, 3), integers);
+        assertEquals(this.newWith(1, 2, 3), integers);
     }
 
     @Test
     public void testContainsAll()
     {
         FastList<Integer> list = this.newWith(1, 2, 3, 4, 5, null);
-        Assert.assertTrue(list.containsAll(mList(1, 3, 5, null)));
-        Assert.assertFalse(list.containsAll(mList(2, null, 6)));
-        Assert.assertTrue(list.containsAll(this.newWith(1, 3, 5, null)));
-        Assert.assertFalse(list.containsAll(this.newWith(2, null, 6)));
+        assertTrue(list.containsAll(mList(1, 3, 5, null)));
+        assertFalse(list.containsAll(mList(2, null, 6)));
+        assertTrue(list.containsAll(this.newWith(1, 3, 5, null)));
+        assertFalse(list.containsAll(this.newWith(2, null, 6)));
     }
 
     @Test
     public void testToArrayFromTo()
     {
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3}, this.newWith(1, 2, 3, 4).toArray(0, 2));
-        Assert.assertArrayEquals(new Integer[]{2, 3, 4}, this.newWith(1, 2, 3, 4).toArray(1, 3));
+        assertArrayEquals(new Integer[]{1, 2, 3}, this.newWith(1, 2, 3, 4).toArray(0, 2));
+        assertArrayEquals(new Integer[]{2, 3, 4}, this.newWith(1, 2, 3, 4).toArray(1, 3));
     }
 
     @Test
@@ -1131,7 +1139,7 @@ public class FastListTest extends AbstractListTestCase
                 FastList.newList(Interval.oneTo(5)).asLazy().collect(Object::toString);
         Procedure<String> builder = Procedures.append(new StringBuilder());
         select.forEach(builder);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -1144,7 +1152,7 @@ public class FastListTest extends AbstractListTestCase
         Appendable builder = new StringBuilder();
         Procedure<String> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     /**
@@ -1157,7 +1165,7 @@ public class FastListTest extends AbstractListTestCase
         LazyIterable<Integer> select = FastList.newList(Interval.oneTo(5)).asLazy().reject(Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     /**
@@ -1170,25 +1178,25 @@ public class FastListTest extends AbstractListTestCase
         LazyIterable<Integer> select = FastList.newList(Interval.oneTo(5)).asLazy().select(Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Test
     public void testWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1"),
                 FastList.<String>newList().with("1"));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2"),
                 FastList.<String>newList().with("1", "2"));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3"),
                 FastList.<String>newList().with("1", "2", "3"));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3", "4"),
                 FastList.<String>newList().with("1", "2", "3", "4"));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3", "4", "5", "6", "7", "8"),
                 FastList.<String>newList().with("1", "2", "3", "4").with("5", "6", "7", "8"));
 
@@ -1196,12 +1204,12 @@ public class FastListTest extends AbstractListTestCase
                 .withAll(Lists.immutable.of("1", "2"))
                 .withAll(Lists.immutable.of())
                 .withAll(Sets.immutable.of("3", "4"));
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("A", "1", "2", "3", "4"),
                 list.toBag());
         Verify.assertStartsWith(list, "A", "1", "2");  // "3" and "4" are from a set, so may not be in order
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(42, 10, 11, 12),
                 FastList.newListWith(42).withAll(Interval.from(10).to(12).toList()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ListAdapterTest.java
@@ -16,8 +16,10 @@ import java.util.LinkedList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link ListAdapter}.
@@ -48,7 +50,7 @@ public class ListAdapterTest extends AbstractListTestCase
     @Test
     public void adapt()
     {
-        Assert.assertEquals(ListAdapter.adapt(Arrays.asList(1, 2, 3)), Lists.adapt(Arrays.asList(1, 2, 3)));
+        assertEquals(ListAdapter.adapt(Arrays.asList(1, 2, 3)), Lists.adapt(Arrays.asList(1, 2, 3)));
     }
 
     @Test
@@ -70,7 +72,7 @@ public class ListAdapterTest extends AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -98,13 +100,13 @@ public class ListAdapterTest extends AbstractListTestCase
     {
         Object item = new Object();
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(item).get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> this.newWith(item).get(-1));
     }
 
     @Test
     public void adaptNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new ListAdapter<>(null));
-        Assert.assertThrows(NullPointerException.class, () -> ListAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> new ListAdapter<>(null));
+        assertThrows(NullPointerException.class, () -> ListAdapter.adapt(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsReadUntouchableTest.java
@@ -14,8 +14,9 @@ import java.io.Serializable;
 
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
 
 public class MultiReaderFastListAsReadUntouchableTest extends UnmodifiableMutableListTestCase
 {
@@ -30,6 +31,6 @@ public class MultiReaderFastListAsReadUntouchableTest extends UnmodifiableMutabl
     public void serialization()
     {
         MutableCollection<Integer> collection = this.getCollection();
-        Assert.assertFalse(collection instanceof Serializable);
+        assertFalse(collection instanceof Serializable);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsWriteUntouchableTest.java
@@ -15,8 +15,11 @@ import java.util.Arrays;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestCase
 {
@@ -31,28 +34,28 @@ public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestC
     public void serialization()
     {
         MutableList<Integer> collection = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertFalse(collection instanceof Serializable);
+        assertFalse(collection instanceof Serializable);
     }
 
     @Override
     @Test
     public void asSynchronized()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
     }
 
     @Override
     @Test
     public void asUnmodifiable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
+        assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
     }
 
     @Override
@@ -70,7 +73,7 @@ public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestC
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -85,7 +88,7 @@ public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestC
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
+        assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
     }
 
     @Override
@@ -94,6 +97,6 @@ public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestC
     {
         Appendable builder = new StringBuilder();
         this.newWith(1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 2, 3", builder.toString());
+        assertEquals("1, 2, 3", builder.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
@@ -44,10 +44,18 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link MultiReaderFastList}.
@@ -78,7 +86,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     @Test
     public void fastListNewWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("Alice", "Bob", "Cooper", "Dio"),
                 MultiReaderFastList.newListWith("Alice", "Bob", "Cooper", "Dio"));
     }
@@ -90,7 +98,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> result = FastList.newList();
         MutableList<Integer> collection = MultiReaderFastList.newListWith(1, 2, 3, 4);
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), result);
     }
 
     @Override
@@ -98,21 +106,21 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void injectInto()
     {
         MutableList<Integer> list = MultiReaderFastList.newListWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(7), list.injectInto(1, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(7), list.injectInto(1, AddFunction.INTEGER));
     }
 
     @Test
     public void injectIntoDouble2()
     {
         MutableList<Double> list = MultiReaderFastList.newListWith(1.0, 2.0, 3.0);
-        Assert.assertEquals(7.0d, list.injectInto(1.0, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
+        assertEquals(7.0d, list.injectInto(1.0, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
     }
 
     @Test
     public void injectIntoString()
     {
         MutableList<String> list = MultiReaderFastList.newListWith("1", "2", "3");
-        Assert.assertEquals("0123", list.injectInto("0", AddFunction.STRING));
+        assertEquals("0123", list.injectInto("0", AddFunction.STRING));
     }
 
     @Test
@@ -120,7 +128,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<String> list = MultiReaderFastList.newListWith("1", "12", "123");
         Function2<Integer, String, Integer> function = MaxSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(3), list.injectInto(Integer.MIN_VALUE, function));
+        assertEquals(Integer.valueOf(3), list.injectInto(Integer.MIN_VALUE, function));
     }
 
     @Test
@@ -128,7 +136,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<String> list = MultiReaderFastList.newListWith("1", "12", "123");
         Function2<Integer, String, Integer> function = MinSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(1), list.injectInto(Integer.MAX_VALUE, function));
+        assertEquals(Integer.valueOf(1), list.injectInto(Integer.MAX_VALUE, function));
     }
 
     @Override
@@ -137,7 +145,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<Boolean> list = MultiReaderFastList.newListWith(Boolean.TRUE, Boolean.FALSE, null);
         MutableList<String> newCollection = list.collect(String::valueOf);
-        Assert.assertEquals(FastList.newListWith("true", "false", "null"), newCollection);
+        assertEquals(FastList.newListWith("true", "false", "null"), newCollection);
     }
 
     private MutableList<Integer> getIntegerList()
@@ -152,7 +160,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         super.forEachWithIndex();
 
         MutableList<Integer> list = MultiReaderFastList.newList(Interval.oneTo(5));
-        list.forEachWithIndex((object, index) -> Assert.assertEquals(index, object - 1));
+        list.forEachWithIndex((object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -162,7 +170,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<String> list1 = MultiReaderFastList.newListWith("1", "2");
         MutableList<String> list2 = MultiReaderFastList.newListWith("a", "b");
         ListIterate.forEachInBoth(list1, list2, (argument1, argument2) -> list.add(Tuples.pair(argument1, argument2)));
-        Assert.assertEquals(FastList.newListWith(Tuples.pair("1", "a"), Tuples.pair("2", "b")), list);
+        assertEquals(FastList.newListWith(Tuples.pair("1", "a"), Tuples.pair("2", "b")), list);
     }
 
     @Override
@@ -175,7 +183,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         list1.forEachInBoth(
                 list2,
                 (argument1, argument2) -> list.add(Tuples.pair(argument1, argument2)));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(Tuples.pair("1", "a"), Tuples.pair("2", "b")),
                 list);
     }
@@ -185,9 +193,9 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void detect()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(1), list.detect(Integer.valueOf(1)::equals));
+        assertEquals(Integer.valueOf(1), list.detect(Integer.valueOf(1)::equals));
         MutableList<Integer> list2 = MultiReaderFastList.newListWith(1, 2, 2);
-        Assert.assertSame(list2.get(1), list2.detect(Integer.valueOf(2)::equals));
+        assertSame(list2.get(1), list2.detect(Integer.valueOf(2)::equals));
     }
 
     @Override
@@ -195,17 +203,17 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void detectWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(1), list.detectWith(Object::equals, 1));
+        assertEquals(Integer.valueOf(1), list.detectWith(Object::equals, 1));
         MutableList<Integer> list2 = MultiReaderFastList.newListWith(1, 2, 2);
-        Assert.assertSame(list2.get(1), list2.detectWith(Object::equals, 2));
+        assertSame(list2.get(1), list2.detectWith(Object::equals, 2));
     }
 
     @Test
     public void detectWithIfNone()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
-        Assert.assertEquals(Integer.valueOf(1), list.detectWithIfNone(Object::equals, Integer.valueOf(1), new PassThruFunction0<>(Integer.valueOf(10000))));
+        assertNull(list.detectWithIfNone(Object::equals, 6, new PassThruFunction0<>(null)));
+        assertEquals(Integer.valueOf(1), list.detectWithIfNone(Object::equals, Integer.valueOf(1), new PassThruFunction0<>(Integer.valueOf(10000))));
     }
 
     @Override
@@ -251,8 +259,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void anySatisfyWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(list.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(list.anySatisfyWith(Predicates2.instanceOf(), Double.class));
+        assertTrue(list.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(list.anySatisfyWith(Predicates2.instanceOf(), Double.class));
     }
 
     @Override
@@ -260,8 +268,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void anySatisfy()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(Predicates.<Integer>anySatisfy(Integer.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.<Integer>anySatisfy(Double.class::isInstance).accept(list));
+        assertTrue(Predicates.<Integer>anySatisfy(Integer.class::isInstance).accept(list));
+        assertFalse(Predicates.<Integer>anySatisfy(Double.class::isInstance).accept(list));
     }
 
     @Override
@@ -269,9 +277,9 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void allSatisfyWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(list.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertTrue(list.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(list.allSatisfyWith(greaterThanPredicate, 2));
+        assertFalse(list.allSatisfyWith(greaterThanPredicate, 2));
     }
 
     @Override
@@ -279,8 +287,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void allSatisfy()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(Predicates.<Integer>allSatisfy(Integer.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.allSatisfy(Predicates.greaterThan(2)).accept(list));
+        assertTrue(Predicates.<Integer>allSatisfy(Integer.class::isInstance).accept(list));
+        assertFalse(Predicates.allSatisfy(Predicates.greaterThan(2)).accept(list));
     }
 
     @Override
@@ -288,8 +296,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void noneSatisfy()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(Predicates.<Integer>noneSatisfy(String.class::isInstance).accept(list));
-        Assert.assertFalse(Predicates.noneSatisfy(Predicates.greaterThan(0)).accept(list));
+        assertTrue(Predicates.<Integer>noneSatisfy(String.class::isInstance).accept(list));
+        assertFalse(Predicates.noneSatisfy(Predicates.greaterThan(0)).accept(list));
     }
 
     @Override
@@ -297,9 +305,9 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void noneSatisfyWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(list.noneSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(list.noneSatisfyWith(Predicates2.instanceOf(), String.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(list.noneSatisfyWith(greaterThanPredicate, 0));
+        assertFalse(list.noneSatisfyWith(greaterThanPredicate, 0));
     }
 
     @Override
@@ -307,8 +315,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void count()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(5, list.count(Integer.class::isInstance));
-        Assert.assertEquals(0, list.count(Double.class::isInstance));
+        assertEquals(5, list.count(Integer.class::isInstance));
+        assertEquals(0, list.count(Double.class::isInstance));
     }
 
     @Override
@@ -316,8 +324,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void countWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(5, list.countWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, list.countWith(Predicates2.instanceOf(), Double.class));
+        assertEquals(5, list.countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, list.countWith(Predicates2.instanceOf(), Double.class));
     }
 
     @Override
@@ -325,10 +333,10 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void detectIfNone()
     {
         Function0<Integer> defaultResultFunction = new PassThruFunction0<>(6);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 MultiReaderFastList.newListWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, defaultResultFunction));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(6),
                 MultiReaderFastList.newListWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, defaultResultFunction));
     }
@@ -340,24 +348,24 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> result = FastList.newList();
         MutableList<Integer> collection = MultiReaderFastList.newListWith(1, 2, 3, 4);
         collection.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 0);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), result);
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNull(MultiReaderFastList.newList().getFirst());
-        Assert.assertEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getFirst());
+        assertNull(MultiReaderFastList.newList().getFirst());
+        assertEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNull(MultiReaderFastList.newList().getLast());
-        Assert.assertNotEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), MultiReaderFastList.newListWith(1, 2, 3).getLast());
+        assertNull(MultiReaderFastList.newList().getLast());
+        assertNotEquals(Integer.valueOf(1), MultiReaderFastList.newListWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), MultiReaderFastList.newListWith(1, 2, 3).getLast());
     }
 
     @Override
@@ -366,19 +374,19 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         Verify.assertEmpty(MultiReaderFastList.newList());
         Verify.assertNotEmpty(MultiReaderFastList.newListWith(1, 2));
-        Assert.assertTrue(MultiReaderFastList.newListWith(1, 2).notEmpty());
+        assertTrue(MultiReaderFastList.newListWith(1, 2).notEmpty());
     }
 
     @Override
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3"),
                 MultiReaderFastList.newListWith(1, 2, 3).collectIf(
                         Integer.class::isInstance,
                         String::valueOf));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("1", "2", "3"),
                 MultiReaderFastList.newListWith(1, 2, 3).collectIf(
                         Integer.class::isInstance,
@@ -405,14 +413,14 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<Integer> objects = MultiReaderFastList.newListWith(1, 2, 3);
         Integer result = objects.injectIntoWith(1, (injectedValued, item, parameter) -> injectedValued + item + parameter, 0);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Test
     public void removeUsingPredicate()
     {
         MutableList<Integer> objects = MultiReaderFastList.newListWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIf(Predicates.isNull()));
+        assertTrue(objects.removeIf(Predicates.isNull()));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -422,7 +430,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void removeIf()
     {
         MutableList<Integer> objects = MultiReaderFastList.newListWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIf(Predicates.cast(Objects::isNull)));
+        assertTrue(objects.removeIf(Predicates.cast(Objects::isNull)));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -432,7 +440,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void removeIfWith()
     {
         MutableList<Integer> objects = MultiReaderFastList.newListWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIfWith((each, ignored) -> each == null, null));
+        assertTrue(objects.removeIfWith((each, ignored) -> each == null, null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -487,7 +495,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         Thread.yield();
         System.gc();
         Thread.yield();
-        Assert.assertNull(ref.get());
+        assertNull(ref.get());
     }
 
     @Override
@@ -570,7 +578,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
         Verify.assertStartsWith(deserializedCollection, 1, 2, 3, 4, 5);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     @Test
@@ -587,7 +595,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection.subList(0, 2));
         Verify.assertSize(2, deserializedCollection);
         Verify.assertStartsWith(deserializedCollection, 1, 2);
-        Assert.assertEquals(collection.subList(0, 2), deserializedCollection);
+        assertEquals(collection.subList(0, 2), deserializedCollection);
     }
 
     @Override
@@ -597,11 +605,11 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         super.addAll();
 
         MutableList<Integer> integers = MultiReaderFastList.newList();
-        Assert.assertTrue(integers.addAll(Lists.fixedSize.of(1, 2, 3, 4)));
+        assertTrue(integers.addAll(Lists.fixedSize.of(1, 2, 3, 4)));
         Verify.assertContainsAll(integers, 1, 2, 3, 4);
-        Assert.assertTrue(integers.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
+        assertTrue(integers.addAll(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
         Verify.assertStartsWith(integers, 1, 2, 3, 4, 1, 2, 3, 4);
-        Assert.assertTrue(integers.addAll(Sets.fixedSize.of(5)));
+        assertTrue(integers.addAll(Sets.fixedSize.of(5)));
         Verify.assertStartsWith(integers, 1, 2, 3, 4, 1, 2, 3, 4, 5);
     }
 
@@ -612,11 +620,11 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         super.addAllIterable();
 
         MutableList<Integer> integers = MultiReaderFastList.newList();
-        Assert.assertTrue(integers.addAllIterable(Lists.fixedSize.of(1, 2, 3, 4)));
+        assertTrue(integers.addAllIterable(Lists.fixedSize.of(1, 2, 3, 4)));
         Verify.assertContainsAll(integers, 1, 2, 3, 4);
-        Assert.assertTrue(integers.addAllIterable(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
+        assertTrue(integers.addAllIterable(FastList.<Integer>newList(4).with(1, 2, 3, 4)));
         Verify.assertStartsWith(integers, 1, 2, 3, 4, 1, 2, 3, 4);
-        Assert.assertTrue(integers.addAllIterable(Sets.fixedSize.of(5)));
+        assertTrue(integers.addAllIterable(Sets.fixedSize.of(5)));
         Verify.assertStartsWith(integers, 1, 2, 3, 4, 1, 2, 3, 4, 5);
     }
 
@@ -640,7 +648,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<Integer> integers = this.getIntegerList();
         integers.replaceAll(i -> i * 2);
-        Assert.assertEquals(Lists.mutable.with(10, 8, 6, 4, 2), integers);
+        assertEquals(Lists.mutable.with(10, 8, 6, 4, 2), integers);
     }
 
     @Override
@@ -649,7 +657,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<Integer> integers = this.getIntegerList();
         integers.sort(Comparator.reverseOrder());
-        Assert.assertEquals(Lists.mutable.with(5, 4, 3, 2, 1), integers);
+        assertEquals(Lists.mutable.with(5, 4, 3, 2, 1), integers);
     }
 
     @Override
@@ -701,7 +709,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> midList = FastList.<Integer>newList(2).with(1, 3);
         midList.add(1, 2);
         Verify.assertStartsWith(midList, 1, 2, 3);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> midList.add(-1, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> midList.add(-1, -1));
     }
 
     @Override
@@ -722,7 +730,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -737,7 +745,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void subListSort()
     {
         MutableList<Integer> list = Interval.from(0).to(20).addAllTo(MultiReaderFastList.newList()).subList(2, 18).sortThis();
-        Assert.assertEquals(FastList.newList(list), Interval.from(2).to(17));
+        assertEquals(FastList.newList(list), Interval.from(2).to(17));
     }
 
     @Test
@@ -752,7 +760,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         Verify.assertSize(3, sublist2);
         Verify.assertStartsWith(sublist2, "A", "B", "X");
         Verify.assertContainsAll(sublist, "A", "B", "C", "X");
-        Assert.assertEquals("X", sublist2.remove(2));
+        assertEquals("X", sublist2.remove(2));
         Verify.assertSize(2, sublist2);
         Verify.assertContainsNone(sublist, "X");
         Verify.assertContainsNone(sublist2, "X");
@@ -762,7 +770,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void setAtIndex()
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 5);
-        Assert.assertEquals(Integer.valueOf(5), integers.set(3, 4));
+        assertEquals(Integer.valueOf(5), integers.set(3, 4));
         Verify.assertStartsWith(integers, 1, 2, 3, 4);
     }
 
@@ -771,11 +779,11 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void indexOf()
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(2, integers.indexOf(3));
-        Assert.assertEquals(-1, integers.indexOf(0));
-        Assert.assertEquals(-1, integers.indexOf(null));
+        assertEquals(2, integers.indexOf(3));
+        assertEquals(-1, integers.indexOf(0));
+        assertEquals(-1, integers.indexOf(null));
         MutableList<Integer> integers2 = this.newWith(null, 2, 3, 4);
-        Assert.assertEquals(0, integers2.indexOf(null));
+        assertEquals(0, integers2.indexOf(null));
     }
 
     @Override
@@ -783,18 +791,18 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void lastIndexOf()
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(2, integers.lastIndexOf(3));
-        Assert.assertEquals(-1, integers.lastIndexOf(0));
-        Assert.assertEquals(-1, integers.lastIndexOf(null));
+        assertEquals(2, integers.lastIndexOf(3));
+        assertEquals(-1, integers.lastIndexOf(0));
+        assertEquals(-1, integers.lastIndexOf(null));
         MutableList<Integer> integers2 = this.newWith(null, 2, 3, 4);
-        Assert.assertEquals(0, integers2.lastIndexOf(null));
+        assertEquals(0, integers2.lastIndexOf(null));
     }
 
     @Test
     public void outOfBoundsCondition()
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.get(4));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.get(4));
     }
 
     @Override
@@ -813,7 +821,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableList<Integer> clone = integers.clone();
-        Assert.assertEquals(integers, clone);
+        assertEquals(integers, clone);
         Verify.assertInstanceOf(MultiReaderFastList.class, clone);
     }
 
@@ -822,9 +830,9 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void toArray()
     {
         Object[] typelessArray = this.newWith(1, 2, 3, 4).toArray();
-        Assert.assertArrayEquals(typelessArray, new Object[]{1, 2, 3, 4});
+        assertArrayEquals(typelessArray, new Object[]{1, 2, 3, 4});
         Integer[] typedArray = this.newWith(1, 2, 3, 4).toArray(new Integer[0]);
-        Assert.assertArrayEquals(typedArray, new Integer[]{1, 2, 3, 4});
+        assertArrayEquals(typedArray, new Integer[]{1, 2, 3, 4});
     }
 
     @Override
@@ -842,14 +850,14 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         Verify.assertPostSerializedEqualsAndHashCode(integers);
         Verify.assertEqualsAndHashCode(integers, integers2);
         Verify.assertEqualsAndHashCode(integers, randomAccessList);
-        Assert.assertNotEquals(integers, integers3);
-        Assert.assertNotEquals(integers, integers5);
-        Assert.assertNotEquals(integers, randomAccessList2);
-        Assert.assertNotEquals(integers, Sets.fixedSize.of());
+        assertNotEquals(integers, integers3);
+        assertNotEquals(integers, integers5);
+        assertNotEquals(integers, randomAccessList2);
+        assertNotEquals(integers, Sets.fixedSize.of());
         Verify.assertEqualsAndHashCode(integers3, integers4);
         Verify.assertEqualsAndHashCode(integers3, ArrayAdapter.newArrayWith(1, null, 3, 4, 5));
-        Assert.assertEquals(integers, integers2);
-        Assert.assertNotEquals(integers, integers3);
+        assertEquals(integers, integers2);
+        assertNotEquals(integers, integers3);
     }
 
     @Override
@@ -863,7 +871,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         integers.remove(doesExist);
         Verify.assertStartsWith(integers, 2, 3, 4);
         Integer doesNotExist = 5;
-        Assert.assertFalse(integers.remove(doesNotExist));
+        assertFalse(integers.remove(doesNotExist));
     }
 
     @Override
@@ -891,7 +899,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
         MutableList<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableMap<String, String> map =
                 integers.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -945,10 +953,10 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void containsAll()
     {
         MutableList<Integer> list = this.newWith(1, 2, 3, 4, 5, null);
-        Assert.assertTrue(list.containsAll(Lists.fixedSize.of(1, 3, 5, null)));
-        Assert.assertFalse(list.containsAll(Lists.fixedSize.of(2, null, 6)));
-        Assert.assertTrue(list.containsAll(FastList.<Integer>newList().with(1, 3, 5, null)));
-        Assert.assertFalse(list.containsAll(FastList.<Integer>newList().with(2, null, 6)));
+        assertTrue(list.containsAll(Lists.fixedSize.of(1, 3, 5, null)));
+        assertFalse(list.containsAll(Lists.fixedSize.of(2, null, 6)));
+        assertTrue(list.containsAll(FastList.<Integer>newList().with(1, 3, 5, null)));
+        assertFalse(list.containsAll(FastList.<Integer>newList().with(2, null, 6)));
     }
 
     @Override
@@ -956,7 +964,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void iterator()
     {
         MultiReaderFastList<Integer> integers = this.newWith(1, 2, 3, 4);
-        Assert.assertThrows(UnsupportedOperationException.class, integers::iterator);
+        assertThrows(UnsupportedOperationException.class, integers::iterator);
     }
 
     @Override
@@ -1009,7 +1017,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
             listIterator.set(delegate.listIterator());
             listIteratorWithPosition.set(delegate.listIterator(3));
         });
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), list);
 
         this.assertIteratorThrows(delegateList.get());
         this.assertIteratorThrows(subLists.get());
@@ -1020,12 +1028,12 @@ public class MultiReaderFastListTest extends AbstractListTestCase
 
     private void assertIteratorThrows(Iterator<?> iterator)
     {
-        Assert.assertThrows(NullPointerException.class, iterator::hasNext);
+        assertThrows(NullPointerException.class, iterator::hasNext);
     }
 
     private void assertIteratorThrows(MutableList<?> list)
     {
-        Assert.assertThrows(NullPointerException.class, list::iterator);
+        assertThrows(NullPointerException.class, list::iterator);
     }
 
     @Test
@@ -1038,27 +1046,27 @@ public class MultiReaderFastListTest extends AbstractListTestCase
             result[0] = delegate.getFirst();
             this.verifyDelegateIsUnmodifiable(delegate);
         });
-        Assert.assertNotNull(result[0]);
+        assertNotNull(result[0]);
     }
 
     private void verifyDelegateIsUnmodifiable(MutableList<Integer> delegate)
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
+        assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
+        assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
     }
 
     @Override
@@ -1067,7 +1075,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     {
         Appendable builder = new StringBuilder();
         this.newWith(1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 2, 3", builder.toString());
+        assertEquals("1, 2, 3", builder.toString());
     }
 
     @Override
@@ -1090,8 +1098,8 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void binarySearch()
     {
         MutableList<Integer> sortedList = this.newWith(1, 2, 3, 4, 5, 7);
-        Assert.assertEquals(1, sortedList.binarySearch(2));
-        Assert.assertEquals(-6, sortedList.binarySearch(6));
+        assertEquals(1, sortedList.binarySearch(2));
+        assertEquals(-6, sortedList.binarySearch(6));
     }
 
     @Override
@@ -1099,7 +1107,7 @@ public class MultiReaderFastListTest extends AbstractListTestCase
     public void binarySearchWithComparator()
     {
         MutableList<Integer> sortedList = this.newWith(7, 5, 4, 3, 2, 1);
-        Assert.assertEquals(4, sortedList.binarySearch(2, Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(-2, sortedList.binarySearch(6, Comparators.reverseNaturalOrder()));
+        assertEquals(4, sortedList.binarySearch(2, Comparators.reverseNaturalOrder()));
+        assertEquals(-2, sortedList.binarySearch(6, Comparators.reverseNaturalOrder()));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/RandomAccessListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/RandomAccessListAdapterTest.java
@@ -21,8 +21,12 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link RandomAccessListAdapter}.
@@ -62,10 +66,10 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         MutableList<Integer> list1 = this.newWith(1, 2, 3);
         MutableList<Integer> list2 = this.newWith(1, 2, 3);
         MutableList<Integer> list3 = this.newWith(2, 3, 4);
-        Assert.assertNotEquals(list1, null);
+        assertNotEquals(list1, null);
         Verify.assertEqualsAndHashCode(list1, list1);
         Verify.assertEqualsAndHashCode(list1, list2);
-        Assert.assertNotEquals(list2, list3);
+        assertNotEquals(list2, list3);
     }
 
     @Test
@@ -85,7 +89,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         sublist.remove("X");
         Verify.assertContainsAll(sublist, "B", "C");
         Verify.assertContainsAll(list, "A", "B", "C", "D");
-        Assert.assertEquals("C", sublist.set(1, "R"));
+        assertEquals("C", sublist.set(1, "R"));
         Verify.assertContainsAll(sublist, "B", "R");
         Verify.assertContainsAll(list, "A", "B", "R", "D");
         sublist.addAll(Arrays.asList("W", "G"));
@@ -104,7 +108,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
 
         MutableList<Integer> collection = this.newWith(1, 2, 3);
         Verify.assertContainsAll(collection, 1, 2, 3);
-        Assert.assertThrows(IllegalArgumentException.class, () -> new RandomAccessListAdapter<>(new LinkedList<>()));
+        assertThrows(IllegalArgumentException.class, () -> new RandomAccessListAdapter<>(new LinkedList<>()));
     }
 
     @Override
@@ -117,7 +121,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         MutableList<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
         Verify.assertContainsAll(deserializedCollection, 1, 2, 3, 4, 5);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     @Override
@@ -140,7 +144,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         super.removeIf();
 
         MutableList<Integer> objects = this.newWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIf(Predicates.isNull()));
+        assertTrue(objects.removeIf(Predicates.isNull()));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -152,7 +156,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         super.removeIf();
 
         MutableList<Integer> objects = this.newWith(1, 2, 3, null);
-        Assert.assertTrue(objects.removeIfWith(Predicates2.isNull(), null));
+        assertTrue(objects.removeIfWith(Predicates2.isNull(), null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
     }
@@ -173,7 +177,7 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         super.indexOf();
 
         MutableList<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertEquals(1, objects.indexOf(2));
+        assertEquals(1, objects.indexOf(2));
     }
 
     @Override
@@ -183,14 +187,14 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
         super.lastIndexOf();
 
         MutableList<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertEquals(1, objects.lastIndexOf(2));
+        assertEquals(1, objects.lastIndexOf(2));
     }
 
     @Test
     public void testSet()
     {
         MutableList<Integer> objects = this.newWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(2), objects.set(1, 4));
+        assertEquals(Integer.valueOf(2), objects.set(1, 4));
         Verify.assertItemAtIndex(4, 1, objects);
     }
 
@@ -232,8 +236,8 @@ public class RandomAccessListAdapterTest extends AbstractListTestCase
     @Test
     public void adaptNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new RandomAccessListAdapter<>(null));
-        Assert.assertThrows(NullPointerException.class, () -> RandomAccessListAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> new RandomAccessListAdapter<>(null));
+        assertThrows(NullPointerException.class, () -> RandomAccessListAdapter.adapt(null));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableListTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.list.mutable;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link SynchronizedMutableList}.
@@ -49,14 +50,14 @@ public class SynchronizedMutableListTest extends AbstractListTestCase
     public void testToString()
     {
         MutableList<Object> list = this.newWith(1, 2, 3);
-        Assert.assertEquals("[1, 2, 3]", list.toString());
+        assertEquals("[1, 2, 3]", list.toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
+        assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
     }
 
     @Override
@@ -65,6 +66,6 @@ public class SynchronizedMutableListTest extends AbstractListTestCase
     {
         Appendable builder = new StringBuilder();
         this.newWith(1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 2, 3", builder.toString());
+        assertEquals("1, 2, 3", builder.toString());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTest.java
@@ -28,11 +28,16 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableList}.
@@ -64,8 +69,8 @@ public class UnmodifiableMutableListTest
     public void delegatingMethods()
     {
         Verify.assertItemAtIndex("Europe", 2, this.unmodifiableList);
-        Assert.assertEquals(2, this.unmodifiableList.indexOf("Europe"));
-        Assert.assertEquals(0, this.unmodifiableList.lastIndexOf(METALLICA));
+        assertEquals(2, this.unmodifiableList.indexOf("Europe"));
+        assertEquals(0, this.unmodifiableList.lastIndexOf(METALLICA));
     }
 
     @Test
@@ -73,38 +78,38 @@ public class UnmodifiableMutableListTest
     {
         Counter counter = new Counter();
         this.unmodifiableList.forEach(1, 2, band -> counter.increment());
-        Assert.assertEquals(2, counter.getCount());
+        assertEquals(2, counter.getCount());
     }
 
     @Test
     public void listIterator()
     {
         ListIterator<String> it = this.unmodifiableList.listIterator();
-        Assert.assertFalse(it.hasPrevious());
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(METALLICA, it.next());
-        Assert.assertTrue(it.hasNext());
-        Assert.assertEquals(1, it.nextIndex());
+        assertFalse(it.hasPrevious());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(METALLICA, it.next());
+        assertTrue(it.hasNext());
+        assertEquals(1, it.nextIndex());
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.set("Rick Astley"));
+        assertThrows(UnsupportedOperationException.class, () -> it.set("Rick Astley"));
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.add("Gloria Gaynor"));
+        assertThrows(UnsupportedOperationException.class, () -> it.add("Gloria Gaynor"));
 
-        Assert.assertEquals(METALLICA, it.previous());
+        assertEquals(METALLICA, it.previous());
     }
 
     @Test
     public void sortThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThis());
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThis());
     }
 
     @Test
     public void sortThisWithComparator()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.unmodifiableList.sortThis(String::compareTo));
     }
@@ -112,7 +117,7 @@ public class UnmodifiableMutableListTest
     @Test
     public void sortThisBy()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.unmodifiableList.sortThisBy(Functions.getStringToInteger()));
     }
@@ -120,62 +125,62 @@ public class UnmodifiableMutableListTest
     @Test
     public void sortThisByBoolean()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByBoolean(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByBoolean(null));
     }
 
     @Test
     public void sortThisByChar()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByChar(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByChar(null));
     }
 
     @Test
     public void sortThisByByte()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByByte(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByByte(null));
     }
 
     @Test
     public void sortThisByShort()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByShort(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByShort(null));
     }
 
     @Test
     public void sortThisByInt()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByInt(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByInt(null));
     }
 
     @Test
     public void sortThisByFloat()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByFloat(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByFloat(null));
     }
 
     @Test
     public void sortThisByLong()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByLong(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByLong(null));
     }
 
     @Test
     public void sortThisByDouble()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByDouble(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sortThisByDouble(null));
     }
 
     @Test
     public void shuffleThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.shuffleThis(null));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.shuffleThis(new Random(4)));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.shuffleThis(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.shuffleThis(new Random(4)));
     }
 
     @Test
     public void reverseThis()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.unmodifiableList.reverseThis());
     }
@@ -183,7 +188,7 @@ public class UnmodifiableMutableListTest
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> this.unmodifiableList.addAll(0, Lists.mutable.of("Madonna")));
     }
@@ -191,39 +196,39 @@ public class UnmodifiableMutableListTest
     @Test
     public void set()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.set(0, "Madonna"));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.set(0, "Madonna"));
     }
 
     @Test
     public void addAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.add(0, "Madonna"));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.add(0, "Madonna"));
     }
 
     @Test
     public void removeFromIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.remove(0));
     }
 
     @Test
     public void replaceAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.replaceAll(e -> e));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.replaceAll(e -> e));
     }
 
     @Test
     public void sort()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sort(Comparator.naturalOrder()));
+        assertThrows(UnsupportedOperationException.class, () -> this.unmodifiableList.sort(Comparator.naturalOrder()));
     }
 
     @Test
     public void subList()
     {
         MutableList<String> subList = this.unmodifiableList.subList(1, 3);
-        Assert.assertEquals(Lists.immutable.of("Bon Jovi", "Europe"), subList);
-        Assert.assertThrows(UnsupportedOperationException.class, subList::clear);
+        assertEquals(Lists.immutable.of("Bon Jovi", "Europe"), subList);
+        assertThrows(UnsupportedOperationException.class, subList::clear);
     }
 
     @Test
@@ -238,13 +243,13 @@ public class UnmodifiableMutableListTest
     public void toImmutable()
     {
         Verify.assertInstanceOf(ImmutableList.class, this.unmodifiableList.toImmutable());
-        Assert.assertEquals(this.unmodifiableList, this.unmodifiableList.toImmutable());
+        assertEquals(this.unmodifiableList, this.unmodifiableList.toImmutable());
     }
 
     @Test
     public void asUnmodifiable()
     {
-        Assert.assertSame(this.unmodifiableList, this.unmodifiableList.asUnmodifiable());
+        assertSame(this.unmodifiableList, this.unmodifiableList.asUnmodifiable());
     }
 
     @Test
@@ -252,7 +257,7 @@ public class UnmodifiableMutableListTest
     {
         MutableList<String> synchronizedList = this.unmodifiableList.asSynchronized();
         Verify.assertInstanceOf(SynchronizedMutableList.class, synchronizedList);
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
         {
             Iterator<String> iterator = synchronizedList.iterator();
             iterator.next();
@@ -264,7 +269,7 @@ public class UnmodifiableMutableListTest
     public void asReversed()
     {
         LazyIterable<String> lazyIterable = this.unmodifiableList.asReversed();
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
         {
             Iterator<String> iterator = lazyIterable.iterator();
             iterator.next();
@@ -275,15 +280,15 @@ public class UnmodifiableMutableListTest
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(Lists.mutable.ofAll(this.unmodifiableList).toReversed(), this.unmodifiableList.toReversed());
+        assertEquals(Lists.mutable.ofAll(this.unmodifiableList).toReversed(), this.unmodifiableList.toReversed());
     }
 
     @Test
     public void selectInstancesOf()
     {
         MutableList<Number> numbers = UnmodifiableMutableList.of(FastList.newListWith(1, 2.0, 3, 4.0, 5));
-        Assert.assertEquals(iList(1, 3, 5), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(iList(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
+        assertEquals(iList(1, 3, 5), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iList(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
     }
 
     @Test
@@ -316,13 +321,13 @@ public class UnmodifiableMutableListTest
     public void take()
     {
         UnmodifiableMutableList<Integer> unmodifiableList = UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5));
-        Assert.assertEquals(iList(), unmodifiableList.take(0));
-        Assert.assertEquals(iList(1, 2, 3), unmodifiableList.take(3));
-        Assert.assertEquals(iList(1, 2, 3, 4), unmodifiableList.take(unmodifiableList.size() - 1));
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(unmodifiableList.size()));
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(10));
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(Integer.MAX_VALUE));
-        Assert.assertNotSame(unmodifiableList, unmodifiableList.take(Integer.MAX_VALUE));
+        assertEquals(iList(), unmodifiableList.take(0));
+        assertEquals(iList(1, 2, 3), unmodifiableList.take(3));
+        assertEquals(iList(1, 2, 3, 4), unmodifiableList.take(unmodifiableList.size() - 1));
+        assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(unmodifiableList.size()));
+        assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(10));
+        assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.take(Integer.MAX_VALUE));
+        assertNotSame(unmodifiableList, unmodifiableList.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -334,7 +339,7 @@ public class UnmodifiableMutableListTest
     @Test
     public void takeWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3),
                 UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5)).takeWhile(Predicates.lessThan(4)));
     }
@@ -343,13 +348,13 @@ public class UnmodifiableMutableListTest
     public void drop()
     {
         UnmodifiableMutableList<Integer> unmodifiableList = UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5));
-        Assert.assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.drop(0));
-        Assert.assertNotSame(unmodifiableList, unmodifiableList.drop(0));
-        Assert.assertEquals(iList(4, 5), unmodifiableList.drop(3));
-        Assert.assertEquals(iList(5), unmodifiableList.drop(unmodifiableList.size() - 1));
-        Assert.assertEquals(iList(), unmodifiableList.drop(unmodifiableList.size()));
-        Assert.assertEquals(iList(), unmodifiableList.drop(10));
-        Assert.assertEquals(iList(), unmodifiableList.drop(Integer.MAX_VALUE));
+        assertEquals(iList(1, 2, 3, 4, 5), unmodifiableList.drop(0));
+        assertNotSame(unmodifiableList, unmodifiableList.drop(0));
+        assertEquals(iList(4, 5), unmodifiableList.drop(3));
+        assertEquals(iList(5), unmodifiableList.drop(unmodifiableList.size() - 1));
+        assertEquals(iList(), unmodifiableList.drop(unmodifiableList.size()));
+        assertEquals(iList(), unmodifiableList.drop(10));
+        assertEquals(iList(), unmodifiableList.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -361,7 +366,7 @@ public class UnmodifiableMutableListTest
     @Test
     public void dropWhile()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(4, 5),
                 UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5)).dropWhile(Predicates.lessThan(4)));
     }
@@ -373,20 +378,20 @@ public class UnmodifiableMutableListTest
         MutableList<Integer> selected = partition.getSelected();
         MutableList<Integer> rejected = partition.getRejected();
 
-        Assert.assertEquals(iList(1, 2, 3), selected);
-        Assert.assertEquals(iList(4, 5), rejected);
+        assertEquals(iList(1, 2, 3), selected);
+        assertEquals(iList(4, 5), rejected);
     }
 
     @Test
     public void binarySearch()
     {
         UnmodifiableMutableList<Integer> sortedList = UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5, 7));
-        Assert.assertEquals(1, sortedList.binarySearch(2));
-        Assert.assertEquals(-6, sortedList.binarySearch(6));
+        assertEquals(1, sortedList.binarySearch(2));
+        assertEquals(-6, sortedList.binarySearch(6));
 
         for (Integer integer : sortedList)
         {
-            Assert.assertEquals(
+            assertEquals(
                     Collections.binarySearch(sortedList, integer),
                     sortedList.binarySearch(integer));
         }
@@ -397,12 +402,12 @@ public class UnmodifiableMutableListTest
     {
         UnmodifiableMutableList<Integer> sortedList = UnmodifiableMutableList.of(FastList.newListWith(1, 2, 3, 4, 5, 7)
                 .toSortedList(Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(sortedList.size() - 1, sortedList.binarySearch(1, Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(-1 - sortedList.size(), sortedList.binarySearch(-1, Comparators.reverseNaturalOrder()));
+        assertEquals(sortedList.size() - 1, sortedList.binarySearch(1, Comparators.reverseNaturalOrder()));
+        assertEquals(-1 - sortedList.size(), sortedList.binarySearch(-1, Comparators.reverseNaturalOrder()));
 
         for (Integer integer : sortedList)
         {
-            Assert.assertEquals(
+            assertEquals(
                     Collections.binarySearch(sortedList, integer, Comparators.reverseNaturalOrder()),
                     sortedList.binarySearch(integer, Comparators.reverseNaturalOrder()));
         }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTestCase.java
@@ -16,8 +16,12 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.fixed.UnmodifiableMemoryEfficientListTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMutableList}.
@@ -27,8 +31,8 @@ public abstract class UnmodifiableMutableListTestCase extends UnmodifiableMemory
     @Test
     public void testClone()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection().clone());
-        Assert.assertNotSame(this.getCollection(), this.getCollection().clone());
+        assertEquals(this.getCollection(), this.getCollection().clone());
+        assertNotSame(this.getCollection(), this.getCollection().clone());
     }
 
     @Test
@@ -43,12 +47,12 @@ public abstract class UnmodifiableMutableListTestCase extends UnmodifiableMemory
     {
         super.subList();
         MutableList<Integer> subList = this.getCollection().subList(0, 1);
-        Assert.assertThrows(UnsupportedOperationException.class, subList::clear);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.set(0, null));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.add(0, null));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.add(null));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> subList.remove(null));
+        assertThrows(UnsupportedOperationException.class, subList::clear);
+        assertThrows(UnsupportedOperationException.class, () -> subList.set(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> subList.add(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> subList.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> subList.remove(null));
     }
 
     @Override
@@ -56,136 +60,136 @@ public abstract class UnmodifiableMutableListTestCase extends UnmodifiableMemory
     public void listIterator()
     {
         ListIterator<Integer> it = this.getCollection().listIterator();
-        Assert.assertFalse(it.hasPrevious());
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(0, it.nextIndex());
+        assertFalse(it.hasPrevious());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(0, it.nextIndex());
         it.next();
-        Assert.assertEquals(1, it.nextIndex());
+        assertEquals(1, it.nextIndex());
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.set(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.set(null));
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.add(null));
     }
 
     @Test
     public void subListListIterator()
     {
         ListIterator<Integer> it = this.getCollection().subList(0, 1).listIterator();
-        Assert.assertFalse(it.hasPrevious());
-        Assert.assertEquals(-1, it.previousIndex());
-        Assert.assertEquals(0, it.nextIndex());
+        assertFalse(it.hasPrevious());
+        assertEquals(-1, it.previousIndex());
+        assertEquals(0, it.nextIndex());
         it.next();
-        Assert.assertEquals(1, it.nextIndex());
+        assertEquals(1, it.nextIndex());
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.set(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.set(null));
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> it.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> it.add(null));
     }
 
     @Test
     public void set()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().set(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().set(0, null));
     }
 
     @Override
     @Test
     public void addAllAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().addAll(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().addAll(0, null));
     }
 
     @Test
     public void removeAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().remove(0));
     }
 
     @Test
     public void setAtIndex()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().set(0, null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().set(0, null));
     }
 
     @Test
     public void sortThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThis());
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThis());
     }
 
     @Test
     public void sortThisWithComparator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThis(Comparators.naturalOrder()));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThis(Comparators.naturalOrder()));
     }
 
     @Test
     public void sortThisBy()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisBy(String::valueOf));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisBy(String::valueOf));
     }
 
     @Test
     public void sortThisByBoolean()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByBoolean(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByBoolean(null));
     }
 
     @Test
     public void sortThisByChar()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByChar(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByChar(null));
     }
 
     @Test
     public void sortThisByByte()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByByte(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByByte(null));
     }
 
     @Test
     public void sortThisByShort()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByShort(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByShort(null));
     }
 
     @Test
     public void sortThisByInt()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByInt(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByInt(null));
     }
 
     @Test
     public void sortThisByFloat()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByFloat(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByFloat(null));
     }
 
     @Test
     public void sortThisByLong()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByLong(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByLong(null));
     }
 
     @Test
     public void sortThisByDouble()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByDouble(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().sortThisByDouble(null));
     }
 
     @Test
     public void reverseThis()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.getCollection().reverseThis());
+        assertThrows(UnsupportedOperationException.class, () -> this.getCollection().reverseThis());
     }
 
     @Test
     public void testEquals()
     {
-        Assert.assertEquals(this.getCollection(), this.getCollection());
+        assertEquals(this.getCollection(), this.getCollection());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
@@ -24,8 +24,14 @@ import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanList}.
@@ -54,9 +60,9 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void get()
     {
         MutableBooleanList list = this.classUnderTest();
-        Assert.assertTrue(list.get(0));
-        Assert.assertFalse(list.get(1));
-        Assert.assertTrue(list.get(2));
+        assertTrue(list.get(0));
+        assertFalse(list.get(1));
+        assertTrue(list.get(2));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -81,8 +87,8 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void getFirst()
     {
         MutableBooleanList singleItemList = this.newWith(true);
-        Assert.assertTrue(singleItemList.getFirst());
-        Assert.assertTrue(this.classUnderTest().getFirst());
+        assertTrue(singleItemList.getFirst());
+        assertTrue(this.classUnderTest().getFirst());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -95,9 +101,9 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void getLast()
     {
         MutableBooleanList singleItemList = this.newWith(true);
-        Assert.assertTrue(singleItemList.getLast());
-        Assert.assertTrue(this.classUnderTest().getLast());
-        Assert.assertFalse(this.newWith(true, true, false).getLast());
+        assertTrue(singleItemList.getLast());
+        assertTrue(this.classUnderTest().getLast());
+        assertFalse(this.newWith(true, true, false).getLast());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -116,31 +122,31 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void indexOf()
     {
         MutableBooleanList arrayList = this.newWith(true, false, true);
-        Assert.assertEquals(0L, arrayList.indexOf(true));
-        Assert.assertEquals(1L, arrayList.indexOf(false));
-        Assert.assertEquals(-1L, this.newWith(false, false).indexOf(true));
+        assertEquals(0L, arrayList.indexOf(true));
+        assertEquals(1L, arrayList.indexOf(false));
+        assertEquals(-1L, this.newWith(false, false).indexOf(true));
         MutableBooleanList emptyList = this.newWith();
-        Assert.assertEquals(-1L, emptyList.indexOf(true));
-        Assert.assertEquals(-1L, emptyList.indexOf(false));
+        assertEquals(-1L, emptyList.indexOf(true));
+        assertEquals(-1L, emptyList.indexOf(false));
     }
 
     @Test
     public void boxed()
     {
         MutableBooleanList list = this.newWith(true, false, true);
-        Assert.assertEquals(Lists.mutable.of(true, false, true), list.boxed());
+        assertEquals(Lists.mutable.of(true, false, true), list.boxed());
     }
 
     @Test
     public void lastIndexOf()
     {
         MutableBooleanList list = this.newWith(true, false, true);
-        Assert.assertEquals(2L, list.lastIndexOf(true));
-        Assert.assertEquals(1L, list.lastIndexOf(false));
-        Assert.assertEquals(-1L, this.newWith(false, false).lastIndexOf(true));
+        assertEquals(2L, list.lastIndexOf(true));
+        assertEquals(1L, list.lastIndexOf(false));
+        assertEquals(-1L, this.newWith(false, false).lastIndexOf(true));
         MutableBooleanList emptyList = this.newWith();
-        Assert.assertEquals(-1L, emptyList.lastIndexOf(true));
-        Assert.assertEquals(-1L, emptyList.lastIndexOf(false));
+        assertEquals(-1L, emptyList.lastIndexOf(true));
+        assertEquals(-1L, emptyList.lastIndexOf(false));
     }
 
     @Test
@@ -148,12 +154,12 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         MutableBooleanList emptyList = this.newWith();
         emptyList.addAtIndex(0, false);
-        Assert.assertEquals(BooleanArrayList.newListWith(false), emptyList);
+        assertEquals(BooleanArrayList.newListWith(false), emptyList);
         MutableBooleanList list = this.classUnderTest();
         list.addAtIndex(3, true);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, true), list);
+        assertEquals(BooleanArrayList.newListWith(true, false, true, true), list);
         list.addAtIndex(2, false);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, false, true, true), list);
+        assertEquals(BooleanArrayList.newListWith(true, false, false, true, true), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -174,10 +180,10 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         super.addAllArray();
         MutableBooleanList list = this.classUnderTest();
-        Assert.assertFalse(list.addAllAtIndex(1));
-        Assert.assertTrue(list.addAll(false, true, false));
-        Assert.assertTrue(list.addAllAtIndex(4, true, true));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, true, true, false), list);
+        assertFalse(list.addAllAtIndex(1));
+        assertTrue(list.addAll(false, true, false));
+        assertTrue(list.addAllAtIndex(4, true, true));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, true, true, false), list);
     }
 
     @Override
@@ -186,10 +192,10 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         super.addAllIterable();
         MutableBooleanList list = this.classUnderTest();
-        Assert.assertFalse(list.addAllAtIndex(1, new BooleanArrayList()));
-        Assert.assertTrue(list.addAll(BooleanArrayList.newListWith(false, true, false)));
-        Assert.assertTrue(list.addAllAtIndex(4, BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, true, true, false), list);
+        assertFalse(list.addAllAtIndex(1, new BooleanArrayList()));
+        assertTrue(list.addAll(BooleanArrayList.newListWith(false, true, false)));
+        assertTrue(list.addAllAtIndex(4, BooleanArrayList.newListWith(true, true)));
+        assertEquals(BooleanArrayList.newListWith(true, false, true, false, true, true, true, false), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -215,25 +221,25 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void remove()
     {
         super.remove();
-        Assert.assertFalse(this.newWith(true, true).remove(false));
+        assertFalse(this.newWith(true, true).remove(false));
         MutableBooleanList list = this.classUnderTest();
-        Assert.assertTrue(list.remove(true));
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), list);
+        assertTrue(list.remove(true));
+        assertEquals(BooleanArrayList.newListWith(false, true), list);
     }
 
     @Test
     public void removeIf()
     {
-        Assert.assertFalse(this.newWith(true, true).removeIf(b -> !b));
+        assertFalse(this.newWith(true, true).removeIf(b -> !b));
 
         MutableBooleanList list1 = this.classUnderTest();
-        Assert.assertTrue(list1.removeIf(b -> b));
-        Assert.assertEquals(BooleanArrayList.newListWith(false), list1);
+        assertTrue(list1.removeIf(b -> b));
+        assertEquals(BooleanArrayList.newListWith(false), list1);
 
         MutableBooleanList list2 = this.classUnderTest();
-        Assert.assertTrue(list2.removeIf(b -> !b));
+        assertTrue(list2.removeIf(b -> !b));
 
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true), list2);
+        assertEquals(BooleanArrayList.newListWith(true, true), list2);
     }
 
     @Test
@@ -241,11 +247,11 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         MutableBooleanList list = this.classUnderTest();
         list.removeAtIndex(1);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true), list);
+        assertEquals(BooleanArrayList.newListWith(true, true), list);
         list.removeAtIndex(1);
-        Assert.assertEquals(BooleanArrayList.newListWith(true), list);
+        assertEquals(BooleanArrayList.newListWith(true), list);
         list.removeAtIndex(0);
-        Assert.assertEquals(BooleanArrayList.newListWith(), list);
+        assertEquals(BooleanArrayList.newListWith(), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -265,9 +271,9 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         MutableBooleanList list = this.classUnderTest();
         list.set(1, false);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), list);
+        assertEquals(BooleanArrayList.newListWith(true, false, true), list);
         list.set(1, true);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, true), list);
+        assertEquals(BooleanArrayList.newListWith(true, true, true), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -281,13 +287,13 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void booleanIterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertFalse(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertFalse(iterator.next());
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -300,8 +306,8 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
         sum[1] = "";
         this.classUnderTest().forEach(each -> sum[0] += each + " ");
         this.newWith().forEach(each -> sum[1] += each);
-        Assert.assertEquals("true false true ", sum[0]);
-        Assert.assertEquals("", sum[1]);
+        assertEquals("true false true ", sum[0]);
+        assertEquals("", sum[1]);
     }
 
     @Override
@@ -318,39 +324,39 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         super.toArray();
         MutableBooleanList list = this.classUnderTest();
-        Assert.assertEquals(3L, (long) list.toArray().length);
-        Assert.assertTrue(list.toArray()[0]);
-        Assert.assertFalse(list.toArray()[1]);
-        Assert.assertTrue(list.toArray()[2]);
+        assertEquals(3L, (long) list.toArray().length);
+        assertTrue(list.toArray()[0]);
+        assertFalse(list.toArray()[1]);
+        assertTrue(list.toArray()[2]);
     }
 
     @Test
     public void reverseThis()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).reverseThis());
+        assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).reverseThis());
         MutableBooleanList originalList = this.newWith(true, true, false, false);
-        Assert.assertSame(originalList, originalList.reverseThis());
+        assertSame(originalList, originalList.reverseThis());
         MutableBooleanList originalList2 = this.newWith(true, false, false);
         originalList2.removeAtIndex(2);
-        Assert.assertEquals(originalList2, BooleanArrayList.newListWith(true, false));
-        Assert.assertEquals(originalList2.reverseThis(), BooleanArrayList.newListWith(false, true));
+        assertEquals(originalList2, BooleanArrayList.newListWith(true, false));
+        assertEquals(originalList2.reverseThis(), BooleanArrayList.newListWith(false, true));
     }
 
     @Test
     public void toReversed()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).toReversed());
+        assertEquals(BooleanArrayList.newListWith(true, true, false, false), this.newWith(false, false, true, true).toReversed());
         MutableBooleanList originalList = this.newWith(true, true, false, false);
-        Assert.assertNotSame(originalList, originalList.toReversed());
+        assertNotSame(originalList, originalList.toReversed());
     }
 
     @Test
     public void distinct()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false), this.newWith(true, true, false, false).distinct());
-        Assert.assertEquals(BooleanArrayList.newListWith(false, true), this.newWith(false, false, true, true).distinct());
-        Assert.assertEquals(BooleanArrayList.newListWith(false), this.newWith(false).distinct());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.newWith(true).distinct());
+        assertEquals(BooleanArrayList.newListWith(true, false), this.newWith(true, true, false, false).distinct());
+        assertEquals(BooleanArrayList.newListWith(false, true), this.newWith(false, false, true, true).distinct());
+        assertEquals(BooleanArrayList.newListWith(false), this.newWith(false).distinct());
+        assertEquals(BooleanArrayList.newListWith(true), this.newWith(true).distinct());
     }
 
     @Test
@@ -358,7 +364,7 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         MutableBooleanList list = this.newWith(true, false, true);
         MutableInteger result = list.injectIntoWithIndex(new MutableInteger(0), (object, value, index) -> object.add((value ? 1 : 0) + index));
-        Assert.assertEquals(new MutableInteger(5), result);
+        assertEquals(new MutableInteger(5), result);
     }
 
     @Test
@@ -369,8 +375,8 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
         sum[1] = "";
         this.classUnderTest().forEachWithIndex((each, index) -> sum[0] += index + ":" + each);
         this.newWith().forEachWithIndex((each, index) -> sum[1] += index + ":" + each);
-        Assert.assertEquals("0:true1:false2:true", sum[0]);
-        Assert.assertEquals("", sum[1]);
+        assertEquals("0:true1:false2:true", sum[0]);
+        assertEquals("", sum[1]);
     }
 
     @Override
@@ -380,7 +386,7 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
         super.testEquals();
         MutableBooleanList list1 = this.newWith(true, false, true, true);
         MutableBooleanList list2 = this.newWith(true, true, false, true);
-        Assert.assertNotEquals(list1, list2);
+        assertNotEquals(list1, list2);
     }
 
     @Override
@@ -388,8 +394,8 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[true, false, true]", this.classUnderTest().toString());
-        Assert.assertEquals("[]", this.newWith().toString());
+        assertEquals("[true, false, true]", this.classUnderTest().toString());
+        assertEquals("[]", this.newWith().toString());
     }
 
     @Override
@@ -397,20 +403,20 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("true, false, true", this.classUnderTest().makeString());
-        Assert.assertEquals("true", this.newWith(true).makeString("/"));
-        Assert.assertEquals("true/false/true", this.classUnderTest().makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
-        Assert.assertEquals("", this.newWith().makeString());
+        assertEquals("true, false, true", this.classUnderTest().makeString());
+        assertEquals("true", this.newWith(true).makeString("/"));
+        assertEquals("true/false/true", this.classUnderTest().makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("[", ", ", "]"));
+        assertEquals("", this.newWith().makeString());
     }
 
     @Test
     public void newWithNValues()
     {
-        Assert.assertEquals(this.newWith(true, true, true), BooleanArrayList.newWithNValues(3, true));
-        Assert.assertEquals(this.newWith(false, false), BooleanArrayList.newWithNValues(2, false));
-        Assert.assertEquals(this.newWith(), BooleanArrayList.newWithNValues(0, false));
-        Assert.assertEquals(this.newWith(), BooleanArrayList.newWithNValues(0, true));
+        assertEquals(this.newWith(true, true, true), BooleanArrayList.newWithNValues(3, true));
+        assertEquals(this.newWith(false, false), BooleanArrayList.newWithNValues(2, false));
+        assertEquals(this.newWith(), BooleanArrayList.newWithNValues(0, false));
+        assertEquals(this.newWith(), BooleanArrayList.newWithNValues(0, true));
     }
 
     @Test(expected = NegativeArraySizeException.class)
@@ -426,16 +432,16 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
         super.appendString();
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2);
-        Assert.assertEquals("true, false, true", appendable2.toString());
+        assertEquals("true, false, true", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "/");
-        Assert.assertEquals("true/false/true", appendable3.toString());
+        assertEquals("true/false/true", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Override
@@ -443,14 +449,14 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), this.classUnderTest().toList());
+        assertEquals(BooleanArrayList.newListWith(true, false, true), this.classUnderTest().toList());
     }
 
     @Test
     public void toImmutable()
     {
         ImmutableBooleanList immutable = this.classUnderTest().toImmutable();
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false, true), immutable);
+        assertEquals(BooleanArrayList.newListWith(true, false, true), immutable);
     }
 
     @Test
@@ -458,7 +464,7 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
     {
         MutableBooleanList list = BooleanLists.mutable.empty();
         this.classUnderTest().tap(list::add);
-        Assert.assertEquals(this.classUnderTest(), list);
+        assertEquals(this.classUnderTest(), list);
     }
 
     @Test
@@ -467,8 +473,8 @@ public abstract class AbstractBooleanListTestCase extends AbstractMutableBoolean
         MutableList<BooleanIntPair> pairs =
                 this.classUnderTest().collectWithIndex(PrimitiveTuples::pair);
         MutableBooleanList list1 = pairs.collectBoolean(BooleanIntPair::getOne);
-        Assert.assertEquals(this.classUnderTest(), list1);
+        assertEquals(this.classUnderTest(), list1);
         MutableIntList list2 = pairs.collectInt(BooleanIntPair::getTwo);
-        Assert.assertEquals(IntInterval.zeroTo(this.classUnderTest().size() - 1), list2);
+        assertEquals(IntInterval.zeroTo(this.classUnderTest().size() - 1), list2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
@@ -16,8 +16,11 @@ import java.util.BitSet;
 import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link BooleanArrayList}.
@@ -45,11 +48,11 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
         Verify.assertEmpty(arrayList);
         Field items = BooleanArrayList.class.getDeclaredField("items");
         items.setAccessible(true);
-        Assert.assertEquals(64L, ((BitSet) items.get(arrayList)).size());
+        assertEquals(64L, ((BitSet) items.get(arrayList)).size());
         BooleanArrayList arrayList1 = new BooleanArrayList(64);
-        Assert.assertEquals(64L, ((BitSet) items.get(arrayList1)).size());
+        assertEquals(64L, ((BitSet) items.get(arrayList1)).size());
         BooleanArrayList arrayList2 = new BooleanArrayList(65);
-        Assert.assertEquals(128L, ((BitSet) items.get(arrayList2)).size());
+        assertEquals(128L, ((BitSet) items.get(arrayList2)).size());
     }
 
     @Test
@@ -57,7 +60,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
     {
         BooleanArrayList booleanArrayList = this.classUnderTest();
         booleanArrayList.addAllAtIndex(0, false, true);
-        Assert.assertEquals(new BooleanArrayList(false, true, true, false, true), booleanArrayList);
+        assertEquals(new BooleanArrayList(false, true, true, false, true), booleanArrayList);
     }
 
     @Test
@@ -65,7 +68,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
     {
         BooleanArrayList booleanArrayList = this.classUnderTest();
         booleanArrayList.addAllAtIndex(1, false, true, true);
-        Assert.assertEquals(new BooleanArrayList(true, false, true, true, false, true), booleanArrayList);
+        assertEquals(new BooleanArrayList(true, false, true, true, false, true), booleanArrayList);
     }
 
     @Test
@@ -73,7 +76,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
     {
         BooleanArrayList booleanArrayList = this.classUnderTest();
         booleanArrayList.addAllAtIndex(2, false, true);
-        Assert.assertEquals(new BooleanArrayList(true, false, false, true, true), booleanArrayList);
+        assertEquals(new BooleanArrayList(true, false, false, true, true), booleanArrayList);
     }
 
     @Test
@@ -81,7 +84,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
     {
         BooleanArrayList booleanArrayList = this.classUnderTest();
         booleanArrayList.addAllAtIndex(3, false, true);
-        Assert.assertEquals(new BooleanArrayList(true, false, true, false, true), booleanArrayList);
+        assertEquals(new BooleanArrayList(true, false, true, false, true), booleanArrayList);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -102,7 +105,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
         listWithCapacity.addAtIndex(64, true);
         Field items = BooleanArrayList.class.getDeclaredField("items");
         items.setAccessible(true);
-        Assert.assertEquals(128L, ((BitSet) items.get(listWithCapacity)).size());
+        assertEquals(128L, ((BitSet) items.get(listWithCapacity)).size());
     }
 
     @Override
@@ -128,12 +131,12 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
         BooleanArrayList arrayList1 = new BooleanArrayList().with(true, true, false);
         BooleanArrayList arrayList2 = new BooleanArrayList().with(true, true, false, true);
         BooleanArrayList arrayList3 = new BooleanArrayList().with(true, true, false, true, false);
-        Assert.assertSame(emptyList, arrayList);
-        Assert.assertEquals(BooleanArrayList.newListWith(true), arrayList);
-        Assert.assertEquals(BooleanArrayList.newListWith(false, false), arrayList0);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false), arrayList1);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true), arrayList2);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true, false), arrayList3);
+        assertSame(emptyList, arrayList);
+        assertEquals(BooleanArrayList.newListWith(true), arrayList);
+        assertEquals(BooleanArrayList.newListWith(false, false), arrayList0);
+        assertEquals(BooleanArrayList.newListWith(true, true, false), arrayList1);
+        assertEquals(BooleanArrayList.newListWith(true, true, false, true), arrayList2);
+        assertEquals(BooleanArrayList.newListWith(true, true, false, true, false), arrayList3);
     }
 
     private static class LastValueBeforeFalseWasFalse
@@ -156,7 +159,7 @@ public class BooleanArrayListTest extends AbstractBooleanListTestCase
     {
         MutableBooleanList list = this.newWith(true, true, false, false, true, false, true, false, false, false);
 
-        Assert.assertTrue(list.removeIf(new LastValueBeforeFalseWasFalse()));
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, false, true, false, true, false), list);
+        assertTrue(list.removeIf(new LastValueBeforeFalseWasFalse()));
+        assertEquals(BooleanArrayList.newListWith(true, true, false, true, false, true, false), list);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BoxedMutableBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BoxedMutableBooleanListTest.java
@@ -12,8 +12,11 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BoxedMutableBooleanListTest
 {
@@ -36,9 +39,9 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList list = this.classUnderTest();
         list.add(Boolean.FALSE);
-        Assert.assertEquals(Lists.mutable.of(true, true, false), list);
+        assertEquals(Lists.mutable.of(true, true, false), list);
         list.add(Boolean.TRUE);
-        Assert.assertEquals(Lists.mutable.of(true, true, false, true), list);
+        assertEquals(Lists.mutable.of(true, true, false, true), list);
     }
 
     @Test
@@ -46,16 +49,16 @@ public class BoxedMutableBooleanListTest
     {
         BooleanArrayList originalList = new BooleanArrayList(true, false);
         BoxedMutableBooleanList list = new BoxedMutableBooleanList(originalList);
-        Assert.assertEquals(list, Lists.mutable.of(Boolean.TRUE, Boolean.FALSE));
+        assertEquals(list, Lists.mutable.of(Boolean.TRUE, Boolean.FALSE));
 
         originalList.add(true);
-        Assert.assertEquals(list, Lists.mutable.of(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE));
+        assertEquals(list, Lists.mutable.of(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE));
 
         originalList.remove(true);
-        Assert.assertEquals(list, Lists.mutable.of(Boolean.FALSE, Boolean.TRUE));
+        assertEquals(list, Lists.mutable.of(Boolean.FALSE, Boolean.TRUE));
 
         originalList.addAllAtIndex(1, false);
-        Assert.assertEquals(list, Lists.mutable.of(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE));
+        assertEquals(list, Lists.mutable.of(Boolean.FALSE, Boolean.FALSE, Boolean.TRUE));
 
         originalList.clear();
         Verify.assertEmpty(list);
@@ -66,10 +69,10 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList list = this.classUnderTest();
         list.addAll(0, Lists.mutable.of(Boolean.FALSE, Boolean.FALSE));
-        Assert.assertEquals(Lists.mutable.of(false, false, true, true), list);
+        assertEquals(Lists.mutable.of(false, false, true, true), list);
 
         list.addAll(4, Lists.mutable.of(Boolean.FALSE, Boolean.TRUE));
-        Assert.assertEquals(Lists.mutable.of(false, false, true, true, false, true), list);
+        assertEquals(Lists.mutable.of(false, false, true, true, false, true), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -97,8 +100,8 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList list = this.classUnderTest();
         list.add(Boolean.FALSE);
-        Assert.assertTrue(list.get(0));
-        Assert.assertFalse(list.get(2));
+        assertTrue(list.get(0));
+        assertFalse(list.get(2));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -112,10 +115,10 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList list = this.classUnderTest();
         list.set(0, Boolean.FALSE);
-        Assert.assertEquals(Lists.mutable.of(false, true), list);
+        assertEquals(Lists.mutable.of(false, true), list);
 
         list.set(1, Boolean.FALSE);
-        Assert.assertEquals(Lists.mutable.of(false, false), list);
+        assertEquals(Lists.mutable.of(false, false), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -129,13 +132,13 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList list = this.classUnderTest();
         list.add(0, Boolean.FALSE);
-        Assert.assertEquals(Lists.mutable.of(false, true, true), list);
+        assertEquals(Lists.mutable.of(false, true, true), list);
 
         list.add(1, Boolean.TRUE);
-        Assert.assertEquals(Lists.mutable.of(false, true, true, true), list);
+        assertEquals(Lists.mutable.of(false, true, true, true), list);
 
         list.add(4, Boolean.FALSE);
-        Assert.assertEquals(Lists.mutable.of(false, true, true, true, false), list);
+        assertEquals(Lists.mutable.of(false, true, true, true, false), list);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -149,8 +152,8 @@ public class BoxedMutableBooleanListTest
     {
         BoxedMutableBooleanList booleanList = this.classUnderTest();
         booleanList.add(Boolean.FALSE);
-        Assert.assertTrue(booleanList.remove(0));
-        Assert.assertFalse(booleanList.remove(1));
+        assertTrue(booleanList.remove(0));
+        assertFalse(booleanList.remove(1));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -163,18 +166,18 @@ public class BoxedMutableBooleanListTest
     public void indexOf()
     {
         BoxedMutableBooleanList booleanList = this.classUnderTest();
-        Assert.assertEquals(0, booleanList.indexOf(Boolean.TRUE));
-        Assert.assertEquals(-1, booleanList.indexOf(Boolean.FALSE));
-        Assert.assertEquals(-1, booleanList.indexOf("String"));
+        assertEquals(0, booleanList.indexOf(Boolean.TRUE));
+        assertEquals(-1, booleanList.indexOf(Boolean.FALSE));
+        assertEquals(-1, booleanList.indexOf("String"));
     }
 
     @Test
     public void lastIndexOf()
     {
         BoxedMutableBooleanList booleanList = this.classUnderTest();
-        Assert.assertEquals(1, booleanList.lastIndexOf(Boolean.TRUE));
-        Assert.assertEquals(-1, booleanList.lastIndexOf(Boolean.FALSE));
-        Assert.assertEquals(-1, booleanList.lastIndexOf("String"));
+        assertEquals(1, booleanList.lastIndexOf(Boolean.TRUE));
+        assertEquals(-1, booleanList.lastIndexOf(Boolean.FALSE));
+        assertEquals(-1, booleanList.lastIndexOf("String"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanIterableTest.java
@@ -19,8 +19,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBoolean
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.primitive.SynchronizedBooleanIterable;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedBooleanIterable}s
@@ -66,13 +69,13 @@ public class SynchronizedBooleanIterableTest extends AbstractBooleanIterableTest
         BooleanIterator iterator = iterable.booleanIterator();
         for (int i = 0; i < 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertTrue(list.remove(iterator.next()));
+            assertTrue(iterator.hasNext());
+            assertTrue(list.remove(iterator.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanListTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanList}.
@@ -38,9 +40,9 @@ public class SynchronizedBooleanListTest extends AbstractBooleanListTestCase
         super.asSynchronized();
         SynchronizedBooleanList list = this.classUnderTest();
         MutableBooleanList listWithLockObject = new SynchronizedBooleanList(BooleanArrayList.newListWith(true, false, true), new Object()).asSynchronized();
-        Assert.assertEquals(list, listWithLockObject);
-        Assert.assertSame(listWithLockObject, listWithLockObject.asSynchronized());
-        Assert.assertSame(list, list.asSynchronized());
-        Assert.assertEquals(list, list.asSynchronized());
+        assertEquals(list, listWithLockObject);
+        assertSame(listWithLockObject, listWithLockObject.asSynchronized());
+        assertSame(list, list.asSynchronized());
+        assertEquals(list, list.asSynchronized());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/UnmodifiableBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/UnmodifiableBooleanListTest.java
@@ -12,8 +12,13 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanList}.
@@ -240,21 +245,21 @@ public class UnmodifiableBooleanListTest extends AbstractBooleanListTestCase
     public void containsAllArray()
     {
         UnmodifiableBooleanList collection = this.classUnderTest();
-        Assert.assertTrue(collection.containsAll(true));
-        Assert.assertTrue(collection.containsAll(true, false, true));
-        Assert.assertTrue(collection.containsAll(true, false));
-        Assert.assertTrue(collection.containsAll(true, true));
-        Assert.assertTrue(collection.containsAll(false, false));
+        assertTrue(collection.containsAll(true));
+        assertTrue(collection.containsAll(true, false, true));
+        assertTrue(collection.containsAll(true, false));
+        assertTrue(collection.containsAll(true, true));
+        assertTrue(collection.containsAll(false, false));
         UnmodifiableBooleanList emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
-        Assert.assertFalse(this.newWith(true, true).containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(this.newWith(true, true).containsAll(false, true, false));
 
         UnmodifiableBooleanList trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(true, false));
+        assertFalse(trueCollection.containsAll(true, false));
         UnmodifiableBooleanList falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(true, false));
+        assertFalse(falseCollection.containsAll(true, false));
     }
 
     @Override
@@ -262,22 +267,22 @@ public class UnmodifiableBooleanListTest extends AbstractBooleanListTestCase
     public void containsAllIterable()
     {
         UnmodifiableBooleanList emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
         UnmodifiableBooleanList collection = this.newWith(true, true, false, false, false);
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
 
         UnmodifiableBooleanList trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
         UnmodifiableBooleanList falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
     }
 
     @Override
@@ -285,8 +290,8 @@ public class UnmodifiableBooleanListTest extends AbstractBooleanListTestCase
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.list, this.list.asUnmodifiable());
-        Assert.assertEquals(this.list, this.list.asUnmodifiable());
+        assertSame(this.list, this.list.asUnmodifiable());
+        assertEquals(this.list, this.list.asUnmodifiable());
     }
 
     @Override
@@ -294,9 +299,9 @@ public class UnmodifiableBooleanListTest extends AbstractBooleanListTestCase
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -304,8 +309,8 @@ public class UnmodifiableBooleanListTest extends AbstractBooleanListTestCase
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -44,8 +44,16 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IntIntervalTest
 {
@@ -64,17 +72,17 @@ public class IntIntervalTest
         Verify.assertSize(Integer.MAX_VALUE, IntInterval.fromTo(1, Integer.MAX_VALUE));
         Verify.assertSize(21, IntInterval.from(10).to(-10).by(-1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(-1, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
-        Assert.assertEquals(IntInterval.fromTo(Integer.MIN_VALUE + 1, -1).size(), IntInterval.oneTo(Integer.MAX_VALUE).size());
+        assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> IntInterval.fromTo(-1, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> IntInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
+        assertEquals(IntInterval.fromTo(Integer.MIN_VALUE + 1, -1).size(), IntInterval.oneTo(Integer.MAX_VALUE).size());
 
-        Assert.assertEquals(IntLists.mutable.with(0), IntInterval.fromToBy(0, 2, 3));
-        Assert.assertEquals(IntLists.mutable.with(0), IntInterval.fromToBy(0, -2, -3));
-        Assert.assertEquals(IntLists.mutable.with(1_000_000_000), IntInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
-        Assert.assertEquals(IntLists.mutable.with(-1_000_000_000), IntInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
-        Assert.assertEquals(IntLists.mutable.with(Integer.MIN_VALUE), IntInterval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
-        Assert.assertEquals(IntLists.mutable.with(Integer.MAX_VALUE), IntInterval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
+        assertEquals(IntLists.mutable.with(0), IntInterval.fromToBy(0, 2, 3));
+        assertEquals(IntLists.mutable.with(0), IntInterval.fromToBy(0, -2, -3));
+        assertEquals(IntLists.mutable.with(1_000_000_000), IntInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
+        assertEquals(IntLists.mutable.with(-1_000_000_000), IntInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
+        assertEquals(IntLists.mutable.with(Integer.MIN_VALUE), IntInterval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
+        assertEquals(IntLists.mutable.with(Integer.MAX_VALUE), IntInterval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -92,8 +100,8 @@ public class IntIntervalTest
     @Test
     public void fromAndToAndBy_throws_step_is_incorrect()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.from(10).to(-10).by(1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> IntInterval.from(-10).to(10).by(-1));
+        assertThrows(IllegalArgumentException.class, () -> IntInterval.from(10).to(-10).by(1));
+        assertThrows(IllegalArgumentException.class, () -> IntInterval.from(-10).to(10).by(-1));
     }
 
     @Test
@@ -101,8 +109,8 @@ public class IntIntervalTest
     {
         MutableIntList integers = IntInterval.fromToBy(2, 2, -2).toList();
 
-        Verify.assertEquals(1, integers.size());
-        Verify.assertEquals(2, integers.getFirst());
+        assertEquals(1, integers.size());
+        assertEquals(2, integers.getFirst());
     }
 
     @Test
@@ -110,8 +118,8 @@ public class IntIntervalTest
     {
         MutableIntList integers = IntInterval.fromToBy(2, 2, -1).toList();
 
-        Verify.assertEquals(1, integers.size());
-        Verify.assertEquals(2, integers.getFirst());
+        assertEquals(1, integers.size());
+        assertEquals(2, integers.getFirst());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -140,16 +148,16 @@ public class IntIntervalTest
         IntInterval interval3 = IntInterval.zeroTo(5);
         Verify.assertPostSerializedEqualsAndHashCode(interval1);
         Verify.assertEqualsAndHashCode(interval1, interval2);
-        Assert.assertNotEquals(interval1, interval3);
-        Assert.assertNotEquals(interval3, interval1);
+        assertNotEquals(interval1, interval3);
+        assertNotEquals(interval3, interval1);
 
         Verify.assertEqualsAndHashCode(IntInterval.fromToBy(1, 5, 2), IntInterval.fromToBy(1, 6, 2));
         Verify.assertEqualsAndHashCode(IntArrayList.newListWith(1, 2, 3), IntInterval.fromTo(1, 3));
         Verify.assertEqualsAndHashCode(IntArrayList.newListWith(3, 2, 1), IntInterval.fromTo(3, 1));
 
-        Assert.assertNotEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.fromTo(1, 3));
-        Assert.assertNotEquals(IntArrayList.newListWith(1, 2, 4), IntInterval.fromTo(1, 3));
-        Assert.assertNotEquals(IntArrayList.newListWith(3, 2, 0), IntInterval.fromTo(3, 1));
+        assertNotEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.fromTo(1, 3));
+        assertNotEquals(IntArrayList.newListWith(1, 2, 4), IntInterval.fromTo(1, 3));
+        assertNotEquals(IntArrayList.newListWith(3, 2, 0), IntInterval.fromTo(3, 1));
 
         Verify.assertEqualsAndHashCode(IntArrayList.newListWith(-1, -2, -3), IntInterval.fromTo(-1, -3));
 
@@ -163,34 +171,34 @@ public class IntIntervalTest
         IntInterval interval6 = IntInterval.fromTo(0, -999);
         Verify.assertPostSerializedEqualsAndHashCode(interval4);
         Verify.assertEqualsAndHashCode(interval4, interval5);
-        Assert.assertNotEquals(interval4, interval6);
-        Assert.assertNotEquals(interval6, interval4);
+        assertNotEquals(interval4, interval6);
+        assertNotEquals(interval6, interval4);
     }
 
     @Test
     public void sumIntInterval()
     {
-        Assert.assertEquals(15, (int) IntInterval.oneTo(5).sum());
+        assertEquals(15, (int) IntInterval.oneTo(5).sum());
     }
 
     @Test
     public void maxIntInterval()
     {
         int value = IntInterval.oneTo(5).max();
-        Assert.assertEquals(5, value);
+        assertEquals(5, value);
     }
 
     @Test
     public void iterator()
     {
         IntIterator iterator = this.intInterval.intIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(1L, iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(2L, iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(3L, iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(1L, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(2L, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(3L, iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -211,7 +219,7 @@ public class IntIntervalTest
         long[] sum = new long[1];
         this.intInterval.forEach(each -> sum[0] += each);
 
-        Assert.assertEquals(6L, sum[0]);
+        assertEquals(6L, sum[0]);
     }
 
     @Test
@@ -220,11 +228,11 @@ public class IntIntervalTest
         MutableIntList list1 = IntLists.mutable.empty();
         IntInterval interval1 = IntInterval.oneTo(5);
         interval1.each(list1::add);
-        Assert.assertEquals(list1, interval1);
+        assertEquals(list1, interval1);
         IntInterval interval2 = IntInterval.fromTo(5, 1);
         MutableIntList list2 = IntLists.mutable.empty();
         interval2.each(list2::add);
-        Assert.assertEquals(list2, interval2);
+        assertEquals(list2, interval2);
     }
 
     @Test
@@ -232,10 +240,10 @@ public class IntIntervalTest
     {
         IntInterval intInterval1 = IntInterval.oneTo(3);
         MutableInteger result = intInterval1.injectInto(new MutableInteger(0), MutableInteger::add);
-        Assert.assertEquals(new MutableInteger(6), result);
+        assertEquals(new MutableInteger(6), result);
         IntInterval intInterval2 = IntInterval.fromTo(3, 1);
         MutableInteger result2 = intInterval2.injectInto(new MutableInteger(0), MutableInteger::add);
-        Assert.assertEquals(new MutableInteger(6), result2);
+        assertEquals(new MutableInteger(6), result2);
     }
 
     @Test
@@ -243,10 +251,10 @@ public class IntIntervalTest
     {
         IntInterval interval1 = IntInterval.oneTo(3);
         MutableInteger result1 = this.intInterval.injectIntoWithIndex(new MutableInteger(0), (object, value, index) -> object.add(value * interval1.get(index)));
-        Assert.assertEquals(new MutableInteger(14), result1);
+        assertEquals(new MutableInteger(14), result1);
         IntInterval interval2 = IntInterval.fromTo(3, 1);
         MutableInteger result2 = interval2.injectIntoWithIndex(new MutableInteger(0), (object, value, index) -> object.add(value * this.intInterval.get(index)));
-        Assert.assertEquals(new MutableInteger(10), result2);
+        assertEquals(new MutableInteger(10), result2);
     }
 
     @Test
@@ -254,7 +262,7 @@ public class IntIntervalTest
     {
         IntInterval interval = IntInterval.fromToBy(2, 2, -2);
 
-        Assert.assertEquals(new MutableInteger(0), interval.injectInto(new MutableInteger(-2), MutableInteger::add));
+        assertEquals(new MutableInteger(0), interval.injectInto(new MutableInteger(-2), MutableInteger::add));
     }
 
     @Test
@@ -265,14 +273,14 @@ public class IntIntervalTest
                 IntInterval.fromToBy(0, 1, 1),
                 IntInterval.fromToBy(2, 3, 1),
                 IntInterval.fromToBy(4, 5, 1));
-        Assert.assertEquals(expected1, interval1.chunk(2));
+        assertEquals(expected1, interval1.chunk(2));
 
         IntInterval interval2 = IntInterval.fromToBy(0, -5, -1);
         MutableList<IntInterval> expected2 = Lists.mutable.with(
                 IntInterval.fromToBy(0, -1, -1),
                 IntInterval.fromToBy(-2, -3, -1),
                 IntInterval.fromToBy(-4, -5, -1));
-        Assert.assertEquals(expected2, interval2.chunk(2));
+        assertEquals(expected2, interval2.chunk(2));
 
         IntInterval interval3 = IntInterval.fromToBy(0, 6, 1);
         MutableList<IntInterval> expected3 = Lists.mutable.with(
@@ -280,7 +288,7 @@ public class IntIntervalTest
                 IntInterval.fromToBy(2, 3, 1),
                 IntInterval.fromToBy(4, 5, 1),
                 IntInterval.fromToBy(6, 6, 1));
-        Assert.assertEquals(expected3, interval3.chunk(2));
+        assertEquals(expected3, interval3.chunk(2));
 
         IntInterval interval4 = IntInterval.fromToBy(0, -6, -1);
         MutableList<IntInterval> expected4 = Lists.mutable.with(
@@ -289,46 +297,46 @@ public class IntIntervalTest
                 IntInterval.fromToBy(-4, -5, -1),
                 IntInterval.fromToBy(-6, -6, -1));
         RichIterable<IntIterable> actual4 = interval4.chunk(2);
-        Assert.assertEquals(expected4, actual4);
+        assertEquals(expected4, actual4);
 
         IntInterval interval5 = IntInterval.fromToBy(0, 6, 1);
         MutableList<IntInterval> expected5 = Lists.mutable.with(IntInterval.fromToBy(0, 6, 1));
-        Assert.assertEquals(expected5, interval5.chunk(7));
+        assertEquals(expected5, interval5.chunk(7));
 
         IntInterval interval6 = IntInterval.fromToBy(0, -6, -1);
         MutableList<IntInterval> expected6 = Lists.mutable.with(IntInterval.fromToBy(0, -6, -1));
-        Assert.assertEquals(expected6, interval6.chunk(7));
+        assertEquals(expected6, interval6.chunk(7));
 
         IntInterval interval7 = IntInterval.fromToBy(0, 6, 1);
         MutableList<IntInterval> expected7 = Lists.mutable.with(IntInterval.fromToBy(0, 6, 1));
-        Assert.assertEquals(expected7, interval7.chunk(8));
+        assertEquals(expected7, interval7.chunk(8));
 
         IntInterval interval8 = IntInterval.fromToBy(0, -6, -1);
         MutableList<IntInterval> expected8 = Lists.mutable.with(IntInterval.fromToBy(0, -6, -1));
-        Assert.assertEquals(expected8, interval8.chunk(8));
+        assertEquals(expected8, interval8.chunk(8));
 
         IntInterval interval9 = IntInterval.fromToBy(0, 9, 4);
         MutableList<IntIterable> expected9 = Lists.mutable.with(
                 IntLists.mutable.with(0, 4),
                 IntLists.mutable.with(8));
-        Assert.assertEquals(expected9, interval9.chunk(2));
+        assertEquals(expected9, interval9.chunk(2));
 
         IntInterval interval10 = IntInterval.fromToBy(0, -9, -4);
         MutableList<IntIterable> expected10 = Lists.mutable.with(
                 IntLists.mutable.with(0, -4),
                 IntLists.mutable.with(-8));
-        Assert.assertEquals(expected10, interval10.chunk(2));
+        assertEquals(expected10, interval10.chunk(2));
 
         IntInterval interval11 = IntInterval.fromToBy(0, 5, 3);
         MutableList<IntIterable> expected11 = Lists.mutable.with(IntLists.mutable.with(0, 3));
-        Assert.assertEquals(expected11, interval11.chunk(3));
+        assertEquals(expected11, interval11.chunk(3));
 
         IntInterval interval12 = IntInterval.fromToBy(0, -5, -3);
         MutableList<IntIterable> expected12 = Lists.mutable.with(IntLists.mutable.with(0, -3));
-        Assert.assertEquals(expected12, interval12.chunk(3));
+        assertEquals(expected12, interval12.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> interval12.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> interval12.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> interval12.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> interval12.chunk(-1));
     }
 
     @Test
@@ -365,14 +373,14 @@ public class IntIntervalTest
     public void subList()
     {
         IntInterval interval = IntInterval.fromToBy(1, 10, 2);
-        Assert.assertEquals(IntLists.immutable.with(3, 5, 7), interval.subList(1, 4));
+        assertEquals(IntLists.immutable.with(3, 5, 7), interval.subList(1, 4));
     }
 
     @Test
     public void dotProduct()
     {
         IntInterval interval = IntInterval.oneTo(3);
-        Assert.assertEquals(14, this.intInterval.dotProduct(interval));
+        assertEquals(14, this.intInterval.dotProduct(interval));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -385,38 +393,38 @@ public class IntIntervalTest
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.intInterval.notEmpty());
+        assertTrue(this.intInterval.notEmpty());
         Verify.assertNotEmpty(this.intInterval);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, IntInterval.zeroTo(2).count(IntPredicates.greaterThan(0)));
+        assertEquals(2L, IntInterval.zeroTo(2).count(IntPredicates.greaterThan(0)));
 
         int count = IntInterval.fromToBy(Integer.MAX_VALUE - 10, Integer.MAX_VALUE, 8).count(IntPredicates.greaterThan(0));
-        Assert.assertEquals(2, count);
+        assertEquals(2, count);
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(IntInterval.fromTo(-1, 2).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(IntInterval.oneTo(2).anySatisfy(IntPredicates.equal(0)));
+        assertTrue(IntInterval.fromTo(-1, 2).anySatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(IntInterval.oneTo(2).anySatisfy(IntPredicates.equal(0)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(IntInterval.zeroTo(2).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(IntInterval.oneTo(3).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(IntInterval.zeroTo(2).allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(IntInterval.oneTo(3).allSatisfy(IntPredicates.greaterThan(0)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(IntInterval.zeroTo(2).noneSatisfy(IntPredicates.isEven()));
-        Assert.assertTrue(IntInterval.evensFromTo(2, 10).noneSatisfy(IntPredicates.isOdd()));
+        assertFalse(IntInterval.zeroTo(2).noneSatisfy(IntPredicates.isEven()));
+        assertTrue(IntInterval.evensFromTo(2, 10).noneSatisfy(IntPredicates.isOdd()));
     }
 
     @Test
@@ -436,149 +444,149 @@ public class IntIntervalTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(1L, this.intInterval.detectIfNone(IntPredicates.lessThan(4), 0));
-        Assert.assertEquals(0L, this.intInterval.detectIfNone(IntPredicates.greaterThan(3), 0));
+        assertEquals(1L, this.intInterval.detectIfNone(IntPredicates.lessThan(4), 0));
+        assertEquals(0L, this.intInterval.detectIfNone(IntPredicates.greaterThan(3), 0));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith(0, 1, 2), this.intInterval.collect(parameter -> parameter - 1).toList());
+        assertEquals(FastList.newListWith(0, 1, 2), this.intInterval.collect(parameter -> parameter - 1).toList());
     }
 
     @Test
     public void lazyCollectPrimitives()
     {
-        Assert.assertEquals(BooleanLists.immutable.of(false, true, false), IntInterval.oneTo(3).asLazy().collectBoolean(e -> e % 2 == 0).toList());
-        Assert.assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), IntInterval.oneTo(3).asLazy().collectChar(e -> (char) (e + 1)).toList());
-        Assert.assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), IntInterval.oneTo(3).asLazy().collectByte(e -> (byte) (e + 1)).toList());
-        Assert.assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), IntInterval.oneTo(3).asLazy().collectShort(e -> (short) (e + 1)).toList());
-        Assert.assertEquals(IntLists.immutable.of(2, 3, 4), IntInterval.oneTo(3).asLazy().collectInt(e -> e + 1).toList());
-        Assert.assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), IntInterval.oneTo(3).asLazy().collectFloat(e -> (float) (e + 1)).toList());
-        Assert.assertEquals(LongLists.immutable.of(2L, 3L, 4L), IntInterval.oneTo(3).asLazy().collectLong(e -> (long) (e + 1)).toList());
-        Assert.assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), IntInterval.oneTo(3).asLazy().collectDouble(e -> (double) (e + 1)).toList());
+        assertEquals(BooleanLists.immutable.of(false, true, false), IntInterval.oneTo(3).asLazy().collectBoolean(e -> e % 2 == 0).toList());
+        assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), IntInterval.oneTo(3).asLazy().collectChar(e -> (char) (e + 1)).toList());
+        assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), IntInterval.oneTo(3).asLazy().collectByte(e -> (byte) (e + 1)).toList());
+        assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), IntInterval.oneTo(3).asLazy().collectShort(e -> (short) (e + 1)).toList());
+        assertEquals(IntLists.immutable.of(2, 3, 4), IntInterval.oneTo(3).asLazy().collectInt(e -> e + 1).toList());
+        assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), IntInterval.oneTo(3).asLazy().collectFloat(e -> (float) (e + 1)).toList());
+        assertEquals(LongLists.immutable.of(2L, 3L, 4L), IntInterval.oneTo(3).asLazy().collectLong(e -> (long) (e + 1)).toList());
+        assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), IntInterval.oneTo(3).asLazy().collectDouble(e -> (double) (e + 1)).toList());
     }
 
     @Test
     public void binarySearch()
     {
         IntInterval interval1 = IntInterval.oneTo(3);
-        Assert.assertEquals(-1, interval1.binarySearch(-1));
-        Assert.assertEquals(-1, interval1.binarySearch(0));
-        Assert.assertEquals(0, interval1.binarySearch(1));
-        Assert.assertEquals(1, interval1.binarySearch(2));
-        Assert.assertEquals(2, interval1.binarySearch(3));
-        Assert.assertEquals(-4, interval1.binarySearch(4));
-        Assert.assertEquals(-4, interval1.binarySearch(5));
+        assertEquals(-1, interval1.binarySearch(-1));
+        assertEquals(-1, interval1.binarySearch(0));
+        assertEquals(0, interval1.binarySearch(1));
+        assertEquals(1, interval1.binarySearch(2));
+        assertEquals(2, interval1.binarySearch(3));
+        assertEquals(-4, interval1.binarySearch(4));
+        assertEquals(-4, interval1.binarySearch(5));
 
         IntInterval interval2 = IntInterval.fromTo(7, 17).by(3);
-        Assert.assertEquals(0, interval2.binarySearch(7));
-        Assert.assertEquals(1, interval2.binarySearch(10));
-        Assert.assertEquals(2, interval2.binarySearch(13));
-        Assert.assertEquals(3, interval2.binarySearch(16));
-        Assert.assertEquals(-1, interval2.binarySearch(6));
-        Assert.assertEquals(-2, interval2.binarySearch(8));
-        Assert.assertEquals(-2, interval2.binarySearch(9));
-        Assert.assertEquals(-3, interval2.binarySearch(12));
-        Assert.assertEquals(-4, interval2.binarySearch(15));
-        Assert.assertEquals(-5, interval2.binarySearch(17));
-        Assert.assertEquals(-5, interval2.binarySearch(19));
+        assertEquals(0, interval2.binarySearch(7));
+        assertEquals(1, interval2.binarySearch(10));
+        assertEquals(2, interval2.binarySearch(13));
+        assertEquals(3, interval2.binarySearch(16));
+        assertEquals(-1, interval2.binarySearch(6));
+        assertEquals(-2, interval2.binarySearch(8));
+        assertEquals(-2, interval2.binarySearch(9));
+        assertEquals(-3, interval2.binarySearch(12));
+        assertEquals(-4, interval2.binarySearch(15));
+        assertEquals(-5, interval2.binarySearch(17));
+        assertEquals(-5, interval2.binarySearch(19));
 
         IntInterval interval3 = IntInterval.fromTo(-21, -11).by(5);
-        Assert.assertEquals(-1, interval3.binarySearch(-22));
-        Assert.assertEquals(0, interval3.binarySearch(-21));
-        Assert.assertEquals(-2, interval3.binarySearch(-17));
-        Assert.assertEquals(1, interval3.binarySearch(-16));
-        Assert.assertEquals(-3, interval3.binarySearch(-15));
-        Assert.assertEquals(2, interval3.binarySearch(-11));
-        Assert.assertEquals(-4, interval3.binarySearch(-9));
+        assertEquals(-1, interval3.binarySearch(-22));
+        assertEquals(0, interval3.binarySearch(-21));
+        assertEquals(-2, interval3.binarySearch(-17));
+        assertEquals(1, interval3.binarySearch(-16));
+        assertEquals(-3, interval3.binarySearch(-15));
+        assertEquals(2, interval3.binarySearch(-11));
+        assertEquals(-4, interval3.binarySearch(-9));
 
         IntInterval interval4 = IntInterval.fromTo(50, 30).by(-10);
-        Assert.assertEquals(-1, interval4.binarySearch(60));
-        Assert.assertEquals(0, interval4.binarySearch(50));
-        Assert.assertEquals(-2, interval4.binarySearch(45));
-        Assert.assertEquals(1, interval4.binarySearch(40));
-        Assert.assertEquals(-3, interval4.binarySearch(35));
-        Assert.assertEquals(2, interval4.binarySearch(30));
-        Assert.assertEquals(-4, interval4.binarySearch(25));
+        assertEquals(-1, interval4.binarySearch(60));
+        assertEquals(0, interval4.binarySearch(50));
+        assertEquals(-2, interval4.binarySearch(45));
+        assertEquals(1, interval4.binarySearch(40));
+        assertEquals(-3, interval4.binarySearch(35));
+        assertEquals(2, interval4.binarySearch(30));
+        assertEquals(-4, interval4.binarySearch(25));
 
         IntInterval interval5 = IntInterval.fromTo(-30, -50).by(-10);
-        Assert.assertEquals(-1, interval5.binarySearch(-20));
-        Assert.assertEquals(0, interval5.binarySearch(-30));
-        Assert.assertEquals(-2, interval5.binarySearch(-35));
-        Assert.assertEquals(1, interval5.binarySearch(-40));
-        Assert.assertEquals(-3, interval5.binarySearch(-47));
-        Assert.assertEquals(2, interval5.binarySearch(-50));
-        Assert.assertEquals(-4, interval5.binarySearch(-65));
+        assertEquals(-1, interval5.binarySearch(-20));
+        assertEquals(0, interval5.binarySearch(-30));
+        assertEquals(-2, interval5.binarySearch(-35));
+        assertEquals(1, interval5.binarySearch(-40));
+        assertEquals(-3, interval5.binarySearch(-47));
+        assertEquals(2, interval5.binarySearch(-50));
+        assertEquals(-4, interval5.binarySearch(-65));
 
         IntInterval interval6 = IntInterval.fromTo(27, -30).by(-9);
-        Assert.assertEquals(-1, interval6.binarySearch(30));
-        Assert.assertEquals(0, interval6.binarySearch(27));
-        Assert.assertEquals(-2, interval6.binarySearch(20));
-        Assert.assertEquals(1, interval6.binarySearch(18));
-        Assert.assertEquals(-3, interval6.binarySearch(15));
-        Assert.assertEquals(2, interval6.binarySearch(9));
-        Assert.assertEquals(-4, interval6.binarySearch(2));
-        Assert.assertEquals(3, interval6.binarySearch(0));
-        Assert.assertEquals(-5, interval6.binarySearch(-7));
-        Assert.assertEquals(4, interval6.binarySearch(-9));
-        Assert.assertEquals(-6, interval6.binarySearch(-12));
-        Assert.assertEquals(5, interval6.binarySearch(-18));
-        Assert.assertEquals(-7, interval6.binarySearch(-23));
-        Assert.assertEquals(6, interval6.binarySearch(-27));
-        Assert.assertEquals(-8, interval6.binarySearch(-28));
-        Assert.assertEquals(-8, interval6.binarySearch(-30));
+        assertEquals(-1, interval6.binarySearch(30));
+        assertEquals(0, interval6.binarySearch(27));
+        assertEquals(-2, interval6.binarySearch(20));
+        assertEquals(1, interval6.binarySearch(18));
+        assertEquals(-3, interval6.binarySearch(15));
+        assertEquals(2, interval6.binarySearch(9));
+        assertEquals(-4, interval6.binarySearch(2));
+        assertEquals(3, interval6.binarySearch(0));
+        assertEquals(-5, interval6.binarySearch(-7));
+        assertEquals(4, interval6.binarySearch(-9));
+        assertEquals(-6, interval6.binarySearch(-12));
+        assertEquals(5, interval6.binarySearch(-18));
+        assertEquals(-7, interval6.binarySearch(-23));
+        assertEquals(6, interval6.binarySearch(-27));
+        assertEquals(-8, interval6.binarySearch(-28));
+        assertEquals(-8, interval6.binarySearch(-30));
 
         IntInterval interval7 = IntInterval.fromTo(-1, 1).by(1);
-        Assert.assertEquals(-1, interval7.binarySearch(-2));
-        Assert.assertEquals(0, interval7.binarySearch(-1));
-        Assert.assertEquals(1, interval7.binarySearch(0));
-        Assert.assertEquals(2, interval7.binarySearch(1));
-        Assert.assertEquals(-4, interval7.binarySearch(2));
+        assertEquals(-1, interval7.binarySearch(-2));
+        assertEquals(0, interval7.binarySearch(-1));
+        assertEquals(1, interval7.binarySearch(0));
+        assertEquals(2, interval7.binarySearch(1));
+        assertEquals(-4, interval7.binarySearch(2));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(9, IntInterval.oneTo(9).max());
-        Assert.assertEquals(5, IntInterval.fromTo(5, 1).max());
-        Assert.assertEquals(1, IntInterval.fromTo(-5, 1).max());
-        Assert.assertEquals(1, IntInterval.fromTo(1, -5).max());
+        assertEquals(9, IntInterval.oneTo(9).max());
+        assertEquals(5, IntInterval.fromTo(5, 1).max());
+        assertEquals(1, IntInterval.fromTo(-5, 1).max());
+        assertEquals(1, IntInterval.fromTo(1, -5).max());
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(1, IntInterval.oneTo(9).min());
-        Assert.assertEquals(1, IntInterval.fromTo(5, 1).min());
-        Assert.assertEquals(-5, IntInterval.fromTo(-5, 1).min());
-        Assert.assertEquals(-5, IntInterval.fromTo(1, -5).min());
+        assertEquals(1, IntInterval.oneTo(9).min());
+        assertEquals(1, IntInterval.fromTo(5, 1).min());
+        assertEquals(-5, IntInterval.fromTo(-5, 1).min());
+        assertEquals(-5, IntInterval.fromTo(1, -5).min());
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(1, IntInterval.oneTo(9).minIfEmpty(0));
+        assertEquals(1, IntInterval.oneTo(9).minIfEmpty(0));
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(9, IntInterval.oneTo(9).maxIfEmpty(0));
+        assertEquals(9, IntInterval.oneTo(9).maxIfEmpty(0));
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(10L, IntInterval.oneTo(4).sum());
-        Assert.assertEquals(5L, IntInterval.oneToBy(4, 3).sum());
-        Assert.assertEquals(4L, IntInterval.oneToBy(4, 2).sum());
-        Assert.assertEquals(-10L, IntInterval.fromTo(-1, -4).sum());
-        Assert.assertEquals(-15L, IntInterval.fromToBy(-2, -10, -3).sum());
+        assertEquals(10L, IntInterval.oneTo(4).sum());
+        assertEquals(5L, IntInterval.oneToBy(4, 3).sum());
+        assertEquals(4L, IntInterval.oneToBy(4, 2).sum());
+        assertEquals(-10L, IntInterval.fromTo(-1, -4).sum());
+        assertEquals(-15L, IntInterval.fromToBy(-2, -10, -3).sum());
 
-        Assert.assertEquals(-7L, IntInterval.fromToBy(-10, 10, 3).sum());
+        assertEquals(-7L, IntInterval.fromToBy(-10, 10, 3).sum());
 
-        Assert.assertEquals(
+        assertEquals(
                 3L * ((long) Integer.MAX_VALUE * 2L - 2L) / 2L,
                 IntInterval.fromTo(Integer.MAX_VALUE - 2, Integer.MAX_VALUE).sum());
     }
@@ -586,68 +594,68 @@ public class IntIntervalTest
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, IntInterval.oneTo(4).average(), 0.0);
-        Assert.assertEquals(5.0, IntInterval.oneToBy(9, 2).average(), 0.0);
-        Assert.assertEquals(5.0, IntInterval.oneToBy(10, 2).average(), 0.0);
-        Assert.assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).average(), 0.0);
+        assertEquals(2.5, IntInterval.oneTo(4).average(), 0.0);
+        assertEquals(5.0, IntInterval.oneToBy(9, 2).average(), 0.0);
+        assertEquals(5.0, IntInterval.oneToBy(10, 2).average(), 0.0);
+        assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).average(), 0.0);
 
-        Assert.assertEquals((double) Integer.MAX_VALUE - 1.5,
+        assertEquals((double) Integer.MAX_VALUE - 1.5,
                 IntInterval.fromTo(Integer.MAX_VALUE - 3, Integer.MAX_VALUE).average(), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, IntInterval.oneTo(4).median(), 0.0);
-        Assert.assertEquals(5.0, IntInterval.oneToBy(9, 2).median(), 0.0);
-        Assert.assertEquals(5.0, IntInterval.oneToBy(10, 2).median(), 0.0);
-        Assert.assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).median(), 0.0);
+        assertEquals(2.5, IntInterval.oneTo(4).median(), 0.0);
+        assertEquals(5.0, IntInterval.oneToBy(9, 2).median(), 0.0);
+        assertEquals(5.0, IntInterval.oneToBy(10, 2).median(), 0.0);
+        assertEquals(-5.0, IntInterval.fromToBy(-1, -9, -2).median(), 0.0);
 
-        Assert.assertEquals((double) Integer.MAX_VALUE - 1.5,
+        assertEquals((double) Integer.MAX_VALUE - 1.5,
                 IntInterval.fromTo(Integer.MAX_VALUE - 3, Integer.MAX_VALUE).median(), 0.0);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new int[]{1, 2, 3, 4}, IntInterval.oneTo(4).toArray());
+        assertArrayEquals(new int[]{1, 2, 3, 4}, IntInterval.oneTo(4).toArray());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.oneTo(4).toList());
+        assertEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.oneTo(4).toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.oneTo(4).toReversed().toSortedList());
+        assertEquals(IntArrayList.newListWith(1, 2, 3, 4), IntInterval.oneTo(4).toReversed().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(IntHashSet.newSetWith(1, 2, 3, 4), IntInterval.oneTo(4).toSet());
+        assertEquals(IntHashSet.newSetWith(1, 2, 3, 4), IntInterval.oneTo(4).toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), IntInterval.oneTo(4).toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), IntInterval.oneTo(4).toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(IntInterval.oneTo(5).toSet(), IntInterval.oneTo(5).asLazy().toSet());
+        assertEquals(IntInterval.oneTo(5).toSet(), IntInterval.oneTo(5).asLazy().toSet());
         Verify.assertInstanceOf(LazyIntIterable.class, IntInterval.oneTo(5).asLazy());
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new int[]{1, 2, 3, 4}, IntInterval.fromTo(4, 1).toSortedArray());
+        assertArrayEquals(new int[]{1, 2, 3, 4}, IntInterval.fromTo(4, 1).toSortedArray());
     }
 
     @Test
@@ -661,29 +669,29 @@ public class IntIntervalTest
 
         Verify.assertEqualsAndHashCode(list1, list2);
         Verify.assertPostSerializedEqualsAndHashCode(list1);
-        Assert.assertNotEquals(list1, list3);
-        Assert.assertNotEquals(list1, list4);
-        Assert.assertNotEquals(list1, list5);
+        assertNotEquals(list1, list3);
+        assertNotEquals(list1, list4);
+        assertNotEquals(list1, list5);
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(FastList.newListWith(1, 2, 3).hashCode(), IntInterval.oneTo(3).hashCode());
+        assertEquals(FastList.newListWith(1, 2, 3).hashCode(), IntInterval.oneTo(3).hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.intInterval.toString());
+        assertEquals("[1, 2, 3]", this.intInterval.toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.intInterval.makeString());
-        Assert.assertEquals("1/2/3", this.intInterval.makeString("/"));
-        Assert.assertEquals(this.intInterval.toString(), this.intInterval.makeString("[", ", ", "]"));
+        assertEquals("1, 2, 3", this.intInterval.makeString());
+        assertEquals("1/2/3", this.intInterval.makeString("/"));
+        assertEquals(this.intInterval.toString(), this.intInterval.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -691,26 +699,26 @@ public class IntIntervalTest
     {
         StringBuilder appendable2 = new StringBuilder();
         this.intInterval.appendString(appendable2);
-        Assert.assertEquals("1, 2, 3", appendable2.toString());
+        assertEquals("1, 2, 3", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.intInterval.appendString(appendable3, "/");
-        Assert.assertEquals("1/2/3", appendable3.toString());
+        assertEquals("1/2/3", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.intInterval.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.intInterval.toString(), appendable4.toString());
+        assertEquals(this.intInterval.toString(), appendable4.toString());
     }
 
     @Test
     public void appendStringThrows()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.intInterval.appendString(new ThrowingAppendable()));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.intInterval
                         .appendString(new ThrowingAppendable(), ", "));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.intInterval
                         .appendString(new ThrowingAppendable(), "[", ", ", "]"));
@@ -721,7 +729,7 @@ public class IntIntervalTest
     {
         IntInterval forward = IntInterval.oneTo(5);
         IntInterval reverse = forward.toReversed();
-        Assert.assertEquals(IntArrayList.newListWith(5, 4, 3, 2, 1), reverse);
+        assertEquals(IntArrayList.newListWith(5, 4, 3, 2, 1), reverse);
     }
 
     @Test
@@ -732,31 +740,31 @@ public class IntIntervalTest
         int[] odds = {1, 3, 5, 7, 9};
         this.assertIntIntervalContainsAll(interval, evens);
         this.denyIntIntervalContainsAny(interval, odds);
-        Assert.assertEquals(6, interval.size());
+        assertEquals(6, interval.size());
 
         IntInterval reverseIntInterval = IntInterval.evensFromTo(10, 0);
         this.assertIntIntervalContainsAll(reverseIntInterval, evens);
         this.denyIntIntervalContainsAny(reverseIntInterval, odds);
-        Assert.assertEquals(6, reverseIntInterval.size());
+        assertEquals(6, reverseIntInterval.size());
 
         IntInterval negativeIntInterval = IntInterval.evensFromTo(-5, 5);
         int[] negativeEvens = {-4, -2, 0, 2, 4};
         int[] negativeOdds = {-3, -1, 1, 3};
         this.assertIntIntervalContainsAll(negativeIntInterval, negativeEvens);
         this.denyIntIntervalContainsAny(negativeIntInterval, negativeOdds);
-        Assert.assertEquals(5, negativeIntInterval.size());
+        assertEquals(5, negativeIntInterval.size());
 
         IntInterval reverseNegativeIntInterval = IntInterval.evensFromTo(5, -5);
         this.assertIntIntervalContainsAll(reverseNegativeIntInterval, negativeEvens);
         this.denyIntIntervalContainsAny(reverseNegativeIntInterval, negativeOdds);
-        Assert.assertEquals(5, reverseNegativeIntInterval.size());
+        assertEquals(5, reverseNegativeIntInterval.size());
     }
 
     private void assertIntIntervalContainsAll(IntInterval interval, int[] expectedValues)
     {
         for (int value : expectedValues)
         {
-            Assert.assertTrue(interval.contains(value));
+            assertTrue(interval.contains(value));
         }
     }
 
@@ -764,7 +772,7 @@ public class IntIntervalTest
     {
         for (int value : expectedValues)
         {
-            Assert.assertFalse(interval.contains(value));
+            assertFalse(interval.contains(value));
         }
     }
 
@@ -772,75 +780,75 @@ public class IntIntervalTest
     public void odds()
     {
         IntInterval interval1 = IntInterval.oddsFromTo(0, 10);
-        Assert.assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(interval1.containsNone(2, 4, 6, 8));
-        Assert.assertEquals(5, interval1.size());
+        assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(interval1.containsNone(2, 4, 6, 8));
+        assertEquals(5, interval1.size());
 
         IntInterval reverseIntInterval1 = IntInterval.oddsFromTo(10, 0);
-        Assert.assertTrue(reverseIntInterval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(reverseIntInterval1.containsNone(0, 2, 4, 6, 8, 10));
-        Assert.assertEquals(5, reverseIntInterval1.size());
+        assertTrue(reverseIntInterval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(reverseIntInterval1.containsNone(0, 2, 4, 6, 8, 10));
+        assertEquals(5, reverseIntInterval1.size());
 
         IntInterval interval2 = IntInterval.oddsFromTo(-5, 5);
-        Assert.assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
-        Assert.assertEquals(6, interval2.size());
+        assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
+        assertEquals(6, interval2.size());
 
         IntInterval reverseIntInterval2 = IntInterval.oddsFromTo(5, -5);
-        Assert.assertTrue(reverseIntInterval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(reverseIntInterval2.containsNone(-4, -2, 0, 2, 4));
-        Assert.assertEquals(6, reverseIntInterval2.size());
+        assertTrue(reverseIntInterval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(reverseIntInterval2.containsNone(-4, -2, 0, 2, 4));
+        assertEquals(6, reverseIntInterval2.size());
     }
 
     @Test
     public void intervalSize()
     {
-        Assert.assertEquals(100, IntInterval.fromTo(1, 100).size());
-        Assert.assertEquals(50, IntInterval.fromToBy(1, 100, 2).size());
-        Assert.assertEquals(34, IntInterval.fromToBy(1, 100, 3).size());
-        Assert.assertEquals(25, IntInterval.fromToBy(1, 100, 4).size());
-        Assert.assertEquals(20, IntInterval.fromToBy(1, 100, 5).size());
-        Assert.assertEquals(17, IntInterval.fromToBy(1, 100, 6).size());
-        Assert.assertEquals(15, IntInterval.fromToBy(1, 100, 7).size());
-        Assert.assertEquals(13, IntInterval.fromToBy(1, 100, 8).size());
-        Assert.assertEquals(12, IntInterval.fromToBy(1, 100, 9).size());
-        Assert.assertEquals(10, IntInterval.fromToBy(1, 100, 10).size());
-        Assert.assertEquals(11, IntInterval.fromTo(0, 10).size());
-        Assert.assertEquals(1, IntInterval.zero().size());
-        Assert.assertEquals(11, IntInterval.fromTo(0, -10).size());
-        Assert.assertEquals(3, IntInterval.evensFromTo(2, -2).size());
-        Assert.assertEquals(2, IntInterval.oddsFromTo(2, -2).size());
-        Assert.assertEquals(1, IntInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000).size());
-        Assert.assertEquals(1, IntInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000).size());
+        assertEquals(100, IntInterval.fromTo(1, 100).size());
+        assertEquals(50, IntInterval.fromToBy(1, 100, 2).size());
+        assertEquals(34, IntInterval.fromToBy(1, 100, 3).size());
+        assertEquals(25, IntInterval.fromToBy(1, 100, 4).size());
+        assertEquals(20, IntInterval.fromToBy(1, 100, 5).size());
+        assertEquals(17, IntInterval.fromToBy(1, 100, 6).size());
+        assertEquals(15, IntInterval.fromToBy(1, 100, 7).size());
+        assertEquals(13, IntInterval.fromToBy(1, 100, 8).size());
+        assertEquals(12, IntInterval.fromToBy(1, 100, 9).size());
+        assertEquals(10, IntInterval.fromToBy(1, 100, 10).size());
+        assertEquals(11, IntInterval.fromTo(0, 10).size());
+        assertEquals(1, IntInterval.zero().size());
+        assertEquals(11, IntInterval.fromTo(0, -10).size());
+        assertEquals(3, IntInterval.evensFromTo(2, -2).size());
+        assertEquals(2, IntInterval.oddsFromTo(2, -2).size());
+        assertEquals(1, IntInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000).size());
+        assertEquals(1, IntInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000).size());
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(IntInterval.zero().contains(0));
-        Assert.assertTrue(IntInterval.oneTo(5).containsAll(1, 5));
-        Assert.assertTrue(IntInterval.oneTo(5).containsNone(6, 7));
-        Assert.assertFalse(IntInterval.oneTo(5).containsAll(1, 6));
-        Assert.assertFalse(IntInterval.oneTo(5).containsNone(1, 6));
-        Assert.assertFalse(IntInterval.oneTo(5).contains(0));
-        Assert.assertTrue(IntInterval.fromTo(-1, -5).containsAll(-1, -5));
-        Assert.assertFalse(IntInterval.fromTo(-1, -5).contains(1));
+        assertTrue(IntInterval.zero().contains(0));
+        assertTrue(IntInterval.oneTo(5).containsAll(1, 5));
+        assertTrue(IntInterval.oneTo(5).containsNone(6, 7));
+        assertFalse(IntInterval.oneTo(5).containsAll(1, 6));
+        assertFalse(IntInterval.oneTo(5).containsNone(1, 6));
+        assertFalse(IntInterval.oneTo(5).contains(0));
+        assertTrue(IntInterval.fromTo(-1, -5).containsAll(-1, -5));
+        assertFalse(IntInterval.fromTo(-1, -5).contains(1));
 
-        Assert.assertTrue(IntInterval.zero().contains(Integer.valueOf(0)));
-        Assert.assertFalse(IntInterval.oneTo(5).contains(Integer.valueOf(0)));
-        Assert.assertFalse(IntInterval.fromTo(-1, -5).contains(Integer.valueOf(1)));
+        assertTrue(IntInterval.zero().contains(Integer.valueOf(0)));
+        assertFalse(IntInterval.oneTo(5).contains(Integer.valueOf(0)));
+        assertFalse(IntInterval.fromTo(-1, -5).contains(Integer.valueOf(1)));
 
         IntInterval bigIntInterval = IntInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 1_000_000);
-        Assert.assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + 1_000_000));
-        Assert.assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + 1_000_001));
-        Assert.assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
-        Assert.assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
-        Assert.assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
-        Assert.assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
-        Assert.assertTrue(
+        assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + 1_000_000));
+        assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + 1_000_001));
+        assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
+        assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
+        assertTrue(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
+        assertFalse(bigIntInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
+        assertTrue(
                 IntInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000)
                         .contains(1_000_000_000));
-        Assert.assertTrue(
+        assertTrue(
                 IntInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000)
                         .contains(-1_000_000_000));
 
@@ -848,42 +856,42 @@ public class IntIntervalTest
         int maxValue = 1_000_000_000;
         IntInterval largeInterval = IntInterval.fromToBy(minValue, maxValue, 10);
 
-        Assert.assertTrue(largeInterval.containsAll(
+        assertTrue(largeInterval.containsAll(
                 maxValue - 10,
                 maxValue - 100,
                 maxValue - 1000,
                 maxValue - 10000));
-        Assert.assertTrue(largeInterval.contains(minValue + 10));
+        assertTrue(largeInterval.contains(minValue + 10));
     }
 
     @Test
     public void largeReverseUnderflowTest()
     {
         IntInterval reverse = IntInterval.fromToBy(Integer.MAX_VALUE, Integer.MIN_VALUE + 10, -10);
-        Assert.assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
-        Assert.assertEquals(Integer.MAX_VALUE, reverse.getFirst());
+        assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
+        assertEquals(Integer.MAX_VALUE, reverse.getFirst());
         int expectedLast = -2_147_483_633;
-        Assert.assertEquals(expectedLast, reverse.getLast());
-        Assert.assertTrue(reverse.contains(Integer.MAX_VALUE));
-        Assert.assertTrue(reverse.contains(7));
-        Assert.assertTrue(reverse.contains(-3));
-        Assert.assertTrue(reverse.contains(expectedLast));
-        Assert.assertTrue(reverse.contains(expectedLast + 1000));
-        Assert.assertEquals(214_748_364, reverse.indexOf(7));
-        Assert.assertEquals(214_748_365, reverse.indexOf(-3));
-        Assert.assertEquals(429_496_728, reverse.indexOf(expectedLast));
-        Assert.assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
-        Assert.assertEquals(429_496_728, reverse.binarySearch(expectedLast));
+        assertEquals(expectedLast, reverse.getLast());
+        assertTrue(reverse.contains(Integer.MAX_VALUE));
+        assertTrue(reverse.contains(7));
+        assertTrue(reverse.contains(-3));
+        assertTrue(reverse.contains(expectedLast));
+        assertTrue(reverse.contains(expectedLast + 1000));
+        assertEquals(214_748_364, reverse.indexOf(7));
+        assertEquals(214_748_365, reverse.indexOf(-3));
+        assertEquals(429_496_728, reverse.indexOf(expectedLast));
+        assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
+        assertEquals(429_496_728, reverse.binarySearch(expectedLast));
         int expectedAtIndex300Million = -852_516_353;
-        Assert.assertTrue(reverse.contains(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.binarySearch(expectedAtIndex300Million));
+        assertTrue(reverse.contains(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.binarySearch(expectedAtIndex300Million));
         int expectedAtIndex400Million = -1_852_516_353;
-        Assert.assertTrue(reverse.contains(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.binarySearch(expectedAtIndex400Million));
+        assertTrue(reverse.contains(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.binarySearch(expectedAtIndex400Million));
     }
 
     @Test
@@ -893,17 +901,17 @@ public class IntIntervalTest
         int second = Integer.MAX_VALUE - 2;
         long expected = (long) from + (long) second;
         IntInterval interval = IntInterval.fromToBy(from, Integer.MAX_VALUE, 8);
-        Assert.assertEquals(2, interval.size());
-        Assert.assertEquals(IntLists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.count(each -> each == second));
+        assertEquals(2, interval.size());
+        assertEquals(IntLists.mutable.with(from, second), interval);
+        assertEquals(1, interval.count(each -> each == second));
         MutableLong result = new MutableLong();
         interval.forEach(result::add);
-        Assert.assertEquals(expected, result.longValue());
+        assertEquals(expected, result.longValue());
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(expected + 1L, result.longValue());
+        assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        assertEquals(
                 expected + 1L,
                 interval
                         .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
@@ -917,18 +925,18 @@ public class IntIntervalTest
         int second = Integer.MIN_VALUE + 2;
         long expected = (long) from + (long) second;
         IntInterval interval = IntInterval.fromToBy(from, Integer.MIN_VALUE, -8);
-        Assert.assertEquals(2, interval.size());
-        Assert.assertEquals(IntLists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.count(each -> each == second));
-        Assert.assertEquals(expected, interval.sum());
+        assertEquals(2, interval.size());
+        assertEquals(IntLists.mutable.with(from, second), interval);
+        assertEquals(1, interval.count(each -> each == second));
+        assertEquals(expected, interval.sum());
         MutableLong result = new MutableLong();
         interval.forEach(result::add);
-        Assert.assertEquals(expected, result.longValue());
+        assertEquals(expected, result.longValue());
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(expected + 1L, result.longValue());
+        assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        assertEquals(
                 expected + 1L,
                 interval
                         .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
@@ -940,25 +948,25 @@ public class IntIntervalTest
     {
         IntInterval zero = IntInterval.zero();
         IntIterator zeroIterator = zero.intIterator();
-        Assert.assertTrue(zeroIterator.hasNext());
-        Assert.assertEquals(0, zeroIterator.next());
-        Assert.assertFalse(zeroIterator.hasNext());
+        assertTrue(zeroIterator.hasNext());
+        assertEquals(0, zeroIterator.next());
+        assertFalse(zeroIterator.hasNext());
         IntInterval oneToFive = IntInterval.oneTo(5);
         IntIterator oneToFiveIterator = oneToFive.intIterator();
         for (int i = 1; i < 6; i++)
         {
-            Assert.assertTrue(oneToFiveIterator.hasNext());
-            Assert.assertEquals(i, oneToFiveIterator.next());
+            assertTrue(oneToFiveIterator.hasNext());
+            assertEquals(i, oneToFiveIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
+        assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
         IntInterval threeToNegativeThree = IntInterval.fromTo(3, -3);
         IntIterator threeToNegativeThreeIterator = threeToNegativeThree.intIterator();
         for (int i = 3; i > -4; i--)
         {
-            Assert.assertTrue(threeToNegativeThreeIterator.hasNext());
-            Assert.assertEquals(i, threeToNegativeThreeIterator.next());
+            assertTrue(threeToNegativeThreeIterator.hasNext());
+            assertEquals(i, threeToNegativeThreeIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
+        assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
     }
 
     @Test
@@ -966,10 +974,10 @@ public class IntIntervalTest
     {
         IntegerSum sum = new IntegerSum(0);
         IntInterval.oneTo(5).forEachWithIndex((each, index) -> sum.add(each + index));
-        Assert.assertEquals(25, sum.getIntSum());
+        assertEquals(25, sum.getIntSum());
         IntegerSum zeroSum = new IntegerSum(0);
         IntInterval.fromTo(0, -4).forEachWithIndex((each, index) -> zeroSum.add(each + index));
-        Assert.assertEquals(0, zeroSum.getIntSum());
+        assertEquals(0, zeroSum.getIntSum());
     }
 
     @Test
@@ -980,119 +988,119 @@ public class IntIntervalTest
         IntInterval interval = IntInterval.fromToBy(2, 2, -2);
         interval.forEach((IntProcedure) each -> counter.add(1));
 
-        Assert.assertEquals(1, counter.toInteger().intValue());
+        assertEquals(1, counter.toInteger().intValue());
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(10, IntInterval.fromTo(10, -10).by(-5).getFirst());
-        Assert.assertEquals(-10, IntInterval.fromTo(-10, 10).by(5).getFirst());
-        Assert.assertEquals(0, IntInterval.zero().getFirst());
+        assertEquals(10, IntInterval.fromTo(10, -10).by(-5).getFirst());
+        assertEquals(-10, IntInterval.fromTo(-10, 10).by(5).getFirst());
+        assertEquals(0, IntInterval.zero().getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals(-10, IntInterval.fromTo(10, -10).by(-5).getLast());
-        Assert.assertEquals(-10, IntInterval.fromTo(10, -12).by(-5).getLast());
-        Assert.assertEquals(10, IntInterval.fromTo(-10, 10).by(5).getLast());
-        Assert.assertEquals(10, IntInterval.fromTo(-10, 12).by(5).getLast());
-        Assert.assertEquals(0, IntInterval.zero().getLast());
+        assertEquals(-10, IntInterval.fromTo(10, -10).by(-5).getLast());
+        assertEquals(-10, IntInterval.fromTo(10, -12).by(-5).getLast());
+        assertEquals(10, IntInterval.fromTo(-10, 10).by(5).getLast());
+        assertEquals(10, IntInterval.fromTo(-10, 12).by(5).getLast());
+        assertEquals(0, IntInterval.zero().getLast());
     }
 
     @Test
     public void indexOf()
     {
         IntInterval interval = IntInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.indexOf(-10));
-        Assert.assertEquals(1, interval.indexOf(-5));
-        Assert.assertEquals(2, interval.indexOf(0));
-        Assert.assertEquals(3, interval.indexOf(5));
-        Assert.assertEquals(4, interval.indexOf(10));
+        assertEquals(0, interval.indexOf(-10));
+        assertEquals(1, interval.indexOf(-5));
+        assertEquals(2, interval.indexOf(0));
+        assertEquals(3, interval.indexOf(5));
+        assertEquals(4, interval.indexOf(10));
 
-        Assert.assertEquals(-1, interval.indexOf(-15));
-        Assert.assertEquals(-1, interval.indexOf(-11));
-        Assert.assertEquals(-1, interval.indexOf(-9));
-        Assert.assertEquals(-1, interval.indexOf(11));
-        Assert.assertEquals(-1, interval.indexOf(15));
+        assertEquals(-1, interval.indexOf(-15));
+        assertEquals(-1, interval.indexOf(-11));
+        assertEquals(-1, interval.indexOf(-9));
+        assertEquals(-1, interval.indexOf(11));
+        assertEquals(-1, interval.indexOf(15));
 
         IntInterval backwardsIntInterval = IntInterval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsIntInterval.indexOf(10));
-        Assert.assertEquals(1, backwardsIntInterval.indexOf(5));
-        Assert.assertEquals(2, backwardsIntInterval.indexOf(0));
-        Assert.assertEquals(3, backwardsIntInterval.indexOf(-5));
-        Assert.assertEquals(4, backwardsIntInterval.indexOf(-10));
+        assertEquals(0, backwardsIntInterval.indexOf(10));
+        assertEquals(1, backwardsIntInterval.indexOf(5));
+        assertEquals(2, backwardsIntInterval.indexOf(0));
+        assertEquals(3, backwardsIntInterval.indexOf(-5));
+        assertEquals(4, backwardsIntInterval.indexOf(-10));
 
-        Assert.assertEquals(-1, backwardsIntInterval.indexOf(15));
-        Assert.assertEquals(-1, backwardsIntInterval.indexOf(11));
-        Assert.assertEquals(-1, backwardsIntInterval.indexOf(9));
-        Assert.assertEquals(-1, backwardsIntInterval.indexOf(-11));
-        Assert.assertEquals(-1, backwardsIntInterval.indexOf(-15));
+        assertEquals(-1, backwardsIntInterval.indexOf(15));
+        assertEquals(-1, backwardsIntInterval.indexOf(11));
+        assertEquals(-1, backwardsIntInterval.indexOf(9));
+        assertEquals(-1, backwardsIntInterval.indexOf(-11));
+        assertEquals(-1, backwardsIntInterval.indexOf(-15));
     }
 
     @Test
     public void lastIndexOf()
     {
         IntInterval interval = IntInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.lastIndexOf(-10));
-        Assert.assertEquals(1, interval.lastIndexOf(-5));
-        Assert.assertEquals(2, interval.lastIndexOf(0));
-        Assert.assertEquals(3, interval.lastIndexOf(5));
-        Assert.assertEquals(4, interval.lastIndexOf(10));
+        assertEquals(0, interval.lastIndexOf(-10));
+        assertEquals(1, interval.lastIndexOf(-5));
+        assertEquals(2, interval.lastIndexOf(0));
+        assertEquals(3, interval.lastIndexOf(5));
+        assertEquals(4, interval.lastIndexOf(10));
 
-        Assert.assertEquals(-1, interval.lastIndexOf(-15));
-        Assert.assertEquals(-1, interval.lastIndexOf(-11));
-        Assert.assertEquals(-1, interval.lastIndexOf(-9));
-        Assert.assertEquals(-1, interval.lastIndexOf(11));
-        Assert.assertEquals(-1, interval.lastIndexOf(15));
+        assertEquals(-1, interval.lastIndexOf(-15));
+        assertEquals(-1, interval.lastIndexOf(-11));
+        assertEquals(-1, interval.lastIndexOf(-9));
+        assertEquals(-1, interval.lastIndexOf(11));
+        assertEquals(-1, interval.lastIndexOf(15));
 
         IntInterval backwardsIntInterval = IntInterval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsIntInterval.lastIndexOf(10));
-        Assert.assertEquals(1, backwardsIntInterval.lastIndexOf(5));
-        Assert.assertEquals(2, backwardsIntInterval.lastIndexOf(0));
-        Assert.assertEquals(3, backwardsIntInterval.lastIndexOf(-5));
-        Assert.assertEquals(4, backwardsIntInterval.lastIndexOf(-10));
+        assertEquals(0, backwardsIntInterval.lastIndexOf(10));
+        assertEquals(1, backwardsIntInterval.lastIndexOf(5));
+        assertEquals(2, backwardsIntInterval.lastIndexOf(0));
+        assertEquals(3, backwardsIntInterval.lastIndexOf(-5));
+        assertEquals(4, backwardsIntInterval.lastIndexOf(-10));
 
-        Assert.assertEquals(-1, backwardsIntInterval.lastIndexOf(15));
-        Assert.assertEquals(-1, backwardsIntInterval.lastIndexOf(11));
-        Assert.assertEquals(-1, backwardsIntInterval.lastIndexOf(9));
-        Assert.assertEquals(-1, backwardsIntInterval.lastIndexOf(-11));
-        Assert.assertEquals(-1, backwardsIntInterval.lastIndexOf(-15));
+        assertEquals(-1, backwardsIntInterval.lastIndexOf(15));
+        assertEquals(-1, backwardsIntInterval.lastIndexOf(11));
+        assertEquals(-1, backwardsIntInterval.lastIndexOf(9));
+        assertEquals(-1, backwardsIntInterval.lastIndexOf(-11));
+        assertEquals(-1, backwardsIntInterval.lastIndexOf(-15));
     }
 
     @Test
     public void get()
     {
         IntInterval interval = IntInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(-10, interval.get(0));
-        Assert.assertEquals(-5, interval.get(1));
-        Assert.assertEquals(0, interval.get(2));
-        Assert.assertEquals(5, interval.get(3));
-        Assert.assertEquals(10, interval.get(4));
+        assertEquals(-10, interval.get(0));
+        assertEquals(-5, interval.get(1));
+        assertEquals(0, interval.get(2));
+        assertEquals(5, interval.get(3));
+        assertEquals(10, interval.get(4));
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(IntInterval.fromTo(1, 3).containsAll(1, 2, 3));
-        Assert.assertFalse(IntInterval.fromTo(1, 3).containsAll(1, 2, 4));
+        assertTrue(IntInterval.fromTo(1, 3).containsAll(1, 2, 3));
+        assertFalse(IntInterval.fromTo(1, 3).containsAll(1, 2, 4));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(IntInterval.fromTo(1, 3).containsAll(IntInterval.fromTo(1, 3)));
-        Assert.assertFalse(IntInterval.fromTo(1, 3).containsAll(IntInterval.fromTo(1, 4)));
+        assertTrue(IntInterval.fromTo(1, 3).containsAll(IntInterval.fromTo(1, 3)));
+        assertFalse(IntInterval.fromTo(1, 3).containsAll(IntInterval.fromTo(1, 4)));
     }
 
     @Test
     public void distinct()
     {
-        Assert.assertSame(this.intInterval, this.intInterval.distinct());
+        assertSame(this.intInterval, this.intInterval.distinct());
     }
 
     @Test
@@ -1100,7 +1108,7 @@ public class IntIntervalTest
     {
         MutableIntList list = IntLists.mutable.empty();
         list.addAll(this.intInterval.asReversed());
-        Assert.assertEquals(IntLists.mutable.with(3, 2, 1), list);
+        assertEquals(IntLists.mutable.with(3, 2, 1), list);
     }
 
     @Test
@@ -1113,10 +1121,10 @@ public class IntIntervalTest
                 PrimitiveTuples.pair(1, "1"),
                 PrimitiveTuples.pair(2, "2"),
                 PrimitiveTuples.pair(3, "3"));
-        Assert.assertEquals(expected, zipped);
-        Assert.assertEquals(expected, zippedLazy);
+        assertEquals(expected, zipped);
+        assertEquals(expected, zippedLazy);
         Verify.assertEmpty(interval.zip(Lists.mutable.empty()));
-        Assert.assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1, "1")), interval.zip(Lists.mutable.with("1")));
+        assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1, "1")), interval.zip(Lists.mutable.with("1")));
     }
 
     @Test
@@ -1129,38 +1137,38 @@ public class IntIntervalTest
                 PrimitiveTuples.pair(1, 3),
                 PrimitiveTuples.pair(2, 2),
                 PrimitiveTuples.pair(3, 1));
-        Assert.assertEquals(expected, zipped);
-        Assert.assertEquals(expected, zippedLazy);
+        assertEquals(expected, zipped);
+        assertEquals(expected, zippedLazy);
         Verify.assertEmpty(interval.zipInt(IntLists.mutable.empty()));
-        Assert.assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1, 3)), interval.zipInt(IntLists.mutable.with(3)));
+        assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1, 3)), interval.zipInt(IntLists.mutable.with(3)));
     }
 
     @Test
     public void primitiveStream()
     {
-        Assert.assertEquals(Lists.mutable.of(1, 2, 3, 4), IntInterval.oneTo(4).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(0, 2, 4), IntInterval.fromToBy(0, 5, 2).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(5, 3, 1), IntInterval.fromToBy(5, 0, -2).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(10, 15, 20, 25, 30), IntInterval.fromToBy(10, 30, 5).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(30, 25, 20, 15, 10), IntInterval.fromToBy(30, 10, -5).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(1, 2, 3, 4), IntInterval.oneTo(4).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(0, 2, 4), IntInterval.fromToBy(0, 5, 2).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(5, 3, 1), IntInterval.fromToBy(5, 0, -2).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(10, 15, 20, 25, 30), IntInterval.fromToBy(10, 30, 5).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(30, 25, 20, 15, 10), IntInterval.fromToBy(30, 10, -5).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void primitiveParallelStream()
     {
-        Assert.assertEquals(Lists.mutable.of(1, 2, 3, 4), IntInterval.oneTo(4).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(0, 2, 4), IntInterval.fromToBy(0, 5, 2).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(5, 3, 1, -1, -3), IntInterval.fromToBy(5, -4, -2).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(10, 15, 20, 25, 30), IntInterval.fromToBy(10, 30, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(30, 25, 20, 15, 10), IntInterval.fromToBy(30, 10, -5).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(-1, 10, 21, 32, 43, 54, 65, 76, 87, 98), IntInterval.fromToBy(-1, 100, 11).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(1, 2, 3, 4), IntInterval.oneTo(4).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(0, 2, 4), IntInterval.fromToBy(0, 5, 2).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(5, 3, 1, -1, -3), IntInterval.fromToBy(5, -4, -2).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(10, 15, 20, 25, 30), IntInterval.fromToBy(10, 30, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(30, 25, 20, 15, 10), IntInterval.fromToBy(30, 10, -5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(-1, 10, 21, 32, 43, 54, 65, 76, 87, 98), IntInterval.fromToBy(-1, 100, 11).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void toImmutable()
     {
         IntInterval interval = IntInterval.oneTo(5);
-        Assert.assertSame(interval, interval.toImmutable());
+        assertSame(interval, interval.toImmutable());
     }
 
     @Test
@@ -1168,8 +1176,8 @@ public class IntIntervalTest
     {
         IntInterval interval = IntInterval.oneTo(4);
         ImmutableIntList list = interval.newWith(5);
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(IntInterval.oneTo(5), list);
+        assertNotSame(interval, list);
+        assertEquals(IntInterval.oneTo(5), list);
     }
 
     @Test
@@ -1177,8 +1185,8 @@ public class IntIntervalTest
     {
         IntInterval interval = IntInterval.oneTo(5);
         ImmutableIntList list = interval.newWithout(5);
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(IntInterval.oneTo(4), list);
+        assertNotSame(interval, list);
+        assertEquals(IntInterval.oneTo(4), list);
     }
 
     @Test
@@ -1186,8 +1194,8 @@ public class IntIntervalTest
     {
         IntInterval interval = IntInterval.oneTo(2);
         ImmutableIntList list = interval.newWithAll(IntInterval.fromTo(3, 5));
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(IntInterval.oneTo(5), list);
+        assertNotSame(interval, list);
+        assertEquals(IntInterval.oneTo(5), list);
     }
 
     @Test
@@ -1195,7 +1203,7 @@ public class IntIntervalTest
     {
         IntInterval interval = IntInterval.oneTo(5);
         ImmutableIntList list = interval.newWithoutAll(IntInterval.fromTo(3, 5));
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(IntInterval.oneTo(2), list);
+        assertNotSame(interval, list);
+        assertEquals(IntInterval.oneTo(2), list);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
@@ -42,8 +42,16 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class LongIntervalTest
 {
@@ -62,17 +70,17 @@ public class LongIntervalTest
         Verify.assertSize(Integer.MAX_VALUE, LongInterval.fromTo(1, Integer.MAX_VALUE));
         Verify.assertSize(21, LongInterval.from(10L).to(-10L).by(-1L));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(-1, Integer.MAX_VALUE));
-        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
-        Assert.assertEquals(LongInterval.fromTo(Integer.MIN_VALUE + 1, -1).size(), LongInterval.oneTo(Integer.MAX_VALUE).size());
+        assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(Integer.MIN_VALUE, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> LongInterval.fromTo(-1, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> LongInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 2));
+        assertEquals(LongInterval.fromTo(Integer.MIN_VALUE + 1, -1).size(), LongInterval.oneTo(Integer.MAX_VALUE).size());
 
-        Assert.assertEquals(LongLists.mutable.with(0), LongInterval.fromToBy(0, 2, 3));
-        Assert.assertEquals(LongLists.mutable.with(0), LongInterval.fromToBy(0, -2, -3));
-        Assert.assertEquals(LongLists.mutable.with(1_000_000_000), LongInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
-        Assert.assertEquals(LongLists.mutable.with(-1_000_000_000), LongInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
-        Assert.assertEquals(LongLists.mutable.with(Integer.MIN_VALUE), LongInterval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
-        Assert.assertEquals(LongLists.mutable.with(Integer.MAX_VALUE), LongInterval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
+        assertEquals(LongLists.mutable.with(0), LongInterval.fromToBy(0, 2, 3));
+        assertEquals(LongLists.mutable.with(0), LongInterval.fromToBy(0, -2, -3));
+        assertEquals(LongLists.mutable.with(1_000_000_000), LongInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000));
+        assertEquals(LongLists.mutable.with(-1_000_000_000), LongInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000));
+        assertEquals(LongLists.mutable.with(Integer.MIN_VALUE), LongInterval.fromToBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 10, 20));
+        assertEquals(LongLists.mutable.with(Integer.MAX_VALUE), LongInterval.fromToBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 10, -20));
     }
 
     @Test
@@ -87,8 +95,8 @@ public class LongIntervalTest
         Verify.assertEqualsAndHashCode(interval2, LongInterval.fromTo(maxint + 1, maxint + 10));
         Verify.assertEqualsAndHashCode(interval3, LongInterval.fromToBy(maxint + 1, maxint + 10, 2));
 
-        Assert.assertEquals(LongLists.mutable.with(maxint, maxint * 2, maxint * 3), LongInterval.fromToBy(maxint, maxint * 3L, maxint));
-        Assert.assertEquals(
+        assertEquals(LongLists.mutable.with(maxint, maxint * 2, maxint * 3), LongInterval.fromToBy(maxint, maxint * 3L, maxint));
+        assertEquals(
                 LongLists.mutable.with(minint, minint + maxint, minint + maxint * 2, minint + maxint * 3),
                 LongInterval.fromToBy(minint, maxint * 2, maxint));
     }
@@ -108,8 +116,8 @@ public class LongIntervalTest
     @Test
     public void fromAndToAndBy_throws_step_is_incorrect()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.from(10L).to(-10L).by(1L));
-        Assert.assertThrows(IllegalArgumentException.class, () -> LongInterval.from(-10L).to(10L).by(-1L));
+        assertThrows(IllegalArgumentException.class, () -> LongInterval.from(10L).to(-10L).by(1L));
+        assertThrows(IllegalArgumentException.class, () -> LongInterval.from(-10L).to(10L).by(-1L));
     }
 
     @Test
@@ -117,8 +125,8 @@ public class LongIntervalTest
     {
         MutableLongList integers = LongInterval.fromToBy(2, 2, -2).toList();
 
-        Verify.assertEquals(1, integers.size());
-        Verify.assertEquals(2, integers.getFirst());
+        assertEquals(1, integers.size());
+        assertEquals(2, integers.getFirst());
     }
 
     @Test
@@ -126,8 +134,8 @@ public class LongIntervalTest
     {
         MutableLongList integers = LongInterval.fromToBy(2, 2, -1).toList();
 
-        Verify.assertEquals(1, integers.size());
-        Verify.assertEquals(2, integers.getFirst());
+        assertEquals(1, integers.size());
+        assertEquals(2, integers.getFirst());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -156,16 +164,16 @@ public class LongIntervalTest
         LongInterval interval3 = LongInterval.zeroTo(5);
         Verify.assertPostSerializedEqualsAndHashCode(interval1);
         Verify.assertEqualsAndHashCode(interval1, interval2);
-        Assert.assertNotEquals(interval1, interval3);
-        Assert.assertNotEquals(interval3, interval1);
+        assertNotEquals(interval1, interval3);
+        assertNotEquals(interval3, interval1);
 
         Verify.assertEqualsAndHashCode(LongInterval.fromToBy(1, 5, 2), LongInterval.fromToBy(1, 6, 2));
         Verify.assertEqualsAndHashCode(LongArrayList.newListWith(1, 2, 3), LongInterval.fromTo(1, 3));
         Verify.assertEqualsAndHashCode(LongArrayList.newListWith(3, 2, 1), LongInterval.fromTo(3, 1));
 
-        Assert.assertNotEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.fromTo(1, 3));
-        Assert.assertNotEquals(LongArrayList.newListWith(1, 2, 4), LongInterval.fromTo(1, 3));
-        Assert.assertNotEquals(LongArrayList.newListWith(3, 2, 0), LongInterval.fromTo(3, 1));
+        assertNotEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.fromTo(1, 3));
+        assertNotEquals(LongArrayList.newListWith(1, 2, 4), LongInterval.fromTo(1, 3));
+        assertNotEquals(LongArrayList.newListWith(3, 2, 0), LongInterval.fromTo(3, 1));
 
         Verify.assertEqualsAndHashCode(LongArrayList.newListWith(-1, -2, -3), LongInterval.fromTo(-1, -3));
 
@@ -179,34 +187,34 @@ public class LongIntervalTest
         LongInterval interval6 = LongInterval.fromTo(0, -999);
         Verify.assertPostSerializedEqualsAndHashCode(interval4);
         Verify.assertEqualsAndHashCode(interval4, interval5);
-        Assert.assertNotEquals(interval4, interval6);
-        Assert.assertNotEquals(interval6, interval4);
+        assertNotEquals(interval4, interval6);
+        assertNotEquals(interval6, interval4);
     }
 
     @Test
     public void sumLongInterval()
     {
-        Assert.assertEquals(15, (int) LongInterval.oneTo(5).sum());
+        assertEquals(15, (int) LongInterval.oneTo(5).sum());
     }
 
     @Test
     public void maxLongInterval()
     {
         long value = LongInterval.oneTo(5).max();
-        Assert.assertEquals(5L, value);
+        assertEquals(5L, value);
     }
 
     @Test
     public void iterator()
     {
         LongIterator iterator = this.longInterval.longIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(1L, iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(2L, iterator.next());
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertEquals(3L, iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertEquals(1L, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(2L, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(3L, iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -227,7 +235,7 @@ public class LongIntervalTest
         long[] sum = new long[1];
         this.longInterval.forEach(each -> sum[0] += each);
 
-        Assert.assertEquals(6L, sum[0]);
+        assertEquals(6L, sum[0]);
     }
 
     @Test
@@ -236,11 +244,11 @@ public class LongIntervalTest
         MutableLongList list1 = LongLists.mutable.empty();
         LongInterval interval1 = LongInterval.oneTo(5);
         interval1.each(list1::add);
-        Assert.assertEquals(list1, interval1);
+        assertEquals(list1, interval1);
         LongInterval interval2 = LongInterval.fromTo(5, 1);
         MutableLongList list2 = LongLists.mutable.empty();
         interval2.each(list2::add);
-        Assert.assertEquals(list2, interval2);
+        assertEquals(list2, interval2);
     }
 
     @Test
@@ -248,10 +256,10 @@ public class LongIntervalTest
     {
         LongInterval longInterval1 = LongInterval.oneTo(3);
         MutableLong result = longInterval1.injectInto(new MutableLong(0), MutableLong::add);
-        Assert.assertEquals(new MutableLong(6), result);
+        assertEquals(new MutableLong(6), result);
         LongInterval longInterval2 = LongInterval.fromTo(3, 1);
         MutableLong result2 = longInterval2.injectInto(new MutableLong(0), MutableLong::add);
-        Assert.assertEquals(new MutableLong(6), result2);
+        assertEquals(new MutableLong(6), result2);
     }
 
     @Test
@@ -259,10 +267,10 @@ public class LongIntervalTest
     {
         LongInterval interval1 = LongInterval.oneTo(3);
         MutableLong result1 = this.longInterval.injectIntoWithIndex(new MutableLong(0), (object, value, index) -> object.add(value * interval1.get(index)));
-        Assert.assertEquals(new MutableLong(14), result1);
+        assertEquals(new MutableLong(14), result1);
         LongInterval interval2 = LongInterval.fromTo(3, 1);
         MutableLong result2 = interval2.injectIntoWithIndex(new MutableLong(0), (object, value, index) -> object.add(value * this.longInterval.get(index)));
-        Assert.assertEquals(new MutableLong(10), result2);
+        assertEquals(new MutableLong(10), result2);
     }
 
     @Test
@@ -270,7 +278,7 @@ public class LongIntervalTest
     {
         LongInterval interval = LongInterval.fromToBy(2, 2, -2);
 
-        Assert.assertEquals(new MutableLong(0), interval.injectInto(new MutableLong(-2), MutableLong::add));
+        assertEquals(new MutableLong(0), interval.injectInto(new MutableLong(-2), MutableLong::add));
     }
 
     @Test
@@ -281,14 +289,14 @@ public class LongIntervalTest
                 LongInterval.fromToBy(0, 1, 1),
                 LongInterval.fromToBy(2, 3, 1),
                 LongInterval.fromToBy(4, 5, 1));
-        Assert.assertEquals(expected1, interval1.chunk(2));
+        assertEquals(expected1, interval1.chunk(2));
 
         LongInterval interval2 = LongInterval.fromToBy(0, -5, -1);
         MutableList<LongInterval> expected2 = Lists.mutable.with(
                 LongInterval.fromToBy(0, -1, -1),
                 LongInterval.fromToBy(-2, -3, -1),
                 LongInterval.fromToBy(-4, -5, -1));
-        Assert.assertEquals(expected2, interval2.chunk(2));
+        assertEquals(expected2, interval2.chunk(2));
 
         LongInterval interval3 = LongInterval.fromToBy(0, 6, 1);
         MutableList<LongInterval> expected3 = Lists.mutable.with(
@@ -296,7 +304,7 @@ public class LongIntervalTest
                 LongInterval.fromToBy(2, 3, 1),
                 LongInterval.fromToBy(4, 5, 1),
                 LongInterval.fromToBy(6, 6, 1));
-        Assert.assertEquals(expected3, interval3.chunk(2));
+        assertEquals(expected3, interval3.chunk(2));
 
         LongInterval interval4 = LongInterval.fromToBy(0, -6, -1);
         MutableList<LongInterval> expected4 = Lists.mutable.with(
@@ -305,46 +313,46 @@ public class LongIntervalTest
                 LongInterval.fromToBy(-4, -5, -1),
                 LongInterval.fromToBy(-6, -6, -1));
         RichIterable<LongIterable> actual4 = interval4.chunk(2);
-        Assert.assertEquals(expected4, actual4);
+        assertEquals(expected4, actual4);
 
         LongInterval interval5 = LongInterval.fromToBy(0, 6, 1);
         MutableList<LongInterval> expected5 = Lists.mutable.with(LongInterval.fromToBy(0, 6, 1));
-        Assert.assertEquals(expected5, interval5.chunk(7));
+        assertEquals(expected5, interval5.chunk(7));
 
         LongInterval interval6 = LongInterval.fromToBy(0, -6, -1);
         MutableList<LongInterval> expected6 = Lists.mutable.with(LongInterval.fromToBy(0, -6, -1));
-        Assert.assertEquals(expected6, interval6.chunk(7));
+        assertEquals(expected6, interval6.chunk(7));
 
         LongInterval interval7 = LongInterval.fromToBy(0, 6, 1);
         MutableList<LongInterval> expected7 = Lists.mutable.with(LongInterval.fromToBy(0, 6, 1));
-        Assert.assertEquals(expected7, interval7.chunk(8));
+        assertEquals(expected7, interval7.chunk(8));
 
         LongInterval interval8 = LongInterval.fromToBy(0, -6, -1);
         MutableList<LongInterval> expected8 = Lists.mutable.with(LongInterval.fromToBy(0, -6, -1));
-        Assert.assertEquals(expected8, interval8.chunk(8));
+        assertEquals(expected8, interval8.chunk(8));
 
         LongInterval interval9 = LongInterval.fromToBy(0, 9, 4);
         MutableList<LongIterable> expected9 = Lists.mutable.with(
                 LongLists.mutable.with(0, 4),
                 LongLists.mutable.with(8));
-        Assert.assertEquals(expected9, interval9.chunk(2));
+        assertEquals(expected9, interval9.chunk(2));
 
         LongInterval interval10 = LongInterval.fromToBy(0, -9, -4);
         MutableList<LongIterable> expected10 = Lists.mutable.with(
                 LongLists.mutable.with(0, -4),
                 LongLists.mutable.with(-8));
-        Assert.assertEquals(expected10, interval10.chunk(2));
+        assertEquals(expected10, interval10.chunk(2));
 
         LongInterval interval11 = LongInterval.fromToBy(0, 5, 3);
         MutableList<LongIterable> expected11 = Lists.mutable.with(LongLists.mutable.with(0, 3));
-        Assert.assertEquals(expected11, interval11.chunk(3));
+        assertEquals(expected11, interval11.chunk(3));
 
         LongInterval interval12 = LongInterval.fromToBy(0, -5, -3);
         MutableList<LongIterable> expected12 = Lists.mutable.with(LongLists.mutable.with(0, -3));
-        Assert.assertEquals(expected12, interval12.chunk(3));
+        assertEquals(expected12, interval12.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> interval12.chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> interval12.chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> interval12.chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> interval12.chunk(-1));
     }
 
     @Test
@@ -387,7 +395,7 @@ public class LongIntervalTest
     public void dotProduct()
     {
         LongInterval interval = LongInterval.oneTo(3);
-        Assert.assertEquals(14, this.longInterval.dotProduct(interval));
+        assertEquals(14, this.longInterval.dotProduct(interval));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -400,39 +408,39 @@ public class LongIntervalTest
     @Test
     public void empty()
     {
-        Assert.assertTrue(this.longInterval.notEmpty());
-        Assert.assertFalse(this.longInterval.isEmpty());
+        assertTrue(this.longInterval.notEmpty());
+        assertFalse(this.longInterval.isEmpty());
         Verify.assertNotEmpty(this.longInterval);
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, LongInterval.zeroTo(2).count(LongPredicates.greaterThan(0)));
+        assertEquals(2L, LongInterval.zeroTo(2).count(LongPredicates.greaterThan(0)));
 
         int count = LongInterval.fromToBy(Integer.MAX_VALUE - 10, Integer.MAX_VALUE, 8).count(LongPredicates.greaterThan(0));
-        Assert.assertEquals(2, count);
+        assertEquals(2, count);
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(LongInterval.fromTo(-1, 2).anySatisfy(LongPredicates.greaterThan(0)));
-        Assert.assertFalse(LongInterval.oneTo(2).anySatisfy(LongPredicates.equal(0)));
+        assertTrue(LongInterval.fromTo(-1, 2).anySatisfy(LongPredicates.greaterThan(0)));
+        assertFalse(LongInterval.oneTo(2).anySatisfy(LongPredicates.equal(0)));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(LongInterval.zeroTo(2).allSatisfy(LongPredicates.greaterThan(0)));
-        Assert.assertTrue(LongInterval.oneTo(3).allSatisfy(LongPredicates.greaterThan(0)));
+        assertFalse(LongInterval.zeroTo(2).allSatisfy(LongPredicates.greaterThan(0)));
+        assertTrue(LongInterval.oneTo(3).allSatisfy(LongPredicates.greaterThan(0)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(LongInterval.zeroTo(2).noneSatisfy(LongPredicates.isEven()));
-        Assert.assertTrue(LongInterval.evensFromTo(2, 10).noneSatisfy(LongPredicates.isOdd()));
+        assertFalse(LongInterval.zeroTo(2).noneSatisfy(LongPredicates.isEven()));
+        assertTrue(LongInterval.evensFromTo(2, 10).noneSatisfy(LongPredicates.isOdd()));
     }
 
     @Test
@@ -452,141 +460,141 @@ public class LongIntervalTest
     @Test
     public void detectIfNone()
     {
-        Assert.assertEquals(1L, this.longInterval.detectIfNone(LongPredicates.lessThan(4), 0));
-        Assert.assertEquals(0L, this.longInterval.detectIfNone(LongPredicates.greaterThan(3), 0));
+        assertEquals(1L, this.longInterval.detectIfNone(LongPredicates.lessThan(4), 0));
+        assertEquals(0L, this.longInterval.detectIfNone(LongPredicates.greaterThan(3), 0));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(FastList.newListWith(0L, 1L, 2L), this.longInterval.collect(parameter -> parameter - 1).toList());
+        assertEquals(FastList.newListWith(0L, 1L, 2L), this.longInterval.collect(parameter -> parameter - 1).toList());
     }
 
     @Test
     public void lazyCollectPrimitives()
     {
-        Assert.assertEquals(BooleanLists.immutable.of(false, true, false), LongInterval.oneTo(3).asLazy().collectBoolean(e -> e % 2 == 0).toList());
-        Assert.assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), LongInterval.oneTo(3).asLazy().collectChar(e -> (char) (e + 1)).toList());
-        Assert.assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), LongInterval.oneTo(3).asLazy().collectByte(e -> (byte) (e + 1)).toList());
-        Assert.assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), LongInterval.oneTo(3).asLazy().collectShort(e -> (short) (e + 1)).toList());
-        Assert.assertEquals(LongLists.immutable.of(2, 3, 4), LongInterval.oneTo(3).asLazy().collectLong(e -> e + 1).toList());
-        Assert.assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), LongInterval.oneTo(3).asLazy().collectFloat(e -> (float) (e + 1)).toList());
-        Assert.assertEquals(LongLists.immutable.of(2L, 3L, 4L), LongInterval.oneTo(3).asLazy().collectLong(e -> (long) (e + 1)).toList());
-        Assert.assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), LongInterval.oneTo(3).asLazy().collectDouble(e -> (double) (e + 1)).toList());
+        assertEquals(BooleanLists.immutable.of(false, true, false), LongInterval.oneTo(3).asLazy().collectBoolean(e -> e % 2 == 0).toList());
+        assertEquals(CharLists.immutable.of((char) 2, (char) 3, (char) 4), LongInterval.oneTo(3).asLazy().collectChar(e -> (char) (e + 1)).toList());
+        assertEquals(ByteLists.immutable.of((byte) 2, (byte) 3, (byte) 4), LongInterval.oneTo(3).asLazy().collectByte(e -> (byte) (e + 1)).toList());
+        assertEquals(ShortLists.immutable.of((short) 2, (short) 3, (short) 4), LongInterval.oneTo(3).asLazy().collectShort(e -> (short) (e + 1)).toList());
+        assertEquals(LongLists.immutable.of(2, 3, 4), LongInterval.oneTo(3).asLazy().collectLong(e -> e + 1).toList());
+        assertEquals(FloatLists.immutable.of(2.0f, 3.0f, 4.0f), LongInterval.oneTo(3).asLazy().collectFloat(e -> (float) (e + 1)).toList());
+        assertEquals(LongLists.immutable.of(2L, 3L, 4L), LongInterval.oneTo(3).asLazy().collectLong(e -> (long) (e + 1)).toList());
+        assertEquals(DoubleLists.immutable.of(2.0, 3.0, 4.0), LongInterval.oneTo(3).asLazy().collectDouble(e -> (double) (e + 1)).toList());
     }
 
     @Test
     public void binarySearch()
     {
         LongInterval interval1 = LongInterval.oneTo(3);
-        Assert.assertEquals(-1, interval1.binarySearch(-1));
-        Assert.assertEquals(-1, interval1.binarySearch(0));
-        Assert.assertEquals(0, interval1.binarySearch(1));
-        Assert.assertEquals(1, interval1.binarySearch(2));
-        Assert.assertEquals(2, interval1.binarySearch(3));
-        Assert.assertEquals(-4, interval1.binarySearch(4));
-        Assert.assertEquals(-4, interval1.binarySearch(5));
+        assertEquals(-1, interval1.binarySearch(-1));
+        assertEquals(-1, interval1.binarySearch(0));
+        assertEquals(0, interval1.binarySearch(1));
+        assertEquals(1, interval1.binarySearch(2));
+        assertEquals(2, interval1.binarySearch(3));
+        assertEquals(-4, interval1.binarySearch(4));
+        assertEquals(-4, interval1.binarySearch(5));
 
         LongInterval interval2 = LongInterval.fromTo(7, 17).by(3);
-        Assert.assertEquals(0, interval2.binarySearch(7));
-        Assert.assertEquals(1, interval2.binarySearch(10));
-        Assert.assertEquals(2, interval2.binarySearch(13));
-        Assert.assertEquals(3, interval2.binarySearch(16));
-        Assert.assertEquals(-1, interval2.binarySearch(6));
-        Assert.assertEquals(-2, interval2.binarySearch(8));
-        Assert.assertEquals(-2, interval2.binarySearch(9));
-        Assert.assertEquals(-3, interval2.binarySearch(12));
-        Assert.assertEquals(-4, interval2.binarySearch(15));
-        Assert.assertEquals(-5, interval2.binarySearch(17));
-        Assert.assertEquals(-5, interval2.binarySearch(19));
+        assertEquals(0, interval2.binarySearch(7));
+        assertEquals(1, interval2.binarySearch(10));
+        assertEquals(2, interval2.binarySearch(13));
+        assertEquals(3, interval2.binarySearch(16));
+        assertEquals(-1, interval2.binarySearch(6));
+        assertEquals(-2, interval2.binarySearch(8));
+        assertEquals(-2, interval2.binarySearch(9));
+        assertEquals(-3, interval2.binarySearch(12));
+        assertEquals(-4, interval2.binarySearch(15));
+        assertEquals(-5, interval2.binarySearch(17));
+        assertEquals(-5, interval2.binarySearch(19));
 
         LongInterval interval3 = LongInterval.fromTo(-21, -11).by(5);
-        Assert.assertEquals(-1, interval3.binarySearch(-22));
-        Assert.assertEquals(0, interval3.binarySearch(-21));
-        Assert.assertEquals(-2, interval3.binarySearch(-17));
-        Assert.assertEquals(1, interval3.binarySearch(-16));
-        Assert.assertEquals(-3, interval3.binarySearch(-15));
-        Assert.assertEquals(2, interval3.binarySearch(-11));
-        Assert.assertEquals(-4, interval3.binarySearch(-9));
+        assertEquals(-1, interval3.binarySearch(-22));
+        assertEquals(0, interval3.binarySearch(-21));
+        assertEquals(-2, interval3.binarySearch(-17));
+        assertEquals(1, interval3.binarySearch(-16));
+        assertEquals(-3, interval3.binarySearch(-15));
+        assertEquals(2, interval3.binarySearch(-11));
+        assertEquals(-4, interval3.binarySearch(-9));
 
         LongInterval interval4 = LongInterval.fromTo(50, 30).by(-10);
-        Assert.assertEquals(-1, interval4.binarySearch(60));
-        Assert.assertEquals(0, interval4.binarySearch(50));
-        Assert.assertEquals(-2, interval4.binarySearch(45));
-        Assert.assertEquals(1, interval4.binarySearch(40));
-        Assert.assertEquals(-3, interval4.binarySearch(35));
-        Assert.assertEquals(2, interval4.binarySearch(30));
-        Assert.assertEquals(-4, interval4.binarySearch(25));
+        assertEquals(-1, interval4.binarySearch(60));
+        assertEquals(0, interval4.binarySearch(50));
+        assertEquals(-2, interval4.binarySearch(45));
+        assertEquals(1, interval4.binarySearch(40));
+        assertEquals(-3, interval4.binarySearch(35));
+        assertEquals(2, interval4.binarySearch(30));
+        assertEquals(-4, interval4.binarySearch(25));
 
         LongInterval interval5 = LongInterval.fromTo(-30, -50).by(-10);
-        Assert.assertEquals(-1, interval5.binarySearch(-20));
-        Assert.assertEquals(0, interval5.binarySearch(-30));
-        Assert.assertEquals(-2, interval5.binarySearch(-35));
-        Assert.assertEquals(1, interval5.binarySearch(-40));
-        Assert.assertEquals(-3, interval5.binarySearch(-47));
-        Assert.assertEquals(2, interval5.binarySearch(-50));
-        Assert.assertEquals(-4, interval5.binarySearch(-65));
+        assertEquals(-1, interval5.binarySearch(-20));
+        assertEquals(0, interval5.binarySearch(-30));
+        assertEquals(-2, interval5.binarySearch(-35));
+        assertEquals(1, interval5.binarySearch(-40));
+        assertEquals(-3, interval5.binarySearch(-47));
+        assertEquals(2, interval5.binarySearch(-50));
+        assertEquals(-4, interval5.binarySearch(-65));
 
         LongInterval interval6 = LongInterval.fromTo(27, -30).by(-9);
-        Assert.assertEquals(-1, interval6.binarySearch(30));
-        Assert.assertEquals(0, interval6.binarySearch(27));
-        Assert.assertEquals(-2, interval6.binarySearch(20));
-        Assert.assertEquals(1, interval6.binarySearch(18));
-        Assert.assertEquals(-3, interval6.binarySearch(15));
-        Assert.assertEquals(2, interval6.binarySearch(9));
-        Assert.assertEquals(-4, interval6.binarySearch(2));
-        Assert.assertEquals(3, interval6.binarySearch(0));
-        Assert.assertEquals(-5, interval6.binarySearch(-7));
-        Assert.assertEquals(4, interval6.binarySearch(-9));
-        Assert.assertEquals(-6, interval6.binarySearch(-12));
-        Assert.assertEquals(5, interval6.binarySearch(-18));
-        Assert.assertEquals(-7, interval6.binarySearch(-23));
-        Assert.assertEquals(6, interval6.binarySearch(-27));
-        Assert.assertEquals(-8, interval6.binarySearch(-28));
-        Assert.assertEquals(-8, interval6.binarySearch(-30));
+        assertEquals(-1, interval6.binarySearch(30));
+        assertEquals(0, interval6.binarySearch(27));
+        assertEquals(-2, interval6.binarySearch(20));
+        assertEquals(1, interval6.binarySearch(18));
+        assertEquals(-3, interval6.binarySearch(15));
+        assertEquals(2, interval6.binarySearch(9));
+        assertEquals(-4, interval6.binarySearch(2));
+        assertEquals(3, interval6.binarySearch(0));
+        assertEquals(-5, interval6.binarySearch(-7));
+        assertEquals(4, interval6.binarySearch(-9));
+        assertEquals(-6, interval6.binarySearch(-12));
+        assertEquals(5, interval6.binarySearch(-18));
+        assertEquals(-7, interval6.binarySearch(-23));
+        assertEquals(6, interval6.binarySearch(-27));
+        assertEquals(-8, interval6.binarySearch(-28));
+        assertEquals(-8, interval6.binarySearch(-30));
 
         LongInterval interval7 = LongInterval.fromTo(-1, 1).by(1);
-        Assert.assertEquals(-1, interval7.binarySearch(-2));
-        Assert.assertEquals(0, interval7.binarySearch(-1));
-        Assert.assertEquals(1, interval7.binarySearch(0));
-        Assert.assertEquals(2, interval7.binarySearch(1));
-        Assert.assertEquals(-4, interval7.binarySearch(2));
+        assertEquals(-1, interval7.binarySearch(-2));
+        assertEquals(0, interval7.binarySearch(-1));
+        assertEquals(1, interval7.binarySearch(0));
+        assertEquals(2, interval7.binarySearch(1));
+        assertEquals(-4, interval7.binarySearch(2));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(9, LongInterval.oneTo(9).max());
-        Assert.assertEquals(5, LongInterval.fromTo(5, 1).max());
-        Assert.assertEquals(1, LongInterval.fromTo(-5, 1).max());
-        Assert.assertEquals(1, LongInterval.fromTo(1, -5).max());
+        assertEquals(9, LongInterval.oneTo(9).max());
+        assertEquals(5, LongInterval.fromTo(5, 1).max());
+        assertEquals(1, LongInterval.fromTo(-5, 1).max());
+        assertEquals(1, LongInterval.fromTo(1, -5).max());
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(1, LongInterval.oneTo(9).min());
-        Assert.assertEquals(1, LongInterval.fromTo(5, 1).min());
-        Assert.assertEquals(-5, LongInterval.fromTo(-5, 1).min());
-        Assert.assertEquals(-5, LongInterval.fromTo(1, -5).min());
+        assertEquals(1, LongInterval.oneTo(9).min());
+        assertEquals(1, LongInterval.fromTo(5, 1).min());
+        assertEquals(-5, LongInterval.fromTo(-5, 1).min());
+        assertEquals(-5, LongInterval.fromTo(1, -5).min());
     }
 
     @Test
     public void minIfEmpty()
     {
-        Assert.assertEquals(1, LongInterval.oneTo(9).minIfEmpty(0));
+        assertEquals(1, LongInterval.oneTo(9).minIfEmpty(0));
     }
 
     @Test
     public void maxIfEmpty()
     {
-        Assert.assertEquals(9, LongInterval.oneTo(9).maxIfEmpty(0));
+        assertEquals(9, LongInterval.oneTo(9).maxIfEmpty(0));
     }
 
     @Test
     public void sum()
     {
-        Assert.assertEquals(10L, LongInterval.oneTo(4).sum());
+        assertEquals(10L, LongInterval.oneTo(4).sum());
     }
 
     @Test
@@ -594,7 +602,7 @@ public class LongIntervalTest
     {
         // checks there is no overflow the during calculation of sum() as long as the final result is <= Long.MAX_VALUE
 
-        Assert.assertEquals(Long.MAX_VALUE, LongInterval.fromTo(Long.MAX_VALUE, Long.MAX_VALUE).sum());
+        assertEquals(Long.MAX_VALUE, LongInterval.fromTo(Long.MAX_VALUE, Long.MAX_VALUE).sum());
 
         long l = Long.MAX_VALUE / 5L;
         long expectedSum = 0;
@@ -605,65 +613,65 @@ public class LongIntervalTest
 
             long actualSum = LongInterval.fromTo(l, l + i).sum();
 
-            Assert.assertEquals("interval size : " + (i + 1), expectedSum, actualSum);
-            Assert.assertTrue(actualSum > 0L);
+            assertEquals("interval size : " + (i + 1), expectedSum, actualSum);
+            assertTrue(actualSum > 0L);
         }
     }
 
     @Test
     public void average()
     {
-        Assert.assertEquals(2.5, LongInterval.oneTo(4).average(), 0.0);
+        assertEquals(2.5, LongInterval.oneTo(4).average(), 0.0);
     }
 
     @Test
     public void median()
     {
-        Assert.assertEquals(2.5, LongInterval.oneTo(4).median(), 0.0);
-        Assert.assertEquals(3.0, LongInterval.oneTo(5).median(), 0.0);
+        assertEquals(2.5, LongInterval.oneTo(4).median(), 0.0);
+        assertEquals(3.0, LongInterval.oneTo(5).median(), 0.0);
     }
 
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new long[]{1, 2, 3, 4}, LongInterval.oneTo(4).toArray());
+        assertArrayEquals(new long[]{1, 2, 3, 4}, LongInterval.oneTo(4).toArray());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.oneTo(4).toList());
+        assertEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.oneTo(4).toList());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.oneTo(4).toReversed().toSortedList());
+        assertEquals(LongArrayList.newListWith(1, 2, 3, 4), LongInterval.oneTo(4).toReversed().toSortedList());
     }
 
     @Test
     public void toSet()
     {
-        Assert.assertEquals(LongHashSet.newSetWith(1, 2, 3, 4), LongInterval.oneTo(4).toSet());
+        assertEquals(LongHashSet.newSetWith(1, 2, 3, 4), LongInterval.oneTo(4).toSet());
     }
 
     @Test
     public void toBag()
     {
-        Assert.assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), LongInterval.oneTo(4).toBag());
+        assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), LongInterval.oneTo(4).toBag());
     }
 
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(LongInterval.oneTo(5).toSet(), LongInterval.oneTo(5).asLazy().toSet());
+        assertEquals(LongInterval.oneTo(5).toSet(), LongInterval.oneTo(5).asLazy().toSet());
         Verify.assertInstanceOf(LazyLongIterable.class, LongInterval.oneTo(5).asLazy());
     }
 
     @Test
     public void toSortedArray()
     {
-        Assert.assertArrayEquals(new long[]{1, 2, 3, 4}, LongInterval.fromTo(4, 1).toSortedArray());
+        assertArrayEquals(new long[]{1, 2, 3, 4}, LongInterval.fromTo(4, 1).toSortedArray());
     }
 
     @Test
@@ -677,29 +685,29 @@ public class LongIntervalTest
 
         Verify.assertEqualsAndHashCode(list1, list2);
         Verify.assertPostSerializedEqualsAndHashCode(list1);
-        Assert.assertNotEquals(list1, list3);
-        Assert.assertNotEquals(list1, list4);
-        Assert.assertNotEquals(list1, list5);
+        assertNotEquals(list1, list3);
+        assertNotEquals(list1, list4);
+        assertNotEquals(list1, list5);
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(FastList.newListWith(1, 2, 3).hashCode(), LongInterval.oneTo(3).hashCode());
+        assertEquals(FastList.newListWith(1, 2, 3).hashCode(), LongInterval.oneTo(3).hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.longInterval.toString());
+        assertEquals("[1, 2, 3]", this.longInterval.toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.longInterval.makeString());
-        Assert.assertEquals("1/2/3", this.longInterval.makeString("/"));
-        Assert.assertEquals(this.longInterval.toString(), this.longInterval.makeString("[", ", ", "]"));
+        assertEquals("1, 2, 3", this.longInterval.makeString());
+        assertEquals("1/2/3", this.longInterval.makeString("/"));
+        assertEquals(this.longInterval.toString(), this.longInterval.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -707,26 +715,26 @@ public class LongIntervalTest
     {
         StringBuilder appendable2 = new StringBuilder();
         this.longInterval.appendString(appendable2);
-        Assert.assertEquals("1, 2, 3", appendable2.toString());
+        assertEquals("1, 2, 3", appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         this.longInterval.appendString(appendable3, "/");
-        Assert.assertEquals("1/2/3", appendable3.toString());
+        assertEquals("1/2/3", appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.longInterval.appendString(appendable4, "[", ", ", "]");
-        Assert.assertEquals(this.longInterval.toString(), appendable4.toString());
+        assertEquals(this.longInterval.toString(), appendable4.toString());
     }
 
     @Test
     public void appendStringThrows()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.longInterval.appendString(new ThrowingAppendable()));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.longInterval
                         .appendString(new ThrowingAppendable(), ", "));
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> this.longInterval
                         .appendString(new ThrowingAppendable(), "[", ", ", "]"));
@@ -737,7 +745,7 @@ public class LongIntervalTest
     {
         LongInterval forward = LongInterval.oneTo(5);
         LongInterval reverse = forward.toReversed();
-        Assert.assertEquals(LongArrayList.newListWith(5, 4, 3, 2, 1), reverse);
+        assertEquals(LongArrayList.newListWith(5, 4, 3, 2, 1), reverse);
     }
 
     @Test
@@ -748,31 +756,31 @@ public class LongIntervalTest
         int[] odds = {1, 3, 5, 7, 9};
         this.assertLongIntervalContainsAll(interval, evens);
         this.denyLongIntervalContainsAny(interval, odds);
-        Assert.assertEquals(6, interval.size());
+        assertEquals(6, interval.size());
 
         LongInterval reverseLongInterval = LongInterval.evensFromTo(10, 0);
         this.assertLongIntervalContainsAll(reverseLongInterval, evens);
         this.denyLongIntervalContainsAny(reverseLongInterval, odds);
-        Assert.assertEquals(6, reverseLongInterval.size());
+        assertEquals(6, reverseLongInterval.size());
 
         LongInterval negativeLongInterval = LongInterval.evensFromTo(-5, 5);
         int[] negativeEvens = {-4, -2, 0, 2, 4};
         int[] negativeOdds = {-3, -1, 1, 3};
         this.assertLongIntervalContainsAll(negativeLongInterval, negativeEvens);
         this.denyLongIntervalContainsAny(negativeLongInterval, negativeOdds);
-        Assert.assertEquals(5, negativeLongInterval.size());
+        assertEquals(5, negativeLongInterval.size());
 
         LongInterval reverseNegativeLongInterval = LongInterval.evensFromTo(5, -5);
         this.assertLongIntervalContainsAll(reverseNegativeLongInterval, negativeEvens);
         this.denyLongIntervalContainsAny(reverseNegativeLongInterval, negativeOdds);
-        Assert.assertEquals(5, reverseNegativeLongInterval.size());
+        assertEquals(5, reverseNegativeLongInterval.size());
     }
 
     private void assertLongIntervalContainsAll(LongInterval interval, int[] expectedValues)
     {
         for (int value : expectedValues)
         {
-            Assert.assertTrue(interval.contains(value));
+            assertTrue(interval.contains(value));
         }
     }
 
@@ -780,7 +788,7 @@ public class LongIntervalTest
     {
         for (int value : expectedValues)
         {
-            Assert.assertFalse(interval.contains(value));
+            assertFalse(interval.contains(value));
         }
     }
 
@@ -788,75 +796,75 @@ public class LongIntervalTest
     public void odds()
     {
         LongInterval interval1 = LongInterval.oddsFromTo(0, 10);
-        Assert.assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(interval1.containsNone(2, 4, 6, 8));
-        Assert.assertEquals(5, interval1.size());
+        assertTrue(interval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(interval1.containsNone(2, 4, 6, 8));
+        assertEquals(5, interval1.size());
 
         LongInterval reverseLongInterval1 = LongInterval.oddsFromTo(10, 0);
-        Assert.assertTrue(reverseLongInterval1.containsAll(1, 3, 5, 7, 9));
-        Assert.assertTrue(reverseLongInterval1.containsNone(0, 2, 4, 6, 8, 10));
-        Assert.assertEquals(5, reverseLongInterval1.size());
+        assertTrue(reverseLongInterval1.containsAll(1, 3, 5, 7, 9));
+        assertTrue(reverseLongInterval1.containsNone(0, 2, 4, 6, 8, 10));
+        assertEquals(5, reverseLongInterval1.size());
 
         LongInterval interval2 = LongInterval.oddsFromTo(-5, 5);
-        Assert.assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
-        Assert.assertEquals(6, interval2.size());
+        assertTrue(interval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(interval2.containsNone(-4, -2, 0, 2, 4));
+        assertEquals(6, interval2.size());
 
         LongInterval reverseLongInterval2 = LongInterval.oddsFromTo(5, -5);
-        Assert.assertTrue(reverseLongInterval2.containsAll(-5, -3, -1, 1, 3, 5));
-        Assert.assertTrue(reverseLongInterval2.containsNone(-4, -2, 0, 2, 4));
-        Assert.assertEquals(6, reverseLongInterval2.size());
+        assertTrue(reverseLongInterval2.containsAll(-5, -3, -1, 1, 3, 5));
+        assertTrue(reverseLongInterval2.containsNone(-4, -2, 0, 2, 4));
+        assertEquals(6, reverseLongInterval2.size());
     }
 
     @Test
     public void intervalSize()
     {
-        Assert.assertEquals(100, LongInterval.fromTo(1, 100).size());
-        Assert.assertEquals(50, LongInterval.fromToBy(1, 100, 2).size());
-        Assert.assertEquals(34, LongInterval.fromToBy(1, 100, 3).size());
-        Assert.assertEquals(25, LongInterval.fromToBy(1, 100, 4).size());
-        Assert.assertEquals(20, LongInterval.fromToBy(1, 100, 5).size());
-        Assert.assertEquals(17, LongInterval.fromToBy(1, 100, 6).size());
-        Assert.assertEquals(15, LongInterval.fromToBy(1, 100, 7).size());
-        Assert.assertEquals(13, LongInterval.fromToBy(1, 100, 8).size());
-        Assert.assertEquals(12, LongInterval.fromToBy(1, 100, 9).size());
-        Assert.assertEquals(10, LongInterval.fromToBy(1, 100, 10).size());
-        Assert.assertEquals(11, LongInterval.fromTo(0, 10).size());
-        Assert.assertEquals(1, LongInterval.zero().size());
-        Assert.assertEquals(11, LongInterval.fromTo(0, -10).size());
-        Assert.assertEquals(3, LongInterval.evensFromTo(2, -2).size());
-        Assert.assertEquals(2, LongInterval.oddsFromTo(2, -2).size());
-        Assert.assertEquals(1, LongInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000).size());
-        Assert.assertEquals(1, LongInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000).size());
+        assertEquals(100, LongInterval.fromTo(1, 100).size());
+        assertEquals(50, LongInterval.fromToBy(1, 100, 2).size());
+        assertEquals(34, LongInterval.fromToBy(1, 100, 3).size());
+        assertEquals(25, LongInterval.fromToBy(1, 100, 4).size());
+        assertEquals(20, LongInterval.fromToBy(1, 100, 5).size());
+        assertEquals(17, LongInterval.fromToBy(1, 100, 6).size());
+        assertEquals(15, LongInterval.fromToBy(1, 100, 7).size());
+        assertEquals(13, LongInterval.fromToBy(1, 100, 8).size());
+        assertEquals(12, LongInterval.fromToBy(1, 100, 9).size());
+        assertEquals(10, LongInterval.fromToBy(1, 100, 10).size());
+        assertEquals(11, LongInterval.fromTo(0, 10).size());
+        assertEquals(1, LongInterval.zero().size());
+        assertEquals(11, LongInterval.fromTo(0, -10).size());
+        assertEquals(3, LongInterval.evensFromTo(2, -2).size());
+        assertEquals(2, LongInterval.oddsFromTo(2, -2).size());
+        assertEquals(1, LongInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000).size());
+        assertEquals(1, LongInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000).size());
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(LongInterval.zero().contains(0));
-        Assert.assertTrue(LongInterval.oneTo(5).containsAll(1, 5));
-        Assert.assertTrue(LongInterval.oneTo(5).containsNone(6, 7));
-        Assert.assertFalse(LongInterval.oneTo(5).containsAll(1, 6));
-        Assert.assertFalse(LongInterval.oneTo(5).containsNone(1, 6));
-        Assert.assertFalse(LongInterval.oneTo(5).contains(0));
-        Assert.assertTrue(LongInterval.fromTo(-1, -5).containsAll(-1, -5));
-        Assert.assertFalse(LongInterval.fromTo(-1, -5).contains(1));
+        assertTrue(LongInterval.zero().contains(0));
+        assertTrue(LongInterval.oneTo(5).containsAll(1, 5));
+        assertTrue(LongInterval.oneTo(5).containsNone(6, 7));
+        assertFalse(LongInterval.oneTo(5).containsAll(1, 6));
+        assertFalse(LongInterval.oneTo(5).containsNone(1, 6));
+        assertFalse(LongInterval.oneTo(5).contains(0));
+        assertTrue(LongInterval.fromTo(-1, -5).containsAll(-1, -5));
+        assertFalse(LongInterval.fromTo(-1, -5).contains(1));
 
-        Assert.assertTrue(LongInterval.zero().contains(Integer.valueOf(0)));
-        Assert.assertFalse(LongInterval.oneTo(5).contains(Integer.valueOf(0)));
-        Assert.assertFalse(LongInterval.fromTo(-1, -5).contains(Integer.valueOf(1)));
+        assertTrue(LongInterval.zero().contains(Integer.valueOf(0)));
+        assertFalse(LongInterval.oneTo(5).contains(Integer.valueOf(0)));
+        assertFalse(LongInterval.fromTo(-1, -5).contains(Integer.valueOf(1)));
 
         LongInterval bigLongInterval = LongInterval.fromToBy(Integer.MIN_VALUE, Integer.MAX_VALUE, 1_000_000);
-        Assert.assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + 1_000_000));
-        Assert.assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + 1_000_001));
-        Assert.assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
-        Assert.assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
-        Assert.assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
-        Assert.assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
-        Assert.assertTrue(
+        assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + 1_000_000));
+        assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + 1_000_001));
+        assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_000 * 10)));
+        assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_001 * 10)));
+        assertTrue(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_000 * 100)));
+        assertFalse(bigLongInterval.contains(Integer.MIN_VALUE + (1_000_001 * 100)));
+        assertTrue(
                 LongInterval.fromToBy(1_000_000_000, 2_000_000_000, 1_500_000_000)
                         .contains(1_000_000_000));
-        Assert.assertTrue(
+        assertTrue(
                 LongInterval.fromToBy(-1_000_000_000, -2_000_000_000, -1_500_000_000)
                         .contains(-1_000_000_000));
 
@@ -864,42 +872,42 @@ public class LongIntervalTest
         int maxValue = 1_000_000_000;
         LongInterval largeInterval = LongInterval.fromToBy(minValue, maxValue, 10);
 
-        Assert.assertTrue(largeInterval.containsAll(
+        assertTrue(largeInterval.containsAll(
                 maxValue - 10,
                 maxValue - 100,
                 maxValue - 1000,
                 maxValue - 10000));
-        Assert.assertTrue(largeInterval.contains(minValue + 10));
+        assertTrue(largeInterval.contains(minValue + 10));
     }
 
     @Test
     public void largeReverseUnderflowTest()
     {
         LongInterval reverse = LongInterval.fromToBy(Integer.MAX_VALUE, Integer.MIN_VALUE + 10, -10);
-        Assert.assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
-        Assert.assertEquals(Integer.MAX_VALUE, reverse.getFirst());
+        assertFalse(reverse.contains(Integer.MIN_VALUE + 10));
+        assertEquals(Integer.MAX_VALUE, reverse.getFirst());
         int expectedLast = -2_147_483_633;
-        Assert.assertEquals(expectedLast, reverse.getLast());
-        Assert.assertTrue(reverse.contains(Integer.MAX_VALUE));
-        Assert.assertTrue(reverse.contains(7));
-        Assert.assertTrue(reverse.contains(-3));
-        Assert.assertTrue(reverse.contains(expectedLast));
-        Assert.assertTrue(reverse.contains(expectedLast + 1000));
-        Assert.assertEquals(214_748_364, reverse.indexOf(7));
-        Assert.assertEquals(214_748_365, reverse.indexOf(-3));
-        Assert.assertEquals(429_496_728, reverse.indexOf(expectedLast));
-        Assert.assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
-        Assert.assertEquals(429_496_728, reverse.binarySearch(expectedLast));
+        assertEquals(expectedLast, reverse.getLast());
+        assertTrue(reverse.contains(Integer.MAX_VALUE));
+        assertTrue(reverse.contains(7));
+        assertTrue(reverse.contains(-3));
+        assertTrue(reverse.contains(expectedLast));
+        assertTrue(reverse.contains(expectedLast + 1000));
+        assertEquals(214_748_364, reverse.indexOf(7));
+        assertEquals(214_748_365, reverse.indexOf(-3));
+        assertEquals(429_496_728, reverse.indexOf(expectedLast));
+        assertEquals(429_496_728, reverse.lastIndexOf(expectedLast));
+        assertEquals(429_496_728, reverse.binarySearch(expectedLast));
         int expectedAtIndex300Million = -852_516_353;
-        Assert.assertTrue(reverse.contains(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
-        Assert.assertEquals(300_000_000, reverse.binarySearch(expectedAtIndex300Million));
+        assertTrue(reverse.contains(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.indexOf(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.lastIndexOf(expectedAtIndex300Million));
+        assertEquals(300_000_000, reverse.binarySearch(expectedAtIndex300Million));
         int expectedAtIndex400Million = -1_852_516_353;
-        Assert.assertTrue(reverse.contains(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
-        Assert.assertEquals(400_000_000, reverse.binarySearch(expectedAtIndex400Million));
+        assertTrue(reverse.contains(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.indexOf(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.lastIndexOf(expectedAtIndex400Million));
+        assertEquals(400_000_000, reverse.binarySearch(expectedAtIndex400Million));
     }
 
     @Test
@@ -909,17 +917,17 @@ public class LongIntervalTest
         int second = Integer.MAX_VALUE - 2;
         long expected = (long) from + (long) second;
         LongInterval interval = LongInterval.fromToBy(from, Integer.MAX_VALUE, 8);
-        Assert.assertEquals(2, interval.size());
-        Assert.assertEquals(LongLists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.count(each -> each == second));
+        assertEquals(2, interval.size());
+        assertEquals(LongLists.mutable.with(from, second), interval);
+        assertEquals(1, interval.count(each -> each == second));
         MutableLong result = new MutableLong();
         interval.forEach(result::add);
-        Assert.assertEquals(expected, result.longValue());
+        assertEquals(expected, result.longValue());
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(expected + 1L, result.longValue());
+        assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        assertEquals(
                 expected + 1L,
                 interval
                         .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
@@ -933,18 +941,18 @@ public class LongIntervalTest
         int second = Integer.MIN_VALUE + 2;
         long expected = (long) from + (long) second;
         LongInterval interval = LongInterval.fromToBy(from, Integer.MIN_VALUE, -8);
-        Assert.assertEquals(2, interval.size());
-        Assert.assertEquals(LongLists.mutable.with(from, second), interval);
-        Assert.assertEquals(1, interval.count(each -> each == second));
-        Assert.assertEquals(expected, interval.sum());
+        assertEquals(2, interval.size());
+        assertEquals(LongLists.mutable.with(from, second), interval);
+        assertEquals(1, interval.count(each -> each == second));
+        assertEquals(expected, interval.sum());
         MutableLong result = new MutableLong();
         interval.forEach(result::add);
-        Assert.assertEquals(expected, result.longValue());
+        assertEquals(expected, result.longValue());
         result.clear();
         interval.forEachWithIndex((each, index) -> result.add(each + index));
-        Assert.assertEquals(expected + 1L, result.longValue());
-        Assert.assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
-        Assert.assertEquals(
+        assertEquals(expected + 1L, result.longValue());
+        assertEquals(expected, interval.injectInto(new MutableLong(), MutableLong::add).longValue());
+        assertEquals(
                 expected + 1L,
                 interval
                         .injectIntoWithIndex(new MutableLong(), (value, each, index) -> value.add(each + index))
@@ -956,25 +964,25 @@ public class LongIntervalTest
     {
         LongInterval zero = LongInterval.zero();
         LongIterator zeroIterator = zero.longIterator();
-        Assert.assertTrue(zeroIterator.hasNext());
-        Assert.assertEquals(0, zeroIterator.next());
-        Assert.assertFalse(zeroIterator.hasNext());
+        assertTrue(zeroIterator.hasNext());
+        assertEquals(0, zeroIterator.next());
+        assertFalse(zeroIterator.hasNext());
         LongInterval oneToFive = LongInterval.oneTo(5);
         LongIterator oneToFiveIterator = oneToFive.longIterator();
         for (int i = 1; i < 6; i++)
         {
-            Assert.assertTrue(oneToFiveIterator.hasNext());
-            Assert.assertEquals(i, oneToFiveIterator.next());
+            assertTrue(oneToFiveIterator.hasNext());
+            assertEquals(i, oneToFiveIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
+        assertThrows(NoSuchElementException.class, oneToFiveIterator::next);
         LongInterval threeToNegativeThree = LongInterval.fromTo(3, -3);
         LongIterator threeToNegativeThreeIterator = threeToNegativeThree.longIterator();
         for (int i = 3; i > -4; i--)
         {
-            Assert.assertTrue(threeToNegativeThreeIterator.hasNext());
-            Assert.assertEquals(i, threeToNegativeThreeIterator.next());
+            assertTrue(threeToNegativeThreeIterator.hasNext());
+            assertEquals(i, threeToNegativeThreeIterator.next());
         }
-        Assert.assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
+        assertThrows(NoSuchElementException.class, threeToNegativeThreeIterator::next);
     }
 
     @Test
@@ -982,10 +990,10 @@ public class LongIntervalTest
     {
         IntegerSum sum = new IntegerSum(0);
         LongInterval.oneTo(5).forEachWithIndex((each, index) -> sum.add(each + index));
-        Assert.assertEquals(25, sum.getIntSum());
+        assertEquals(25, sum.getIntSum());
         IntegerSum zeroSum = new IntegerSum(0);
         LongInterval.fromTo(0, -4).forEachWithIndex((each, index) -> zeroSum.add(each + index));
-        Assert.assertEquals(0, zeroSum.getIntSum());
+        assertEquals(0, zeroSum.getIntSum());
     }
 
     @Test
@@ -996,119 +1004,119 @@ public class LongIntervalTest
         LongInterval interval = LongInterval.fromToBy(2, 2, -2);
         interval.forEach((LongProcedure) each -> counter.add(1));
 
-        Assert.assertEquals(1, counter.toLong().intValue());
+        assertEquals(1, counter.toLong().intValue());
     }
 
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(10, LongInterval.fromTo(10, -10).by(-5).getFirst());
-        Assert.assertEquals(-10, LongInterval.fromTo(-10, 10).by(5).getFirst());
-        Assert.assertEquals(0, LongInterval.zero().getFirst());
+        assertEquals(10, LongInterval.fromTo(10, -10).by(-5).getFirst());
+        assertEquals(-10, LongInterval.fromTo(-10, 10).by(5).getFirst());
+        assertEquals(0, LongInterval.zero().getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals(-10, LongInterval.fromTo(10, -10).by(-5).getLast());
-        Assert.assertEquals(-10, LongInterval.fromTo(10, -12).by(-5).getLast());
-        Assert.assertEquals(10, LongInterval.fromTo(-10, 10).by(5).getLast());
-        Assert.assertEquals(10, LongInterval.fromTo(-10, 12).by(5).getLast());
-        Assert.assertEquals(0, LongInterval.zero().getLast());
+        assertEquals(-10, LongInterval.fromTo(10, -10).by(-5).getLast());
+        assertEquals(-10, LongInterval.fromTo(10, -12).by(-5).getLast());
+        assertEquals(10, LongInterval.fromTo(-10, 10).by(5).getLast());
+        assertEquals(10, LongInterval.fromTo(-10, 12).by(5).getLast());
+        assertEquals(0, LongInterval.zero().getLast());
     }
 
     @Test
     public void indexOf()
     {
         LongInterval interval = LongInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.indexOf(-10));
-        Assert.assertEquals(1, interval.indexOf(-5));
-        Assert.assertEquals(2, interval.indexOf(0));
-        Assert.assertEquals(3, interval.indexOf(5));
-        Assert.assertEquals(4, interval.indexOf(10));
+        assertEquals(0, interval.indexOf(-10));
+        assertEquals(1, interval.indexOf(-5));
+        assertEquals(2, interval.indexOf(0));
+        assertEquals(3, interval.indexOf(5));
+        assertEquals(4, interval.indexOf(10));
 
-        Assert.assertEquals(-1, interval.indexOf(-15));
-        Assert.assertEquals(-1, interval.indexOf(-11));
-        Assert.assertEquals(-1, interval.indexOf(-9));
-        Assert.assertEquals(-1, interval.indexOf(11));
-        Assert.assertEquals(-1, interval.indexOf(15));
+        assertEquals(-1, interval.indexOf(-15));
+        assertEquals(-1, interval.indexOf(-11));
+        assertEquals(-1, interval.indexOf(-9));
+        assertEquals(-1, interval.indexOf(11));
+        assertEquals(-1, interval.indexOf(15));
 
         LongInterval backwardsLongInterval = LongInterval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsLongInterval.indexOf(10));
-        Assert.assertEquals(1, backwardsLongInterval.indexOf(5));
-        Assert.assertEquals(2, backwardsLongInterval.indexOf(0));
-        Assert.assertEquals(3, backwardsLongInterval.indexOf(-5));
-        Assert.assertEquals(4, backwardsLongInterval.indexOf(-10));
+        assertEquals(0, backwardsLongInterval.indexOf(10));
+        assertEquals(1, backwardsLongInterval.indexOf(5));
+        assertEquals(2, backwardsLongInterval.indexOf(0));
+        assertEquals(3, backwardsLongInterval.indexOf(-5));
+        assertEquals(4, backwardsLongInterval.indexOf(-10));
 
-        Assert.assertEquals(-1, backwardsLongInterval.indexOf(15));
-        Assert.assertEquals(-1, backwardsLongInterval.indexOf(11));
-        Assert.assertEquals(-1, backwardsLongInterval.indexOf(9));
-        Assert.assertEquals(-1, backwardsLongInterval.indexOf(-11));
-        Assert.assertEquals(-1, backwardsLongInterval.indexOf(-15));
+        assertEquals(-1, backwardsLongInterval.indexOf(15));
+        assertEquals(-1, backwardsLongInterval.indexOf(11));
+        assertEquals(-1, backwardsLongInterval.indexOf(9));
+        assertEquals(-1, backwardsLongInterval.indexOf(-11));
+        assertEquals(-1, backwardsLongInterval.indexOf(-15));
     }
 
     @Test
     public void lastIndexOf()
     {
         LongInterval interval = LongInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(0, interval.lastIndexOf(-10));
-        Assert.assertEquals(1, interval.lastIndexOf(-5));
-        Assert.assertEquals(2, interval.lastIndexOf(0));
-        Assert.assertEquals(3, interval.lastIndexOf(5));
-        Assert.assertEquals(4, interval.lastIndexOf(10));
+        assertEquals(0, interval.lastIndexOf(-10));
+        assertEquals(1, interval.lastIndexOf(-5));
+        assertEquals(2, interval.lastIndexOf(0));
+        assertEquals(3, interval.lastIndexOf(5));
+        assertEquals(4, interval.lastIndexOf(10));
 
-        Assert.assertEquals(-1, interval.lastIndexOf(-15));
-        Assert.assertEquals(-1, interval.lastIndexOf(-11));
-        Assert.assertEquals(-1, interval.lastIndexOf(-9));
-        Assert.assertEquals(-1, interval.lastIndexOf(11));
-        Assert.assertEquals(-1, interval.lastIndexOf(15));
+        assertEquals(-1, interval.lastIndexOf(-15));
+        assertEquals(-1, interval.lastIndexOf(-11));
+        assertEquals(-1, interval.lastIndexOf(-9));
+        assertEquals(-1, interval.lastIndexOf(11));
+        assertEquals(-1, interval.lastIndexOf(15));
 
         LongInterval backwardsLongInterval = LongInterval.fromTo(10, -12).by(-5);
-        Assert.assertEquals(0, backwardsLongInterval.lastIndexOf(10));
-        Assert.assertEquals(1, backwardsLongInterval.lastIndexOf(5));
-        Assert.assertEquals(2, backwardsLongInterval.lastIndexOf(0));
-        Assert.assertEquals(3, backwardsLongInterval.lastIndexOf(-5));
-        Assert.assertEquals(4, backwardsLongInterval.lastIndexOf(-10));
+        assertEquals(0, backwardsLongInterval.lastIndexOf(10));
+        assertEquals(1, backwardsLongInterval.lastIndexOf(5));
+        assertEquals(2, backwardsLongInterval.lastIndexOf(0));
+        assertEquals(3, backwardsLongInterval.lastIndexOf(-5));
+        assertEquals(4, backwardsLongInterval.lastIndexOf(-10));
 
-        Assert.assertEquals(-1, backwardsLongInterval.lastIndexOf(15));
-        Assert.assertEquals(-1, backwardsLongInterval.lastIndexOf(11));
-        Assert.assertEquals(-1, backwardsLongInterval.lastIndexOf(9));
-        Assert.assertEquals(-1, backwardsLongInterval.lastIndexOf(-11));
-        Assert.assertEquals(-1, backwardsLongInterval.lastIndexOf(-15));
+        assertEquals(-1, backwardsLongInterval.lastIndexOf(15));
+        assertEquals(-1, backwardsLongInterval.lastIndexOf(11));
+        assertEquals(-1, backwardsLongInterval.lastIndexOf(9));
+        assertEquals(-1, backwardsLongInterval.lastIndexOf(-11));
+        assertEquals(-1, backwardsLongInterval.lastIndexOf(-15));
     }
 
     @Test
     public void get()
     {
         LongInterval interval = LongInterval.fromTo(-10, 12).by(5);
-        Assert.assertEquals(-10, interval.get(0));
-        Assert.assertEquals(-5, interval.get(1));
-        Assert.assertEquals(0, interval.get(2));
-        Assert.assertEquals(5, interval.get(3));
-        Assert.assertEquals(10, interval.get(4));
+        assertEquals(-10, interval.get(0));
+        assertEquals(-5, interval.get(1));
+        assertEquals(0, interval.get(2));
+        assertEquals(5, interval.get(3));
+        assertEquals(10, interval.get(4));
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> interval.get(5));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(LongInterval.fromTo(1, 3).containsAll(1, 2, 3));
-        Assert.assertFalse(LongInterval.fromTo(1, 3).containsAll(1, 2, 4));
+        assertTrue(LongInterval.fromTo(1, 3).containsAll(1, 2, 3));
+        assertFalse(LongInterval.fromTo(1, 3).containsAll(1, 2, 4));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(LongInterval.fromTo(1, 3).containsAll(LongInterval.fromTo(1, 3)));
-        Assert.assertFalse(LongInterval.fromTo(1, 3).containsAll(LongInterval.fromTo(1, 4)));
+        assertTrue(LongInterval.fromTo(1, 3).containsAll(LongInterval.fromTo(1, 3)));
+        assertFalse(LongInterval.fromTo(1, 3).containsAll(LongInterval.fromTo(1, 4)));
     }
 
     @Test
     public void distinct()
     {
-        Assert.assertSame(this.longInterval, this.longInterval.distinct());
+        assertSame(this.longInterval, this.longInterval.distinct());
     }
 
     @Test
@@ -1116,7 +1124,7 @@ public class LongIntervalTest
     {
         MutableLongList list = LongLists.mutable.empty();
         list.addAll(this.longInterval.asReversed());
-        Assert.assertEquals(LongLists.mutable.with(3, 2, 1), list);
+        assertEquals(LongLists.mutable.with(3, 2, 1), list);
     }
 
     @Test
@@ -1129,10 +1137,10 @@ public class LongIntervalTest
                 PrimitiveTuples.pair(1L, "1"),
                 PrimitiveTuples.pair(2L, "2"),
                 PrimitiveTuples.pair(3L, "3"));
-        Assert.assertEquals(expected, zipped);
-        Assert.assertEquals(expected, zippedLazy);
+        assertEquals(expected, zipped);
+        assertEquals(expected, zippedLazy);
         Verify.assertEmpty(interval.zip(Lists.mutable.empty()));
-        Assert.assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1L, "1")), interval.zip(Lists.mutable.with("1")));
+        assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1L, "1")), interval.zip(Lists.mutable.with("1")));
     }
 
     @Test
@@ -1145,38 +1153,38 @@ public class LongIntervalTest
                 PrimitiveTuples.pair(1L, 3L),
                 PrimitiveTuples.pair(2L, 2L),
                 PrimitiveTuples.pair(3L, 1L));
-        Assert.assertEquals(expected, zipped);
-        Assert.assertEquals(expected, zippedLazy);
+        assertEquals(expected, zipped);
+        assertEquals(expected, zippedLazy);
         Verify.assertEmpty(interval.zipLong(LongLists.mutable.empty()));
-        Assert.assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1L, 3L)), interval.zipLong(LongLists.mutable.with(3)));
+        assertEquals(Lists.immutable.with(PrimitiveTuples.pair(1L, 3L)), interval.zipLong(LongLists.mutable.with(3)));
     }
 
     @Test
     public void primitiveStream()
     {
-        Assert.assertEquals(Lists.mutable.of(1L, 2L, 3L, 4L), LongInterval.oneTo(4L).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(0L, 2L, 4L), LongInterval.fromToBy(0L, 5L, 2L).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(5L, 3L, 1L), LongInterval.fromToBy(5L, 0L, -2L).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(10L, 15L, 20L, 25L, 30L), LongInterval.fromToBy(10L, 30L, 5L).primitiveStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(30L, 25L, 20L, 15L, 10L), LongInterval.fromToBy(30L, 10L, -5L).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(1L, 2L, 3L, 4L), LongInterval.oneTo(4L).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(0L, 2L, 4L), LongInterval.fromToBy(0L, 5L, 2L).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(5L, 3L, 1L), LongInterval.fromToBy(5L, 0L, -2L).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(10L, 15L, 20L, 25L, 30L), LongInterval.fromToBy(10L, 30L, 5L).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(30L, 25L, 20L, 15L, 10L), LongInterval.fromToBy(30L, 10L, -5L).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void primitiveParallelStream()
     {
-        Assert.assertEquals(Lists.mutable.of(1L, 2L, 3L, 4L), LongInterval.oneTo(4).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(0L, 2L, 4L), LongInterval.fromToBy(0, 5, 2).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(5L, 3L, 1L, -1L, -3L), LongInterval.fromToBy(5, -4, -2).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(10L, 15L, 20L, 25L, 30L), LongInterval.fromToBy(10, 30, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(30L, 25L, 20L, 15L, 10L), LongInterval.fromToBy(30, 10, -5).primitiveParallelStream().boxed().collect(Collectors.toList()));
-        Assert.assertEquals(Lists.mutable.of(-1L, 10L, 21L, 32L, 43L, 54L, 65L, 76L, 87L, 98L), LongInterval.fromToBy(-1, 100, 11).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(1L, 2L, 3L, 4L), LongInterval.oneTo(4).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(0L, 2L, 4L), LongInterval.fromToBy(0, 5, 2).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(5L, 3L, 1L, -1L, -3L), LongInterval.fromToBy(5, -4, -2).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(10L, 15L, 20L, 25L, 30L), LongInterval.fromToBy(10, 30, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(30L, 25L, 20L, 15L, 10L), LongInterval.fromToBy(30, 10, -5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Lists.mutable.of(-1L, 10L, 21L, 32L, 43L, 54L, 65L, 76L, 87L, 98L), LongInterval.fromToBy(-1, 100, 11).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void toImmutable()
     {
         LongInterval interval = LongInterval.oneTo(5);
-        Assert.assertSame(interval, interval.toImmutable());
+        assertSame(interval, interval.toImmutable());
     }
 
     @Test
@@ -1184,8 +1192,8 @@ public class LongIntervalTest
     {
         LongInterval interval = LongInterval.oneTo(4);
         ImmutableLongList list = interval.newWith(5);
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(LongInterval.oneTo(5), list);
+        assertNotSame(interval, list);
+        assertEquals(LongInterval.oneTo(5), list);
     }
 
     @Test
@@ -1193,8 +1201,8 @@ public class LongIntervalTest
     {
         LongInterval interval = LongInterval.oneTo(5);
         ImmutableLongList list = interval.newWithout(5);
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(LongInterval.oneTo(4), list);
+        assertNotSame(interval, list);
+        assertEquals(LongInterval.oneTo(4), list);
     }
 
     @Test
@@ -1202,8 +1210,8 @@ public class LongIntervalTest
     {
         LongInterval interval = LongInterval.oneTo(2);
         ImmutableLongList list = interval.newWithAll(LongInterval.fromTo(3, 5));
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(LongInterval.oneTo(5), list);
+        assertNotSame(interval, list);
+        assertEquals(LongInterval.oneTo(5), list);
     }
 
     @Test
@@ -1211,7 +1219,7 @@ public class LongIntervalTest
     {
         LongInterval interval = LongInterval.oneTo(5);
         ImmutableLongList list = interval.newWithoutAll(LongInterval.fromTo(3, 5));
-        Assert.assertNotSame(interval, list);
-        Assert.assertEquals(LongInterval.oneTo(2), list);
+        assertNotSame(interval, list);
+        assertEquals(LongInterval.oneTo(2), list);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
@@ -89,11 +89,18 @@ import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class MapIterableTestCase
 {
@@ -121,20 +128,20 @@ public abstract class MapIterableTestCase
     public void stream()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(
+        assertEquals(
                 "123",
                 CharAdapter.adapt(map.stream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
-        Assert.assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
+        assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
     }
 
     @Test
     public void parallelStream()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(
+        assertEquals(
                 "123",
                 CharAdapter.adapt(map.stream().reduce("", (r, s) -> r + s)).toSortedList().makeString(""));
-        Assert.assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
+        assertEquals(map.reduce((r, s) -> r + s), map.stream().reduce((r, s) -> r + s));
     }
 
     @Test
@@ -145,9 +152,9 @@ public abstract class MapIterableTestCase
         Verify.assertEqualsAndHashCode(Maps.mutable.of(1, "1", 2, "2", 3, "3"), map);
         Verify.assertEqualsAndHashCode(Maps.immutable.of(1, "1", 2, "2", 3, "3"), map);
 
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
 
         Verify.assertEqualsAndHashCode(
                 Maps.immutable.with(1, "1", 2, "2", 3, null),
@@ -160,73 +167,73 @@ public abstract class MapIterableTestCase
         MapIterable<Integer, String> original = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         MapIterable<Integer, String> copy = SerializeTestHelper.serializeDeserialize(original);
         Verify.assertIterableSize(3, copy);
-        Assert.assertEquals(original, copy);
+        assertEquals(original, copy);
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertFalse(this.newMapWithKeysValues(1, "1", 2, "2").isEmpty());
-        Assert.assertTrue(this.newMap().isEmpty());
+        assertFalse(this.newMapWithKeysValues(1, "1", 2, "2").isEmpty());
+        assertTrue(this.newMap().isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.newMap().notEmpty());
-        Assert.assertTrue(this.newMapWithKeysValues(1, "1", 2, "2").notEmpty());
+        assertFalse(this.newMap().notEmpty());
+        assertTrue(this.newMapWithKeysValues(1, "1", 2, "2").notEmpty());
     }
 
     @Test
     public void ifPresentApply()
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2);
-        Assert.assertEquals("1", map.ifPresentApply("1", String::valueOf));
-        Assert.assertNull(map.ifPresentApply("3", String::valueOf));
+        assertEquals("1", map.ifPresentApply("1", String::valueOf));
+        assertNull(map.ifPresentApply("3", String::valueOf));
     }
 
     @Test
     public void getIfAbsent_function()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("4")));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("3", map.getIfAbsent(3, new PassThruFunction0<>("3")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("4")));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertEquals("3", map.getIfAbsent(3, new PassThruFunction0<>("3")));
+        assertNull(map.get(4));
     }
 
     @Test
     public void getOrDefault()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getOrDefault(1, "4"));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertEquals("3", map.getOrDefault(3, "3"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getOrDefault(1, "4"));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertEquals("3", map.getOrDefault(3, "3"));
+        assertNull(map.get(4));
     }
 
     @Test
     public void getIfAbsent()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsentValue(1, "4"));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertEquals("3", map.getIfAbsentValue(3, "3"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsentValue(1, "4"));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertEquals("3", map.getIfAbsentValue(3, "3"));
+        assertNull(map.get(4));
     }
 
     @Test
     public void getIfAbsentWith()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertEquals("3", map.getIfAbsentWith(3, String::valueOf, 3));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertEquals("3", map.getIfAbsentWith(3, String::valueOf, 3));
+        assertNull(map.get(4));
     }
 
     @Test
@@ -234,8 +241,8 @@ public abstract class MapIterableTestCase
     {
         MutableList<String> tapResult = Lists.mutable.of();
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Assert.assertSame(map, map.tap(tapResult::add));
-        Assert.assertEquals(tapResult.toList(), tapResult);
+        assertSame(map, map.tap(tapResult::add));
+        assertEquals(tapResult.toList(), tapResult);
     }
 
     @Test
@@ -244,7 +251,7 @@ public abstract class MapIterableTestCase
         MutableBag<String> result = Bags.mutable.of();
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
         map.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(Bags.mutable.of("One", "Two", "Three", "Four"), result);
+        assertEquals(Bags.mutable.of("One", "Two", "Three", "Four"), result);
     }
 
     @Test
@@ -298,12 +305,12 @@ public abstract class MapIterableTestCase
         UnifiedMap<Integer, String> result = UnifiedMap.newMap();
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         map.forEachKeyValue(result::put);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), result);
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), result);
 
         MutableBag<String> result2 = Bags.mutable.of();
         MapIterable<Integer, String> map2 = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three");
         map2.forEachKeyValue((key, value) -> result2.add(key + value));
-        Assert.assertEquals(Bags.mutable.of("1One", "2Two", "3Three"), result2);
+        assertEquals(Bags.mutable.of("1One", "2Two", "3Three"), result2);
     }
 
     @Test
@@ -311,11 +318,11 @@ public abstract class MapIterableTestCase
     {
         MapIterable<Integer, Integer> map1 = this.newMapWithKeysValues(3, 3, 2, 2, 1, 1);
         Integer sum1 = map1.injectIntoKeyValue(0, (sum, key, value) -> sum + key + value);
-        Assert.assertEquals(Integer.valueOf(12), sum1);
+        assertEquals(Integer.valueOf(12), sum1);
 
         MutableMap<Integer, String> result = map1.injectIntoKeyValue(Maps.mutable.empty(),
                 (map, key, value) -> map.withKeyValue(key, value.toString()));
-        Assert.assertEquals(Maps.mutable.with(3, "3", 2, "2", 1, "1"), result);
+        assertEquals(Maps.mutable.with(3, "3", 2, "2", 1, "1"), result);
     }
 
     @Test
@@ -323,9 +330,9 @@ public abstract class MapIterableTestCase
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         MapIterable<String, Integer> result = map.flipUniqueValues();
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", 1, "2", 2, "3", 3), result);
+        assertEquals(UnifiedMap.newWithKeysValues("1", 1, "2", 2, "3", 3), result);
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalStateException.class,
                 () -> this.newMapWithKeysValues(1, "2", 2, "2").flipUniqueValues());
     }
@@ -338,7 +345,7 @@ public abstract class MapIterableTestCase
                 map.collect((Function2<String, String, Pair<Integer, String>>) (argument1, argument2) -> Tuples.pair(
                         Integer.valueOf(argument1),
                         argument1 + ':' + new StringBuilder(argument2).reverse()));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1:enO", 2, "2:owT", 3, "3:eerhT"), actual);
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1:enO", 2, "2:owT", 3, "3:eerhT"), actual);
     }
 
     @Test
@@ -346,7 +353,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "true", "Two", "nah", "Three", "TrUe");
         BooleanIterable actual = map.collectBoolean(Boolean::parseBoolean);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), actual.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), actual.toBag());
     }
 
     @Test
@@ -355,8 +362,8 @@ public abstract class MapIterableTestCase
         BooleanHashBag target = new BooleanHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "true", "Two", "nah", "Three", "TrUe");
         BooleanHashBag result = map.collectBoolean(Boolean::parseBoolean, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, false, true), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(BooleanHashBag.newBagWith(true, false, true), result.toBag());
     }
 
     @Test
@@ -364,7 +371,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ByteIterable actual = map.collectByte(Byte::parseByte);
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), actual.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), actual.toBag());
     }
 
     @Test
@@ -373,8 +380,8 @@ public abstract class MapIterableTestCase
         ByteHashBag target = new ByteHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ByteHashBag result = map.collectByte(Byte::parseByte, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
     }
 
     @Test
@@ -382,7 +389,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "A1", "Two", "B", "Three", "C#++");
         CharIterable actual = map.collectChar((CharFunction<String>) string -> string.charAt(0));
-        Assert.assertEquals(CharHashBag.newBagWith('A', 'B', 'C'), actual.toBag());
+        assertEquals(CharHashBag.newBagWith('A', 'B', 'C'), actual.toBag());
     }
 
     @Test
@@ -391,8 +398,8 @@ public abstract class MapIterableTestCase
         CharHashBag target = new CharHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "A1", "Two", "B", "Three", "C#++");
         CharHashBag result = map.collectChar((CharFunction<String>) string -> string.charAt(0), target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(CharHashBag.newBagWith('A', 'B', 'C'), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(CharHashBag.newBagWith('A', 'B', 'C'), result.toBag());
     }
 
     @Test
@@ -400,7 +407,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         DoubleIterable actual = map.collectDouble(Double::parseDouble);
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d), actual.toBag());
+        assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d), actual.toBag());
     }
 
     @Test
@@ -409,8 +416,8 @@ public abstract class MapIterableTestCase
         DoubleHashBag target = new DoubleHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         DoubleHashBag result = map.collectDouble(Double::parseDouble, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d), result.toBag());
     }
 
     @Test
@@ -418,7 +425,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         FloatIterable actual = map.collectFloat(Float::parseFloat);
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), actual.toBag());
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), actual.toBag());
     }
 
     @Test
@@ -427,8 +434,8 @@ public abstract class MapIterableTestCase
         FloatHashBag target = new FloatHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         FloatHashBag result = map.collectFloat(Float::parseFloat, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
     }
 
     @Test
@@ -436,7 +443,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         IntIterable actual = map.collectInt(Integer::parseInt);
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3), actual.toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2, 3), actual.toBag());
     }
 
     @Test
@@ -445,8 +452,8 @@ public abstract class MapIterableTestCase
         IntHashBag target = new IntHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         IntHashBag result = map.collectInt(Integer::parseInt, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
     }
 
     @Test
@@ -454,7 +461,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         LongIterable actual = map.collectLong(Long::parseLong);
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), actual.toBag());
+        assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), actual.toBag());
     }
 
     @Test
@@ -463,8 +470,8 @@ public abstract class MapIterableTestCase
         LongHashBag target = new LongHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         LongHashBag result = map.collectLong(Long::parseLong, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
     }
 
     @Test
@@ -472,7 +479,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ShortIterable actual = map.collectShort(Short::parseShort);
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), actual.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), actual.toBag());
     }
 
     @Test
@@ -481,8 +488,8 @@ public abstract class MapIterableTestCase
         ShortHashBag target = new ShortHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ShortHashBag result = map.collectShort(Short::parseShort, target);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
+        assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
     }
 
     @Test
@@ -491,7 +498,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         MapIterable<String, String> actual =
                 map.collectValues((argument1, argument2) -> new StringBuilder(argument2).reverse().toString());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "enO", "2", "owT", "3", "eerhT"), actual);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "enO", "2", "owT", "3", "eerhT"), actual);
     }
 
     @Test
@@ -499,7 +506,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         RichIterable<String> actual = map.select("Two"::equals);
-        Assert.assertEquals(HashBag.newBagWith("Two"), actual.toBag());
+        assertEquals(HashBag.newBagWith("Two"), actual.toBag());
     }
 
     @Test
@@ -507,7 +514,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         RichIterable<String> actual = map.selectWith(Object::equals, "Two");
-        Assert.assertEquals(HashBag.newBagWith("Two"), actual.toBag());
+        assertEquals(HashBag.newBagWith("Two"), actual.toBag());
     }
 
     @Test
@@ -515,7 +522,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         RichIterable<String> actual = map.reject("Two"::equals);
-        Assert.assertEquals(HashBag.newBagWith("One", "Three"), actual.toBag());
+        assertEquals(HashBag.newBagWith("One", "Three"), actual.toBag());
     }
 
     @Test
@@ -523,7 +530,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         RichIterable<String> actual = map.rejectWith(Object::equals, "Two");
-        Assert.assertEquals(HashBag.newBagWith("One", "Three"), actual.toBag());
+        assertEquals(HashBag.newBagWith("One", "Three"), actual.toBag());
     }
 
     @Test
@@ -531,7 +538,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         RichIterable<String> actual = map.collect(StringFunctions.toLowerCase());
-        Assert.assertEquals(HashBag.newBagWith("one", "two", "three"), actual.toBag());
+        assertEquals(HashBag.newBagWith("one", "two", "three"), actual.toBag());
     }
 
     @Test
@@ -569,9 +576,9 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         MapIterable<String, String> actual =
                 map.select((argument1, argument2) -> "1".equals(argument1) || "Two".equals(argument2));
-        Assert.assertEquals(2, actual.size());
-        Assert.assertTrue(actual.keysView().containsAllArguments("1", "2"));
-        Assert.assertTrue(actual.valuesView().containsAllArguments("One", "Two"));
+        assertEquals(2, actual.size());
+        assertTrue(actual.keysView().containsAllArguments("1", "2"));
+        assertTrue(actual.valuesView().containsAllArguments("One", "Two"));
     }
 
     @Test
@@ -580,7 +587,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         MapIterable<String, String> actual =
                 map.reject((argument1, argument2) -> "1".equals(argument1) || "Two".equals(argument2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("3", "Three"), actual);
+        assertEquals(UnifiedMap.newWithKeysValues("3", "Three"), actual);
     }
 
     @Test
@@ -594,7 +601,7 @@ public abstract class MapIterableTestCase
         expected.put("odd", "Three");
         expected.put("even", "Four");
 
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 this.newMapWithKeysValues("One", "odd", "Two", "even", "Three", "odd", "Four", "even").flip());
     }
@@ -604,16 +611,16 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         Pair<String, String> one = map.detect((argument1, argument2) -> "1".equals(argument1));
-        Assert.assertNotNull(one);
-        Assert.assertEquals("1", one.getOne());
-        Assert.assertEquals("One", one.getTwo());
+        assertNotNull(one);
+        assertEquals("1", one.getOne());
+        assertEquals("One", one.getTwo());
 
         Pair<String, String> two = map.detect((argument1, argument2) -> "Two".equals(argument2));
-        Assert.assertNotNull(two);
-        Assert.assertEquals("2", two.getOne());
-        Assert.assertEquals("Two", two.getTwo());
+        assertNotNull(two);
+        assertEquals("2", two.getOne());
+        assertEquals("Two", two.getTwo());
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Test
@@ -622,17 +629,17 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
         Pair<String, String> one =
                 map.detectOptional((argument1, argument2) -> "1".equals(argument1)).get();
-        Assert.assertNotNull(one);
-        Assert.assertEquals("1", one.getOne());
-        Assert.assertEquals("One", one.getTwo());
+        assertNotNull(one);
+        assertEquals("1", one.getOne());
+        assertEquals("One", one.getTwo());
 
         Pair<String, String> two =
                 map.detectOptional((argument1, argument2) -> "Two".equals(argument2)).get();
-        Assert.assertNotNull(two);
-        Assert.assertEquals("2", two.getOne());
-        Assert.assertEquals("Two", two.getTwo());
+        assertNotNull(two);
+        assertEquals("2", two.getOne());
+        assertEquals("Two", two.getTwo());
 
-        Assert.assertFalse(map.detectOptional((ignored1, ignored2) -> false).isPresent());
+        assertFalse(map.detectOptional((ignored1, ignored2) -> false).isPresent());
     }
 
     @Test
@@ -641,7 +648,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         Verify.assertAnySatisfy((Map<String, String>) map, String.class::isInstance);
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Test
@@ -649,8 +656,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(map.anySatisfyWith(Object::equals, "Monkey"));
+        assertTrue(map.anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(map.anySatisfyWith(Object::equals, "Monkey"));
     }
 
     @Test
@@ -659,7 +666,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         Verify.assertAllSatisfy((Map<String, String>) map, String.class::isInstance);
-        Assert.assertFalse(map.allSatisfy("Monkey"::equals));
+        assertFalse(map.allSatisfy("Monkey"::equals));
     }
 
     @Test
@@ -667,8 +674,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.allSatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(map.allSatisfyWith(Object::equals, "Monkey"));
+        assertTrue(map.allSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(map.allSatisfyWith(Object::equals, "Monkey"));
     }
 
     @Test
@@ -677,8 +684,8 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         Verify.assertNoneSatisfy((Map<String, String>) map, Integer.class::isInstance);
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
-        Assert.assertFalse(map.noneSatisfy("Two"::equals));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertFalse(map.noneSatisfy("Two"::equals));
     }
 
     @Test
@@ -686,9 +693,9 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertTrue(map.noneSatisfyWith(Object::equals, "Monkey"));
-        Assert.assertFalse(map.noneSatisfyWith(Object::equals, "Two"));
+        assertTrue(map.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertTrue(map.noneSatisfyWith(Object::equals, "Monkey"));
+        assertFalse(map.noneSatisfyWith(Object::equals, "Two"));
     }
 
     @Test
@@ -699,21 +706,21 @@ public abstract class MapIterableTestCase
         StringBuilder builder1 = new StringBuilder();
         map.appendString(builder1);
         String defaultString = builder1.toString();
-        Assert.assertEquals(15, defaultString.length());
+        assertEquals(15, defaultString.length());
 
         StringBuilder builder2 = new StringBuilder();
         map.appendString(builder2, "|");
         String delimitedString = builder2.toString();
-        Assert.assertEquals(13, delimitedString.length());
+        assertEquals(13, delimitedString.length());
         Verify.assertContains("|", delimitedString);
 
         StringBuilder builder3 = new StringBuilder();
         map.appendString(builder3, "{", "|", "}");
         String wrappedString = builder3.toString();
-        Assert.assertEquals(15, wrappedString.length());
+        assertEquals(15, wrappedString.length());
         Verify.assertContains("|", wrappedString);
-        Assert.assertTrue(wrappedString.startsWith("{"));
-        Assert.assertTrue(wrappedString.endsWith("}"));
+        assertTrue(wrappedString.startsWith("{"));
+        assertTrue(wrappedString.endsWith("}"));
     }
 
     @Test
@@ -722,7 +729,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         MutableBag<String> bag = map.toBag();
-        Assert.assertEquals(Bags.mutable.of("One", "Two", "Three"), bag);
+        assertEquals(Bags.mutable.of("One", "Two", "Three"), bag);
     }
 
     @Test
@@ -770,7 +777,7 @@ public abstract class MapIterableTestCase
 
         MapIterable<Integer, String> actual = map.toMap(String::length, String::valueOf);
 
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
+        assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
     }
 
     @Test
@@ -788,10 +795,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         MutableList<Integer> sorted = map.toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), sorted);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), sorted);
 
         MutableList<Integer> reverse = map.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), reverse);
+        assertEquals(FastList.newListWith(4, 3, 2, 1), reverse);
     }
 
     @Test
@@ -800,7 +807,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         MutableList<Integer> list = map.toSortedListBy(String::valueOf);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), list);
     }
 
     @Test
@@ -854,7 +861,7 @@ public abstract class MapIterableTestCase
         RichIterable<RichIterable<String>> chunks = map.chunk(2).toList();
 
         RichIterable<Integer> sizes = chunks.collect(RichIterable::size);
-        Assert.assertEquals(FastList.newListWith(2, 1), sizes);
+        assertEquals(FastList.newListWith(2, 1), sizes);
     }
 
     @Test
@@ -877,10 +884,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         Bag<String> odd = map.collectIf(IntegerPredicates.isOdd(), Functions.getToString()).toBag();
-        Assert.assertEquals(Bags.mutable.of("1", "3"), odd);
+        assertEquals(Bags.mutable.of("1", "3"), odd);
 
         Bag<String> even = map.collectIf(IntegerPredicates.isEven(), String::valueOf, HashBag.newBag());
-        Assert.assertEquals(Bags.mutable.of("2", "4"), even);
+        assertEquals(Bags.mutable.of("2", "4"), even);
     }
 
     @Test
@@ -906,59 +913,59 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.contains("Two"));
+        assertTrue(map.contains("Two"));
     }
 
     @Test
     public void containsAnyIterable()
     {
         RichIterable<Integer> collection = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertTrue(collection.containsAnyIterable(Lists.mutable.with(0, 1)));
-        Assert.assertTrue(collection.containsAnyIterable(Arrays.asList(0, 1)));
-        Assert.assertFalse(collection.containsAnyIterable(Lists.mutable.with(5, 6)));
-        Assert.assertFalse(collection.containsAnyIterable(Arrays.asList(5, 6)));
-        Assert.assertTrue(collection.containsAnyIterable(Interval.oneTo(100)));
-        Assert.assertFalse(collection.containsAnyIterable(Interval.fromTo(5, 100)));
-        Assert.assertTrue(Interval.oneTo(100).containsAnyIterable(collection));
-        Assert.assertFalse(Interval.fromTo(5, 100).containsAnyIterable(collection));
+        assertTrue(collection.containsAnyIterable(Lists.mutable.with(0, 1)));
+        assertTrue(collection.containsAnyIterable(Arrays.asList(0, 1)));
+        assertFalse(collection.containsAnyIterable(Lists.mutable.with(5, 6)));
+        assertFalse(collection.containsAnyIterable(Arrays.asList(5, 6)));
+        assertTrue(collection.containsAnyIterable(Interval.oneTo(100)));
+        assertFalse(collection.containsAnyIterable(Interval.fromTo(5, 100)));
+        assertTrue(Interval.oneTo(100).containsAnyIterable(collection));
+        assertFalse(Interval.fromTo(5, 100).containsAnyIterable(collection));
     }
 
     @Test
     public void containsNoneIterable()
     {
         RichIterable<Integer> collection = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertTrue(collection.containsNoneIterable(Lists.mutable.with(0, 5, 6, 7)));
-        Assert.assertTrue(collection.containsNoneIterable(Arrays.asList(0, 5, 6, 7)));
-        Assert.assertFalse(collection.containsNoneIterable(Lists.mutable.with(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNoneIterable(Arrays.asList(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNoneIterable(Interval.oneTo(100)));
-        Assert.assertTrue(collection.containsNoneIterable(Interval.fromTo(5, 100)));
-        Assert.assertFalse(Interval.oneTo(100).containsNoneIterable(collection));
-        Assert.assertTrue(Interval.fromTo(5, 100).containsNoneIterable(collection));
+        assertTrue(collection.containsNoneIterable(Lists.mutable.with(0, 5, 6, 7)));
+        assertTrue(collection.containsNoneIterable(Arrays.asList(0, 5, 6, 7)));
+        assertFalse(collection.containsNoneIterable(Lists.mutable.with(0, 1, 5, 6)));
+        assertFalse(collection.containsNoneIterable(Arrays.asList(0, 1, 5, 6)));
+        assertFalse(collection.containsNoneIterable(Interval.oneTo(100)));
+        assertTrue(collection.containsNoneIterable(Interval.fromTo(5, 100)));
+        assertFalse(Interval.oneTo(100).containsNoneIterable(collection));
+        assertTrue(Interval.fromTo(5, 100).containsNoneIterable(collection));
     }
 
     @Test
     public void containsAnyCollection()
     {
         RichIterable<Integer> collection = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertTrue(collection.containsAny(Lists.mutable.with(0, 1)));
-        Assert.assertTrue(collection.containsAny(Arrays.asList(0, 1)));
-        Assert.assertFalse(collection.containsAny(Lists.mutable.with(5, 6)));
-        Assert.assertFalse(collection.containsAny(Arrays.asList(5, 6)));
-        Assert.assertTrue(collection.containsAny(Interval.oneTo(100)));
-        Assert.assertFalse(collection.containsAny(Interval.fromTo(5, 100)));
+        assertTrue(collection.containsAny(Lists.mutable.with(0, 1)));
+        assertTrue(collection.containsAny(Arrays.asList(0, 1)));
+        assertFalse(collection.containsAny(Lists.mutable.with(5, 6)));
+        assertFalse(collection.containsAny(Arrays.asList(5, 6)));
+        assertTrue(collection.containsAny(Interval.oneTo(100)));
+        assertFalse(collection.containsAny(Interval.fromTo(5, 100)));
     }
 
     @Test
     public void containsNoneCollection()
     {
         RichIterable<Integer> collection = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertTrue(collection.containsNone(Lists.mutable.with(0, 5, 6, 7)));
-        Assert.assertTrue(collection.containsNone(Arrays.asList(0, 5, 6, 7)));
-        Assert.assertFalse(collection.containsNone(Lists.mutable.with(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNone(Arrays.asList(0, 1, 5, 6)));
-        Assert.assertFalse(collection.containsNone(Interval.oneTo(100)));
-        Assert.assertTrue(collection.containsNone(Interval.fromTo(5, 100)));
+        assertTrue(collection.containsNone(Lists.mutable.with(0, 5, 6, 7)));
+        assertTrue(collection.containsNone(Arrays.asList(0, 5, 6, 7)));
+        assertFalse(collection.containsNone(Lists.mutable.with(0, 1, 5, 6)));
+        assertFalse(collection.containsNone(Arrays.asList(0, 1, 5, 6)));
+        assertFalse(collection.containsNone(Interval.oneTo(100)));
+        assertTrue(collection.containsNone(Interval.fromTo(5, 100)));
     }
 
     @Test
@@ -966,29 +973,29 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(map.containsAll(FastList.newListWith("One", "Two", "Three")));
-        Assert.assertFalse(map.containsAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertTrue(map.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(map.containsAll(FastList.newListWith("One", "Two", "Three")));
+        assertFalse(map.containsAll(FastList.newListWith("One", "Two", "Three", "Four")));
     }
 
     @Test
     public void containsKey()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertTrue(map.containsKey(1));
-        Assert.assertFalse(map.containsKey(4));
+        assertTrue(map.containsKey(1));
+        assertFalse(map.containsKey(4));
     }
 
     @Test
     public void containsValue()
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertTrue(map.containsValue("1"));
-        Assert.assertFalse(map.containsValue("4"));
+        assertTrue(map.containsValue("1"));
+        assertFalse(map.containsValue("4"));
 
         MapIterable<Integer, String> map2 = this.newMapWithKeysValues(3, "1", 2, "2", 1, "3");
-        Assert.assertTrue(map2.containsValue("1"));
-        Assert.assertFalse(map2.containsValue("4"));
+        assertTrue(map2.containsValue("1"));
+        assertFalse(map2.containsValue("4"));
     }
 
     @Test
@@ -997,10 +1004,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String value = map.getFirst();
-        Assert.assertNotNull(value);
-        Assert.assertTrue(value, map.valuesView().contains(value));
+        assertNotNull(value);
+        assertTrue(value, map.valuesView().contains(value));
 
-        Assert.assertNull(this.newMap().getFirst());
+        assertNull(this.newMap().getFirst());
     }
 
     @Test
@@ -1009,10 +1016,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String value = map.getLast();
-        Assert.assertNotNull(value);
-        Assert.assertTrue(value, map.valuesView().contains(value));
+        assertNotNull(value);
+        assertTrue(value, map.valuesView().contains(value));
 
-        Assert.assertNull(this.newMap().getLast());
+        assertNull(this.newMap().getLast());
     }
 
     @Test
@@ -1020,7 +1027,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeyValue("1", "One");
 
-        Assert.assertEquals("One", map.getOnly());
+        assertEquals("One", map.getOnly());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1040,8 +1047,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.containsAllIterable(FastList.newListWith("One", "Two")));
-        Assert.assertFalse(map.containsAllIterable(FastList.newListWith("One", "Four")));
+        assertTrue(map.containsAllIterable(FastList.newListWith("One", "Two")));
+        assertFalse(map.containsAllIterable(FastList.newListWith("One", "Four")));
     }
 
     @Test
@@ -1049,8 +1056,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
-        Assert.assertTrue(map.containsAllArguments("One", "Two"));
-        Assert.assertFalse(map.containsAllArguments("One", "Four"));
+        assertTrue(map.containsAllArguments("One", "Two"));
+        assertFalse(map.containsAllArguments("One", "Four"));
     }
 
     @Test
@@ -1060,7 +1067,7 @@ public abstract class MapIterableTestCase
 
         int actual = map.count(Predicates.or("One"::equals, "Three"::equals));
 
-        Assert.assertEquals(2, actual);
+        assertEquals(2, actual);
     }
 
     @Test
@@ -1070,7 +1077,7 @@ public abstract class MapIterableTestCase
 
         int actual = map.countWith(Object::equals, "One");
 
-        Assert.assertEquals(1, actual);
+        assertEquals(1, actual);
     }
 
     @Test
@@ -1079,10 +1086,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultFound = map.detect("One"::equals);
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
 
         String resultNotFound = map.detect("Four"::equals);
-        Assert.assertNull(resultNotFound);
+        assertNull(resultNotFound);
     }
 
     @Test
@@ -1092,9 +1099,9 @@ public abstract class MapIterableTestCase
                 this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultFound = map.detectOptional("One"::equals).get();
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
 
-        Assert.assertFalse(map.detectOptional("Four"::equals).isPresent());
+        assertFalse(map.detectOptional("Four"::equals).isPresent());
     }
 
     @Test
@@ -1103,10 +1110,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultFound = map.detectWith(Object::equals, "One");
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
 
         String resultNotFound = map.detectWith(Object::equals, "Four");
-        Assert.assertNull(resultNotFound);
+        assertNull(resultNotFound);
     }
 
     @Test
@@ -1115,9 +1122,9 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultFound = map.detectWithOptional(Object::equals, "One").get();
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
 
-        Assert.assertFalse(map.detectWithOptional(Object::equals, "Four").isPresent());
+        assertFalse(map.detectWithOptional(Object::equals, "Four").isPresent());
     }
 
     @Test
@@ -1126,10 +1133,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultNotFound = map.detectIfNone("Four"::equals, () -> "Zero");
-        Assert.assertEquals("Zero", resultNotFound);
+        assertEquals("Zero", resultNotFound);
 
         String resultFound = map.detectIfNone("One"::equals, () -> "Zero");
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
     }
 
     @Test
@@ -1138,10 +1145,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String resultNotFound = map.detectWithIfNone(Object::equals, "Four", () -> "Zero");
-        Assert.assertEquals("Zero", resultNotFound);
+        assertEquals("Zero", resultNotFound);
 
         String resultFound = map.detectWithIfNone(Object::equals, "One", () -> "Zero");
-        Assert.assertEquals("One", resultFound);
+        assertEquals("One", resultFound);
     }
 
     @Test
@@ -1161,7 +1168,7 @@ public abstract class MapIterableTestCase
         };
 
         RichIterable<Character> blob = map.flatCollect(function);
-        Assert.assertTrue(blob.containsAllArguments(
+        assertTrue(blob.containsAllArguments(
                 Character.valueOf('O'),
                 Character.valueOf('n'),
                 Character.valueOf('e'),
@@ -1170,7 +1177,7 @@ public abstract class MapIterableTestCase
                 Character.valueOf('o')));
 
         RichIterable<Character> blobFromTarget = map.flatCollect(function, FastList.newList());
-        Assert.assertTrue(blobFromTarget.containsAllArguments(
+        assertTrue(blobFromTarget.containsAllArguments(
                 Character.valueOf('O'),
                 Character.valueOf('n'),
                 Character.valueOf('e'),
@@ -1187,11 +1194,11 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
         Bag<Integer> evensAndOdds = map.countBy(each -> Integer.valueOf(each % 2));
-        Assert.assertEquals(2, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(2, evensAndOdds.occurrencesOf(0));
+        assertEquals(2, evensAndOdds.occurrencesOf(1));
+        assertEquals(2, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 = map.countBy(each -> Integer.valueOf(each % 2), Bags.mutable.empty());
-        Assert.assertEquals(2, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(2, evensAndOdds2.occurrencesOf(0));
+        assertEquals(2, evensAndOdds2.occurrencesOf(1));
+        assertEquals(2, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1202,12 +1209,12 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
         Bag<Integer> evensAndOdds = map.countByWith((each, parm) -> Integer.valueOf(each % parm), 2);
-        Assert.assertEquals(2, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(2, evensAndOdds.occurrencesOf(0));
+        assertEquals(2, evensAndOdds.occurrencesOf(1));
+        assertEquals(2, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 =
                 map.countByWith((each, parm) -> Integer.valueOf(each % parm), 2, Bags.mutable.empty());
-        Assert.assertEquals(2, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(2, evensAndOdds2.occurrencesOf(0));
+        assertEquals(2, evensAndOdds2.occurrencesOf(1));
+        assertEquals(2, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1218,18 +1225,18 @@ public abstract class MapIterableTestCase
     {
         RichIterable<Integer> integerList = this.newMapWithKeysValues("1", 1, "2", 2, "4", 4);
         Bag<Integer> integerBag1 = integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i));
-        Assert.assertEquals(1, integerBag1.occurrencesOf(1));
-        Assert.assertEquals(2, integerBag1.occurrencesOf(2));
-        Assert.assertEquals(3, integerBag1.occurrencesOf(4));
-        Assert.assertEquals(2, integerBag1.occurrencesOf(8));
-        Assert.assertEquals(1, integerBag1.occurrencesOf(12));
+        assertEquals(1, integerBag1.occurrencesOf(1));
+        assertEquals(2, integerBag1.occurrencesOf(2));
+        assertEquals(3, integerBag1.occurrencesOf(4));
+        assertEquals(2, integerBag1.occurrencesOf(8));
+        assertEquals(1, integerBag1.occurrencesOf(12));
         Bag<Integer> integerBag2 =
                 integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i), Bags.mutable.empty());
-        Assert.assertEquals(1, integerBag2.occurrencesOf(1));
-        Assert.assertEquals(2, integerBag2.occurrencesOf(2));
-        Assert.assertEquals(3, integerBag2.occurrencesOf(4));
-        Assert.assertEquals(2, integerBag2.occurrencesOf(8));
-        Assert.assertEquals(1, integerBag2.occurrencesOf(12));
+        assertEquals(1, integerBag2.occurrencesOf(1));
+        assertEquals(2, integerBag2.occurrencesOf(2));
+        assertEquals(3, integerBag2.occurrencesOf(4));
+        assertEquals(2, integerBag2.occurrencesOf(8));
+        assertEquals(1, integerBag2.occurrencesOf(12));
     }
 
     @Test
@@ -1246,19 +1253,19 @@ public abstract class MapIterableTestCase
         Multimap<Boolean, Integer> actual = map.groupBy(isOddFunction);
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actual.containsKey(each));
+            assertTrue(actual.containsKey(each));
             MutableList<Integer> values = actual.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
 
         Multimap<Boolean, Integer> actualFromTarget = map.groupBy(isOddFunction, FastListMultimap.newMultimap());
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actualFromTarget.containsKey(each));
+            assertTrue(actualFromTarget.containsKey(each));
             MutableList<Integer> values = actualFromTarget.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
     }
 
@@ -1277,19 +1284,19 @@ public abstract class MapIterableTestCase
         Multimap<Integer, Integer> actual = map.groupByEach(function);
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actual.containsKey(each));
+            assertTrue(actual.containsKey(each));
             MutableList<Integer> values = actual.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
 
         Multimap<Integer, Integer> actualFromTarget = map.groupByEach(function, FastListMultimap.newMultimap());
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actualFromTarget.containsKey(each));
+            assertTrue(actualFromTarget.containsKey(each));
             MutableList<Integer> values = actualFromTarget.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
     }
 
@@ -1297,7 +1304,7 @@ public abstract class MapIterableTestCase
     public void groupByUniqueKey()
     {
         MapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), map.groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), map.groupByUniqueKey(id -> id));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1311,7 +1318,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
         MutableMap<Integer, Integer> integers = map.groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1326,10 +1333,10 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         Integer actual = map.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(10), actual);
+        assertEquals(Integer.valueOf(10), actual);
 
         Sum sum = map.injectInto(new IntegerSum(0), SumProcedure.number());
-        Assert.assertEquals(new IntegerSum(10), sum);
+        assertEquals(new IntegerSum(10), sum);
     }
 
     @Test
@@ -1338,7 +1345,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         int actual = map.injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(10, actual);
+        assertEquals(10, actual);
     }
 
     @Test
@@ -1347,7 +1354,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         long actual = map.injectInto(0, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(10, actual);
+        assertEquals(10, actual);
     }
 
     @Test
@@ -1356,7 +1363,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         float actual = map.injectInto(0, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(10.0F, actual, 0.01);
+        assertEquals(10.0F, actual, 0.01);
     }
 
     @Test
@@ -1365,7 +1372,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         double actual = map.injectInto(0, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(10.0d, actual, 0.01);
+        assertEquals(10.0d, actual, 0.01);
     }
 
     @Test
@@ -1374,7 +1381,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         long actual = map.sumOfInt(integer -> integer);
-        Assert.assertEquals(10L, actual);
+        assertEquals(10L, actual);
     }
 
     @Test
@@ -1383,7 +1390,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         long actual = map.sumOfLong(Integer::longValue);
-        Assert.assertEquals(10, actual);
+        assertEquals(10, actual);
     }
 
     @Test
@@ -1413,7 +1420,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Long> expected =
                 Maps.mutable.with(lessThanTen, Interval.fromTo(1, 9).sumOfInt(Integer::intValue),
                         greaterOrEqualsToTen, Interval.fromTo(10, 20).sumOfInt(Integer::intValue));
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Test
@@ -1422,7 +1429,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         double actual = map.sumOfFloat(Integer::floatValue);
-        Assert.assertEquals(10.0d, actual, 0.01);
+        assertEquals(10.0d, actual, 0.01);
     }
 
     @Test
@@ -1431,7 +1438,7 @@ public abstract class MapIterableTestCase
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
         double actual = map.sumOfDouble(Integer::doubleValue);
-        Assert.assertEquals(10.0d, actual, 0.01);
+        assertEquals(10.0d, actual, 0.01);
     }
 
     @Test
@@ -1439,8 +1446,8 @@ public abstract class MapIterableTestCase
     {
         RichIterable<String> values = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ObjectLongMap<Integer> result = values.sumByInt(s -> Integer.parseInt(s) % 2, Integer::parseInt);
-        Assert.assertEquals(4, result.get(1));
-        Assert.assertEquals(2, result.get(0));
+        assertEquals(4, result.get(1));
+        assertEquals(2, result.get(0));
     }
 
     @Test
@@ -1448,8 +1455,8 @@ public abstract class MapIterableTestCase
     {
         RichIterable<String> values = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ObjectDoubleMap<Integer> result = values.sumByFloat(s -> Integer.parseInt(s) % 2, Float::parseFloat);
-        Assert.assertEquals(4.0f, result.get(1), 0.0);
-        Assert.assertEquals(2.0f, result.get(0), 0.0);
+        assertEquals(4.0f, result.get(1), 0.0);
+        assertEquals(2.0f, result.get(0), 0.0);
     }
 
     @Test
@@ -1457,8 +1464,8 @@ public abstract class MapIterableTestCase
     {
         RichIterable<String> values = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ObjectLongMap<Integer> result = values.sumByLong(s -> Integer.parseInt(s) % 2, Long::parseLong);
-        Assert.assertEquals(4, result.get(1));
-        Assert.assertEquals(2, result.get(0));
+        assertEquals(4, result.get(1));
+        assertEquals(2, result.get(0));
     }
 
     @Test
@@ -1466,8 +1473,8 @@ public abstract class MapIterableTestCase
     {
         RichIterable<String> values = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
         ObjectDoubleMap<Integer> result = values.sumByDouble(s -> Integer.parseInt(s) % 2, Double::parseDouble);
-        Assert.assertEquals(4.0d, result.get(1), 0.0);
-        Assert.assertEquals(2.0d, result.get(0), 0.0);
+        assertEquals(4.0d, result.get(1), 0.0);
+        assertEquals(2.0d, result.get(0), 0.0);
     }
 
     @Test
@@ -1476,17 +1483,17 @@ public abstract class MapIterableTestCase
         MapIterable<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three");
 
         String defaultString = map.makeString();
-        Assert.assertEquals(15, defaultString.length());
+        assertEquals(15, defaultString.length());
 
         String delimitedString = map.makeString("|");
-        Assert.assertEquals(13, delimitedString.length());
+        assertEquals(13, delimitedString.length());
         Verify.assertContains("|", delimitedString);
 
         String wrappedString = map.makeString("{", "|", "}");
-        Assert.assertEquals(15, wrappedString.length());
+        assertEquals(15, wrappedString.length());
         Verify.assertContains("|", wrappedString);
-        Assert.assertTrue(wrappedString.startsWith("{"));
-        Assert.assertTrue(wrappedString.endsWith("}"));
+        assertTrue(wrappedString.startsWith("{"));
+        assertTrue(wrappedString.endsWith("}"));
     }
 
     @Test
@@ -1494,8 +1501,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(1), map.min());
-        Assert.assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), map.min());
+        assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
     }
 
     @Test
@@ -1503,8 +1510,8 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(4), map.max());
-        Assert.assertEquals(Integer.valueOf(4), map.max(Integer::compareTo));
+        assertEquals(Integer.valueOf(4), map.max());
+        assertEquals(Integer.valueOf(4), map.max(Integer::compareTo));
     }
 
     @Test
@@ -1512,7 +1519,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
     }
 
     @Test
@@ -1520,7 +1527,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(4), map.maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(4), map.maxBy(String::valueOf));
     }
 
     @Test
@@ -1566,8 +1573,8 @@ public abstract class MapIterableTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iSet(4, 2), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(3, 1), partition.getRejected().toSet());
+        assertEquals(iSet(4, 2), partition.getSelected().toSet());
+        assertEquals(iSet(3, 1), partition.getRejected().toSet());
     }
 
     @Test
@@ -1580,15 +1587,15 @@ public abstract class MapIterableTestCase
                 "D", 4);
         PartitionIterable<Integer> partition =
                 map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iSet(4, 2), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(3, 1), partition.getRejected().toSet());
+        assertEquals(iSet(4, 2), partition.getSelected().toSet());
+        assertEquals(iSet(3, 1), partition.getRejected().toSet());
     }
 
     @Test
     public void selectInstancesOf_value()
     {
         MapIterable<String, Number> map = this.newMapWithKeysValues("1", 1, "2", 2.0, "3", 3, "4", 4.0);
-        Assert.assertEquals(iBag(1, 3), map.selectInstancesOf(Integer.class).toBag());
+        assertEquals(iBag(1, 3), map.selectInstancesOf(Integer.class).toBag());
     }
 
     @Test
@@ -1616,28 +1623,28 @@ public abstract class MapIterableTestCase
         List<Object> nullsMinusOne = Collections.nCopies(map.size() - 1, null);
 
         RichIterable<Pair<String, Object>> pairs = map.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsPlusOne = map.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsMinusOne = map.zip(nullsMinusOne);
-        Assert.assertEquals(map.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(map
+        assertEquals(map.size() - 1, pairsMinusOne.size());
+        assertTrue(map
                 .valuesView()
                 .containsAllIterable(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet()));
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zip(nulls).toSet(),
                 map.zip(nulls, UnifiedSet.newSet()));
     }
@@ -1649,14 +1656,14 @@ public abstract class MapIterableTestCase
 
         RichIterable<Pair<String, Integer>> pairs = map.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect(Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(map.size() - 1).toSet(),
                 pairs.collect(Pair::getTwo, UnifiedSet.newSet()));
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zipWithIndex().toSet(),
                 map.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -1668,9 +1675,9 @@ public abstract class MapIterableTestCase
         RichIterable<Integer> collection = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
         MapIterable<String, AtomicInteger> aggregation =
                 collection.aggregateInPlaceBy(String::valueOf, valueCreator, AtomicInteger::addAndGet);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Test
@@ -1680,9 +1687,9 @@ public abstract class MapIterableTestCase
         Function2<Integer, Integer, Integer> sumAggregator = (integer1, integer2) -> integer1 + integer2;
         RichIterable<Integer> collection = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
         MapIterable<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Test
@@ -1690,7 +1697,7 @@ public abstract class MapIterableTestCase
     {
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "A", 2, "B", 3, "C", 4, "D");
         MutableSet<Pair<Integer, String>> keyValues = map.keyValuesView().toSet();
-        Assert.assertEquals(UnifiedSet.newSetWith(
+        assertEquals(UnifiedSet.newSetWith(
                 Tuples.pair(1, "A"),
                 Tuples.pair(2, "B"),
                 Tuples.pair(3, "C"),
@@ -1708,13 +1715,13 @@ public abstract class MapIterableTestCase
                 new IntegerWithCast(0), "Test 2",
                 new IntegerWithCast(0), "Test 3",
                 null, "Test 1");
-        Assert.assertEquals(
+        assertEquals(
                 this.newMapWithKeysValues(
                         new IntegerWithCast(0), "Test 3",
                         null, "Test 1"),
                 mutableMap);
-        Assert.assertEquals("Test 3", mutableMap.get(new IntegerWithCast(0)));
-        Assert.assertEquals("Test 1", mutableMap.get(null));
+        assertEquals("Test 3", mutableMap.get(new IntegerWithCast(0)));
+        assertEquals("Test 1", mutableMap.get(null));
     }
 
     @Test
@@ -1766,28 +1773,28 @@ public abstract class MapIterableTestCase
     {
         MapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
         Iterator<Integer> iterator = map.iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         int sum = 0;
         while (iterator.hasNext())
         {
             sum += iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(6, sum);
+        assertFalse(iterator.hasNext());
+        assertEquals(6, sum);
     }
 
     @Test
     public void keysView()
     {
         MutableList<Integer> keys = this.newMapWithKeysValues(1, 1, 2, 2).keysView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), keys);
+        assertEquals(FastList.newListWith(1, 2), keys);
     }
 
     @Test
     public void valuesView()
     {
         MutableList<Integer> values = this.newMapWithKeysValues(1, 1, 2, 2).valuesView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), values);
+        assertEquals(FastList.newListWith(1, 2), values);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
@@ -52,11 +52,17 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link AbstractMemoryEfficientMutableMap}.
@@ -213,7 +219,7 @@ public abstract class AbstractMemoryEfficientMutableMapTest
                 Verify.assertContainsAllKeyValues(result, "1", "enO", "2", "owT", "3", "eerhT");
                 break;
             default:
-                Assert.fail();
+                fail();
         }
     }
 
@@ -239,7 +245,7 @@ public abstract class AbstractMemoryEfficientMutableMapTest
                 Verify.assertContainsAllKeyValues(result, 1, "1:enO", 2, "2:owT", 3, "3:eerhT");
                 break;
             default:
-                Assert.fail();
+                fail();
         }
     }
 
@@ -258,8 +264,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, String> map = this.classUnderTest();
 
-        Assert.assertTrue(map.allSatisfy(String.class::isInstance));
-        Assert.assertFalse(map.allSatisfy("Monkey"::equals));
+        assertTrue(map.allSatisfy(String.class::isInstance));
+        assertFalse(map.allSatisfy("Monkey"::equals));
     }
 
     @Test
@@ -267,9 +273,9 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, String> map = this.classUnderTest();
 
-        Assert.assertTrue(map.noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(map.noneSatisfy(String.class::isInstance));
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertTrue(map.noneSatisfy(Boolean.class::isInstance));
+        assertFalse(map.noneSatisfy(String.class::isInstance));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
     }
 
     @Test
@@ -277,8 +283,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, String> map = this.classUnderTest();
 
-        Assert.assertTrue(map.anySatisfy(String.class::isInstance));
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertTrue(map.anySatisfy(String.class::isInstance));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Test
@@ -301,32 +307,32 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals("One", defaultString);
-                Assert.assertEquals("One", delimitedString);
-                Assert.assertEquals("{One}", wrappedString);
+                assertEquals("One", defaultString);
+                assertEquals("One", delimitedString);
+                assertEquals("{One}", wrappedString);
                 break;
             case 2:
-                Assert.assertEquals(8, defaultString.length());
-                Assert.assertEquals(7, delimitedString.length());
+                assertEquals(8, defaultString.length());
+                assertEquals(7, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(9, wrappedString.length());
+                assertEquals(9, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 3:
-                Assert.assertEquals(15, defaultString.length());
-                Assert.assertEquals(13, delimitedString.length());
+                assertEquals(15, defaultString.length());
+                assertEquals(13, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(15, wrappedString.length());
+                assertEquals(15, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             default:
-                Assert.assertEquals("", defaultString);
-                Assert.assertEquals("", delimitedString);
-                Assert.assertEquals("{}", wrappedString);
+                assertEquals("", defaultString);
+                assertEquals("", delimitedString);
+                assertEquals("{}", wrappedString);
                 break;
         }
     }
@@ -366,13 +372,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         Collection<String> values = map.values();
         multi.forEachKey(each -> Verify.assertContains(each, values));
 
-        Assert.assertEquals(multi.size(), map.size());
-        Assert.assertTrue(multi.sizeDistinct() <= map.size()); // should be the same or less since values are degenerate
+        assertEquals(multi.size(), map.size());
+        assertTrue(multi.sizeDistinct() <= map.size()); // should be the same or less since values are degenerate
 
         MutableMap<String, Integer> siMap = this.mixedTypeClassUnderTest();
         MutableMultimap<Integer, String> siMulti = siMap.flip();
-        Assert.assertEquals(siMulti.size(), siMap.size());
-        Assert.assertTrue(siMulti.sizeDistinct() <= siMap.size());
+        assertEquals(siMulti.size(), siMap.size());
+        assertTrue(siMulti.sizeDistinct() <= siMap.size());
     }
 
     @Test
@@ -431,13 +437,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One"), actual);
                 break;
             case 2:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three"), actual);
                 break;
             case 3:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
                 break;
             default:
                 Verify.assertEmpty(actual);
@@ -477,13 +483,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), sorted);
+                assertEquals(iList(1), sorted);
                 break;
             case 2:
-                Assert.assertEquals(iList(1, 2), sorted);
+                assertEquals(iList(1, 2), sorted);
                 break;
             case 3:
-                Assert.assertEquals(iList(1, 2, 3), sorted);
+                assertEquals(iList(1, 2, 3), sorted);
                 break;
             default:
                 Verify.assertEmpty(sorted);
@@ -494,13 +500,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), reverse);
+                assertEquals(iList(1), reverse);
                 break;
             case 2:
-                Assert.assertEquals(iList(2, 1), reverse);
+                assertEquals(iList(2, 1), reverse);
                 break;
             case 3:
-                Assert.assertEquals(iList(3, 2, 1), reverse);
+                assertEquals(iList(3, 2, 1), reverse);
                 break;
             default:
                 Verify.assertEmpty(reverse);
@@ -517,13 +523,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), list);
+                assertEquals(iList(1), list);
                 break;
             case 2:
-                Assert.assertEquals(iList(1, 2), list);
+                assertEquals(iList(1, 2), list);
                 break;
             case 3:
-                Assert.assertEquals(iList(1, 2, 3), list);
+                assertEquals(iList(1, 2, 3), list);
                 break;
             default:
                 Verify.assertEmpty(list);
@@ -543,16 +549,16 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), sizes);
+                assertEquals(iList(1), sizes);
                 break;
             case 2:
-                Assert.assertEquals(iList(2), sizes);
+                assertEquals(iList(2), sizes);
                 break;
             case 3:
-                Assert.assertEquals(iList(2, 1), sizes);
+                assertEquals(iList(2, 1), sizes);
                 break;
             default:
-                Assert.assertEquals(0, chunks.size());
+                assertEquals(0, chunks.size());
                 break;
         }
     }
@@ -622,13 +628,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(Bags.mutable.of(2), collectWith);
+                assertEquals(Bags.mutable.of(2), collectWith);
                 break;
             case 2:
-                Assert.assertEquals(Bags.mutable.of(2, 3), collectWith);
+                assertEquals(Bags.mutable.of(2, 3), collectWith);
                 break;
             case 3:
-                Assert.assertEquals(Bags.mutable.of(2, 3, 4), collectWith);
+                assertEquals(Bags.mutable.of(2, 3, 4), collectWith);
                 break;
             default:
                 Verify.assertEmpty(collectWith);
@@ -644,14 +650,14 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.contains("One"));
-                Assert.assertFalse(map.contains("Two"));
+                assertTrue(map.contains("One"));
+                assertFalse(map.contains("Two"));
                 break;
             case 2:
-                Assert.assertTrue(map.contains("Two"));
+                assertTrue(map.contains("Two"));
                 break;
             case 3:
-                Assert.assertTrue(map.contains("Two"));
+                assertTrue(map.contains("Two"));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -667,12 +673,12 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         if (map.isEmpty())
         {
             String value = map.getFirst();
-            Assert.assertNull(value);
+            assertNull(value);
         }
         else
         {
             String value = map.getFirst();
-            Assert.assertNotNull(value);
+            assertNotNull(value);
             Verify.assertContains(value, map.values());
         }
     }
@@ -685,12 +691,12 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         if (map.isEmpty())
         {
             String value = map.getLast();
-            Assert.assertNull(value);
+            assertNull(value);
         }
         else
         {
             String value = map.getLast();
-            Assert.assertNotNull(value);
+            assertNotNull(value);
             Verify.assertContains(value, map.values());
         }
     }
@@ -703,13 +709,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.containsAllIterable(iList("One")));
+                assertTrue(map.containsAllIterable(iList("One")));
                 break;
             case 2:
-                Assert.assertTrue(map.containsAllIterable(iList("One", "Two")));
+                assertTrue(map.containsAllIterable(iList("One", "Two")));
                 break;
             case 3:
-                Assert.assertTrue(map.containsAllIterable(iList("One", "Two", "Three")));
+                assertTrue(map.containsAllIterable(iList("One", "Two", "Three")));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -725,13 +731,13 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.containsAllArguments("One"));
+                assertTrue(map.containsAllArguments("One"));
                 break;
             case 2:
-                Assert.assertTrue(map.containsAllArguments("One", "Two"));
+                assertTrue(map.containsAllArguments("One", "Two"));
                 break;
             case 3:
-                Assert.assertTrue(map.containsAllArguments("One", "Two", "Three"));
+                assertTrue(map.containsAllArguments("One", "Two", "Three"));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -749,16 +755,16 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(1, actual);
+                assertEquals(1, actual);
                 break;
             case 2:
-                Assert.assertEquals(1, actual);
+                assertEquals(1, actual);
                 break;
             case 3:
-                Assert.assertEquals(2, actual);
+                assertEquals(2, actual);
                 break;
             default:
-                Assert.assertEquals(0, actual);
+                assertEquals(0, actual);
                 break;
         }
     }
@@ -771,15 +777,15 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         if (map.isEmpty())
         {
             String resultNotFound = map.detect(ignored -> true);
-            Assert.assertNull(resultNotFound);
+            assertNull(resultNotFound);
         }
         else
         {
             String resultFound = map.detect("One"::equals);
-            Assert.assertEquals("One", resultFound);
+            assertEquals("One", resultFound);
 
             String resultNotFound = map.detect("Four"::equals);
-            Assert.assertNull(resultNotFound);
+            assertNull(resultNotFound);
         }
     }
 
@@ -791,15 +797,15 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         if (map.isEmpty())
         {
             String resultNotFound = map.detectIfNone(ignored -> true, () -> "Zero");
-            Assert.assertEquals("Zero", resultNotFound);
+            assertEquals("Zero", resultNotFound);
         }
         else
         {
             String resultNotFound = map.detectIfNone("Four"::equals, () -> "Zero");
-            Assert.assertEquals("Zero", resultNotFound);
+            assertEquals("Zero", resultNotFound);
 
             String resultFound = map.detectIfNone("One"::equals, () -> "Zero");
-            Assert.assertEquals("One", resultFound);
+            assertEquals("One", resultFound);
         }
     }
 
@@ -828,25 +834,25 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(blob.containsAllArguments(
+                assertTrue(blob.containsAllArguments(
                         Character.valueOf('O'),
                         Character.valueOf('n'),
                         Character.valueOf('e')));
-                Assert.assertTrue(blobFromTarget.containsAllArguments(
+                assertTrue(blobFromTarget.containsAllArguments(
                         Character.valueOf('O'),
                         Character.valueOf('n'),
                         Character.valueOf('e')));
                 break;
             case 2:
             case 3:
-                Assert.assertTrue(blob.containsAllArguments(
+                assertTrue(blob.containsAllArguments(
                         Character.valueOf('O'),
                         Character.valueOf('n'),
                         Character.valueOf('e'),
                         Character.valueOf('T'),
                         Character.valueOf('w'),
                         Character.valueOf('o')));
-                Assert.assertTrue(blobFromTarget.containsAllArguments(
+                assertTrue(blobFromTarget.containsAllArguments(
                         Character.valueOf('O'),
                         Character.valueOf('n'),
                         Character.valueOf('e'),
@@ -855,8 +861,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
                         Character.valueOf('o')));
                 break;
             default:
-                Assert.assertEquals(0, blob.size());
-                Assert.assertEquals(0, blobFromTarget.size());
+                assertEquals(0, blob.size());
+                assertEquals(0, blobFromTarget.size());
                 break;
         }
     }
@@ -887,10 +893,10 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         }
 
         Multimap<Boolean, Integer> actual = map.groupBy(isOddFunction);
-        Assert.assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actual));
+        assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actual));
 
         Multimap<Boolean, Integer> actualFromTarget = map.groupBy(isOddFunction, FastListMultimap.newMultimap());
-        Assert.assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actualFromTarget));
+        assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actualFromTarget));
     }
 
     @Test
@@ -908,19 +914,19 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         Multimap<Integer, Integer> actual = map.groupByEach(function);
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actual.containsKey(each));
+            assertTrue(actual.containsKey(each));
             MutableList<Integer> values = actual.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
 
         Multimap<Integer, Integer> actualFromTarget = map.groupByEach(function, FastListMultimap.newMultimap());
         expected.forEachKey(each ->
         {
-            Assert.assertTrue(actualFromTarget.containsKey(each));
+            assertTrue(actualFromTarget.containsKey(each));
             MutableList<Integer> values = actualFromTarget.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
     }
 
@@ -953,10 +959,10 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         }
 
         Integer actual = map.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(expectedInteger, actual);
+        assertEquals(expectedInteger, actual);
 
         Sum sum = map.injectInto(new IntegerSum(0), SumProcedure.number());
-        Assert.assertEquals(expectedSum, sum);
+        assertEquals(expectedSum, sum);
     }
 
     @Test
@@ -971,32 +977,32 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals("One", defaultString);
-                Assert.assertEquals("One", delimitedString);
-                Assert.assertEquals("{One}", wrappedString);
+                assertEquals("One", defaultString);
+                assertEquals("One", delimitedString);
+                assertEquals("{One}", wrappedString);
                 break;
             case 2:
-                Assert.assertEquals(8, defaultString.length());
-                Assert.assertEquals(7, delimitedString.length());
+                assertEquals(8, defaultString.length());
+                assertEquals(7, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(9, wrappedString.length());
+                assertEquals(9, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 3:
-                Assert.assertEquals(15, defaultString.length());
-                Assert.assertEquals(13, delimitedString.length());
+                assertEquals(15, defaultString.length());
+                assertEquals(13, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(15, wrappedString.length());
+                assertEquals(15, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             default:
-                Assert.assertEquals("", defaultString);
-                Assert.assertEquals("", delimitedString);
-                Assert.assertEquals("{}", wrappedString);
+                assertEquals("", defaultString);
+                assertEquals("", delimitedString);
+                assertEquals("{}", wrappedString);
                 break;
         }
     }
@@ -1006,8 +1012,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
 
-        Assert.assertEquals(Integer.valueOf(1), map.min());
-        Assert.assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), map.min());
+        assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
     }
 
     @Test
@@ -1032,8 +1038,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
                 throw new IllegalStateException("We should not get here, this test method should be overriden by the empty map.");
         }
 
-        Assert.assertEquals(max, map.max());
-        Assert.assertEquals(max, map.max(Integer::compareTo));
+        assertEquals(max, map.max());
+        assertEquals(max, map.max(Integer::compareTo));
     }
 
     @Test
@@ -1041,14 +1047,14 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
 
-        Assert.assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
-        Assert.assertEquals(Integer.valueOf(map.size()), map.maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(map.size()), map.maxBy(String::valueOf));
         Verify.assertContains(Integer.valueOf(map.size()), iList(1, 2, 3));
     }
 
@@ -1061,8 +1067,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         UnifiedSet<Integer> rejectedIntoTarget = map.reject(IntegerPredicates.isEven(), UnifiedSet.newSet());
 
         ImmutableSet<Integer> expected = this.expectReject(map.size());
-        Assert.assertEquals(expected, rejected);
-        Assert.assertEquals(expected, rejectedIntoTarget);
+        assertEquals(expected, rejected);
+        assertEquals(expected, rejectedIntoTarget);
     }
 
     private ImmutableSet<Integer> expectReject(int size)
@@ -1109,8 +1115,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
         ImmutableSet<Integer> expected = this.expectSelect(map.size());
 
-        Assert.assertEquals(expected, map.select(IntegerPredicates.isEven()).toSet());
-        Assert.assertEquals(expected, map.select(IntegerPredicates.isEven(), UnifiedSet.newSet()));
+        assertEquals(expected, map.select(IntegerPredicates.isEven()).toSet());
+        assertEquals(expected, map.select(IntegerPredicates.isEven(), UnifiedSet.newSet()));
     }
 
     private ImmutableSet<Integer> expectSelect(int size)
@@ -1156,8 +1162,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
         PartitionMutableCollection<Integer> partition = map.partition(IntegerPredicates.isEven());
 
-        Assert.assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
-        Assert.assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
+        assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
+        assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
     }
 
     @Test
@@ -1166,8 +1172,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         MutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3);
         PartitionMutableCollection<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
 
-        Assert.assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
-        Assert.assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
+        assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
+        assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
     }
 
     @Test
@@ -1203,28 +1209,28 @@ public abstract class AbstractMemoryEfficientMutableMapTest
         List<Object> nullsPlusOne = Collections.nCopies(map.size() + 1, null);
 
         RichIterable<Pair<String, Object>> pairs = map.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsPlusOne = map.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         if (map.notEmpty())
         {
             List<Object> nullsMinusOne = Collections.nCopies(map.size() - 1, null);
             RichIterable<Pair<String, Object>> pairsMinusOne = map.zip(nullsMinusOne);
-            Assert.assertEquals(map.size() - 1, pairsMinusOne.size());
-            Assert.assertTrue(map.values().containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet()));
+            assertEquals(map.size() - 1, pairsMinusOne.size());
+            assertTrue(map.values().containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet()));
         }
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zip(nulls).toSet(),
                 map.zip(nulls, UnifiedSet.newSet()));
     }
@@ -1236,17 +1242,17 @@ public abstract class AbstractMemoryEfficientMutableMapTest
 
         RichIterable<Pair<String, Integer>> pairs = map.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
         if (map.notEmpty())
         {
-            Assert.assertEquals(
+            assertEquals(
                     Interval.zeroTo(map.size() - 1).toSet(),
                     pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
         }
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zipWithIndex().toSet(),
                 map.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -1312,8 +1318,8 @@ public abstract class AbstractMemoryEfficientMutableMapTest
     {
         MutableList<String> tapResult = Lists.mutable.of();
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertSame(map, map.tap(tapResult::add));
-        Assert.assertEquals(map.toList(), tapResult);
+        assertSame(map, map.tap(tapResult::add));
+        assertEquals(map.toList(), tapResult);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/DoubletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/DoubletonMapTest.java
@@ -26,8 +26,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link DoubletonMap}.
@@ -50,7 +55,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue("One"));
+        assertTrue(this.classUnderTest().containsValue("One"));
     }
 
     @Override
@@ -60,7 +65,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "One", 2, "Two");
         map.forEachKeyValue((key, value) -> collection.add(key + value));
-        Assert.assertEquals(FastList.newListWith("1One", "2Two"), collection);
+        assertEquals(FastList.newListWith("1One", "2Two"), collection);
     }
 
     @Test
@@ -69,9 +74,9 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "One", 2, "Two");
         MutableMap<String, Integer> flip = map.flipUniqueValues();
         Verify.assertInstanceOf(DoubletonMap.class, flip);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2), flip);
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2), flip);
 
-        Assert.assertThrows(IllegalStateException.class, () -> new DoubletonMap<>(1, "One", 2, "One").flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> new DoubletonMap<>(1, "One", 2, "One").flipUniqueValues());
     }
 
     @Override
@@ -82,16 +87,16 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         Twin<String> twin2 = Tuples.twin("2", "2");
 
         DoubletonMap<Twin<String>, Twin<String>> map = new DoubletonMap<>(twin1, twin1, twin2, twin2);
-        Assert.assertSame(map.getKey1(), twin1);
-        Assert.assertSame(map.getKey2(), twin2);
+        assertSame(map.getKey1(), twin1);
+        assertSame(map.getKey2(), twin2);
 
         Twin<String> twin3 = Tuples.twin("1", "1");
         map.withKeyValue(twin3, twin3);
-        Assert.assertSame(map.get(twin1), twin3);
+        assertSame(map.get(twin1), twin3);
 
         Twin<String> twin4 = Tuples.twin("2", "2");
         map.withKeyValue(twin4, twin4);
-        Assert.assertSame(map.get(twin2), twin4);
+        assertSame(map.get(twin2), twin4);
     }
 
     @Override
@@ -104,7 +109,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new DoubletonMap<>(1, "A", 2, "B");
         MutableMap<Integer, String> map2with = map2.withKeyValue(1, "AA");
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA", 2, "B"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -118,7 +123,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new DoubletonMap<>(1, "A", 2, "B");
         MutableMap<Integer, String> map2with = map2.withAllKeyValueArguments(Tuples.pair(1, "AA"));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA", 2, "B"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -126,7 +131,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "A", 2, "B");
         MutableMap<Integer, String> mapWithout1 = map.withoutKey(3);
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutKey(1);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(2, "B"), mapWithout2);
         Verify.assertInstanceOf(SingletonMap.class, mapWithout2);
@@ -137,7 +142,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "A", 2, "B");
         MutableMap<Integer, String> mapWithout1 = map.withoutAllKeys(FastList.newListWith(3, 4));
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutAllKeys(FastList.newListWith(2, 3));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "A"), mapWithout2);
         Verify.assertInstanceOf(SingletonMap.class, mapWithout2);
@@ -150,7 +155,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
         map.forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2"), collection);
+        assertEquals(FastList.newListWith("1", "2"), collection);
     }
 
     @Override
@@ -160,7 +165,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
         map.forEach(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2"), collection);
+        assertEquals(FastList.newListWith("1", "2"), collection);
     }
 
     @Override
@@ -170,7 +175,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
         map.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2), collection);
+        assertEquals(FastList.newListWith(1, 2), collection);
     }
 
     @Override
@@ -178,8 +183,8 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPut()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
+        assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
     }
 
     @Override
@@ -187,8 +192,8 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPutWith()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
-        Assert.assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
+        assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
     }
 
     @Override
@@ -196,9 +201,9 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent_function()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -206,10 +211,10 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getOrDefault()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getOrDefault(1, "4"));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getOrDefault(1, "4"));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -217,10 +222,10 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsentValue(1, "4"));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsentValue(1, "4"));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -228,9 +233,9 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentWith()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -238,16 +243,16 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void ifPresentApply()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "1", 2, "2");
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
-        Assert.assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(new DoubletonMap<>(1, "1", 2, "2").notEmpty());
+        assertTrue(new DoubletonMap<>(1, "1", 2, "2").notEmpty());
     }
 
     @Override
@@ -257,7 +262,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> result = Lists.mutable.of();
         MutableMap<Integer, Integer> map = new DoubletonMap<>(1, 1, 2, 2);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11, 12), result);
+        assertEquals(FastList.newListWith(11, 12), result);
     }
 
     @Override
@@ -271,7 +276,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0", "Two", "1"), result);
+        assertEquals(FastList.newListWith("One", "0", "Two", "1"), result);
     }
 
     @Override
@@ -284,7 +289,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(entry.getValue());
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two"), result);
+        assertEquals(FastList.newListWith("One", "Two"), result);
     }
 
     @Override
@@ -297,7 +302,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two"), result);
+        assertEquals(FastList.newListWith("One", "Two"), result);
     }
 
     @Override
@@ -310,7 +315,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1, 2), result);
+        assertEquals(FastList.newListWith(1, 2), result);
     }
 
     @Override
@@ -318,7 +323,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void testToString()
     {
         MutableMap<Integer, String> map = new DoubletonMap<>(1, "One", 2, "Two");
-        Assert.assertEquals("{1=One, 2=Two}", map.toString());
+        assertEquals("{1=One, 2=Two}", map.toString());
     }
 
     @Override
@@ -326,7 +331,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void asLazyKeys()
     {
         MutableList<Integer> keys = Maps.fixedSize.of(1, 1, 2, 2).keysView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), keys);
+        assertEquals(FastList.newListWith(1, 2), keys);
     }
 
     @Override
@@ -334,7 +339,7 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void asLazyValues()
     {
         MutableList<Integer> values = Maps.fixedSize.of(1, 1, 2, 2).valuesView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), values);
+        assertEquals(FastList.newListWith(1, 2), values);
     }
 
     @Override
@@ -356,15 +361,15 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         Verify.assertInstanceOf(EmptyMap.class, empty);
 
         MutableMap<String, String> full = map.select((ignored1, ignored2) -> true);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         MutableMap<String, String> one = map.select((argument1, argument2) -> "1".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, one);
-        Assert.assertEquals(new SingletonMap<>("1", "One"), one);
+        assertEquals(new SingletonMap<>("1", "One"), one);
 
         MutableMap<String, String> two = map.select((argument1, argument2) -> "2".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, two);
-        Assert.assertEquals(new SingletonMap<>("2", "Two"), two);
+        assertEquals(new SingletonMap<>("2", "Two"), two);
     }
 
     @Override
@@ -378,15 +383,15 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
 
         MutableMap<String, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(DoubletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         MutableMap<String, String> one = map.reject((argument1, argument2) -> "2".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, one);
-        Assert.assertEquals(new SingletonMap<>("1", "One"), one);
+        assertEquals(new SingletonMap<>("1", "One"), one);
 
         MutableMap<String, String> two = map.reject((argument1, argument2) -> "1".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, two);
-        Assert.assertEquals(new SingletonMap<>("2", "Two"), two);
+        assertEquals(new SingletonMap<>("2", "Two"), two);
     }
 
     @Override
@@ -396,12 +401,12 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<String, String> map = this.classUnderTest();
 
         Pair<String, String> one = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair("1", "One"), one);
+        assertEquals(Tuples.pair("1", "One"), one);
 
         Pair<String, String> two = map.detect((argument1, argument2) -> "2".equals(argument1));
-        Assert.assertEquals(Tuples.pair("2", "Two"), two);
+        assertEquals(Tuples.pair("2", "Two"), two);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override
@@ -426,12 +431,12 @@ public class DoubletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             collection.add(eachValue);
         }
-        Assert.assertEquals(FastList.newListWith("1", "2"), collection);
+        assertEquals(FastList.newListWith("1", "2"), collection);
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
@@ -27,8 +27,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link EmptyMap}.
@@ -51,7 +57,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(new EmptyMap<>().containsValue("One"));
+        assertFalse(new EmptyMap<>().containsValue("One"));
     }
 
     @Test
@@ -64,11 +70,11 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void empty()
     {
         Verify.assertEmpty(new EmptyMap<>());
-        Assert.assertFalse(new EmptyMap<>().notEmpty());
+        assertFalse(new EmptyMap<>().notEmpty());
         Verify.assertEmpty(new EmptyMap<>());
-        Assert.assertFalse(new EmptyMap<>().notEmpty());
+        assertFalse(new EmptyMap<>().notEmpty());
         Verify.assertEmpty(Maps.fixedSize.of());
-        Assert.assertFalse(Maps.fixedSize.of().notEmpty());
+        assertFalse(Maps.fixedSize.of().notEmpty());
     }
 
     @Test
@@ -99,7 +105,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void testClone()
     {
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertSame(map, map.clone());
+        assertSame(map, map.clone());
     }
 
     @Test
@@ -109,29 +115,29 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Object, Object> map = new EmptyMap<>();
 
         map.each(procedure);
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
 
         map.forEachKey(procedure);
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
 
         map.forEachValue(procedure);
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
 
         map.forEachKeyValue(procedure);
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
 
         map.forEachWith(procedure, new Object());
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
 
         map.forEachWithIndex(procedure);
-        Assert.assertFalse(procedure.called);
+        assertFalse(procedure.called);
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", new EmptyMap<Integer, String>().toString());
+        assertEquals("{}", new EmptyMap<Integer, String>().toString());
     }
 
     @Override
@@ -166,7 +172,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void detect()
     {
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertNull(map.detect((ignored1, ignored2) -> true));
+        assertNull(map.detect((ignored1, ignored2) -> true));
     }
 
     @Override
@@ -186,7 +192,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void allSatisfy()
     {
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertTrue(map.allSatisfy(ignored -> true));
+        assertTrue(map.allSatisfy(ignored -> true));
     }
 
     @Override
@@ -194,7 +200,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void anySatisfy()
     {
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertFalse(map.anySatisfy(ignored -> true));
+        assertFalse(map.anySatisfy(ignored -> true));
     }
 
     @Override
@@ -202,7 +208,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void noneSatisfy()
     {
         MutableMap<String, String> map = this.classUnderTest();
-        Assert.assertTrue(map.noneSatisfy(ignored -> true));
+        assertTrue(map.noneSatisfy(ignored -> true));
     }
 
     @Override
@@ -341,7 +347,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPut()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
     }
 
     @Override
@@ -349,7 +355,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPutWith()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
     }
 
     @Override
@@ -357,9 +363,9 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent_function()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -367,9 +373,9 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getOrDefault()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -377,9 +383,9 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -387,9 +393,9 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentWith()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -397,14 +403,14 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     public void ifPresentApply()
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(new EmptyMap<Integer, String>().notEmpty());
+        assertFalse(new EmptyMap<Integer, String>().notEmpty());
     }
 
     @Override
@@ -460,7 +466,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
         MutableMap<Integer, String> mapWithout = map.withoutKey(1);
-        Assert.assertSame(map, mapWithout);
+        assertSame(map, mapWithout);
     }
 
     @Override
@@ -468,7 +474,7 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new EmptyMap<>();
         MutableMap<Integer, String> mapWithout = map.withoutAllKeys(FastList.newListWith(1, 2));
-        Assert.assertSame(map, mapWithout);
+        assertSame(map, mapWithout);
     }
 
     @Override
@@ -481,12 +487,12 @@ public class EmptyMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             collection.add(eachValue);
         }
-        Assert.assertEquals(FastList.newListWith(), collection);
+        assertEquals(FastList.newListWith(), collection);
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> new EmptyMap<>().getOnly());
+        assertThrows(IllegalStateException.class, () -> new EmptyMap<>().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/SingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/SingletonMapTest.java
@@ -26,8 +26,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SingletonMap}.
@@ -50,7 +55,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue("One"));
+        assertTrue(this.classUnderTest().containsValue("One"));
     }
 
     @Override
@@ -60,7 +65,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new SingletonMap<>(1, "One");
         map.forEachKeyValue((key, value) -> collection.add(key + value));
-        Assert.assertEquals(FastList.newListWith("1One"), collection);
+        assertEquals(FastList.newListWith("1One"), collection);
     }
 
     @Override
@@ -71,8 +76,8 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         Twin<String> twin2 = Tuples.twin("1", "1");
         SingletonMap<Twin<String>, Twin<String>> map = new SingletonMap<>(twin1, twin1);
         map.withKeyValue(twin2, twin2);
-        Assert.assertSame(map.getKey1(), twin1);
-        Assert.assertSame(map.get(twin1), twin2);
+        assertSame(map.getKey1(), twin1);
+        assertSame(map.get(twin1), twin2);
     }
 
     @Override
@@ -86,7 +91,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new SingletonMap<>(1, "A");
         MutableMap<Integer, String> map2with = map2.withKeyValue(1, "AA");
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -101,7 +106,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new SingletonMap<>(1, "A");
         MutableMap<Integer, String> map2with = map2.withAllKeyValueArguments(Tuples.pair(1, "AA"));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -110,7 +115,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "A");
         MutableMap<Integer, String> mapWithout1 = map.withoutKey(2);
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutKey(1);
         Verify.assertMapsEqual(UnifiedMap.newMap(), mapWithout2);
         Verify.assertInstanceOf(EmptyMap.class, mapWithout2);
@@ -122,7 +127,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "A");
         MutableMap<Integer, String> mapWithout1 = map.withoutAllKeys(FastList.newListWith(2, 3));
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutAllKeys(FastList.newListWith(1, 2));
         Verify.assertMapsEqual(UnifiedMap.newMap(), mapWithout2);
         Verify.assertInstanceOf(EmptyMap.class, mapWithout2);
@@ -135,7 +140,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
         map.forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -145,7 +150,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
         map.forEach(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -158,7 +163,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             collection.add(eachValue);
         }
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -168,7 +173,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
         map.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1), collection);
+        assertEquals(FastList.newListWith(1), collection);
     }
 
     @Override
@@ -176,8 +181,8 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPut()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
+        assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
     }
 
     @Override
@@ -185,8 +190,8 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPutWith()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
-        Assert.assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
+        assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
     }
 
     @Override
@@ -194,10 +199,10 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent_function()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("1")));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("1")));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -205,10 +210,10 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getOrDefault()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getOrDefault(1, "1"));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("1", map.getOrDefault(1, "1"));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -216,10 +221,10 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsentValue(1, "1"));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsentValue(1, "1"));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -227,10 +232,10 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentWith()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 1));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 1));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -238,15 +243,15 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void ifPresentApply()
     {
         MutableMap<Integer, String> map = new SingletonMap<>(1, "1");
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(new SingletonMap<>(1, "1").notEmpty());
+        assertTrue(new SingletonMap<>(1, "1").notEmpty());
     }
 
     @Override
@@ -256,7 +261,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> result = Lists.mutable.of();
         MutableMap<Integer, Integer> map = new SingletonMap<>(1, 1);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11), result);
+        assertEquals(FastList.newListWith(11), result);
     }
 
     @Override
@@ -270,7 +275,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0"), result);
+        assertEquals(FastList.newListWith("One", "0"), result);
     }
 
     @Override
@@ -283,7 +288,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(entry.getValue());
         }
-        Assert.assertEquals(FastList.newListWith("One"), result);
+        assertEquals(FastList.newListWith("One"), result);
     }
 
     @Override
@@ -296,7 +301,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One"), result);
+        assertEquals(FastList.newListWith("One"), result);
     }
 
     @Override
@@ -309,16 +314,16 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{1=One}", new SingletonMap<>(1, "One").toString());
-        Assert.assertEquals("{1=null}", new SingletonMap<Integer, String>(1, null).toString());
-        Assert.assertEquals("{null=One}", new SingletonMap<Integer, String>(null, "One").toString());
+        assertEquals("{1=One}", new SingletonMap<>(1, "One").toString());
+        assertEquals("{1=null}", new SingletonMap<Integer, String>(1, null).toString());
+        assertEquals("{null=One}", new SingletonMap<Integer, String>(null, "One").toString());
     }
 
     @Override
@@ -335,7 +340,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void asLazyKeys()
     {
         MutableList<Integer> keys = Maps.fixedSize.of(1, 1).keysView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1), keys);
+        assertEquals(FastList.newListWith(1), keys);
     }
 
     @Override
@@ -343,7 +348,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void asLazyValues()
     {
         MutableList<Integer> values = Maps.fixedSize.of(1, 1).valuesView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1), values);
+        assertEquals(FastList.newListWith(1), values);
     }
 
     @Override
@@ -357,7 +362,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
 
         MutableMap<String, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(SingletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
     }
 
     @Override
@@ -371,7 +376,7 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
 
         MutableMap<String, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(SingletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
     }
 
     @Override
@@ -381,9 +386,9 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<String, String> map = this.classUnderTest();
 
         Pair<String, String> actual = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair("1", "One"), actual);
+        assertEquals(Tuples.pair("1", "One"), actual);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Test
@@ -391,14 +396,14 @@ public class SingletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<String, String> flip = new SingletonMap<>("1", "One").flipUniqueValues();
         Verify.assertInstanceOf(SingletonMap.class, flip);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", "1"), flip);
+        assertEquals(UnifiedMap.newWithKeysValues("One", "1"), flip);
     }
 
     @Test
     public void getOnly()
     {
         String only = this.classUnderTest().getOnly();
-        Assert.assertEquals("One", only);
+        assertEquals("One", only);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/TripletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/TripletonMapTest.java
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link TripletonMap}.
@@ -60,26 +65,26 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableSetMultimap<Integer, String> flipOne = degenerateOne.flip();
         MutableSetMultimap<Integer, String> flipTwo = degenerateTwo.flip();
 
-        Assert.assertEquals(Multimaps.immutable.set.with(1, "A", 2, "B", 3, "C"), flipZero);
-        Assert.assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", 3, "C"), flipOne);
-        Assert.assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", 1, "C"), flipTwo);
+        assertEquals(Multimaps.immutable.set.with(1, "A", 2, "B", 3, "C"), flipZero);
+        assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", 3, "C"), flipOne);
+        assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", 1, "C"), flipTwo);
 
         MutableMap<String, Integer> nullValue = new TripletonMap<>("A", 1, "B", 1, "C", null);
         MutableSetMultimap<Integer, String> flipNull = nullValue.flip();
 
-        Assert.assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", null, "C"), flipNull);
+        assertEquals(Multimaps.immutable.set.with(1, "A", 1, "B", null, "C"), flipNull);
 
         MutableMap<String, Integer> nullValueAllNull = new TripletonMap<>("A", null, "B", null, "C", null);
         MutableSetMultimap<Integer, String> flipNullAllNull = nullValueAllNull.flip();
 
-        Assert.assertEquals(Multimaps.immutable.set.with(null, "A", null, "B", null, "C"), flipNullAllNull);
+        assertEquals(Multimaps.immutable.set.with(null, "A", null, "B", null, "C"), flipNullAllNull);
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue("One"));
+        assertTrue(this.classUnderTest().containsValue("One"));
     }
 
     @Override
@@ -89,7 +94,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new TripletonMap<>(1, "One", 2, "Two", 3, "Three");
         map.forEachKeyValue((key, value) -> collection.add(key + value));
-        Assert.assertEquals(FastList.newListWith("1One", "2Two", "3Three"), collection);
+        assertEquals(FastList.newListWith("1One", "2Two", "3Three"), collection);
     }
 
     @Test
@@ -98,11 +103,11 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map = new TripletonMap<>(1, "One", 2, "Two", 3, "Three");
         MutableMap<String, Integer> flip = map.flipUniqueValues();
         Verify.assertInstanceOf(TripletonMap.class, flip);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), flip);
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), flip);
 
-        Assert.assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "One", 3, "Three").flipUniqueValues());
-        Assert.assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "Three", 3, "Three").flipUniqueValues());
-        Assert.assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "Two", 3, "One").flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "One", 3, "Three").flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "Three", 3, "Three").flipUniqueValues());
+        assertThrows(IllegalStateException.class, () -> new TripletonMap<>(1, "One", 2, "Two", 3, "One").flipUniqueValues());
     }
 
     @Override
@@ -123,12 +128,12 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         Twin<String> twin6 = Tuples.twin("3", "3");
         map.withKeyValue(twin6, twin6);
 
-        Assert.assertSame(map.getKey1(), twin1);
-        Assert.assertSame(map.getKey2(), twin2);
-        Assert.assertSame(map.getKey3(), twin3);
-        Assert.assertSame(map.get(twin1), twin4);
-        Assert.assertSame(map.get(twin2), twin5);
-        Assert.assertSame(map.get(twin3), twin6);
+        assertSame(map.getKey1(), twin1);
+        assertSame(map.getKey2(), twin2);
+        assertSame(map.getKey3(), twin3);
+        assertSame(map.get(twin1), twin4);
+        assertSame(map.get(twin2), twin5);
+        assertSame(map.get(twin3), twin6);
     }
 
     @Override
@@ -141,7 +146,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new TripletonMap<>(1, "A", 2, "B", 3, "C");
         MutableMap<Integer, String> map2with = map2.withKeyValue(1, "AA");
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA", 2, "B", 3, "C"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -155,7 +160,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<Integer, String> map2 = new TripletonMap<>(1, "A", 2, "B", 3, "C");
         MutableMap<Integer, String> map2with = map2.withAllKeyValueArguments(Tuples.pair(1, "AA"));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "AA", 2, "B", 3, "C"), map2with);
-        Assert.assertSame(map2, map2with);
+        assertSame(map2, map2with);
     }
 
     @Override
@@ -163,7 +168,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "A", 2, "B", 3, "C");
         MutableMap<Integer, String> mapWithout1 = map.withoutKey(4);
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutKey(1);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(2, "B", 3, "C"), mapWithout2);
         Verify.assertInstanceOf(DoubletonMap.class, mapWithout2);
@@ -174,7 +179,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "A", 2, "B", 3, "C");
         MutableMap<Integer, String> mapWithout1 = map.withoutAllKeys(FastList.newListWith(4, 5));
-        Assert.assertSame(map, mapWithout1);
+        assertSame(map, mapWithout1);
         MutableMap<Integer, String> mapWithout2 = map.withoutAllKeys(FastList.newListWith(3, 4));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues(1, "A", 2, "B"), mapWithout2);
         Verify.assertInstanceOf(DoubletonMap.class, mapWithout2);
@@ -187,7 +192,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
         map.forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), collection);
+        assertEquals(FastList.newListWith("1", "2", "3"), collection);
     }
 
     @Override
@@ -197,7 +202,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<String> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
         map.forEach(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), collection);
+        assertEquals(FastList.newListWith("1", "2", "3"), collection);
     }
 
     @Override
@@ -207,7 +212,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> collection = Lists.mutable.of();
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
         map.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), collection);
+        assertEquals(FastList.newListWith(1, 2, 3), collection);
     }
 
     @Override
@@ -215,8 +220,8 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPut()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
+        assertEquals("1", map.getIfAbsentPut(1, new PassThruFunction0<>("1")));
     }
 
     @Override
@@ -224,8 +229,8 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentPutWith()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
-        Assert.assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
+        assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith(4, String::valueOf, 4));
+        assertEquals("1", map.getIfAbsentPutWith(1, String::valueOf, 1));
     }
 
     @Override
@@ -233,9 +238,9 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent_function()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -243,10 +248,10 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getOrDefault()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getOrDefault(1, "4"));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getOrDefault(1, "4"));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -254,10 +259,10 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsent()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("1", map.getIfAbsentValue(1, "4"));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("1", map.getIfAbsentValue(1, "4"));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -265,9 +270,9 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void getIfAbsentWith()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -275,17 +280,17 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void ifPresentApply()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
-        Assert.assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
-        Assert.assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
+        assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(new TripletonMap<>(1, "1", 2, "2", 3, "3").notEmpty());
+        assertTrue(new TripletonMap<>(1, "1", 2, "2", 3, "3").notEmpty());
     }
 
     @Override
@@ -295,7 +300,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableList<Integer> result = Lists.mutable.of();
         MutableMap<Integer, Integer> map = new TripletonMap<>(1, 1, 2, 2, 3, 3);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11, 12, 13), result);
+        assertEquals(FastList.newListWith(11, 12, 13), result);
     }
 
     @Override
@@ -309,7 +314,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2"), result);
+        assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2"), result);
     }
 
     @Override
@@ -322,7 +327,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(entry.getValue());
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three"), result);
     }
 
     @Override
@@ -335,7 +340,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three"), result);
     }
 
     @Override
@@ -348,7 +353,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), result);
+        assertEquals(FastList.newListWith(1, 2, 3), result);
     }
 
     @Override
@@ -356,7 +361,7 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
     public void testToString()
     {
         MutableMap<Integer, String> map = new TripletonMap<>(1, "One", 2, "Two", 3, "Three");
-        Assert.assertEquals("{1=One, 2=Two, 3=Three}", map.toString());
+        assertEquals("{1=One, 2=Two, 3=Three}", map.toString());
     }
 
     @Override
@@ -398,31 +403,31 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
 
         MutableMap<String, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(TripletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         MutableMap<String, String> one = map.select((argument1, argument2) -> "1".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, one);
-        Assert.assertEquals(new SingletonMap<>("1", "One"), one);
+        assertEquals(new SingletonMap<>("1", "One"), one);
 
         MutableMap<String, String> two = map.select((argument1, argument2) -> "2".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, two);
-        Assert.assertEquals(new SingletonMap<>("2", "Two"), two);
+        assertEquals(new SingletonMap<>("2", "Two"), two);
 
         MutableMap<String, String> three = map.select((argument1, argument2) -> "3".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, three);
-        Assert.assertEquals(new SingletonMap<>("3", "Three"), three);
+        assertEquals(new SingletonMap<>("3", "Three"), three);
 
         MutableMap<String, String> oneAndThree = map.select((argument1, argument2) -> "1".equals(argument1) || "3".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new DoubletonMap<>("1", "One", "3", "Three"), oneAndThree);
+        assertEquals(new DoubletonMap<>("1", "One", "3", "Three"), oneAndThree);
 
         MutableMap<String, String> oneAndTwo = map.select((argument1, argument2) -> "1".equals(argument1) || "2".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new DoubletonMap<>("1", "One", "2", "Two"), oneAndTwo);
+        assertEquals(new DoubletonMap<>("1", "One", "2", "Two"), oneAndTwo);
 
         MutableMap<String, String> twoAndThree = map.select((argument1, argument2) -> "2".equals(argument1) || "3".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new DoubletonMap<>("2", "Two", "3", "Three"), twoAndThree);
+        assertEquals(new DoubletonMap<>("2", "Two", "3", "Three"), twoAndThree);
     }
 
     @Override
@@ -436,31 +441,31 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
 
         MutableMap<String, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(TripletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         MutableMap<String, String> one = map.reject((argument1, argument2) -> "2".equals(argument1) || "3".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, one);
-        Assert.assertEquals(new SingletonMap<>("1", "One"), one);
+        assertEquals(new SingletonMap<>("1", "One"), one);
 
         MutableMap<String, String> two = map.reject((argument1, argument2) -> "1".equals(argument1) || "3".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, two);
-        Assert.assertEquals(new SingletonMap<>("2", "Two"), two);
+        assertEquals(new SingletonMap<>("2", "Two"), two);
 
         MutableMap<String, String> three = map.reject((argument1, argument2) -> "1".equals(argument1) || "2".equals(argument1));
         Verify.assertInstanceOf(SingletonMap.class, three);
-        Assert.assertEquals(new SingletonMap<>("3", "Three"), three);
+        assertEquals(new SingletonMap<>("3", "Three"), three);
 
         MutableMap<String, String> oneAndThree = map.reject((argument1, argument2) -> "2".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new DoubletonMap<>("1", "One", "3", "Three"), oneAndThree);
+        assertEquals(new DoubletonMap<>("1", "One", "3", "Three"), oneAndThree);
 
         MutableMap<String, String> oneAndTwo = map.reject((argument1, argument2) -> "3".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new DoubletonMap<>("1", "One", "2", "Two"), oneAndTwo);
+        assertEquals(new DoubletonMap<>("1", "One", "2", "Two"), oneAndTwo);
 
         MutableMap<String, String> twoAndThree = map.reject((argument1, argument2) -> "1".equals(argument1));
         Verify.assertInstanceOf(DoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new DoubletonMap<>("2", "Two", "3", "Three"), twoAndThree);
+        assertEquals(new DoubletonMap<>("2", "Two", "3", "Three"), twoAndThree);
     }
 
     @Override
@@ -470,15 +475,15 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         MutableMap<String, String> map = this.classUnderTest();
 
         Pair<String, String> one = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair("1", "One"), one);
+        assertEquals(Tuples.pair("1", "One"), one);
 
         Pair<String, String> two = map.detect((argument1, argument2) -> "2".equals(argument1));
-        Assert.assertEquals(Tuples.pair("2", "Two"), two);
+        assertEquals(Tuples.pair("2", "Two"), two);
 
         Pair<String, String> three = map.detect((argument1, argument2) -> "3".equals(argument1));
-        Assert.assertEquals(Tuples.pair("3", "Three"), three);
+        assertEquals(Tuples.pair("3", "Three"), three);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override
@@ -503,26 +508,26 @@ public class TripletonMapTest extends AbstractMemoryEfficientMutableMapTest
         {
             collection.add(eachValue);
         }
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), collection);
+        assertEquals(FastList.newListWith("1", "2", "3"), collection);
     }
 
     @Override
     @Test
     public void asLazyKeys()
     {
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), this.classUnderTest().keysView().toSortedList());
+        assertEquals(FastList.newListWith("1", "2", "3"), this.classUnderTest().keysView().toSortedList());
     }
 
     @Override
     @Test
     public void asLazyValues()
     {
-        Assert.assertEquals(Bags.mutable.of("One", "Two", "Three"), this.classUnderTest().valuesView().toBag());
+        assertEquals(Bags.mutable.of("One", "Two", "Three"), this.classUnderTest().valuesView().toBag());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMapTest.java
@@ -22,8 +22,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableDoubletonMap}.
@@ -60,7 +64,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<String> collection = Lists.mutable.of();
         ImmutableMap<Integer, String> map = this.classUnderTest();
         map.forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2"), collection);
+        assertEquals(FastList.newListWith("1", "2"), collection);
     }
 
     @Override
@@ -71,7 +75,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<Integer> collection = Lists.mutable.of();
         ImmutableMap<Integer, String> map = this.classUnderTest();
         map.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2), collection);
+        assertEquals(FastList.newListWith(1, 2), collection);
     }
 
     @Override
@@ -80,9 +84,9 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent_function();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -92,9 +96,9 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.getOrDefault();
 
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -103,9 +107,9 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -114,9 +118,9 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.ifPresentApply();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
-        Assert.assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
     }
 
     @Override
@@ -124,7 +128,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -135,7 +139,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableMap<Integer, Integer> map = new ImmutableDoubletonMap<>(1, 1, 2, 2);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11, 12), result);
+        assertEquals(FastList.newListWith(11, 12), result);
     }
 
     @Override
@@ -150,7 +154,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0", "Two", "1"), result);
+        assertEquals(FastList.newListWith("One", "0", "Two", "1"), result);
     }
 
     @Override
@@ -164,7 +168,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(entry.getTwo());
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two"), result);
+        assertEquals(FastList.newListWith("One", "Two"), result);
     }
 
     @Override
@@ -178,7 +182,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two"), result);
+        assertEquals(FastList.newListWith("One", "Two"), result);
     }
 
     @Override
@@ -192,7 +196,7 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1, 2), result);
+        assertEquals(FastList.newListWith(1, 2), result);
     }
 
     @Override
@@ -200,21 +204,21 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void testToString()
     {
         ImmutableMap<Integer, String> map = new ImmutableDoubletonMap<>(1, "One", 2, "Two");
-        Assert.assertEquals("{1=One, 2=Two}", map.toString());
+        assertEquals("{1=One, 2=Two}", map.toString());
     }
 
     @Test
     public void asLazyKeys()
     {
         MutableList<Integer> keys = new ImmutableDoubletonMap<>(1, 1, 2, 2).keysView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), keys);
+        assertEquals(FastList.newListWith(1, 2), keys);
     }
 
     @Test
     public void asLazyValues()
     {
         MutableList<Integer> values = new ImmutableDoubletonMap<>(1, 1, 2, 2).valuesView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1, 2), values);
+        assertEquals(FastList.newListWith(1, 2), values);
     }
 
     @Test
@@ -224,13 +228,13 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
                 new ImmutableDoubletonMap<>(1, 1, 2, 2)
                         .keyValuesView()
                         .toSortedList(Comparators.byFunction((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(FastList.newListWith(Tuples.pair(1, 1), Tuples.pair(2, 2)), values);
+        assertEquals(FastList.newListWith(Tuples.pair(1, 1), Tuples.pair(2, 2)), values);
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
@@ -243,15 +247,15 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.select((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.select((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
     }
 
     @Override
@@ -264,15 +268,15 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.reject((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.reject((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
     }
 
     @Override
@@ -281,12 +285,12 @@ public class ImmutableDoubletonMapTest extends ImmutableMemoryEfficientMapTestCa
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
         Pair<Integer, String> one = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair(1, "1"), one);
+        assertEquals(Tuples.pair(1, "1"), one);
 
         Pair<Integer, String> two = map.detect((argument1, argument2) -> "2".equals(argument2));
-        Assert.assertEquals(Tuples.pair(2, "2"), two);
+        assertEquals(Tuples.pair(2, "2"), two);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableEmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableEmptyMapTest.java
@@ -16,8 +16,12 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptyMap}.
@@ -41,7 +45,7 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
     public void testToString()
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertEquals("{}", map.toString());
+        assertEquals("{}", map.toString());
     }
 
     @Override
@@ -59,13 +63,13 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
 
         Integer absentKey = this.size() + 1;
-        Assert.assertNull(classUnderTest.get(absentKey));
+        assertNull(classUnderTest.get(absentKey));
 
         String absentValue = String.valueOf(absentKey);
-        Assert.assertFalse(classUnderTest.containsValue(absentValue));
+        assertFalse(classUnderTest.containsValue(absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -77,10 +81,10 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
+        assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -94,10 +98,10 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -109,10 +113,10 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -124,10 +128,10 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -137,14 +141,14 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
         Integer absentKey = this.size() + 1;
 
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
+        assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -153,8 +157,8 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
     {
         ImmutableMap<String, String> map = new ImmutableEmptyMap<>();
 
-        Assert.assertTrue(map.allSatisfy(String.class::isInstance));
-        Assert.assertTrue(map.allSatisfy("Monkey"::equals));
+        assertTrue(map.allSatisfy(String.class::isInstance));
+        assertTrue(map.allSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -163,8 +167,8 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
     {
         ImmutableMap<String, String> map = new ImmutableEmptyMap<>();
 
-        Assert.assertFalse(map.anySatisfy(String.class::isInstance));
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertFalse(map.anySatisfy(String.class::isInstance));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Override
@@ -173,8 +177,8 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
     {
         ImmutableMap<String, String> map = new ImmutableEmptyMap<>();
 
-        Assert.assertTrue(map.noneSatisfy(String.class::isInstance));
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertTrue(map.noneSatisfy(String.class::isInstance));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -239,7 +243,7 @@ public class ImmutableEmptyMapTest extends ImmutableMemoryEfficientMapTestCase
     public void detect()
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.detect((ignored1, ignored2) -> true));
+        assertNull(map.detect((ignored1, ignored2) -> true));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
 
 public class ImmutableMapFactoryTest
 {
@@ -100,6 +101,6 @@ public class ImmutableMapFactoryTest
         ImmutableMap<Key, Integer> map4 = ImmutableMapFactoryImpl.INSTANCE.of(key, 1, new Key("still not a dupe"), 2, new Key("me neither"), 3, duplicateKey, 4);
         Verify.assertSize(3, map4);
         Verify.assertContainsAllKeyValues(map4, key, 4, new Key("still not a dupe"), 2, new Key("me neither"), 3);
-        Assert.assertSame(key, map4.keysView().detect(key::equals));
+        assertSame(key, map4.keysView().detect(key::equals));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapIterableTestCase.java
@@ -31,8 +31,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ImmutableMapIterableTestCase
 {
@@ -67,10 +73,10 @@ public abstract class ImmutableMapIterableTestCase
         });
 
         MutableSet<Integer> expectedKeys = this.expectedKeys();
-        Assert.assertEquals(expectedKeys, actualKeys);
+        assertEquals(expectedKeys, actualKeys);
 
         MutableSet<String> expectedValues = expectedKeys.collect(String::valueOf);
-        Assert.assertEquals(expectedValues, actualValues);
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test
@@ -78,7 +84,7 @@ public abstract class ImmutableMapIterableTestCase
     {
         MutableSet<String> actualValues = UnifiedSet.newSet();
         this.classUnderTest().forEachValue(CollectionAddProcedure.on(actualValues));
-        Assert.assertEquals(this.expectedValues(), actualValues);
+        assertEquals(this.expectedValues(), actualValues);
     }
 
     @Test
@@ -86,8 +92,8 @@ public abstract class ImmutableMapIterableTestCase
     {
         MutableList<String> tapResult = Lists.mutable.of();
         ImmutableMapIterable<Integer, String> map = this.classUnderTest();
-        Assert.assertSame(map, map.tap(tapResult::add));
-        Assert.assertEquals(map.toList(), tapResult);
+        assertSame(map, map.tap(tapResult::add));
+        assertEquals(map.toList(), tapResult);
     }
 
     @Test
@@ -95,14 +101,14 @@ public abstract class ImmutableMapIterableTestCase
     {
         MutableSet<String> actualValues = UnifiedSet.newSet();
         this.classUnderTest().forEach(CollectionAddProcedure.on(actualValues));
-        Assert.assertEquals(this.expectedValues(), actualValues);
+        assertEquals(this.expectedValues(), actualValues);
     }
 
     @Test
     public void flipUniqueValues()
     {
         ImmutableMapIterable<Integer, String> immutableMap = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Interval.oneTo(this.size()).toMap(String::valueOf, Functions.getIntegerPassThru()),
                 immutableMap.flipUniqueValues());
     }
@@ -115,13 +121,13 @@ public abstract class ImmutableMapIterableTestCase
         {
             actualValues.add(eachValue);
         }
-        Assert.assertEquals(this.expectedValues(), actualValues);
+        assertEquals(this.expectedValues(), actualValues);
     }
 
     @Test
     public void iteratorThrows()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
         {
             Iterator<String> iterator = this.classUnderTest().iterator();
             iterator.remove();
@@ -133,7 +139,7 @@ public abstract class ImmutableMapIterableTestCase
     {
         MutableSet<Integer> actualKeys = UnifiedSet.newSet();
         this.classUnderTest().forEachKey(CollectionAddProcedure.on(actualKeys));
-        Assert.assertEquals(this.expectedKeys(), actualKeys);
+        assertEquals(this.expectedKeys(), actualKeys);
     }
 
     @Test
@@ -143,16 +149,16 @@ public abstract class ImmutableMapIterableTestCase
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
 
         Integer absentKey = this.size() + 1;
-        Assert.assertNull(classUnderTest.get(absentKey));
+        assertNull(classUnderTest.get(absentKey));
 
         String absentValue = String.valueOf(absentKey);
-        Assert.assertFalse(classUnderTest.containsValue(absentValue));
+        assertFalse(classUnderTest.containsValue(absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.get(1));
+        assertEquals("1", classUnderTest.get(1));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -163,13 +169,13 @@ public abstract class ImmutableMapIterableTestCase
 
         // Absent key behavior
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
+        assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsent(1, new PassThruFunction0<>(absentValue)));
+        assertEquals("1", classUnderTest.getIfAbsent(1, new PassThruFunction0<>(absentValue)));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -180,13 +186,13 @@ public abstract class ImmutableMapIterableTestCase
 
         // Absent key behavior
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getOrDefault(1, absentValue));
+        assertEquals("1", classUnderTest.getOrDefault(1, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -197,13 +203,13 @@ public abstract class ImmutableMapIterableTestCase
 
         // Absent key behavior
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsentValue(1, absentValue));
+        assertEquals("1", classUnderTest.getIfAbsentValue(1, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -214,13 +220,13 @@ public abstract class ImmutableMapIterableTestCase
 
         // Absent key behavior
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsentWith(1, String::valueOf, absentValue));
+        assertEquals("1", classUnderTest.getIfAbsentWith(1, String::valueOf, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -229,14 +235,14 @@ public abstract class ImmutableMapIterableTestCase
         Integer absentKey = this.size() + 1;
 
         ImmutableMapIterable<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
-        Assert.assertEquals("1", classUnderTest.ifPresentApply(1, Functions.getPassThru()));
+        assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
+        assertEquals("1", classUnderTest.ifPresentApply(1, Functions.getPassThru()));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Test
@@ -253,8 +259,8 @@ public abstract class ImmutableMapIterableTestCase
             actualParameters.add(parameter);
         }, actualParameter);
 
-        Assert.assertEquals(this.expectedKeys().collect(String::valueOf), actualValues);
-        Assert.assertEquals(Collections.nCopies(this.size(), actualParameter), actualParameters);
+        assertEquals(this.expectedKeys().collect(String::valueOf), actualValues);
+        assertEquals(Collections.nCopies(this.size(), actualParameter), actualParameters);
     }
 
     @Test
@@ -269,8 +275,8 @@ public abstract class ImmutableMapIterableTestCase
             actualIndices.add(index);
         });
 
-        Assert.assertEquals(this.expectedKeys().collect(String::valueOf), actualValues);
-        Assert.assertEquals(this.expectedIndices(), actualIndices);
+        assertEquals(this.expectedKeys().collect(String::valueOf), actualValues);
+        assertEquals(this.expectedIndices(), actualIndices);
     }
 
     @Test
@@ -286,10 +292,10 @@ public abstract class ImmutableMapIterableTestCase
         }
 
         MutableSet<Integer> expectedKeys = this.expectedKeys();
-        Assert.assertEquals(expectedKeys, actualKeys);
+        assertEquals(expectedKeys, actualKeys);
 
         MutableSet<String> expectedValues = expectedKeys.collect(String::valueOf);
-        Assert.assertEquals(expectedValues, actualValues);
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test
@@ -301,7 +307,7 @@ public abstract class ImmutableMapIterableTestCase
             actualValues.add(eachValue);
         }
         MutableSet<String> expectedValues = this.expectedValues();
-        Assert.assertEquals(expectedValues, actualValues);
+        assertEquals(expectedValues, actualValues);
     }
 
     @Test
@@ -312,31 +318,31 @@ public abstract class ImmutableMapIterableTestCase
         {
             actualKeys.add(eachKey);
         }
-        Assert.assertEquals(this.expectedKeys(), actualKeys);
+        assertEquals(this.expectedKeys(), actualKeys);
     }
 
     @Test
     public void putAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).putAll(null));
+        assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).putAll(null));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).clear());
+        assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).clear());
     }
 
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).put(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).put(null, null));
     }
 
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> ((Map<Integer, String>) this.classUnderTest()).remove(null));
     }
 
     @Test
@@ -429,7 +435,7 @@ public abstract class ImmutableMapIterableTestCase
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.classUnderTest().newWithMap(null));
+        assertThrows(NullPointerException.class, () -> this.classUnderTest().newWithMap(null));
     }
 
     @Test
@@ -477,7 +483,7 @@ public abstract class ImmutableMapIterableTestCase
     @Test
     public void withMapIterableNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.classUnderTest().newWithMapIterable(null));
+        assertThrows(NullPointerException.class, () -> this.classUnderTest().newWithMapIterable(null));
     }
 
     @Test
@@ -514,7 +520,7 @@ public abstract class ImmutableMapIterableTestCase
         ImmutableMapIterable<Integer, String> immutable = this.classUnderTest();
         ImmutableMapIterable<Integer, String> immutable2 = immutable.newWithoutAllKeys(immutable.keysView());
         ImmutableMapIterable<Integer, String> immutable3 = immutable.newWithoutAllKeys(Lists.immutable.of());
-        Assert.assertEquals(immutable, immutable3);
-        Assert.assertEquals(Maps.immutable.of(), immutable2);
+        assertEquals(immutable, immutable3);
+        assertEquals(Maps.immutable.of(), immutable2);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapTestCase.java
@@ -15,8 +15,11 @@ import java.util.Map;
 
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link ImmutableMap}.
@@ -31,8 +34,8 @@ public abstract class ImmutableMapTestCase extends ImmutableMapIterableTestCase
     {
         ImmutableMap<Integer, String> immutable = this.classUnderTest();
         Map<Integer, String> map = immutable.castToMap();
-        Assert.assertSame(immutable, map);
-        Assert.assertEquals(immutable, new HashMap<>(map));
+        assertSame(immutable, map);
+        assertEquals(immutable, new HashMap<>(map));
     }
 
     @Test
@@ -40,8 +43,8 @@ public abstract class ImmutableMapTestCase extends ImmutableMapIterableTestCase
     {
         ImmutableMap<Integer, String> immutable = this.classUnderTest();
         MutableMap<Integer, String> map = immutable.toMap();
-        Assert.assertNotSame(immutable, map);
-        Assert.assertEquals(immutable, map);
+        assertNotSame(immutable, map);
+        assertEquals(immutable, map);
     }
 
     @Test
@@ -49,7 +52,7 @@ public abstract class ImmutableMapTestCase extends ImmutableMapIterableTestCase
     {
         ImmutableMap<Integer, String> immutable = this.classUnderTest();
         Map<Integer, String> map = new HashMap<>(immutable.castToMap());
-        Assert.assertEquals(immutable.size(), immutable.castToMap().entrySet().size());
-        Assert.assertEquals(map.entrySet(), immutable.castToMap().entrySet());
+        assertEquals(immutable.size(), immutable.castToMap().entrySet().size());
+        assertEquals(map.entrySet(), immutable.castToMap().entrySet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMemoryEfficientMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMemoryEfficientMapTestCase.java
@@ -46,11 +46,16 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTestCase
 {
@@ -89,7 +94,7 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
                 Verify.assertContainsAllKeyValues(result, "1", "enO", "2", "owT", "3", "eerhT", "4", "ruoF");
                 break;
             default:
-                Assert.fail();
+                fail();
         }
     }
 
@@ -117,7 +122,7 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
                 Verify.assertContainsAllKeyValues(result, 1, "1:enO", 2, "2:owT", 3, "3:eerhT", 4, "4:ruoF");
                 break;
             default:
-                Assert.fail();
+                fail();
         }
     }
 
@@ -126,8 +131,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
     {
         ImmutableMap<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three", "4", "Four");
 
-        Assert.assertTrue(map.allSatisfy(String.class::isInstance));
-        Assert.assertFalse(map.allSatisfy("Monkey"::equals));
+        assertTrue(map.allSatisfy(String.class::isInstance));
+        assertFalse(map.allSatisfy("Monkey"::equals));
     }
 
     @Test
@@ -135,8 +140,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
     {
         ImmutableMap<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three", "4", "Four");
 
-        Assert.assertTrue(map.anySatisfy(String.class::isInstance));
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertTrue(map.anySatisfy(String.class::isInstance));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Test
@@ -144,8 +149,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
     {
         ImmutableMap<String, String> map = this.newMapWithKeysValues("1", "One", "2", "Two", "3", "Three", "4", "Four");
 
-        Assert.assertTrue(map.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertTrue(map.noneSatisfy(Integer.class::isInstance));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
     }
 
     @Test
@@ -168,41 +173,41 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals("One", defaultString);
-                Assert.assertEquals("One", delimitedString);
-                Assert.assertEquals("{One}", wrappedString);
+                assertEquals("One", defaultString);
+                assertEquals("One", delimitedString);
+                assertEquals("{One}", wrappedString);
                 break;
             case 2:
-                Assert.assertEquals(8, defaultString.length());
-                Assert.assertEquals(7, delimitedString.length());
+                assertEquals(8, defaultString.length());
+                assertEquals(7, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(9, wrappedString.length());
+                assertEquals(9, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 3:
-                Assert.assertEquals(15, defaultString.length());
-                Assert.assertEquals(13, delimitedString.length());
+                assertEquals(15, defaultString.length());
+                assertEquals(13, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(15, wrappedString.length());
+                assertEquals(15, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 4:
-                Assert.assertEquals(21, defaultString.length());
-                Assert.assertEquals(18, delimitedString.length());
+                assertEquals(21, defaultString.length());
+                assertEquals(18, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(20, wrappedString.length());
+                assertEquals(20, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             default:
-                Assert.assertEquals("", defaultString);
-                Assert.assertEquals("", delimitedString);
-                Assert.assertEquals("{}", wrappedString);
+                assertEquals("", defaultString);
+                assertEquals("", delimitedString);
+                assertEquals("{}", wrappedString);
                 break;
         }
     }
@@ -295,16 +300,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One"), actual);
                 break;
             case 2:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three"), actual);
                 break;
             case 3:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four"), actual);
                 break;
             case 4:
-                Assert.assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four", 6, "Eleven"), actual);
+                assertEquals(UnifiedMap.newWithKeysValues(3, "One", 5, "Three", 4, "Four", 6, "Eleven"), actual);
                 break;
             default:
                 Verify.assertEmpty(actual);
@@ -347,16 +352,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), sorted);
+                assertEquals(iList(1), sorted);
                 break;
             case 2:
-                Assert.assertEquals(iList(1, 2), sorted);
+                assertEquals(iList(1, 2), sorted);
                 break;
             case 3:
-                Assert.assertEquals(iList(1, 2, 3), sorted);
+                assertEquals(iList(1, 2, 3), sorted);
                 break;
             case 4:
-                Assert.assertEquals(iList(1, 2, 3, 4), sorted);
+                assertEquals(iList(1, 2, 3, 4), sorted);
                 break;
             default:
                 Verify.assertEmpty(sorted);
@@ -367,16 +372,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), reverse);
+                assertEquals(iList(1), reverse);
                 break;
             case 2:
-                Assert.assertEquals(iList(2, 1), reverse);
+                assertEquals(iList(2, 1), reverse);
                 break;
             case 3:
-                Assert.assertEquals(iList(3, 2, 1), reverse);
+                assertEquals(iList(3, 2, 1), reverse);
                 break;
             case 4:
-                Assert.assertEquals(iList(4, 3, 2, 1), reverse);
+                assertEquals(iList(4, 3, 2, 1), reverse);
                 break;
             default:
                 Verify.assertEmpty(reverse);
@@ -393,16 +398,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), list);
+                assertEquals(iList(1), list);
                 break;
             case 2:
-                Assert.assertEquals(iList(1, 2), list);
+                assertEquals(iList(1, 2), list);
                 break;
             case 3:
-                Assert.assertEquals(iList(1, 2, 3), list);
+                assertEquals(iList(1, 2, 3), list);
                 break;
             case 4:
-                Assert.assertEquals(iList(1, 2, 3, 4), list);
+                assertEquals(iList(1, 2, 3, 4), list);
                 break;
             default:
                 Verify.assertEmpty(list);
@@ -422,19 +427,19 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(iList(1), sizes);
+                assertEquals(iList(1), sizes);
                 break;
             case 2:
-                Assert.assertEquals(iList(2), sizes);
+                assertEquals(iList(2), sizes);
                 break;
             case 3:
-                Assert.assertEquals(iList(2, 1), sizes);
+                assertEquals(iList(2, 1), sizes);
                 break;
             case 4:
-                Assert.assertEquals(iList(2, 2), sizes);
+                assertEquals(iList(2, 2), sizes);
                 break;
             default:
-                Assert.assertEquals(0, chunks.size());
+                assertEquals(0, chunks.size());
                 break;
         }
     }
@@ -512,16 +517,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(Bags.mutable.of(2), collectWith);
+                assertEquals(Bags.mutable.of(2), collectWith);
                 break;
             case 2:
-                Assert.assertEquals(Bags.mutable.of(2, 3), collectWith);
+                assertEquals(Bags.mutable.of(2, 3), collectWith);
                 break;
             case 3:
-                Assert.assertEquals(Bags.mutable.of(2, 3, 4), collectWith);
+                assertEquals(Bags.mutable.of(2, 3, 4), collectWith);
                 break;
             case 4:
-                Assert.assertEquals(Bags.mutable.of(2, 3, 4, 5), collectWith);
+                assertEquals(Bags.mutable.of(2, 3, 4, 5), collectWith);
                 break;
             default:
                 Verify.assertEmpty(collectWith);
@@ -537,20 +542,20 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.contains("One"));
-                Assert.assertFalse(map.contains("Two"));
+                assertTrue(map.contains("One"));
+                assertFalse(map.contains("Two"));
                 break;
             case 2:
-                Assert.assertTrue(map.contains("Two"));
-                Assert.assertFalse(map.contains("Three"));
+                assertTrue(map.contains("Two"));
+                assertFalse(map.contains("Three"));
                 break;
             case 3:
-                Assert.assertTrue(map.contains("Three"));
-                Assert.assertFalse(map.contains("Four"));
+                assertTrue(map.contains("Three"));
+                assertFalse(map.contains("Four"));
                 break;
             case 4:
-                Assert.assertTrue(map.contains("Four"));
-                Assert.assertFalse(map.contains("Five"));
+                assertTrue(map.contains("Four"));
+                assertFalse(map.contains("Five"));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -566,12 +571,12 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         if (map.isEmpty())
         {
             String value = map.getFirst();
-            Assert.assertNull(value);
+            assertNull(value);
         }
         else
         {
             String value = map.getFirst();
-            Assert.assertNotNull(value);
+            assertNotNull(value);
             Verify.assertContains(value, UnifiedSet.newSetWith("One", "Two", "Three", "Four"));
         }
     }
@@ -584,12 +589,12 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         if (map.isEmpty())
         {
             String value = map.getLast();
-            Assert.assertNull(value);
+            assertNull(value);
         }
         else
         {
             String value = map.getLast();
-            Assert.assertNotNull(value);
+            assertNotNull(value);
             Verify.assertContains(value, UnifiedSet.newSetWith("One", "Two", "Three", "Four"));
         }
     }
@@ -602,16 +607,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.containsAllIterable(iList("One")));
+                assertTrue(map.containsAllIterable(iList("One")));
                 break;
             case 2:
-                Assert.assertTrue(map.containsAllIterable(iList("One", "Two")));
+                assertTrue(map.containsAllIterable(iList("One", "Two")));
                 break;
             case 3:
-                Assert.assertTrue(map.containsAllIterable(iList("One", "Two", "Three")));
+                assertTrue(map.containsAllIterable(iList("One", "Two", "Three")));
                 break;
             case 4:
-                Assert.assertTrue(map.containsAllIterable(iList("One", "Two", "Three", "Four")));
+                assertTrue(map.containsAllIterable(iList("One", "Two", "Three", "Four")));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -627,16 +632,16 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertTrue(map.containsAllArguments("One"));
+                assertTrue(map.containsAllArguments("One"));
                 break;
             case 2:
-                Assert.assertTrue(map.containsAllArguments("One", "Two"));
+                assertTrue(map.containsAllArguments("One", "Two"));
                 break;
             case 3:
-                Assert.assertTrue(map.containsAllArguments("One", "Two", "Three"));
+                assertTrue(map.containsAllArguments("One", "Two", "Three"));
                 break;
             case 4:
-                Assert.assertTrue(map.containsAllArguments("One", "Two", "Three", "Four"));
+                assertTrue(map.containsAllArguments("One", "Two", "Three", "Four"));
                 break;
             default:
                 Verify.assertEmpty(map);
@@ -654,19 +659,19 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals(1, actual);
+                assertEquals(1, actual);
                 break;
             case 2:
-                Assert.assertEquals(1, actual);
+                assertEquals(1, actual);
                 break;
             case 3:
-                Assert.assertEquals(2, actual);
+                assertEquals(2, actual);
                 break;
             case 4:
-                Assert.assertEquals(2, actual);
+                assertEquals(2, actual);
                 break;
             default:
-                Assert.assertEquals(0, actual);
+                assertEquals(0, actual);
                 break;
         }
     }
@@ -679,15 +684,15 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         if (map.isEmpty())
         {
             String resultNotFound = map.detect(ignored -> true);
-            Assert.assertNull(resultNotFound);
+            assertNull(resultNotFound);
         }
         else
         {
             String resultFound = map.detect("One"::equals);
-            Assert.assertEquals("One", resultFound);
+            assertEquals("One", resultFound);
 
             String resultNotFound = map.detect("Five"::equals);
-            Assert.assertNull(resultNotFound);
+            assertNull(resultNotFound);
         }
     }
 
@@ -699,15 +704,15 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         if (map.isEmpty())
         {
             String resultNotFound = map.detectIfNone(ignored -> true, () -> "Zero");
-            Assert.assertEquals("Zero", resultNotFound);
+            assertEquals("Zero", resultNotFound);
         }
         else
         {
             String resultNotFound = map.detectIfNone("Five"::equals, () -> "Zero");
-            Assert.assertEquals("Zero", resultNotFound);
+            assertEquals("Zero", resultNotFound);
 
             String resultFound = map.detectIfNone("One"::equals, () -> "Zero");
-            Assert.assertEquals("One", resultFound);
+            assertEquals("One", resultFound);
         }
     }
 
@@ -721,14 +726,14 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
             Function<Integer, Iterable<Object>> fail = each -> {
                 throw new AssertionError();
             };
-            Assert.assertEquals(Bags.immutable.empty(), map.flatCollect(fail));
-            Assert.assertEquals(Bags.immutable.empty(), map.flatCollect(fail, HashBag.newBag()));
+            assertEquals(Bags.immutable.empty(), map.flatCollect(fail));
+            assertEquals(Bags.immutable.empty(), map.flatCollect(fail, HashBag.newBag()));
         }
         else
         {
             MutableBag<Integer> expected = Interval.oneTo(map.size()).flatCollect(Interval::oneTo).toBag();
-            Assert.assertEquals(expected, map.flatCollect(Interval::oneTo));
-            Assert.assertEquals(expected, map.flatCollect(Interval::oneTo, HashBag.newBag()));
+            assertEquals(expected, map.flatCollect(Interval::oneTo));
+            assertEquals(expected, map.flatCollect(Interval::oneTo, HashBag.newBag()));
         }
     }
 
@@ -761,10 +766,10 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         }
 
         Multimap<Boolean, Integer> actual = map.groupBy(isOddFunction);
-        Assert.assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actual));
+        assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actual));
 
         Multimap<Boolean, Integer> actualFromTarget = map.groupBy(isOddFunction, FastListMultimap.newMultimap());
-        Assert.assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actualFromTarget));
+        assertEquals(HashBagMultimap.newMultimap(expected), HashBagMultimap.newMultimap(actualFromTarget));
     }
 
     @Test
@@ -781,18 +786,18 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         Multimap<Integer, Integer> actual = map.groupByEach(function);
         expected.forEachKey(each -> {
-            Assert.assertTrue(actual.containsKey(each));
+            assertTrue(actual.containsKey(each));
             MutableList<Integer> values = actual.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
 
         Multimap<Integer, Integer> actualFromTarget = map.groupByEach(function, FastListMultimap.newMultimap());
         expected.forEachKey(each -> {
-            Assert.assertTrue(actualFromTarget.containsKey(each));
+            assertTrue(actualFromTarget.containsKey(each));
             MutableList<Integer> values = actualFromTarget.get(each).toList();
             Verify.assertNotEmpty(values);
-            Assert.assertTrue(expected.get(each).containsAllIterable(values));
+            assertTrue(expected.get(each).containsAllIterable(values));
         });
     }
 
@@ -829,10 +834,10 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         }
 
         Integer actual = map.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(expectedInteger, actual);
+        assertEquals(expectedInteger, actual);
 
         Sum sum = map.injectInto(new IntegerSum(0), SumProcedure.number());
-        Assert.assertEquals(expectedSum, sum);
+        assertEquals(expectedSum, sum);
     }
 
     @Test
@@ -847,41 +852,41 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         switch (map.size())
         {
             case 1:
-                Assert.assertEquals("One", defaultString);
-                Assert.assertEquals("One", delimitedString);
-                Assert.assertEquals("{One}", wrappedString);
+                assertEquals("One", defaultString);
+                assertEquals("One", delimitedString);
+                assertEquals("{One}", wrappedString);
                 break;
             case 2:
-                Assert.assertEquals(8, defaultString.length());
-                Assert.assertEquals(7, delimitedString.length());
+                assertEquals(8, defaultString.length());
+                assertEquals(7, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(9, wrappedString.length());
+                assertEquals(9, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 3:
-                Assert.assertEquals(15, defaultString.length());
-                Assert.assertEquals(13, delimitedString.length());
+                assertEquals(15, defaultString.length());
+                assertEquals(13, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(15, wrappedString.length());
+                assertEquals(15, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             case 4:
-                Assert.assertEquals(21, defaultString.length());
-                Assert.assertEquals(18, delimitedString.length());
+                assertEquals(21, defaultString.length());
+                assertEquals(18, delimitedString.length());
                 Verify.assertContains("|", delimitedString);
-                Assert.assertEquals(20, wrappedString.length());
+                assertEquals(20, wrappedString.length());
                 Verify.assertContains("|", wrappedString);
-                Assert.assertTrue(wrappedString.startsWith("{"));
-                Assert.assertTrue(wrappedString.endsWith("}"));
+                assertTrue(wrappedString.startsWith("{"));
+                assertTrue(wrappedString.endsWith("}"));
                 break;
             default:
-                Assert.assertEquals("", defaultString);
-                Assert.assertEquals("", delimitedString);
-                Assert.assertEquals("{}", wrappedString);
+                assertEquals("", defaultString);
+                assertEquals("", delimitedString);
+                assertEquals("{}", wrappedString);
                 break;
         }
     }
@@ -891,8 +896,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
     {
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(1), map.min());
-        Assert.assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), map.min());
+        assertEquals(Integer.valueOf(1), map.min(Integer::compareTo));
     }
 
     @Test
@@ -921,8 +926,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
                 break;
         }
 
-        Assert.assertEquals(max, map.max());
-        Assert.assertEquals(max, map.max(Integer::compareTo));
+        assertEquals(max, map.max());
+        assertEquals(max, map.max(Integer::compareTo));
     }
 
     @Test
@@ -930,14 +935,14 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
     {
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
 
-        Assert.assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), map.minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertEquals(Integer.valueOf(map.size()), map.maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(map.size()), map.maxBy(String::valueOf));
         Verify.assertContains(Integer.valueOf(map.size()), iList(1, 2, 3, 4));
     }
 
@@ -950,8 +955,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         UnifiedSet<Integer> rejectedIntoTarget = map.reject(IntegerPredicates.isEven(), UnifiedSet.newSet());
 
         ImmutableSet<Integer> expected = this.expectReject(map.size());
-        Assert.assertEquals(expected, rejected);
-        Assert.assertEquals(expected, rejectedIntoTarget);
+        assertEquals(expected, rejected);
+        assertEquals(expected, rejectedIntoTarget);
     }
 
     private ImmutableSet<Integer> expectReject(int size)
@@ -1002,8 +1007,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
         ImmutableSet<Integer> expected = this.expectSelect(map.size());
 
-        Assert.assertEquals(expected, map.select(IntegerPredicates.isEven()).toSet());
-        Assert.assertEquals(expected, map.select(IntegerPredicates.isEven(), UnifiedSet.newSet()));
+        assertEquals(expected, map.select(IntegerPredicates.isEven()).toSet());
+        assertEquals(expected, map.select(IntegerPredicates.isEven(), UnifiedSet.newSet()));
     }
 
     private ImmutableSet<Integer> expectSelect(int size)
@@ -1050,8 +1055,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
         PartitionImmutableCollection<Integer> partition = map.partition(IntegerPredicates.isEven());
 
-        Assert.assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
-        Assert.assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
+        assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
+        assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
     }
 
     @Test
@@ -1060,8 +1065,8 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         ImmutableMap<String, Integer> map = this.newMapWithKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
         PartitionImmutableCollection<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
 
-        Assert.assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
-        Assert.assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
+        assertEquals(this.expectSelect(map.size()), partition.getSelected().toSet());
+        assertEquals(this.expectReject(map.size()), partition.getRejected().toSet());
     }
 
     @Test
@@ -1097,27 +1102,27 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
         List<Object> nullsPlusOne = Collections.nCopies(map.size() + 1, null);
 
         RichIterable<Pair<String, Object>> pairs = map.zip(nulls);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         RichIterable<Pair<String, Object>> pairsPlusOne = map.zip(nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         if (map.notEmpty())
         {
             List<Object> nullsMinusOne = Collections.nCopies(map.size() - 1, null);
             RichIterable<Pair<String, Object>> pairsMinusOne = map.zip(nullsMinusOne);
-            Assert.assertEquals(map.size() - 1, pairsMinusOne.size());
+            assertEquals(map.size() - 1, pairsMinusOne.size());
         }
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zip(nulls).toSet(),
                 map.zip(nulls, UnifiedSet.newSet()));
     }
@@ -1129,17 +1134,17 @@ public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTe
 
         RichIterable<Pair<String, Integer>> pairs = map.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 map.toSet(),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne).toSet());
         if (map.notEmpty())
         {
-            Assert.assertEquals(
+            assertEquals(
                     Interval.zeroTo(map.size() - 1).toSet(),
                     pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
         }
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zipWithIndex().toSet(),
                 map.zipWithIndex(UnifiedSet.newSet()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMapTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableQuadrupletonMap}.
@@ -57,7 +61,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         super.forEachValue();
         MutableList<String> collection = Lists.mutable.of();
         this.classUnderTest().forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), collection);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), collection);
     }
 
     @Override
@@ -67,7 +71,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         super.forEachKey();
         MutableList<Integer> collection = Lists.mutable.of();
         this.classUnderTest().forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), collection);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), collection);
     }
 
     @Override
@@ -76,9 +80,9 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
     {
         super.getIfAbsent_function();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(5));
-        Assert.assertEquals("5", map.getIfAbsent(5, new PassThruFunction0<>("5")));
-        Assert.assertNull(map.get(5));
+        assertNull(map.get(5));
+        assertEquals("5", map.getIfAbsent(5, new PassThruFunction0<>("5")));
+        assertNull(map.get(5));
     }
 
     @Override
@@ -88,9 +92,9 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         super.getOrDefault();
 
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(5));
-        Assert.assertEquals("5", map.getOrDefault(5, "5"));
-        Assert.assertNull(map.get(5));
+        assertNull(map.get(5));
+        assertEquals("5", map.getOrDefault(5, "5"));
+        assertNull(map.get(5));
     }
 
     @Override
@@ -99,9 +103,9 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
     {
         super.getIfAbsent();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(5));
-        Assert.assertEquals("5", map.getIfAbsentValue(5, "5"));
-        Assert.assertNull(map.get(5));
+        assertNull(map.get(5));
+        assertEquals("5", map.getIfAbsentValue(5, "5"));
+        assertNull(map.get(5));
     }
 
     @Override
@@ -110,11 +114,11 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
     {
         super.ifPresentApply();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.ifPresentApply(5, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
-        Assert.assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
-        Assert.assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
-        Assert.assertEquals("4", map.ifPresentApply(4, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(5, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
+        assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
+        assertEquals("4", map.ifPresentApply(4, Functions.getPassThru()));
     }
 
     @Override
@@ -122,7 +126,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -133,7 +137,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableMap<Integer, Integer> map = new ImmutableQuadrupletonMap<>(1, 1, 2, 2, 3, 3, 4, 4);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11, 12, 13, 14), result);
+        assertEquals(FastList.newListWith(11, 12, 13, 14), result);
     }
 
     @Override
@@ -148,7 +152,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2", "Four", "3"), result);
+        assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2", "Four", "3"), result);
     }
 
     @Override
@@ -162,7 +166,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         {
             result.add(keyValue.getTwo());
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three", "Four"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three", "Four"), result);
     }
 
     @Override
@@ -176,7 +180,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three", "Four"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three", "Four"), result);
     }
 
     @Override
@@ -190,7 +194,7 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), result);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), result);
     }
 
     @Override
@@ -198,13 +202,13 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
     public void testToString()
     {
         ImmutableMap<Integer, String> map = new ImmutableQuadrupletonMap<>(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Assert.assertEquals("{1=One, 2=Two, 3=Three, 4=Four}", map.toString());
+        assertEquals("{1=One, 2=Two, 3=Three, 4=Four}", map.toString());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
@@ -217,63 +221,63 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
 
         ImmutableMap<Integer, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableQuadrupletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.select((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.select((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
 
         ImmutableMap<Integer, String> three = map.select((argument1, argument2) -> "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, three);
-        Assert.assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
+        assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
 
         ImmutableMap<Integer, String> four = map.select((argument1, argument2) -> "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, four);
-        Assert.assertEquals(new ImmutableSingletonMap<>(4, "4"), four);
+        assertEquals(new ImmutableSingletonMap<>(4, "4"), four);
 
         ImmutableMap<Integer, String> oneAndFour = map.select((argument1, argument2) -> "1".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 4, "4"), oneAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 4, "4"), oneAndFour);
 
         ImmutableMap<Integer, String> oneAndThree = map.select((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
 
         ImmutableMap<Integer, String> oneAndTwo = map.select((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
 
         ImmutableMap<Integer, String> twoAndFour = map.select((argument1, argument2) -> "2".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 4, "4"), twoAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 4, "4"), twoAndFour);
 
         ImmutableMap<Integer, String> twoAndThree = map.select((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
 
         ImmutableMap<Integer, String> threeAndFour = map.select((argument1, argument2) -> "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, threeAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(3, "3", 4, "4"), threeAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(3, "3", 4, "4"), threeAndFour);
 
         ImmutableMap<Integer, String> twoThreeFour = map.select((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, twoThreeFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(2, "2", 3, "3", 4, "4"), twoThreeFour);
+        assertEquals(new ImmutableTripletonMap<>(2, "2", 3, "3", 4, "4"), twoThreeFour);
 
         ImmutableMap<Integer, String> oneThreeFour = map.select((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneThreeFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 3, "3", 4, "4"), oneThreeFour);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 3, "3", 4, "4"), oneThreeFour);
 
         ImmutableMap<Integer, String> oneTwoFour = map.select((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneTwoFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 4, "4"), oneTwoFour);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 4, "4"), oneTwoFour);
 
         ImmutableMap<Integer, String> oneTwoThree = map.select((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneTwoThree);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 3, "3"), oneTwoThree);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 3, "3"), oneTwoThree);
     }
 
     @Override
@@ -286,63 +290,63 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
 
         ImmutableMap<Integer, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(ImmutableQuadrupletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.reject((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.reject((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
 
         ImmutableMap<Integer, String> three = map.reject((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, three);
-        Assert.assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
+        assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
 
         ImmutableMap<Integer, String> four = map.reject((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, four);
-        Assert.assertEquals(new ImmutableSingletonMap<>(4, "4"), four);
+        assertEquals(new ImmutableSingletonMap<>(4, "4"), four);
 
         ImmutableMap<Integer, String> oneAndFour = map.reject((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 4, "4"), oneAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 4, "4"), oneAndFour);
 
         ImmutableMap<Integer, String> oneAndThree = map.reject((argument1, argument2) -> "2".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
 
         ImmutableMap<Integer, String> oneAndTwo = map.reject((argument1, argument2) -> "3".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
 
         ImmutableMap<Integer, String> twoAndFour = map.reject((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 4, "4"), twoAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 4, "4"), twoAndFour);
 
         ImmutableMap<Integer, String> twoAndThree = map.reject((argument1, argument2) -> "1".equals(argument2) || "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
 
         ImmutableMap<Integer, String> threeAndFour = map.reject((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, threeAndFour);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(3, "3", 4, "4"), threeAndFour);
+        assertEquals(new ImmutableDoubletonMap<>(3, "3", 4, "4"), threeAndFour);
 
         ImmutableMap<Integer, String> twoThreeFour = map.reject((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, twoThreeFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(2, "2", 3, "3", 4, "4"), twoThreeFour);
+        assertEquals(new ImmutableTripletonMap<>(2, "2", 3, "3", 4, "4"), twoThreeFour);
 
         ImmutableMap<Integer, String> oneThreeFour = map.reject((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneThreeFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 3, "3", 4, "4"), oneThreeFour);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 3, "3", 4, "4"), oneThreeFour);
 
         ImmutableMap<Integer, String> oneTwoFour = map.reject((argument1, argument2) -> "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneTwoFour);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 4, "4"), oneTwoFour);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 4, "4"), oneTwoFour);
 
         ImmutableMap<Integer, String> oneTwoThree = map.reject((argument1, argument2) -> "4".equals(argument2));
         Verify.assertInstanceOf(ImmutableTripletonMap.class, oneTwoThree);
-        Assert.assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 3, "3"), oneTwoThree);
+        assertEquals(new ImmutableTripletonMap<>(1, "1", 2, "2", 3, "3"), oneTwoThree);
     }
 
     @Override
@@ -351,18 +355,18 @@ public class ImmutableQuadrupletonMapTest extends ImmutableMemoryEfficientMapTes
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
         Pair<Integer, String> one = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair(1, "1"), one);
+        assertEquals(Tuples.pair(1, "1"), one);
 
         Pair<Integer, String> two = map.detect((argument1, argument2) -> "2".equals(argument2));
-        Assert.assertEquals(Tuples.pair(2, "2"), two);
+        assertEquals(Tuples.pair(2, "2"), two);
 
         Pair<Integer, String> three = map.detect((argument1, argument2) -> "3".equals(argument2));
-        Assert.assertEquals(Tuples.pair(3, "3"), three);
+        assertEquals(Tuples.pair(3, "3"), three);
 
         Pair<Integer, String> four = map.detect((argument1, argument2) -> "4".equals(argument2));
-        Assert.assertEquals(Tuples.pair(4, "4"), four);
+        assertEquals(Tuples.pair(4, "4"), four);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMapTest.java
@@ -23,8 +23,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableSingletonMap}.
@@ -68,7 +71,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.forEachValue();
         MutableList<String> collection = Lists.mutable.of();
         this.classUnderTest().forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -78,7 +81,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.forEach();
         MutableList<String> collection = Lists.mutable.of();
         this.classUnderTest().forEach(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -91,7 +94,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             collection.add(eachValue);
         }
-        Assert.assertEquals(FastList.newListWith("1"), collection);
+        assertEquals(FastList.newListWith("1"), collection);
     }
 
     @Override
@@ -102,7 +105,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<Integer> collection = Lists.mutable.of();
         ImmutableMap<Integer, String> map = this.classUnderTest();
         map.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1), collection);
+        assertEquals(FastList.newListWith(1), collection);
     }
 
     @Override
@@ -111,10 +114,10 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent_function();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("1")));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertEquals("1", map.getIfAbsent(1, new PassThruFunction0<>("1")));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -124,10 +127,10 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.getOrDefault();
 
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertEquals("1", map.getOrDefault(1, "1"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertEquals("1", map.getOrDefault(1, "1"));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -136,10 +139,10 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertEquals("1", map.getIfAbsentValue(1, "1"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertEquals("1", map.getIfAbsentValue(1, "1"));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -148,10 +151,10 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsentWith();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
-        Assert.assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 1));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentWith(4, String::valueOf, 4));
+        assertEquals("1", map.getIfAbsentWith(1, String::valueOf, 1));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1"), map);
     }
 
     @Override
@@ -160,8 +163,8 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.ifPresentApply();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
     }
 
     @Override
@@ -169,7 +172,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -180,7 +183,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableMap<Integer, Integer> map = new ImmutableSingletonMap<>(1, 1);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11), result);
+        assertEquals(FastList.newListWith(11), result);
     }
 
     @Override
@@ -194,7 +197,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0"), result);
+        assertEquals(FastList.newListWith("One", "0"), result);
     }
 
     @Override
@@ -208,7 +211,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(entry.getTwo());
         }
-        Assert.assertEquals(FastList.newListWith("One"), result);
+        assertEquals(FastList.newListWith("One"), result);
     }
 
     @Override
@@ -222,7 +225,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One"), result);
+        assertEquals(FastList.newListWith("One"), result);
     }
 
     @Override
@@ -236,7 +239,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     @Override
@@ -244,28 +247,28 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void testToString()
     {
         ImmutableMap<Integer, String> map = new ImmutableSingletonMap<>(1, "One");
-        Assert.assertEquals("{1=One}", map.toString());
+        assertEquals("{1=One}", map.toString());
     }
 
     @Test
     public void asLazyKeys()
     {
         MutableList<Integer> keys = Maps.fixedSize.of(1, 1).keysView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1), keys);
+        assertEquals(FastList.newListWith(1), keys);
     }
 
     @Test
     public void asLazyValues()
     {
         MutableList<Integer> values = Maps.fixedSize.of(1, 1).valuesView().toSortedList();
-        Assert.assertEquals(FastList.newListWith(1), values);
+        assertEquals(FastList.newListWith(1), values);
     }
 
     @Test
     public void getOnly()
     {
         ImmutableSingletonMap<Integer, String> singletonMap = new ImmutableSingletonMap<>(1, "One");
-        Assert.assertEquals("One", singletonMap.getOnly());
+        assertEquals("One", singletonMap.getOnly());
     }
 
     @Override
@@ -278,7 +281,7 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableSingletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
     }
 
     @Override
@@ -288,11 +291,11 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> empty = map.reject((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableEmptyMap.class, empty);
-        Assert.assertEquals(new ImmutableEmptyMap<Integer, String>(), empty);
+        assertEquals(new ImmutableEmptyMap<Integer, String>(), empty);
 
         ImmutableMap<Integer, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(ImmutableSingletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
     }
 
     @Override
@@ -301,9 +304,9 @@ public class ImmutableSingletonMapTest extends ImmutableMemoryEfficientMapTestCa
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
         Pair<Integer, String> actual = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair(1, "1"), actual);
+        assertEquals(Tuples.pair(1, "1"), actual);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMapTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableTripletonMap}.
@@ -57,7 +61,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.forEachValue();
         MutableList<String> collection = Lists.mutable.of();
         this.classUnderTest().forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), collection);
+        assertEquals(FastList.newListWith("1", "2", "3"), collection);
     }
 
     @Override
@@ -67,7 +71,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.forEachKey();
         MutableList<Integer> collection = Lists.mutable.of();
         this.classUnderTest().forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), collection);
+        assertEquals(FastList.newListWith(1, 2, 3), collection);
     }
 
     @Override
@@ -76,9 +80,9 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent_function();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsent(4, new PassThruFunction0<>("4")));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -88,9 +92,9 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         super.getOrDefault();
 
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getOrDefault(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getOrDefault(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -99,9 +103,9 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.getIfAbsent();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentValue(4, "4"));
-        Assert.assertNull(map.get(4));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentValue(4, "4"));
+        assertNull(map.get(4));
     }
 
     @Override
@@ -110,10 +114,10 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
     {
         super.ifPresentApply();
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.ifPresentApply(4, Functions.getPassThru()));
-        Assert.assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
-        Assert.assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
-        Assert.assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
+        assertNull(map.ifPresentApply(4, Functions.getPassThru()));
+        assertEquals("1", map.ifPresentApply(1, Functions.getPassThru()));
+        assertEquals("2", map.ifPresentApply(2, Functions.getPassThru()));
+        assertEquals("3", map.ifPresentApply(3, Functions.getPassThru()));
     }
 
     @Override
@@ -121,7 +125,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -132,7 +136,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         MutableList<Integer> result = Lists.mutable.of();
         ImmutableMap<Integer, Integer> map = new ImmutableTripletonMap<>(1, 1, 2, 2, 3, 3);
         map.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        Assert.assertEquals(FastList.newListWith(11, 12, 13), result);
+        assertEquals(FastList.newListWith(11, 12, 13), result);
     }
 
     @Override
@@ -147,7 +151,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
             result.add(value);
             result.add(String.valueOf(index));
         });
-        Assert.assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2"), result);
+        assertEquals(FastList.newListWith("One", "0", "Two", "1", "Three", "2"), result);
     }
 
     @Override
@@ -161,7 +165,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(keyValue.getTwo());
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three"), result);
     }
 
     @Override
@@ -175,7 +179,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(value);
         }
-        Assert.assertEquals(FastList.newListWith("One", "Two", "Three"), result);
+        assertEquals(FastList.newListWith("One", "Two", "Three"), result);
     }
 
     @Override
@@ -189,7 +193,7 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         {
             result.add(key);
         }
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), result);
+        assertEquals(FastList.newListWith(1, 2, 3), result);
     }
 
     @Override
@@ -197,13 +201,13 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
     public void testToString()
     {
         ImmutableMap<Integer, String> map = new ImmutableTripletonMap<>(1, "One", 2, "Two", 3, "Three");
-        Assert.assertEquals("{1=One, 2=Two, 3=Three}", map.toString());
+        assertEquals("{1=One, 2=Two, 3=Three}", map.toString());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
@@ -216,31 +220,31 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> full = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableTripletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.select((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.select((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
 
         ImmutableMap<Integer, String> three = map.select((argument1, argument2) -> "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, three);
-        Assert.assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
+        assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
 
         ImmutableMap<Integer, String> oneAndThree = map.select((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
 
         ImmutableMap<Integer, String> oneAndTwo = map.select((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
 
         ImmutableMap<Integer, String> twoAndThree = map.select((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
     }
 
     @Override
@@ -253,31 +257,31 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
 
         ImmutableMap<Integer, String> full = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(ImmutableTripletonMap.class, full);
-        Assert.assertEquals(map, full);
+        assertEquals(map, full);
 
         ImmutableMap<Integer, String> one = map.reject((argument1, argument2) -> "2".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, one);
-        Assert.assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
+        assertEquals(new ImmutableSingletonMap<>(1, "1"), one);
 
         ImmutableMap<Integer, String> two = map.reject((argument1, argument2) -> "1".equals(argument2) || "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, two);
-        Assert.assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
+        assertEquals(new ImmutableSingletonMap<>(2, "2"), two);
 
         ImmutableMap<Integer, String> three = map.reject((argument1, argument2) -> "1".equals(argument2) || "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableSingletonMap.class, three);
-        Assert.assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
+        assertEquals(new ImmutableSingletonMap<>(3, "3"), three);
 
         ImmutableMap<Integer, String> oneAndThree = map.reject((argument1, argument2) -> "2".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 3, "3"), oneAndThree);
 
         ImmutableMap<Integer, String> oneAndTwo = map.reject((argument1, argument2) -> "3".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, oneAndTwo);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
+        assertEquals(new ImmutableDoubletonMap<>(1, "1", 2, "2"), oneAndTwo);
 
         ImmutableMap<Integer, String> twoAndThree = map.reject((argument1, argument2) -> "1".equals(argument2));
         Verify.assertInstanceOf(ImmutableDoubletonMap.class, twoAndThree);
-        Assert.assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
+        assertEquals(new ImmutableDoubletonMap<>(2, "2", 3, "3"), twoAndThree);
     }
 
     @Override
@@ -286,15 +290,15 @@ public class ImmutableTripletonMapTest extends ImmutableMemoryEfficientMapTestCa
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
         Pair<Integer, String> one = map.detect((ignored1, ignored2) -> true);
-        Assert.assertEquals(Tuples.pair(1, "1"), one);
+        assertEquals(Tuples.pair(1, "1"), one);
 
         Pair<Integer, String> two = map.detect((argument1, argument2) -> "2".equals(argument2));
-        Assert.assertEquals(Tuples.pair(2, "2"), two);
+        assertEquals(Tuples.pair(2, "2"), two);
 
         Pair<Integer, String> three = map.detect((argument1, argument2) -> "3".equals(argument2));
-        Assert.assertEquals(Tuples.pair(3, "3"), three);
+        assertEquals(Tuples.pair(3, "3"), three);
 
-        Assert.assertNull(map.detect((ignored1, ignored2) -> false));
+        assertNull(map.detect((ignored1, ignored2) -> false));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMap2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMap2Test.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableUnifiedMap2Test extends MapIterableTestCase
 {
@@ -64,8 +64,8 @@ public class ImmutableUnifiedMap2Test extends MapIterableTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
@@ -78,7 +78,7 @@ public class ImmutableUnifiedMap2Test extends MapIterableTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
@@ -18,6 +18,8 @@ import org.eclipse.collections.impl.tuple.Tuples;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class ImmutableUnifiedMapTest extends ImmutableMapTestCase
 {
     @Override
@@ -36,14 +38,14 @@ public class ImmutableUnifiedMapTest extends ImmutableMapTestCase
     @Override
     public void testToString()
     {
-        Assert.assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
+        assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
     }
 
     @Test
     public void getBatchCount()
     {
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.classUnderTest();
-        Assert.assertEquals(5, integerBatchIterable.getBatchCount(3));
+        assertEquals(5, integerBatchIterable.getBatchCount(3));
     }
 
     @Test
@@ -52,6 +54,6 @@ public class ImmutableUnifiedMapTest extends ImmutableMapTestCase
         Sum sum = new IntegerSum(0);
         BatchIterable<String> integerBatchIterable = (BatchIterable<String>) this.classUnderTest();
         integerBatchIterable.batchForEach(each -> sum.add(Integer.valueOf(each)), 0, 1);
-        Assert.assertEquals(10, sum.getValue());
+        assertEquals(10, sum.getValue());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
@@ -15,7 +15,6 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/AbstractImmutableObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/AbstractImmutableObjectBooleanMapTestCase.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.impl.map.mutable.primitive.AbstractObjectBooleanMapTestCase;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
 
 public abstract class AbstractImmutableObjectBooleanMapTestCase extends AbstractObjectBooleanMapTestCase
 {
@@ -57,6 +58,6 @@ public abstract class AbstractImmutableObjectBooleanMapTestCase extends Abstract
     {
         super.toImmutable();
         ImmutableObjectBooleanMap<String> map = this.classUnderTest();
-        Assert.assertSame(map, map.toImmutable());
+        assertSame(map, map.toImmutable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableByteByteMapKeySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableByteByteMapKeySetTest.java
@@ -14,8 +14,10 @@ import org.eclipse.collections.api.set.primitive.ByteSet;
 import org.eclipse.collections.api.set.primitive.ImmutableByteSet;
 import org.eclipse.collections.impl.map.mutable.primitive.ByteByteHashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutableByteHashSetTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableByteSet} created from the freeze() method.
@@ -49,7 +51,7 @@ public class ImmutableByteByteMapKeySetTest extends AbstractImmutableByteHashSet
         ByteByteHashMap byteByteHashMap = ByteByteHashMap.newWithKeysValues(collision1, (byte) 0, collision2, (byte) 0);
         byteByteHashMap.removeKey(collision2);
         ByteSet byteSet = byteByteHashMap.keySet().freeze();
-        Assert.assertTrue(byteSet.contains(collision1));
-        Assert.assertFalse(byteSet.contains(collision2));
+        assertTrue(byteSet.contains(collision1));
+        assertFalse(byteSet.contains(collision2));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanEmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanEmptyMapTest.java
@@ -21,8 +21,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanEmptyMap}.
@@ -40,9 +47,9 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected = ObjectBooleanHashMap.newWithKeysValues("3", true).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", true));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", true));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", true));
+        assertNotSame(map1, map1.newWithKeyValue("3", true));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -50,9 +57,9 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected1 = this.getEmptyMap();
-        Assert.assertEquals(expected1, map1.newWithoutKey("2"));
-        Assert.assertSame(map1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutKey("2"));
+        assertSame(map1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -60,28 +67,28 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected1 = this.getEmptyMap();
-        Assert.assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey("0"));
-        Assert.assertFalse(this.classUnderTest().containsKey("1"));
-        Assert.assertFalse(this.classUnderTest().containsKey("2"));
-        Assert.assertFalse(this.classUnderTest().containsKey("3"));
-        Assert.assertFalse(this.classUnderTest().containsKey(null));
+        assertFalse(this.classUnderTest().containsKey("0"));
+        assertFalse(this.classUnderTest().containsKey("1"));
+        assertFalse(this.classUnderTest().containsKey("2"));
+        assertFalse(this.classUnderTest().containsKey("3"));
+        assertFalse(this.classUnderTest().containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(true));
-        Assert.assertFalse(this.classUnderTest().containsValue(false));
+        assertFalse(this.classUnderTest().containsValue(true));
+        assertFalse(this.classUnderTest().containsValue(false));
     }
 
     @Override
@@ -89,53 +96,53 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     public void detectIfNone()
     {
         boolean detect = this.classUnderTest().detectIfNone(value -> true, false);
-        Assert.assertFalse(detect);
+        assertFalse(detect);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("0", true));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("1", true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("2", false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("5", false));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("5", true));
+        assertTrue(this.classUnderTest().getIfAbsent("0", true));
+        assertTrue(this.classUnderTest().getIfAbsent("1", true));
+        assertFalse(this.classUnderTest().getIfAbsent("2", false));
+        assertFalse(this.classUnderTest().getIfAbsent("5", false));
+        assertTrue(this.classUnderTest().getIfAbsent("5", true));
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(null, true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(null, false));
+        assertTrue(this.classUnderTest().getIfAbsent(null, true));
+        assertFalse(this.classUnderTest().getIfAbsent(null, false));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(value -> false));
+        assertTrue(this.classUnderTest().allSatisfy(value -> false));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(value -> true));
+        assertFalse(this.classUnderTest().anySatisfy(value -> true));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((object, value1) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((object, value1) -> false));
 
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().reject(value -> false).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().reject(value -> false).toBag());
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((object, value1) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((object, value1) -> true));
 
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().select(value -> true).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().select(value -> true).toBag());
     }
 
     @Override
@@ -143,73 +150,73 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     public void iterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(true));
-        Assert.assertFalse(this.classUnderTest().contains(false));
+        assertFalse(this.classUnderTest().contains(true));
+        assertFalse(this.classUnderTest().contains(false));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertFalse(this.classUnderTest().get("0"));
-        Assert.assertFalse(this.classUnderTest().get("1"));
-        Assert.assertFalse(this.classUnderTest().get(null));
+        assertFalse(this.classUnderTest().get("0"));
+        assertFalse(this.classUnderTest().get("1"));
+        assertFalse(this.classUnderTest().get(null));
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0L, this.classUnderTest().count(value -> true));
+        assertEquals(0L, this.classUnderTest().count(value -> true));
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(), this.classUnderTest().toBag());
+        assertEquals(BooleanHashBag.newBagWith(), this.classUnderTest().toBag());
     }
 
     @Override
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.classUnderTest().toSet());
+        assertEquals(BooleanHashSet.newSetWith(), this.classUnderTest().toSet());
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(true, false));
-        Assert.assertFalse(this.classUnderTest().containsAll(true, true));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(true, false));
+        assertFalse(this.classUnderTest().containsAll(true, true));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
     }
 
     @Override
@@ -219,7 +226,7 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
         ObjectBooleanMap<String> map1 = this.newWithKeysValues("0", true, "1", false, null, true);
         ObjectBooleanMap<String> map2 = this.getEmptyMap();
 
-        Assert.assertNotEquals(this.classUnderTest(), map1);
+        assertNotEquals(this.classUnderTest(), map1);
         Verify.assertEqualsAndHashCode(this.classUnderTest(), map2);
         Verify.assertPostSerializedIdentity(this.classUnderTest());
     }
@@ -235,13 +242,13 @@ public class ImmutableObjectBooleanEmptyMapTest extends AbstractImmutableObjectB
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(value -> true));
+        assertTrue(this.classUnderTest().noneSatisfy(value -> true));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanHashMapTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanHashMap}.
@@ -32,9 +34,9 @@ public class ImmutableObjectBooleanHashMapTest extends AbstractImmutableObjectBo
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected = ObjectBooleanHashMap.newWithKeysValues("0", true, "1", true, "2", false, "3", false).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", false));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", false));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", false));
+        assertNotSame(map1, map1.newWithKeyValue("3", false));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -42,9 +44,9 @@ public class ImmutableObjectBooleanHashMapTest extends AbstractImmutableObjectBo
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected = this.newWithKeysValues("0", true, "1", true);
-        Assert.assertEquals(expected, map1.newWithoutKey("2"));
-        Assert.assertNotSame(map1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutKey("2"));
+        assertNotSame(map1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -52,8 +54,8 @@ public class ImmutableObjectBooleanHashMapTest extends AbstractImmutableObjectBo
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected = this.newWithKeysValues("1", true);
-        Assert.assertEquals(expected, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("0", "2")));
+        assertEquals(this.classUnderTest(), map1);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanSingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanSingletonMapTest.java
@@ -22,8 +22,14 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanSingletonMap}.
@@ -41,9 +47,9 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected = ObjectBooleanHashMap.newWithKeysValues("1", true, "3", true).toImmutable();
-        Assert.assertEquals(expected, map1.newWithKeyValue("3", true));
-        Assert.assertNotSame(map1, map1.newWithKeyValue("3", true));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected, map1.newWithKeyValue("3", true));
+        assertNotSame(map1, map1.newWithKeyValue("3", true));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -51,13 +57,13 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected1 = this.newWithKeysValues("1", true);
-        Assert.assertEquals(expected1, map1.newWithoutKey("2"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutKey("2"));
+        assertEquals(this.classUnderTest(), map1);
 
         ImmutableObjectBooleanMap<String> expected2 = this.getEmptyMap();
-        Assert.assertEquals(expected2, map1.newWithoutKey("1"));
-        Assert.assertNotSame(map1, map1.newWithoutKey("1"));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected2, map1.newWithoutKey("1"));
+        assertNotSame(map1, map1.newWithoutKey("1"));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Test
@@ -65,33 +71,33 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     {
         ImmutableObjectBooleanMap<String> map1 = this.classUnderTest();
         ImmutableObjectBooleanMap<String> expected1 = this.newWithKeysValues("1", true);
-        Assert.assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("2", "3")));
+        assertEquals(this.classUnderTest(), map1);
 
         ImmutableObjectBooleanMap<String> expected2 = this.getEmptyMap();
-        Assert.assertEquals(expected2, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
-        Assert.assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
-        Assert.assertEquals(this.classUnderTest(), map1);
+        assertEquals(expected2, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
+        assertNotSame(map1, map1.newWithoutAllKeys(FastList.newListWith("1", "3")));
+        assertEquals(this.classUnderTest(), map1);
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertFalse(this.classUnderTest().containsKey("0"));
-        Assert.assertTrue(this.classUnderTest().containsKey("1"));
-        Assert.assertFalse(this.classUnderTest().containsKey("2"));
-        Assert.assertFalse(this.classUnderTest().containsKey("3"));
-        Assert.assertFalse(this.classUnderTest().containsKey(null));
+        assertFalse(this.classUnderTest().containsKey("0"));
+        assertTrue(this.classUnderTest().containsKey("1"));
+        assertFalse(this.classUnderTest().containsKey("2"));
+        assertFalse(this.classUnderTest().containsKey("3"));
+        assertFalse(this.classUnderTest().containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertFalse(this.classUnderTest().containsValue(false));
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
+        assertFalse(this.classUnderTest().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(true));
     }
 
     @Override
@@ -99,59 +105,59 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     public void detectIfNone()
     {
         boolean detect = this.classUnderTest().detectIfNone(value -> true, false);
-        Assert.assertTrue(detect);
+        assertTrue(detect);
 
         boolean detect1 = this.classUnderTest().detectIfNone(value -> false, false);
-        Assert.assertFalse(detect1);
+        assertFalse(detect1);
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("0", true));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("1", false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("2", false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("5", false));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("5", true));
+        assertTrue(this.classUnderTest().getIfAbsent("0", true));
+        assertTrue(this.classUnderTest().getIfAbsent("1", false));
+        assertFalse(this.classUnderTest().getIfAbsent("2", false));
+        assertFalse(this.classUnderTest().getIfAbsent("5", false));
+        assertTrue(this.classUnderTest().getIfAbsent("5", true));
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(null, true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(null, false));
+        assertTrue(this.classUnderTest().getIfAbsent(null, true));
+        assertFalse(this.classUnderTest().getIfAbsent(null, false));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfy(value1 -> false));
+        assertFalse(this.classUnderTest().allSatisfy(value1 -> false));
 
-        Assert.assertTrue(this.classUnderTest().allSatisfy(value -> true));
+        assertTrue(this.classUnderTest().allSatisfy(value -> true));
     }
 
     @Override
     @Test
     public void reject()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().reject((object1, value3) -> false));
+        assertEquals(this.classUnderTest(), this.classUnderTest().reject((object1, value3) -> false));
 
-        Assert.assertEquals(this.getEmptyMap(), this.classUnderTest().reject((object, value2) -> true));
+        assertEquals(this.getEmptyMap(), this.classUnderTest().reject((object, value2) -> true));
 
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().reject(value1 -> true).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().reject(value1 -> true).toBag());
 
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().reject(value -> false).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().reject(value -> false).toBag());
     }
 
     @Override
     @Test
     public void select()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().select((object1, value3) -> true));
+        assertEquals(this.classUnderTest(), this.classUnderTest().select((object1, value3) -> true));
 
-        Assert.assertEquals(this.getEmptyMap(), this.classUnderTest().select((object, value2) -> false));
+        assertEquals(this.getEmptyMap(), this.classUnderTest().select((object, value2) -> false));
 
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().select(value1 -> false).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().select(value1 -> false).toBag());
 
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().select(value -> true).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().select(value -> true).toBag());
     }
 
     @Override
@@ -159,90 +165,90 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     public void iterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(iterator.hasNext());
-        Assert.assertTrue(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.next());
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertFalse(this.classUnderTest().contains(false));
-        Assert.assertTrue(this.classUnderTest().contains(true));
+        assertFalse(this.classUnderTest().contains(false));
+        assertTrue(this.classUnderTest().contains(true));
     }
 
     @Override
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.classUnderTest().getOrThrow("1"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
+        assertTrue(this.classUnderTest().getOrThrow("1"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
     }
 
     @Override
     @Test
     public void get()
     {
-        Assert.assertFalse(this.classUnderTest().get("0"));
-        Assert.assertTrue(this.classUnderTest().get("1"));
-        Assert.assertFalse(this.classUnderTest().get(null));
+        assertFalse(this.classUnderTest().get("0"));
+        assertTrue(this.classUnderTest().get("1"));
+        assertFalse(this.classUnderTest().get(null));
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(1L, this.classUnderTest().count(value1 -> true));
+        assertEquals(1L, this.classUnderTest().count(value1 -> true));
 
-        Assert.assertEquals(0L, this.classUnderTest().count(value -> false));
+        assertEquals(0L, this.classUnderTest().count(value -> false));
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.classUnderTest().toBag());
     }
 
     @Override
     @Test
     public void toSet()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.classUnderTest().toSet());
+        assertEquals(BooleanHashSet.newSetWith(true), this.classUnderTest().toSet());
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(false, false));
-        Assert.assertFalse(this.classUnderTest().containsAll(true, false));
-        Assert.assertTrue(this.classUnderTest().containsAll(true));
-        Assert.assertTrue(this.classUnderTest().containsAll());
+        assertFalse(this.classUnderTest().containsAll(false, false));
+        assertFalse(this.classUnderTest().containsAll(true, false));
+        assertTrue(this.classUnderTest().containsAll(true));
+        assertTrue(this.classUnderTest().containsAll());
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(this.classUnderTest().containsAll(new BooleanArrayList()));
     }
 
     @Override
@@ -253,8 +259,8 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", false);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false, "1", true);
 
-        Assert.assertNotEquals(this.classUnderTest(), map3);
-        Assert.assertNotEquals(this.classUnderTest(), map2);
+        assertNotEquals(this.classUnderTest(), map3);
+        assertNotEquals(this.classUnderTest(), map2);
         Verify.assertEqualsAndHashCode(this.classUnderTest(), map1);
         Verify.assertPostSerializedEqualsAndHashCode(this.classUnderTest());
     }
@@ -270,15 +276,15 @@ public class ImmutableObjectBooleanSingletonMapTest extends AbstractImmutableObj
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(value1 -> true));
+        assertFalse(this.classUnderTest().noneSatisfy(value1 -> true));
 
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(value -> false));
+        assertTrue(this.classUnderTest().noneSatisfy(value -> false));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ObjectBooleanMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ObjectBooleanMapFactoryTest.java
@@ -15,67 +15,70 @@ import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.factory.primitive.ObjectBooleanMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ObjectBooleanMapFactoryTest
 {
     @Test
     public void of()
     {
-        Assert.assertEquals(new ObjectBooleanHashMap<>(), ObjectBooleanMaps.mutable.of());
-        Assert.assertEquals(ObjectBooleanMaps.mutable.of(), ObjectBooleanMaps.mutable.empty());
-        Assert.assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.empty());
-        Assert.assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.of());
-        Assert.assertTrue(ObjectBooleanMaps.immutable.empty() instanceof ImmutableObjectBooleanEmptyMap);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true).toImmutable(), ObjectBooleanMaps.immutable.of("2", true));
-        Assert.assertTrue(ObjectBooleanMaps.immutable.of("2", true) instanceof ImmutableObjectBooleanSingletonMap);
+        assertEquals(new ObjectBooleanHashMap<>(), ObjectBooleanMaps.mutable.of());
+        assertEquals(ObjectBooleanMaps.mutable.of(), ObjectBooleanMaps.mutable.empty());
+        assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.empty());
+        assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.of());
+        assertTrue(ObjectBooleanMaps.immutable.empty() instanceof ImmutableObjectBooleanEmptyMap);
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true).toImmutable(), ObjectBooleanMaps.immutable.of("2", true));
+        assertTrue(ObjectBooleanMaps.immutable.of("2", true) instanceof ImmutableObjectBooleanSingletonMap);
 
-        Assert.assertEquals(ObjectBooleanMaps.mutable.of("2", true), ObjectBooleanHashMap.newWithKeysValues("2", true));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false),
+        assertEquals(ObjectBooleanMaps.mutable.of("2", true), ObjectBooleanHashMap.newWithKeysValues("2", true));
+        assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false, 4, false),
+        assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false, 4, false),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false, 4, false));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false, 4, false, 5, true),
+        assertEquals(ObjectBooleanMaps.mutable.of("2", true, 3, false, 4, false, 5, true),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false, 4, false, 5, true));
     }
 
     @Test
     public void with()
     {
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with(), ObjectBooleanMaps.mutable.empty());
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with("2", false), ObjectBooleanHashMap.newWithKeysValues("2", false));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with("2", true), ObjectBooleanHashMap.newWithKeysValues("2", true));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false),
+        assertEquals(ObjectBooleanMaps.mutable.with(), ObjectBooleanMaps.mutable.empty());
+        assertEquals(ObjectBooleanMaps.mutable.with("2", false), ObjectBooleanHashMap.newWithKeysValues("2", false));
+        assertEquals(ObjectBooleanMaps.mutable.with("2", true), ObjectBooleanHashMap.newWithKeysValues("2", true));
+        assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false, 4, false),
+        assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false, 4, false),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false, 4, false));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false, 4, false, 5, true),
+        assertEquals(ObjectBooleanMaps.mutable.with("2", true, 3, false, 4, false, 5, true),
                 ObjectBooleanHashMap.newWithKeysValues("2", true, 3, false, 4, false, 5, true));
     }
 
     @Test
     public void ofAll()
     {
-        Assert.assertEquals(ObjectBooleanMaps.mutable.empty(), ObjectBooleanMaps.mutable.ofAll(ObjectBooleanMaps.mutable.empty()));
-        Assert.assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanMaps.mutable.empty()));
-        Assert.assertSame(ObjectBooleanMaps.immutable.empty(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanMaps.immutable.empty()));
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true), ObjectBooleanMaps.mutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true)));
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true).toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true)));
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true, "3", false).toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true, "3", false)));
+        assertEquals(ObjectBooleanMaps.mutable.empty(), ObjectBooleanMaps.mutable.ofAll(ObjectBooleanMaps.mutable.empty()));
+        assertEquals(ObjectBooleanMaps.mutable.empty().toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanMaps.mutable.empty()));
+        assertSame(ObjectBooleanMaps.immutable.empty(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanMaps.immutable.empty()));
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true), ObjectBooleanMaps.mutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true)));
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true).toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true)));
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues("2", true, "3", false).toImmutable(), ObjectBooleanMaps.immutable.ofAll(ObjectBooleanHashMap.newWithKeysValues("2", true, "3", false)));
     }
 
     @Test
     public void from()
     {
         Iterable<String> iterable = Lists.mutable.with("1", "2", "3");
-        Assert.assertEquals(
+        assertEquals(
                 ObjectBooleanHashMap.newWithKeysValues("1", false, "2", true, "3", false),
                 ObjectBooleanMaps.mutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0));
-        Assert.assertTrue(ObjectBooleanMaps.mutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0) instanceof MutableObjectBooleanMap);
-        Assert.assertEquals(
+        assertTrue(ObjectBooleanMaps.mutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0) instanceof MutableObjectBooleanMap);
+        assertEquals(
                 ObjectBooleanHashMap.newWithKeysValues("1", false, "2", true, "3", false),
                 ObjectBooleanMaps.immutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0));
-        Assert.assertTrue(ObjectBooleanMaps.immutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0) instanceof ImmutableObjectBooleanMap);
+        assertTrue(ObjectBooleanMaps.immutable.from(iterable, each -> each, each -> Integer.valueOf(each) % 2 == 0) instanceof ImmutableObjectBooleanMap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTest.java
@@ -34,10 +34,15 @@ import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentHashMap}.
@@ -96,7 +101,7 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
                 return this.visited += object;
             }
         }).toReversed();
-        Assert.assertEquals(FastList.newListWith("321", "32", "3"), expectedDoubleReverse);
+        assertEquals(FastList.newListWith("321", "32", "3"), expectedDoubleReverse);
         MutableList<String> expectedNormal = source.collect(new Function<String, String>()
         {
             private String visited = "";
@@ -106,59 +111,59 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
                 return this.visited += object;
             }
         });
-        Assert.assertEquals(FastList.newListWith("1", "12", "123"), expectedNormal);
+        assertEquals(FastList.newListWith("1", "12", "123"), expectedNormal);
     }
 
     @Test
     public void putIfAbsent()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
-        Assert.assertNull(map.putIfAbsent(3, 3));
+        assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
+        assertNull(map.putIfAbsent(3, 3));
     }
 
     @Test
     public void replace()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.replace(1, 7));
-        Assert.assertEquals(Integer.valueOf(7), map.get(1));
-        Assert.assertNull(map.replace(3, 3));
+        assertEquals(Integer.valueOf(1), map.replace(1, 7));
+        assertEquals(Integer.valueOf(7), map.get(1));
+        assertNull(map.replace(3, 3));
     }
 
     @Test
     public void entrySetContains()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", Integer.valueOf(1), "Two", Integer.valueOf(2), "Three", Integer.valueOf(3));
-        Assert.assertFalse(map.entrySet().contains(null));
-        Assert.assertFalse(map.entrySet().contains(ImmutableEntry.of("Zero", Integer.valueOf(0))));
-        Assert.assertTrue(map.entrySet().contains(ImmutableEntry.of("One", Integer.valueOf(1))));
+        assertFalse(map.entrySet().contains(null));
+        assertFalse(map.entrySet().contains(ImmutableEntry.of("Zero", Integer.valueOf(0))));
+        assertTrue(map.entrySet().contains(ImmutableEntry.of("One", Integer.valueOf(1))));
     }
 
     @Test
     public void entrySetRemove()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", Integer.valueOf(1), "Two", Integer.valueOf(2), "Three", Integer.valueOf(3));
-        Assert.assertFalse(map.entrySet().remove(null));
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Zero", Integer.valueOf(0))));
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("One", Integer.valueOf(1))));
+        assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Zero", Integer.valueOf(0))));
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("One", Integer.valueOf(1))));
     }
 
     @Test
     public void replaceWithOldValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.replace(1, 1, 7));
-        Assert.assertEquals(Integer.valueOf(7), map.get(1));
-        Assert.assertFalse(map.replace(2, 3, 3));
+        assertTrue(map.replace(1, 1, 7));
+        assertEquals(Integer.valueOf(7), map.get(1));
+        assertFalse(map.replace(2, 3, 3));
     }
 
     @Test
     public void removeWithKeyValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.remove(1, 1));
-        Assert.assertFalse(map.remove(2, 3));
+        assertTrue(map.remove(1, 1));
+        assertFalse(map.remove(2, 3));
     }
 
     @Override
@@ -166,10 +171,10 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
     public void removeFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
@@ -178,12 +183,12 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
     public void removeAllFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().removeAll(FastList.newListWith(
+        assertTrue(map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
+        assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues("Two", 2), map);
     }
 
@@ -198,8 +203,8 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
     @Test
     public void equalsEdgeCases()
     {
-        Assert.assertNotEquals(ConcurrentHashMap.newMap().withKeyValue(1, 1), ConcurrentHashMap.newMap());
-        Assert.assertNotEquals(ConcurrentHashMap.newMap().withKeyValue(1, 1), ConcurrentHashMap.newMap().withKeyValue(1, 1).withKeyValue(2, 2));
+        assertNotEquals(ConcurrentHashMap.newMap().withKeyValue(1, 1), ConcurrentHashMap.newMap());
+        assertNotEquals(ConcurrentHashMap.newMap().withKeyValue(1, 1), ConcurrentHashMap.newMap().withKeyValue(1, 1).withKeyValue(2, 2));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -218,8 +223,8 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
@@ -232,15 +237,15 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newMap().withMap(null));
+        assertThrows(IllegalArgumentException.class, () -> this.newMap().withMap(null));
     }
 
     @Test
@@ -299,23 +304,23 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
         ParallelIterate.forEach(Interval.oneTo(100), each ->
         {
             map1.put(each, each);
-            Assert.assertEquals(each, map1.get(each));
+            assertEquals(each, map1.get(each));
             map2.putAll(Maps.mutable.of(each, each));
             map1.remove(each);
             map1.putAll(Maps.mutable.of(each, each));
-            Assert.assertEquals(each, map2.get(each));
+            assertEquals(each, map2.get(each));
             map2.remove(each);
-            Assert.assertNull(map2.get(each));
-            Assert.assertFalse(map2.containsValue(each));
-            Assert.assertFalse(map2.containsKey(each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
-            Assert.assertTrue(map2.containsValue(each));
-            Assert.assertTrue(map2.containsKey(each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertNull(map2.get(each));
+            assertFalse(map2.containsValue(each));
+            assertFalse(map2.containsKey(each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertTrue(map2.containsValue(each));
+            assertTrue(map2.containsKey(each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
             map2.remove(each);
-            Assert.assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
-            Assert.assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
         }, 1, this.executor);
         Verify.assertEqualsAndHashCode(map1, map2);
     }
@@ -329,14 +334,14 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
         {
             map1.put(each, each);
             map1.put(each, each);
-            Assert.assertEquals(each, map1.get(each));
+            assertEquals(each, map1.get(each));
             map2.putAll(Maps.mutable.of(each, each));
             map2.putAll(Maps.mutable.of(each, each));
             map1.remove(each);
-            Assert.assertNull(map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
-            Assert.assertEquals(each, map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
+            assertNull(map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
+            assertEquals(each, map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
         }, 1, this.executor);
-        Assert.assertEquals(map1, map2);
+        assertEquals(map1, map2);
     }
 
     @Test
@@ -360,26 +365,26 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
         ConcurrentHashMap<Integer, Integer> map1 = ConcurrentHashMap.newMap();
         ParallelIterate.forEach(Interval.oneTo(100), each ->
         {
-            Assert.assertNull(map1.put(each, each));
+            assertNull(map1.put(each, each));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
-            Assert.assertEquals(each, map1.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertNull(map1.get(each));
+            assertEquals(each, map1.getIfAbsentPut(each, Functions.getIntegerPassThru()));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
-            Assert.assertEquals(each, map1.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertNull(map1.get(each));
+            assertEquals(each, map1.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
+            assertNull(map1.get(each));
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertNull(map1.putIfAbsent(each + i * 1000, each));
+                assertNull(map1.putIfAbsent(each + i * 1000, each));
             }
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertEquals(each, map1.putIfAbsent(each + i * 1000, each));
+                assertEquals(each, map1.putIfAbsent(each + i * 1000, each));
             }
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertEquals(each, map1.remove(each + i * 1000));
+                assertEquals(each, map1.remove(each + i * 1000));
             }
         }, 1, this.executor);
     }
@@ -388,7 +393,7 @@ public class ConcurrentHashMapTest extends ConcurrentHashMapTestCase
     public void emptyToString()
     {
         ConcurrentHashMap<?, ?> empty = ConcurrentHashMap.newMap(0);
-        Assert.assertEquals("{}", empty.toString());
+        assertEquals("{}", empty.toString());
     }
 
     private static class KeyTransformer implements Function2<Integer, Integer, Integer>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
@@ -21,9 +21,10 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
 {
@@ -52,8 +53,8 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
 
         ConcurrentMutableMap<Integer, Integer> map = this.newMap();
         ParallelIterate.forEach(Interval.oneTo(100), each -> map.updateValue(each % 10, () -> 0, integer -> integer + 1), 1, this.executor);
-        Assert.assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
-        Assert.assertEquals(FastList.newList(Collections.nCopies(10, 10)), FastList.newList(map.values()));
+        assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
+        assertEquals(FastList.newList(Collections.nCopies(10, 10)), FastList.newList(map.values()));
     }
 
     @Override
@@ -65,8 +66,8 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
         ConcurrentMutableMap<Integer, Integer> map = this.newMap();
         MutableList<Integer> list = Interval.oneTo(100).toList().shuffleThis();
         ParallelIterate.forEach(list, each -> map.updateValue(each % 50, () -> 0, integer -> integer + 1), 1, this.executor);
-        Assert.assertEquals(Interval.zeroTo(49).toSet(), map.keySet());
-        Assert.assertEquals(
+        assertEquals(Interval.zeroTo(49).toSet(), map.keySet());
+        assertEquals(
                 HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(50, 2)),
                 FastList.newList(map.values()));
@@ -80,11 +81,11 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
 
         ConcurrentMutableMap<Integer, Integer> map = this.newMap();
         ParallelIterate.forEach(Interval.oneTo(100), each -> map.updateValueWith(each % 10, () -> 0, (integer, parameter) -> {
-            Assert.assertEquals("test", parameter);
+            assertEquals("test", parameter);
             return integer + 1;
         }, "test"), 1, this.executor);
-        Assert.assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
-        Assert.assertEquals(FastList.newList(Collections.nCopies(10, 10)), FastList.newList(map.values()));
+        assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
+        assertEquals(FastList.newList(Collections.nCopies(10, 10)), FastList.newList(map.values()));
     }
 
     @Override
@@ -96,11 +97,11 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
         ConcurrentMutableMap<Integer, Integer> map = this.newMap();
         MutableList<Integer> list = Interval.oneTo(200).toList().shuffleThis();
         ParallelIterate.forEach(list, each -> map.updateValueWith(each % 100, () -> 0, (integer, parameter) -> {
-            Assert.assertEquals("test", parameter);
+            assertEquals("test", parameter);
             return integer + 1;
         }, "test"), 1, this.executor);
-        Assert.assertEquals(Interval.zeroTo(99).toSet(), map.keySet());
-        Assert.assertEquals(
+        assertEquals(Interval.zeroTo(99).toSet(), map.keySet());
+        assertEquals(
                 HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(100, 2)),
                 FastList.newList(map.values()));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafeTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafeTest.java
@@ -35,10 +35,15 @@ import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentHashMapUnsafe}.
@@ -97,7 +102,7 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
                 return this.visited += object;
             }
         }).toReversed();
-        Assert.assertEquals(FastList.newListWith("321", "32", "3"), expectedDoubleReverse);
+        assertEquals(FastList.newListWith("321", "32", "3"), expectedDoubleReverse);
         MutableList<String> expectedNormal = source.collect(new Function<String, String>()
         {
             private String visited = "";
@@ -107,59 +112,59 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
                 return this.visited += object;
             }
         });
-        Assert.assertEquals(FastList.newListWith("1", "12", "123"), expectedNormal);
+        assertEquals(FastList.newListWith("1", "12", "123"), expectedNormal);
     }
 
     @Test
     public void putIfAbsent()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
-        Assert.assertNull(map.putIfAbsent(3, 3));
+        assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
+        assertNull(map.putIfAbsent(3, 3));
     }
 
     @Test
     public void replace()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.replace(1, 7));
-        Assert.assertEquals(Integer.valueOf(7), map.get(1));
-        Assert.assertNull(map.replace(3, 3));
+        assertEquals(Integer.valueOf(1), map.replace(1, 7));
+        assertEquals(Integer.valueOf(7), map.get(1));
+        assertNull(map.replace(3, 3));
     }
 
     @Test
     public void entrySetContains()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", Integer.valueOf(1), "Two", Integer.valueOf(2), "Three", Integer.valueOf(3));
-        Assert.assertFalse(map.entrySet().contains(null));
-        Assert.assertFalse(map.entrySet().contains(ImmutableEntry.of("Zero", Integer.valueOf(0))));
-        Assert.assertTrue(map.entrySet().contains(ImmutableEntry.of("One", Integer.valueOf(1))));
+        assertFalse(map.entrySet().contains(null));
+        assertFalse(map.entrySet().contains(ImmutableEntry.of("Zero", Integer.valueOf(0))));
+        assertTrue(map.entrySet().contains(ImmutableEntry.of("One", Integer.valueOf(1))));
     }
 
     @Test
     public void entrySetRemove()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", Integer.valueOf(1), "Two", Integer.valueOf(2), "Three", Integer.valueOf(3));
-        Assert.assertFalse(map.entrySet().remove(null));
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Zero", Integer.valueOf(0))));
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("One", Integer.valueOf(1))));
+        assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Zero", Integer.valueOf(0))));
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("One", Integer.valueOf(1))));
     }
 
     @Test
     public void replaceWithOldValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.replace(1, 1, 7));
-        Assert.assertEquals(Integer.valueOf(7), map.get(1));
-        Assert.assertFalse(map.replace(2, 3, 3));
+        assertTrue(map.replace(1, 1, 7));
+        assertEquals(Integer.valueOf(7), map.get(1));
+        assertFalse(map.replace(2, 3, 3));
     }
 
     @Test
     public void removeWithKeyValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.remove(1, 1));
-        Assert.assertFalse(map.remove(2, 3));
+        assertTrue(map.remove(1, 1));
+        assertFalse(map.remove(2, 3));
     }
 
     @Override
@@ -167,10 +172,10 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
     public void removeFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
@@ -179,12 +184,12 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
     public void removeAllFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().removeAll(FastList.newListWith(
+        assertTrue(map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
+        assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
         Verify.assertEqualsAndHashCode(UnifiedMap.newWithKeysValues("Two", 2), map);
     }
 
@@ -199,8 +204,8 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
     @Test
     public void equalsEdgeCases()
     {
-        Assert.assertNotEquals(ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1), ConcurrentHashMapUnsafe.newMap());
-        Assert.assertNotEquals(ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1), ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1).withKeyValue(2, 2));
+        assertNotEquals(ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1), ConcurrentHashMapUnsafe.newMap());
+        assertNotEquals(ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1), ConcurrentHashMapUnsafe.newMap().withKeyValue(1, 1).withKeyValue(2, 2));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -219,8 +224,8 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
@@ -233,15 +238,15 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.newMap().withMap(null));
+        assertThrows(IllegalArgumentException.class, () -> this.newMap().withMap(null));
     }
 
     @Test
@@ -300,23 +305,23 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
         ParallelIterate.forEach(Interval.oneTo(100), each ->
         {
             map1.put(each, each);
-            Assert.assertEquals(each, map1.get(each));
+            assertEquals(each, map1.get(each));
             map2.putAll(Maps.mutable.of(each, each));
             map1.remove(each);
             map1.putAll(Maps.mutable.of(each, each));
-            Assert.assertEquals(each, map2.get(each));
+            assertEquals(each, map2.get(each));
             map2.remove(each);
-            Assert.assertNull(map2.get(each));
-            Assert.assertFalse(map2.containsValue(each));
-            Assert.assertFalse(map2.containsKey(each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
-            Assert.assertTrue(map2.containsValue(each));
-            Assert.assertTrue(map2.containsKey(each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertNull(map2.get(each));
+            assertFalse(map2.containsValue(each));
+            assertFalse(map2.containsKey(each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertTrue(map2.containsValue(each));
+            assertTrue(map2.containsKey(each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
             map2.remove(each);
-            Assert.assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
-            Assert.assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
-            Assert.assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertEquals(each, map2.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertEquals(each, map2.getIfAbsentPut(each, Functions.getIntegerPassThru()));
         }, 1, this.executor);
         Verify.assertEqualsAndHashCode(map1, map2);
     }
@@ -330,14 +335,14 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
         {
             map1.put(each, each);
             map1.put(each, each);
-            Assert.assertEquals(each, map1.get(each));
+            assertEquals(each, map1.get(each));
             map2.putAll(Maps.mutable.of(each, each));
             map2.putAll(Maps.mutable.of(each, each));
             map1.remove(each);
-            Assert.assertNull(map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
-            Assert.assertEquals(each, map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
+            assertNull(map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
+            assertEquals(each, map1.putIfAbsentGetIfPresent(each, new KeyTransformer(), new ValueFactory(), null, null));
         }, 1, this.executor);
-        Assert.assertEquals(map1, map2);
+        assertEquals(map1, map2);
     }
 
     @Test
@@ -361,26 +366,26 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
         ConcurrentHashMapUnsafe<Integer, Integer> map1 = ConcurrentHashMapUnsafe.newMap();
         ParallelIterate.forEach(Interval.oneTo(100), each ->
         {
-            Assert.assertNull(map1.put(each, each));
+            assertNull(map1.put(each, each));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
-            Assert.assertEquals(each, map1.getIfAbsentPut(each, Functions.getIntegerPassThru()));
+            assertNull(map1.get(each));
+            assertEquals(each, map1.getIfAbsentPut(each, Functions.getIntegerPassThru()));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
-            Assert.assertEquals(each, map1.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
+            assertNull(map1.get(each));
+            assertEquals(each, map1.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each));
             map1.remove(each);
-            Assert.assertNull(map1.get(each));
+            assertNull(map1.get(each));
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertNull(map1.putIfAbsent(each + i * 1000, each));
+                assertNull(map1.putIfAbsent(each + i * 1000, each));
             }
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertEquals(each, map1.putIfAbsent(each + i * 1000, each));
+                assertEquals(each, map1.putIfAbsent(each + i * 1000, each));
             }
             for (int i = 0; i < 10; i++)
             {
-                Assert.assertEquals(each, map1.remove(each + i * 1000));
+                assertEquals(each, map1.remove(each + i * 1000));
             }
         }, 1, this.executor);
     }
@@ -389,7 +394,7 @@ public class ConcurrentHashMapUnsafeTest extends ConcurrentHashMapTestCase
     public void emptyToString()
     {
         ConcurrentHashMapUnsafe<?, ?> empty = ConcurrentHashMapUnsafe.newMap(0);
-        Assert.assertEquals("{}", empty.toString());
+        assertEquals("{}", empty.toString());
     }
 
     private static class KeyTransformer implements Function2<Integer, Integer, Integer>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMapTest.java
@@ -21,10 +21,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentMutableHashMap}.
@@ -72,32 +76,32 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
     public void putIfAbsent()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
-        Assert.assertNull(map.putIfAbsent(3, 3));
+        assertEquals(Integer.valueOf(1), map.putIfAbsent(1, 1));
+        assertNull(map.putIfAbsent(3, 3));
     }
 
     @Test
     public void replace()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertEquals(Integer.valueOf(1), map.replace(1, 1));
-        Assert.assertNull(map.replace(3, 3));
+        assertEquals(Integer.valueOf(1), map.replace(1, 1));
+        assertNull(map.replace(3, 3));
     }
 
     @Test
     public void replaceWithOldValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.replace(1, 1, 1));
-        Assert.assertFalse(map.replace(2, 3, 3));
+        assertTrue(map.replace(1, 1, 1));
+        assertFalse(map.replace(2, 3, 3));
     }
 
     @Test
     public void removeWithKeyValue()
     {
         ConcurrentMutableMap<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2);
-        Assert.assertTrue(map.remove(1, 1));
-        Assert.assertFalse(map.remove(2, 3));
+        assertTrue(map.remove(1, 1));
+        assertFalse(map.remove(2, 3));
     }
 
     @Override
@@ -105,11 +109,11 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
     public void removeFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Override
@@ -117,13 +121,13 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
     public void removeAllFromEntrySet()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().removeAll(FastList.newListWith(
+        assertTrue(map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
     }
 
     @Override
@@ -144,8 +148,8 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
@@ -158,8 +162,8 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
                 "C", 3,
                 "D", 4);
         PartitionIterable<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iSet(2, 4), partition.getSelected().toSet());
-        Assert.assertEquals(iSet(1, 3), partition.getRejected().toSet());
+        assertEquals(iSet(2, 4), partition.getSelected().toSet());
+        assertEquals(iSet(1, 3), partition.getRejected().toSet());
     }
 
     @Override
@@ -171,8 +175,8 @@ public class ConcurrentMutableHashMapTest extends ConcurrentHashMapTestCase
         Verify.assertEqualsAndHashCode(Maps.mutable.of(1, "1", 2, "2", 3, "3"), map);
         Verify.assertEqualsAndHashCode(Maps.immutable.of(1, "1", 2, "2", 3, "3"), map);
 
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MapAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MapAdapterTest.java
@@ -14,8 +14,10 @@ import java.util.HashMap;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.factory.Maps;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link MapAdapter}.
@@ -63,14 +65,14 @@ public class MapAdapterTest extends MutableMapTestCase
     public void adapt()
     {
         MutableMap<Integer, Integer> map = Maps.mutable.with(1, 1, 2, 2, 3, 3);
-        Assert.assertEquals(MapAdapter.adapt(new HashMap<>(map)), Maps.adapt(new HashMap<>(map)));
+        assertEquals(MapAdapter.adapt(new HashMap<>(map)), Maps.adapt(new HashMap<>(map)));
     }
 
     @Test
     public void adaptNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new MapAdapter<>(null));
+        assertThrows(NullPointerException.class, () -> new MapAdapter<>(null));
 
-        Assert.assertThrows(NullPointerException.class, () -> MapAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> MapAdapter.adapt(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
@@ -40,11 +40,17 @@ import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iMap;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit TestCase for {@link MutableMapIterable}s.
@@ -71,7 +77,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeyValue(1, "One");
         ImmutableMapIterable<Integer, String> immutable = map.toImmutable();
-        Assert.assertEquals(Maps.immutable.with(1, "One"), immutable);
+        assertEquals(Maps.immutable.with(1, "One"), immutable);
     }
 
     @Test
@@ -99,58 +105,58 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void removeFromEntrySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(null));
 
         MutableMapIterable<String, Integer> mapWithNullKey = this.newMapWithKeysValues("One", 1, null, 2, "Three", 3);
-        Assert.assertTrue(mapWithNullKey.entrySet().remove(new ImmutableEntry<String, Integer>(null, 2)));
+        assertTrue(mapWithNullKey.entrySet().remove(new ImmutableEntry<String, Integer>(null, 2)));
     }
 
     @Test
     public void removeAllFromEntrySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().removeAll(FastList.newListWith(
+        assertTrue(map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(null));
 
         MutableMapIterable<String, Integer> mapWithNullKey = this.newMapWithKeysValues("One", 1, null, 2, "Three", 3);
-        Assert.assertTrue(mapWithNullKey.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of(null, 2))));
+        assertTrue(mapWithNullKey.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of(null, 2))));
     }
 
     @Test
     public void retainAllFromEntrySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.entrySet().retainAll(FastList.newListWith(
+        assertFalse(map.entrySet().retainAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Two", 2),
                 ImmutableEntry.of("Three", 3),
                 ImmutableEntry.of("Four", 4))));
 
-        Assert.assertTrue(map.entrySet().retainAll(FastList.newListWith(
+        assertTrue(map.entrySet().retainAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3),
                 ImmutableEntry.of("Four", 4))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
         MutableMapIterable<Integer, Integer> integers = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
         Integer copy = new Integer(1);
-        Assert.assertTrue(integers.entrySet().retainAll(mList(ImmutableEntry.of(copy, copy))));
-        Assert.assertEquals(iMap(copy, copy), integers);
-        Assert.assertNotSame(copy, Iterate.getOnly(integers.entrySet()).getKey());
-        Assert.assertNotSame(copy, Iterate.getOnly(integers.entrySet()).getValue());
+        assertTrue(integers.entrySet().retainAll(mList(ImmutableEntry.of(copy, copy))));
+        assertEquals(iMap(copy, copy), integers);
+        assertNotSame(copy, Iterate.getOnly(integers.entrySet()).getKey());
+        assertNotSame(copy, Iterate.getOnly(integers.entrySet()).getValue());
     }
 
     @Test
@@ -177,10 +183,10 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void removeFromKeySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().remove("Four"));
+        assertFalse(map.keySet().remove("Four"));
 
-        Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.keySet().remove("Two"));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
@@ -192,31 +198,31 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         }
 
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().remove(null));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertFalse(map.keySet().remove(null));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
         map.put(null, 4);
-        Assert.assertTrue(map.keySet().remove(null));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertTrue(map.keySet().remove(null));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
     }
 
     @Test
     public void removeAllFromKeySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
+        assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
 
-        Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
     public void retainAllFromKeySet()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
 
-        Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
@@ -240,18 +246,18 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
         MutableList<String> expected = FastList.newListWith("One", "Two", "Three").toSortedList();
         Set<String> keySet = map.keySet();
-        Assert.assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
-        Assert.assertEquals(expected, FastList.newListWith(keySet.toArray(new String[keySet.size()])).toSortedList());
+        assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
+        assertEquals(expected, FastList.newListWith(keySet.toArray(new String[keySet.size()])).toSortedList());
     }
 
     @Test
     public void removeFromValues()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.values().remove(4));
+        assertFalse(map.values().remove(4));
 
-        Assert.assertTrue(map.values().remove(2));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.values().remove(2));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
@@ -263,39 +269,39 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         }
 
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.values().remove(null));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertFalse(map.values().remove(null));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
         map.put("Four", null);
-        Assert.assertTrue(map.values().remove(null));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
+        assertTrue(map.values().remove(null));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Two", 2, "Three", 3), map);
     }
 
     @Test
     public void removeAllFromValues()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.values().removeAll(FastList.newListWith(4)));
+        assertFalse(map.values().removeAll(FastList.newListWith(4)));
 
-        Assert.assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.values().removeAll(FastList.newListWith(2, 4)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
     public void retainAllFromValues()
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
+        assertFalse(map.values().retainAll(FastList.newListWith(1, 2, 3, 4)));
 
-        Assert.assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.values().retainAll(FastList.newListWith(1, 3)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
     public void put()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertNull(map.put(3, "Three"));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Two", 3, "Three"), map);
+        assertNull(map.put(3, "Three"));
+        assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Two", 3, "Three"), map);
 
         ImmutableList<Integer> key1 = Lists.immutable.with(null);
         ImmutableList<Integer> key2 = Lists.immutable.with(null);
@@ -303,8 +309,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         Object value2 = new Object();
         MutableMapIterable<ImmutableList<Integer>, Object> map2 = this.newMapWithKeyValue(key1, value1);
         Object previousValue = map2.put(key2, value2);
-        Assert.assertSame(value1, previousValue);
-        Assert.assertSame(key1, map2.keysView().getFirst());
+        assertSame(value1, previousValue);
+        assertSame(key1, map2.keysView().getFirst());
     }
 
     @Test
@@ -330,14 +336,14 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
 
-        Assert.assertEquals("1", map.removeKey(1));
+        assertEquals("1", map.removeKey(1));
         Verify.assertSize(1, map);
         Verify.denyContainsKey(1, map);
 
-        Assert.assertNull(map.removeKey(42));
+        assertNull(map.removeKey(42));
         Verify.assertSize(1, map);
 
-        Assert.assertEquals("Two", map.removeKey(2));
+        assertEquals("Two", map.removeKey(2));
         Verify.assertEmpty(map);
     }
 
@@ -346,21 +352,21 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two", 3, "Three");
 
-        Assert.assertThrows(NullPointerException.class, () -> map.removeAllKeys(null));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4)));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6)));
-        Assert.assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6, 7, 8, 9)));
+        assertThrows(NullPointerException.class, () -> map.removeAllKeys(null));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4)));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6)));
+        assertFalse(map.removeAllKeys(Sets.mutable.with(4, 5, 6, 7, 8, 9)));
 
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(1)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(1)));
         Verify.denyContainsKey(1, map);
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(3, 4, 5, 6, 7)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(3, 4, 5, 6, 7)));
         Verify.denyContainsKey(3, map);
 
         map.putAll(Maps.mutable.with(4, "Four", 5, "Five", 6, "Six", 7, "Seven"));
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(2, 3, 9, 10)));
+        assertTrue(map.removeAllKeys(Sets.mutable.with(2, 3, 9, 10)));
         Verify.denyContainsKey(2, map);
-        Assert.assertTrue(map.removeAllKeys(Sets.mutable.with(5, 3, 7, 8, 9)));
-        Assert.assertEquals(Maps.mutable.with(4, "Four", 6, "Six"), map);
+        assertTrue(map.removeAllKeys(Sets.mutable.with(5, 3, 7, 8, 9)));
+        assertEquals(Maps.mutable.with(4, "Four", 6, "Six"), map);
     }
 
     @Test
@@ -368,37 +374,37 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
 
-        Assert.assertFalse(map.removeIf(Predicates2.alwaysFalse()));
-        Assert.assertEquals(this.newMapWithKeysValues(1, "1", 2, "Two"), map);
-        Assert.assertTrue(map.removeIf(Predicates2.alwaysTrue()));
+        assertFalse(map.removeIf(Predicates2.alwaysFalse()));
+        assertEquals(this.newMapWithKeysValues(1, "1", 2, "Two"), map);
+        assertTrue(map.removeIf(Predicates2.alwaysTrue()));
         Verify.assertEmpty(map);
 
         map.putAll(Maps.mutable.with(1, "One", 2, "TWO", 3, "THREE", 4, "four"));
         map.putAll(Maps.mutable.with(5, "Five", 6, "Six", 7, "Seven", 8, "Eight"));
-        Assert.assertTrue(map.removeIf((each, value) -> each % 2 == 0 && value.length() < 4));
+        assertTrue(map.removeIf((each, value) -> each % 2 == 0 && value.length() < 4));
         Verify.denyContainsKey(2, map);
         Verify.denyContainsKey(6, map);
         MutableMapIterable<Integer, String> expected = this.newMapWithKeysValues(1, "One", 3, "THREE", 4, "four", 5, "Five");
         expected.put(7, "Seven");
         expected.put(8, "Eight");
-        Assert.assertEquals(expected, map);
+        assertEquals(expected, map);
 
-        Assert.assertTrue(map.removeIf((each, value) -> each % 2 != 0 && value.equals("THREE")));
+        assertTrue(map.removeIf((each, value) -> each % 2 != 0 && value.equals("THREE")));
         Verify.denyContainsKey(3, map);
         Verify.assertSize(5, map);
 
-        Assert.assertTrue(map.removeIf((each, value) -> each % 2 != 0));
-        Assert.assertFalse(map.removeIf((each, value) -> each % 2 != 0));
-        Assert.assertEquals(this.newMapWithKeysValues(4, "four", 8, "Eight"), map);
+        assertTrue(map.removeIf((each, value) -> each % 2 != 0));
+        assertFalse(map.removeIf((each, value) -> each % 2 != 0));
+        assertEquals(this.newMapWithKeysValues(4, "four", 8, "Eight"), map);
     }
 
     @Test
     public void getIfAbsentPut()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
-        Assert.assertEquals("3", map.getIfAbsentPut(3, new PassThruFunction0<>("3")));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentPut(4, new PassThruFunction0<>("4")));
+        assertEquals("3", map.getIfAbsentPut(3, new PassThruFunction0<>("3")));
         Verify.assertContainsKeyValue(4, "4", map);
     }
 
@@ -406,9 +412,9 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void getIfAbsentPutValue()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentPut(4, "4"));
-        Assert.assertEquals("3", map.getIfAbsentPut(3, "5"));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentPut(4, "4"));
+        assertEquals("3", map.getIfAbsentPut(3, "5"));
         Verify.assertContainsKeyValue(1, "1", map);
         Verify.assertContainsKeyValue(2, "2", map);
         Verify.assertContainsKeyValue(3, "3", map);
@@ -419,9 +425,9 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void getIfAbsentPutWithKey()
     {
         MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals(Integer.valueOf(4), map.getIfAbsentPutWithKey(4, Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), map.getIfAbsentPutWithKey(3, Functions.getIntegerPassThru()));
+        assertNull(map.get(4));
+        assertEquals(Integer.valueOf(4), map.getIfAbsentPutWithKey(4, Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), map.getIfAbsentPutWithKey(3, Functions.getIntegerPassThru()));
         Verify.assertContainsKeyValue(Integer.valueOf(4), Integer.valueOf(4), map);
     }
 
@@ -429,9 +435,9 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void getIfAbsentPutWith()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertNull(map.get(4));
-        Assert.assertEquals("4", map.getIfAbsentPutWith(4, String::valueOf, 4));
-        Assert.assertEquals("3", map.getIfAbsentPutWith(3, String::valueOf, 3));
+        assertNull(map.get(4));
+        assertEquals("4", map.getIfAbsentPutWith(4, String::valueOf, 4));
+        assertEquals("3", map.getIfAbsentPutWith(3, String::valueOf, 3));
         Verify.assertContainsKeyValue(4, "4", map);
     }
 
@@ -439,22 +445,22 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     public void getIfAbsentPut_block_throws()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(RuntimeException.class, () -> map.getIfAbsentPut(4, () ->
+        assertThrows(RuntimeException.class, () -> map.getIfAbsentPut(4, () ->
         {
             throw new RuntimeException();
         }));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 
     @Test
     public void getIfAbsentPutWith_block_throws()
     {
         MutableMapIterable<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertThrows(RuntimeException.class, () -> map.getIfAbsentPutWith(4, object ->
+        assertThrows(RuntimeException.class, () -> map.getIfAbsentPutWith(4, object ->
         {
             throw new RuntimeException();
         }, null));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(UnifiedMap.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 
     @Test
@@ -491,36 +497,36 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MapIterable<Key, Integer> map1 = this.newMapWithKeysValues(key, 1, duplicateKey1, 2);
         Verify.assertSize(1, map1);
         Verify.assertContainsKeyValue(key, 2, map1);
-        Assert.assertSame(key, map1.keysView().getFirst());
+        assertSame(key, map1.keysView().getFirst());
 
         Key duplicateKey2 = new Key("key");
         MapIterable<Key, Integer> map2 = this.newMapWithKeysValues(key, 1, duplicateKey1, 2, duplicateKey2, 3);
         Verify.assertSize(1, map2);
         Verify.assertContainsKeyValue(key, 3, map2);
-        Assert.assertSame(key, map1.keysView().getFirst());
+        assertSame(key, map1.keysView().getFirst());
 
         Key duplicateKey3 = new Key("key");
         MapIterable<Key, Integer> map3 = this.newMapWithKeysValues(key, 1, new Key("not a dupe"), 2, duplicateKey3, 3);
         Verify.assertSize(2, map3);
         Verify.assertContainsAllKeyValues(map3, key, 3, new Key("not a dupe"), 2);
-        Assert.assertSame(key, map3.keysView().detect(key::equals));
+        assertSame(key, map3.keysView().detect(key::equals));
 
         Key duplicateKey4 = new Key("key");
         MapIterable<Key, Integer> map4 = this.newMapWithKeysValues(key, 1, new Key("still not a dupe"), 2, new Key("me neither"), 3, duplicateKey4, 4);
         Verify.assertSize(3, map4);
         Verify.assertContainsAllKeyValues(map4, key, 4, new Key("still not a dupe"), 2, new Key("me neither"), 3);
-        Assert.assertSame(key, map4.keysView().detect(key::equals));
+        assertSame(key, map4.keysView().detect(key::equals));
 
         MapIterable<Key, Integer> map5 = this.newMapWithKeysValues(key, 1, duplicateKey1, 2, duplicateKey3, 3, duplicateKey4, 4);
         Verify.assertSize(1, map5);
         Verify.assertContainsKeyValue(key, 4, map5);
-        Assert.assertSame(key, map5.keysView().getFirst());
+        assertSame(key, map5.keysView().getFirst());
     }
 
     @Test
     public void asUnmodifiable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, 1, 2, 2).asUnmodifiable().put(3, 3));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, 1, 2, 2).asUnmodifiable().put(3, 3));
     }
 
     @Test
@@ -535,8 +541,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeyValue("A", 1);
 
-        Assert.assertEquals(Integer.valueOf(1), map.add(Tuples.pair("A", 3)));
-        Assert.assertNull(map.add(Tuples.pair("B", 2)));
+        assertEquals(Integer.valueOf(1), map.add(Tuples.pair("A", 3)));
+        assertNull(map.add(Tuples.pair("B", 2)));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 3, "B", 2), map);
     }
 
@@ -545,8 +551,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeyValue("A", 1);
 
-        Assert.assertEquals(Integer.valueOf(1), map.putPair(Tuples.pair("A", 3)));
-        Assert.assertNull(map.putPair(Tuples.pair("B", 2)));
+        assertEquals(Integer.valueOf(1), map.putPair(Tuples.pair("A", 3)));
+        assertNull(map.putPair(Tuples.pair("B", 2)));
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 3, "B", 2), map);
     }
 
@@ -556,12 +562,12 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<String, Integer> map = this.newMapWithKeyValue("A", 1);
 
         MutableMapIterable<String, Integer> mapWith = map.withKeyValue("B", 2);
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 2), mapWith);
 
         MutableMapIterable<String, Integer> mapWith2 = mapWith.withKeyValue("A", 11);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 11, "B", 2), mapWith2);
-        Assert.assertSame(mapWith, mapWith2);
+        assertSame(mapWith, mapWith2);
     }
 
     @Test
@@ -571,7 +577,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         Map<String, Integer> simpleMap = Maps.mutable.with("B", 22, "C", 3);
         map.putAll(simpleMap);
         MutableMapIterable<String, Integer> mapWith = map.withMap(simpleMap);
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 22, "C", 3), mapWith);
     }
 
@@ -580,7 +586,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWith = map.withMap(Maps.mutable.empty());
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 2), mapWith);
     }
 
@@ -590,7 +596,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<String, Integer> map = this.newMap();
         Map<String, Integer> simpleMap = Maps.mutable.with("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWith = map.withMap(simpleMap);
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 2), mapWith);
     }
 
@@ -599,14 +605,14 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMap();
         MutableMapIterable<String, Integer> mapWith = map.withMap(Maps.mutable.empty());
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newMap(), mapWith);
     }
 
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.newMap().withMap(null));
+        assertThrows(NullPointerException.class, () -> this.newMap().withMap(null));
     }
 
     @Test
@@ -616,7 +622,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<String, Integer> simpleMap = Maps.mutable.with("B", 22, "C", 3);
         map.putAll(simpleMap);
         MutableMapIterable<String, Integer> mapWith = map.withMapIterable(simpleMap);
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(Maps.mutable.with("A", 1, "B", 22, "C", 3), mapWith);
     }
 
@@ -625,7 +631,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWith = map.withMapIterable(Maps.mutable.empty());
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(Maps.mutable.with("A", 1, "B", 2), mapWith);
     }
 
@@ -634,7 +640,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMap();
         MutableMapIterable<String, Integer> mapWith = map.withMapIterable(Maps.mutable.with("A", 1, "B", 2));
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(Maps.mutable.with("A", 1, "B", 2), mapWith);
     }
 
@@ -643,14 +649,14 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMap();
         MutableMapIterable<String, Integer> mapWith = map.withMapIterable(Maps.mutable.empty());
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(Maps.mutable.withMapIterable(map), mapWith);
     }
 
     @Test
     public void withMapIterableNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.newMap().withMapIterable(null));
+        assertThrows(NullPointerException.class, () -> this.newMap().withMapIterable(null));
     }
 
     @Test
@@ -689,7 +695,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     @Test
     public void putAllMapIterableNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> this.newMap().putAllMapIterable(null));
+        assertThrows(NullPointerException.class, () -> this.newMap().putAllMapIterable(null));
     }
 
     @Test
@@ -698,7 +704,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWith = map.withAllKeyValues(
                 FastList.newListWith(Tuples.pair("B", 22), Tuples.pair("C", 3)));
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 22, "C", 3), mapWith);
     }
 
@@ -707,7 +713,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWith = map.withAllKeyValueArguments(Tuples.pair("B", 22), Tuples.pair("C", 3));
-        Assert.assertSame(map, mapWith);
+        assertSame(map, mapWith);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1, "B", 22, "C", 3), mapWith);
     }
 
@@ -716,7 +722,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2);
         MutableMapIterable<String, Integer> mapWithout = map.withoutKey("B");
-        Assert.assertSame(map, mapWithout);
+        assertSame(map, mapWithout);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("A", 1), mapWithout);
     }
 
@@ -725,7 +731,7 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<String, Integer> map = this.newMapWithKeysValues("A", 1, "B", 2, "C", 3);
         MutableMapIterable<String, Integer> mapWithout = map.withoutAllKeys(FastList.newListWith("A", "C"));
-        Assert.assertSame(map, mapWithout);
+        assertSame(map, mapWithout);
         Verify.assertMapsEqual(UnifiedMap.newWithKeysValues("B", 2), mapWithout);
     }
 
@@ -742,9 +748,9 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
                 null, "Test 1",
                 key, "Test 2");
 
-        Assert.assertFalse(mutableMapIterable.keySet().retainAll(FastList.newListWith(key, null)));
+        assertFalse(mutableMapIterable.keySet().retainAll(FastList.newListWith(key, null)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.newMapWithKeysValues(
                         null, "Test 1",
                         key, "Test 2"),
@@ -771,8 +777,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
     {
         MutableMapIterable<Integer, Integer> map = this.newMap();
         Iterate.forEach(Interval.oneTo(1000), each -> map.updateValue(each % 10, () -> 0, integer -> integer + 1));
-        Assert.assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
-        Assert.assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
+        assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
+        assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
     }
 
     @Test
@@ -781,8 +787,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<Integer, Integer> map = this.newMap();
         MutableList<Integer> list = Interval.oneTo(2000).toList().shuffleThis();
         Iterate.forEach(list, each -> map.updateValue(each % 1000, () -> 0, integer -> integer + 1));
-        Assert.assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
-        Assert.assertEquals(
+        assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
+        assertEquals(
                 HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(1000, 2)),
                 FastList.newList(map.values()));
@@ -794,11 +800,11 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableMapIterable<Integer, Integer> map = this.newMap();
         Iterate.forEach(Interval.oneTo(1000), each -> map.updateValueWith(each % 10, () -> 0, (integer, parameter) ->
         {
-            Assert.assertEquals("test", parameter);
+            assertEquals("test", parameter);
             return integer + 1;
         }, "test"));
-        Assert.assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
-        Assert.assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
+        assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
+        assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
     }
 
     @Test
@@ -808,11 +814,11 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         MutableList<Integer> list = Interval.oneTo(2000).toList().shuffleThis();
         Iterate.forEach(list, each -> map.updateValueWith(each % 1000, () -> 0, (integer, parameter) ->
         {
-            Assert.assertEquals("test", parameter);
+            assertEquals("test", parameter);
             return integer + 1;
         }, "test"));
-        Assert.assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
-        Assert.assertEquals(
+        assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
+        assertEquals(
                 HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(1000, 2)),
                 FastList.newList(map.values()));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapTestCase.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Abstract JUnit TestCase for {@link MutableMap}s.
@@ -53,7 +54,7 @@ public abstract class MutableMapTestCase extends MutableMapIterableTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
         MutableMap<Integer, String> clone = map.clone();
-        Assert.assertNotSame(map, clone);
+        assertNotSame(map, clone);
         Verify.assertEqualsAndHashCode(map, clone);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
@@ -36,8 +36,14 @@ import org.eclipse.collections.impl.test.ClassComparer;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class UnifiedMapTest extends UnifiedMapTestCase
 {
@@ -76,10 +82,10 @@ public class UnifiedMapTest extends UnifiedMapTestCase
     @Test
     public void newMap_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(-1, 0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, 0.0f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, -0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, 1.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(-1, 0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, 0.0f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, -0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMap<Integer, Integer>(1, 1.5f));
     }
 
     @Test
@@ -119,26 +125,26 @@ public class UnifiedMapTest extends UnifiedMapTestCase
             }
             capacity <<= 1;
 
-            Assert.assertEquals(capacity, table.length);
+            assertEquals(capacity, table.length);
         }
         catch (SecurityException ignored)
         {
-            Assert.fail("Unable to modify the visibility of the table on UnifiedMap");
+            fail("Unable to modify the visibility of the table on UnifiedMap");
         }
         catch (NoSuchFieldException ignored)
         {
-            Assert.fail("No field named table UnifiedMap");
+            fail("No field named table UnifiedMap");
         }
         catch (IllegalAccessException ignored)
         {
-            Assert.fail("No access the field table in UnifiedMap");
+            fail("No access the field table in UnifiedMap");
         }
     }
 
     @Test
     public void constructorOfPairs()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(1, "one", 2, "two", 3, "three"),
                 UnifiedMap.newMapWith(Tuples.pair(1, "one"), Tuples.pair(2, "two"), Tuples.pair(3, "three")));
     }
@@ -150,11 +156,11 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         Pair<Integer, String> pair2 = Tuples.pair(2, "Two");
         Pair<Integer, String> pair3 = Tuples.pair(3, "Three");
         Pair<Integer, String> pair4 = Tuples.pair(4, "Four");
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newMapWith(pair1, pair2, pair3, pair4),
                 UnifiedMap.newMapWith(FastList.newListWith(pair1, pair2, pair3, pair4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newMapWith(pair1, pair2, pair3, pair4),
                 UnifiedMap.newMapWith(UnifiedSet.newSetWith(pair1, pair2, pair3, pair4)));
     }
@@ -162,7 +168,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
     @Test
     public void unifiedMapProperSuperSetOfHashMap()
     {
-        Assert.assertTrue(ClassComparer.isProperSupersetOfInstance(UnifiedMap.class, HashMap.class));
+        assertTrue(ClassComparer.isProperSupersetOfInstance(UnifiedMap.class, HashMap.class));
     }
 
     @Test
@@ -223,7 +229,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
             {
                 entries.batchForEach(new EntrySumProcedure(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(20, sum.getValue());
+            assertEquals(20, sum.getValue());
         }
     }
 
@@ -241,8 +247,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         {
             collisions.batchForEach(new EntrySumProcedure(sum2), i, numBatches);
         }
-        Assert.assertEquals(1, numBatches);
-        Assert.assertEquals(78, sum2.getValue());
+        assertEquals(1, numBatches);
+        assertEquals(78, sum2.getValue());
 
         //Testing 3 batches with chains and uneven last batch
         Sum sum3 = new IntegerSum(0);
@@ -250,7 +256,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         {
             collisions.batchForEach(new EntrySumProcedure(sum3), i, 5);
         }
-        Assert.assertEquals(78, sum3.getValue());
+        assertEquals(78, sum3.getValue());
     }
 
     @Test
@@ -268,7 +274,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
                 sum4.add(each.getValue() == null ? 1 : each.getValue());
             }, i, nulls.getBatchCount(7));
         }
-        Assert.assertEquals(52, sum4.getValue());
+        assertEquals(52, sum4.getValue());
     }
 
     @Test
@@ -278,7 +284,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         Sum sum5 = new IntegerSum(0);
         BatchIterable<Map.Entry<Integer, Integer>> empty = (BatchIterable<Map.Entry<Integer, Integer>>) UnifiedMap.newMap().entrySet();
         empty.batchForEach(new EntrySumProcedure(sum5), 0, empty.getBatchCount(1));
-        Assert.assertEquals(0, sum5.getValue());
+        assertEquals(0, sum5.getValue());
     }
 
     private void batchForEachTestCases(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -291,7 +297,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
             {
                 batchIterable.batchForEach(new SumProcedure<>(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(expectedValue, sum.getValue());
+            assertEquals(expectedValue, sum.getValue());
         }
     }
 
@@ -305,8 +311,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(new SumProcedure<>(sum), i, numBatches);
         }
-        Assert.assertEquals(1, numBatches);
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(1, numBatches);
+        assertEquals(expectedValue, sum.getValue());
 
         //Testing 3 batches with chains and uneven last batch
         Sum sum2 = new IntegerSum(0);
@@ -314,7 +320,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(new SumProcedure<>(sum2), i, 5);
         }
-        Assert.assertEquals(expectedValue, sum2.getValue());
+        assertEquals(expectedValue, sum2.getValue());
     }
 
     private void batchForEachNullHandling(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -326,7 +332,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(each -> sum.add(each == null ? 1 : each), i, batchIterable.getBatchCount(7));
         }
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchForEachEmptyBatchIterable(BatchIterable<Integer> batchIterable)
@@ -334,7 +340,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         //Test batchForEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum = new IntegerSum(0);
         batchIterable.batchForEach(new SumProcedure<>(sum), 0, batchIterable.getBatchCount(1));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     @Test
@@ -389,7 +395,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
                 (BatchIterable<Map.Entry<Integer, Integer>>) UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3, 4, 4).entrySet();
         Sum sum = new IntegerSum(0);
         entries.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(20, sum.getValue());
+        assertEquals(20, sum.getValue());
     }
 
     @Test
@@ -401,7 +407,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
 
         Sum sum = new IntegerSum(0);
         collisions.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(78, sum.getValue());
+        assertEquals(78, sum.getValue());
     }
 
     @Test
@@ -418,7 +424,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
             sum.add(each.getValue() == null ? 0 : each.getValue());
         });
 
-        Assert.assertEquals(48, sum.getValue());
+        assertEquals(48, sum.getValue());
     }
 
     @Test
@@ -429,14 +435,14 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         BatchIterable<Map.Entry<Integer, Integer>> empty =
                 (BatchIterable<Map.Entry<Integer, Integer>>) UnifiedMap.newMap().entrySet();
         empty.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     private void batchIterable_forEach(BatchIterable<Integer> batchIterable, int expectedValue)
     {
         IntegerSum sum = new IntegerSum(0);
         batchIterable.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchIterable_forEachNullHandling(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -444,7 +450,7 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         //Testing forEach handling null keys and null values
         Sum sum = new IntegerSum(0);
         batchIterable.forEach(each -> sum.add(each == null ? 0 : each));
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchIterable_forEachEmptyBatchIterable(BatchIterable<Integer> batchIterable)
@@ -452,35 +458,35 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         //Test forEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum = new IntegerSum(0);
         batchIterable.batchForEach(new SumProcedure<>(sum), 0, batchIterable.getBatchCount(1));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     @Test
     public void getMapMemoryUsedInWords()
     {
         UnifiedMap<String, String> map = UnifiedMap.newMap();
-        Assert.assertEquals(34, map.getMapMemoryUsedInWords());
+        assertEquals(34, map.getMapMemoryUsedInWords());
         map.put("1", "1");
-        Assert.assertEquals(34, map.getMapMemoryUsedInWords());
+        assertEquals(34, map.getMapMemoryUsedInWords());
 
         UnifiedMap<Integer, Integer> map2 = this.mapWithCollisionsOfSize(2);
-        Assert.assertEquals(16, map2.getMapMemoryUsedInWords());
+        assertEquals(16, map2.getMapMemoryUsedInWords());
     }
 
     @Test
     public void getCollidingBuckets()
     {
         UnifiedMap<Object, Object> map = UnifiedMap.newMap();
-        Assert.assertEquals(0, map.getCollidingBuckets());
+        assertEquals(0, map.getCollidingBuckets());
 
         UnifiedMap<Integer, Integer> map2 = this.mapWithCollisionsOfSize(2);
-        Assert.assertEquals(1, map2.getCollidingBuckets());
+        assertEquals(1, map2.getCollidingBuckets());
 
         map2.put(42, 42);
-        Assert.assertEquals(1, map2.getCollidingBuckets());
+        assertEquals(1, map2.getCollidingBuckets());
 
         UnifiedMap<String, String> map3 = UnifiedMap.newWithKeysValues("Six", "6", "Bar", "-", "Three", "3", "Five", "5");
-        Assert.assertEquals(2, map3.getCollidingBuckets());
+        assertEquals(2, map3.getCollidingBuckets());
     }
 
     @Override
@@ -493,19 +499,19 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         UnifiedMap<Integer, Integer> map = UnifiedMap.newMap(2, 0.75f);
         COLLISIONS.subList(0, 5).forEach(Procedures.cast(each -> map.getIfAbsentPut(each, new PassThruFunction0<>(each))));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(5), map);
+        assertEquals(this.mapWithCollisionsOfSize(5), map);
 
         //Test getting element present in chain
         UnifiedMap<Integer, Integer> map2 = UnifiedMap.newWithKeysValues(COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, COLLISION_4, 4);
-        Assert.assertEquals(Integer.valueOf(3), map2.getIfAbsentPut(COLLISION_3, () -> {
-            Assert.fail();
+        assertEquals(Integer.valueOf(3), map2.getIfAbsentPut(COLLISION_3, () -> {
+            fail();
             return null;
         }));
 
         //Test rehashing while creating a new chained key
         UnifiedMap<Integer, Integer> map3 = UnifiedMap.<Integer, Integer>newMap(2, 0.75f).withKeysValues(1, COLLISION_1, 2, COLLISION_2, 3, COLLISION_3);
-        Assert.assertEquals(COLLISION_4, map3.getIfAbsentPut(4, new PassThruFunction0<>(COLLISION_4)));
-        Assert.assertNull(map3.getIfAbsentPut(5, new PassThruFunction0<>(null)));
+        assertEquals(COLLISION_4, map3.getIfAbsentPut(4, new PassThruFunction0<>(COLLISION_4)));
+        assertNull(map3.getIfAbsentPut(5, new PassThruFunction0<>(null)));
     }
 
     @Override
@@ -517,13 +523,13 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         // this map is deliberately small to force a rehash to occur from the put method, in a map with a chained bucket
         UnifiedMap<Integer, Integer> map = UnifiedMap.newMap(2, 0.75f);
         COLLISIONS.subList(0, 5).forEach(Procedures.cast(each -> {
-            Assert.assertThrows(RuntimeException.class, () -> map.getIfAbsentPut(each, () -> {
+            assertThrows(RuntimeException.class, () -> map.getIfAbsentPut(each, () -> {
                 throw new RuntimeException();
             }));
             map.put(each, each);
         }));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(5), map);
+        assertEquals(this.mapWithCollisionsOfSize(5), map);
     }
 
     @Override
@@ -534,9 +540,9 @@ public class UnifiedMapTest extends UnifiedMapTestCase
 
         // this map is deliberately small to force a rehash to occur from the put method, in a map with a chained bucket
         UnifiedMap<Integer, Integer> map = UnifiedMap.newMap(2, 0.75f);
-        COLLISIONS.subList(0, 5).forEach(Procedures.cast(each -> Assert.assertNull(map.put(each, each))));
+        COLLISIONS.subList(0, 5).forEach(Procedures.cast(each -> assertNull(map.put(each, each))));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(5), map);
+        assertEquals(this.mapWithCollisionsOfSize(5), map);
     }
 
     @Override
@@ -546,17 +552,17 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.collectValues();
 
         UnifiedMap<String, Integer> map = UnifiedMap.<String, Integer>newMap().withKeysValues("1", 1, "2", 2, "3", 3, "4", 4);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.<String, String>newMap(5).withKeysValues("1", "11", "2", "22", "3", "33", "4", "44"),
                 map.collectValues((key, value) -> key + value));
 
         UnifiedMap<Integer, Integer> collisions = UnifiedMap.<Integer, Integer>newMap().withKeysValues(COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, 1, 4);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.<Integer, Integer>newMap().withKeysValues(COLLISION_1, COLLISION_1 + 1, COLLISION_2, COLLISION_2 + 2, COLLISION_3, COLLISION_3 + 3, 1, 5),
                 collisions.collectValues((key, value) -> key + value));
 
         UnifiedMap<Integer, Integer> nulls = UnifiedMap.<Integer, Integer>newMap().withKeysValues(null, 10, 1, null, 2, 11, 3, 12);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.<Integer, Boolean>newMap().withKeysValues(null, true, 1, true, 2, false, 3, false),
                 nulls.collectValues((key, value) -> key == null || value == null));
 
@@ -571,8 +577,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detect();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertNull(collisions.detect((key, value) -> COLLISION_4.equals(key) && "four".equals(value)));
-        Assert.assertEquals(
+        assertNull(collisions.detect((key, value) -> COLLISION_4.equals(key) && "four".equals(value)));
+        assertEquals(
                 Tuples.pair(COLLISION_1, "one"),
                 collisions.detect((key, value) -> COLLISION_1.equals(key) && "one".equals(value)));
     }
@@ -584,8 +590,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectOptional();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertFalse(collisions.detectOptional((key, value) -> COLLISION_4.equals(key) && "four".equals(value)).isPresent());
-        Assert.assertEquals(
+        assertFalse(collisions.detectOptional((key, value) -> COLLISION_4.equals(key) && "four".equals(value)).isPresent());
+        assertEquals(
                 Tuples.pair(COLLISION_1, "one"),
                 collisions.detectOptional((key, value) -> COLLISION_1.equals(key) && "one".equals(value)).get());
     }
@@ -597,8 +603,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detect_value();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertNull(collisions.detect("four"::equals));
-        Assert.assertEquals("one", collisions.detect("one"::equals));
+        assertNull(collisions.detect("four"::equals));
+        assertEquals("one", collisions.detect("one"::equals));
     }
 
     @Override
@@ -608,8 +614,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectOptional_value();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertFalse(collisions.detectOptional("four"::equals).isPresent());
-        Assert.assertEquals("one", collisions.detectOptional("one"::equals).get());
+        assertFalse(collisions.detectOptional("four"::equals).isPresent());
+        assertEquals("one", collisions.detectOptional("one"::equals).get());
     }
 
     @Override
@@ -619,11 +625,11 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectWith();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertNull(
+        assertNull(
                 collisions.detectWith(
                         (String value, String parameter) -> "value is four".equals(parameter + value),
                         "value is "));
-        Assert.assertEquals(
+        assertEquals(
                 "one",
                 collisions.detectWith(
                         (String value, String parameter) -> "value is one".equals(parameter + value),
@@ -637,11 +643,11 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectWithOptional();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertFalse(
+        assertFalse(
                 collisions.detectWithOptional(
                         (String value, String parameter) -> "value is four".equals(parameter + value),
                         "value is ").isPresent());
-        Assert.assertEquals(
+        assertEquals(
                 "one",
                 collisions.detectWithOptional(
                         (String value, String parameter) -> "value is one".equals(parameter + value),
@@ -655,12 +661,12 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectIfNone_value();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertEquals(
+        assertEquals(
                 "if none string",
                 collisions.detectIfNone(
                         "four"::equals,
                         () -> "if none string"));
-        Assert.assertEquals(
+        assertEquals(
                 "one",
                 collisions.detectIfNone(
                         "one"::equals,
@@ -674,13 +680,13 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.detectWithIfNone();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertEquals(
+        assertEquals(
                 "if none string",
                 collisions.detectWithIfNone(
                         (String value, String parameter) -> "value is four".equals(parameter + value),
                         "value is ",
                         () -> "if none string"));
-        Assert.assertEquals(
+        assertEquals(
                 "one",
                 collisions.detectWithIfNone(
                         (String value, String parameter) -> "value is one".equals(parameter + value),
@@ -695,8 +701,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.anySatisfy();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertFalse(collisions.anySatisfy("four"::equals));
-        Assert.assertTrue(collisions.anySatisfy("one"::equals));
+        assertFalse(collisions.anySatisfy("four"::equals));
+        assertTrue(collisions.anySatisfy("one"::equals));
     }
 
     @Override
@@ -706,11 +712,11 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.anySatisfyWith();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertTrue(
+        assertTrue(
                 collisions.anySatisfyWith(
                         (value, parameter) -> "value is one".equals(parameter + value),
                         "value is "));
-        Assert.assertFalse(
+        assertFalse(
                 collisions.anySatisfyWith(
                         (value, parameter) -> "value is four".equals(parameter + value),
                         "value is "));
@@ -723,8 +729,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.allSatisfy();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertTrue(collisions.allSatisfy(value -> !value.isEmpty()));
-        Assert.assertFalse(collisions.allSatisfy(value -> value.length() > 3));
+        assertTrue(collisions.allSatisfy(value -> !value.isEmpty()));
+        assertFalse(collisions.allSatisfy(value -> value.length() > 3));
     }
 
     @Override
@@ -734,8 +740,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.allSatisfyWith();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertTrue(collisions.allSatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(collisions.allSatisfyWith(String::equals, "one"));
+        assertTrue(collisions.allSatisfyWith(Predicates2.instanceOf(), String.class));
+        assertFalse(collisions.allSatisfyWith(String::equals, "one"));
     }
 
     @Override
@@ -745,8 +751,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.allSatisfy();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertTrue(collisions.noneSatisfy("four"::equals));
-        Assert.assertFalse(collisions.noneSatisfy("one"::equals));
+        assertTrue(collisions.noneSatisfy("four"::equals));
+        assertFalse(collisions.noneSatisfy("one"::equals));
     }
 
     @Override
@@ -756,8 +762,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         super.allSatisfyWith();
 
         UnifiedMap<Integer, String> collisions = UnifiedMap.<Integer, String>newMap().withKeysValues(COLLISION_1, "one", COLLISION_2, "two", COLLISION_3, "three");
-        Assert.assertTrue(collisions.noneSatisfyWith(String::equals, "monkey"));
-        Assert.assertFalse(collisions.allSatisfyWith(String::equals, "one"));
+        assertTrue(collisions.noneSatisfyWith(String::equals, "monkey"));
+        assertFalse(collisions.allSatisfyWith(String::equals, "one"));
     }
 
     @Test
@@ -778,8 +784,8 @@ public class UnifiedMapTest extends UnifiedMapTestCase
             expected.put(each, each);
         });
 
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(261, map.size());
+        assertEquals(expected, map);
+        assertEquals(261, map.size());
 
         MutableList<Integer> toRemove = Lists.mutable.withAll(Interval.evensFromTo(0, 20));
 
@@ -791,9 +797,9 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         });
 
         // First assertion to verify that trim does not happen since, the table is already at the smallest required power of 2.
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(239, map.size());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        assertEquals(239, map.size());
 
         Interval.evensFromTo(0, 250).each(each ->
         {
@@ -802,68 +808,68 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         });
 
         // Second assertion to verify that trim happens since, the table length is less than smallest required power of 2.
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(124, map.size());
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        assertEquals(124, map.size());
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         integers.each(each ->
         {
             map.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         map.clear();
         expected.clear();
-        Assert.assertTrue(map.trimToSize());
+        assertTrue(map.trimToSize());
 
         Interval.zeroTo(20).each(each ->
         {
             map.put(each.toString(), each.toString());
             expected.put(each.toString(), each.toString());
         });
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         Interval.fromTo(9, 18).each(each ->
         {
             map.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         map.clear();
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(map.trimToSize());
+        assertTrue(map.isEmpty());
         Interval.zeroTo(6).each(each -> map.put(each.toString(), each.toString()));
         // Assert that trim does not happen as long as table.size is already as smaller than required
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         map.put("7", "7");
 
         map.removeKey("2");
         map.removeKey("3");
         // Assert that trim does not happen as long as table.size is as small as required
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         map.removeKey("5");
         map.removeKey("7");
-        Assert.assertTrue(map.trimToSize());
+        assertTrue(map.trimToSize());
         // Inflate the map so that table.length increases to next power of 2 and check that trim does not happen
         map.put("2", "2");
         map.put("5", "5");
         map.put("7", "7");
         // Assert that the resized table due to put is the required size and no need to trim that.
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
 
         Interval.zeroTo(4).each(each -> map.put(each.toString(), each.toString()));
         Interval.oneTo(3).each(each -> map.removeKey(each.toString()));
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertEquals(5, map.size());
+        assertTrue(map.trimToSize());
+        assertEquals(5, map.size());
     }
 
     @Test
@@ -871,9 +877,9 @@ public class UnifiedMapTest extends UnifiedMapTestCase
     {
         MutableMap<Integer, Integer> actualMap = this.mapWithCollisionsOfSize(8);
         Integer merge = actualMap.merge(COLLISION_1, 1, (integer1, integer2) -> null);
-        Assert.assertNull(merge);
+        assertNull(merge);
         MutableMap<Integer, Integer> expectedMap = MORE_COLLISIONS.subList(1, 8).toMap(k -> k, v -> v);
-        Assert.assertEquals(expectedMap, actualMap);
+        assertEquals(expectedMap, actualMap);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
@@ -34,11 +34,19 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iMap;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class UnifiedMapTestCase extends MutableMapTestCase
 {
@@ -71,13 +79,13 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, Integer> chainedMap = this.mapWithCollisionsOfSize(2);
         Object[] chainedValues = chainedMap.values().toArray();
         Arrays.sort(chainedValues);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2}, chainedValues);
+        assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2}, chainedValues);
 
         // map containing chain with empty slots
         MutableMap<Integer, Integer> chainedMapWithEmpties = this.mapWithCollisionsOfSize(3);
         Object[] chainedValuesWithEmpties = chainedMapWithEmpties.values().toArray();
         Arrays.sort(chainedValuesWithEmpties);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3}, chainedValuesWithEmpties);
+        assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3}, chainedValuesWithEmpties);
     }
 
     @Test
@@ -85,10 +93,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One");
         String[] values = map.values().toArray(new String[0]);
-        Assert.assertArrayEquals(new String[]{"One"}, values);
+        assertArrayEquals(new String[]{"One"}, values);
 
         Object[] objects = map.values().toArray(new Object[0]);
-        Assert.assertArrayEquals(new String[]{"One"}, objects);
+        assertArrayEquals(new String[]{"One"}, objects);
     }
 
     @Test
@@ -97,14 +105,14 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
         String[] values = map.values().toArray(new String[2]);
         Arrays.sort(values);
-        Assert.assertArrayEquals(new String[]{"One", "Two"}, values);
+        assertArrayEquals(new String[]{"One", "Two"}, values);
 
         String[] target = new String[3];
         target[0] = "HERE";
         target[1] = "HERE";
         target[2] = "HERE";
         String[] array = this.newMapWithKeyValue(1, "One").values().toArray(target);
-        Assert.assertArrayEquals(new String[]{"One", null, "HERE"}, array);
+        assertArrayEquals(new String[]{"One", null, "HERE"}, array);
     }
 
     @Test
@@ -115,7 +123,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         target[2] = "yow!";
         String[] values = map.values().toArray(target);
         ArrayIterate.sort(values, values.length, Comparators.safeNullsHigh(String::compareTo));
-        Assert.assertArrayEquals(new String[]{"One", "Two", null}, values);
+        assertArrayEquals(new String[]{"One", "Two", null}, values);
     }
 
     @Test
@@ -145,7 +153,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         Integer[] destination = new Integer[2]; // deliberately to small to force the method to allocate one of the correct size
         Integer[] result = map.keySet().toArray(destination);
         Arrays.sort(result);
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
     }
 
     @Test
@@ -157,7 +165,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         target[5] = 42;
         Integer[] result = map.keySet().toArray(target);
         ArrayIterate.sort(result, result.length, Comparators.safeNullsHigh(Integer::compareTo));
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4, 42, null}, result);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 42, null}, result);
     }
 
     @Test
@@ -169,7 +177,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         map.put(new NoInstanceOfInEquals(12), 15);
         map.put(new NoInstanceOfInEquals(14), 18);
 
-        Assert.assertEquals(3, map.size());
+        assertEquals(3, map.size());
     }
 
     @Test
@@ -196,18 +204,18 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     {
         // a map with a null key
         MutableMap<Integer, Integer> map1 = this.newMapWithKeyValue(null, 0);
-        Assert.assertArrayEquals(new Object[]{null}, map1.keySet().toArray());
+        assertArrayEquals(new Object[]{null}, map1.keySet().toArray());
 
         // a map with a chain containing empty slots
         MutableMap<Integer, Integer> map2 = this.mapWithCollisionsOfSize(5);
-        Assert.assertArrayEquals(new Object[]{0, 17, 34, 51, 68}, map2.keySet().toArray());
+        assertArrayEquals(new Object[]{0, 17, 34, 51, 68}, map2.keySet().toArray());
 
         // a map with a chain containing empty slots and null key
         MutableMap<Integer, Integer> map3 = this.mapWithCollisionsOfSize(5);
         map3.put(null, 42);
         Integer[] array = map3.keySet().toArray(new Integer[map3.size()]);
         ArrayIterate.sort(array, array.length, Comparators.safeNullsHigh(Integer::compareTo));
-        Assert.assertArrayEquals(new Object[]{0, 17, 34, 51, 68, null}, array);
+        assertArrayEquals(new Object[]{0, 17, 34, 51, 68, null}, array);
     }
 
     @Test
@@ -215,7 +223,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One");
         Object[] entries = map.entrySet().toArray();
-        Assert.assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
+        assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
     }
 
     @Test
@@ -223,10 +231,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One");
         Map.Entry<Integer, String>[] entries = map.entrySet().toArray(new Map.Entry[0]);
-        Assert.assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
+        assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
 
         Object[] objects = map.entrySet().toArray(new Object[0]);
-        Assert.assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, objects);
+        assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, objects);
     }
 
     @Test
@@ -234,7 +242,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One");
         Map.Entry<Integer, String>[] entries = map.entrySet().toArray(new Map.Entry[map.size()]);
-        Assert.assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
+        assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One")}, entries);
     }
 
     @Test
@@ -247,7 +255,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         target[2] = immutableEntry;
         target[3] = immutableEntry;
         Map.Entry<Integer, String>[] entries = map.entrySet().toArray(target);
-        Assert.assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One"), null, immutableEntry, immutableEntry}, entries);
+        assertArrayEquals(new Map.Entry[]{ImmutableEntry.of(1, "One"), null, immutableEntry, immutableEntry}, entries);
     }
 
     protected MutableMap<Integer, Integer> mapWithCollisionsOfSize(int size)
@@ -290,9 +298,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         Collection<Integer> values = map.values();
         // This test is not using Verify.assertPostSerializedEqualsAndHashCode b/c the deserialized form of the values view is a FastList, which will not be equals to the original view (a Collection).
         Collection<Integer> revived = SerializeTestHelper.serializeDeserialize(values);
-        Assert.assertNotNull(revived);
+        assertNotNull(revived);
         Verify.assertSize(values.size(), revived);
-        Assert.assertTrue(revived.containsAll(values));
+        assertTrue(revived.containsAll(values));
     }
 
     @Test
@@ -301,9 +309,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(2);
         Collection<Integer> values = map.values();
         Collection<Integer> revived = SerializeTestHelper.serializeDeserialize(values);
-        Assert.assertNotNull(revived);
+        assertNotNull(revived);
         Verify.assertSize(values.size(), revived);
-        Assert.assertTrue(revived.containsAll(values));
+        assertTrue(revived.containsAll(values));
     }
 
     @Test
@@ -314,9 +322,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         Collection<Integer> values = map.values();
         // This test is not using Verify.assertPostSerializedEqualsAndHashCode b/c the deserialized form of the values view is a FastList, which will not be equals to the orginal view (a Collection).
         Collection<Integer> revived = SerializeTestHelper.serializeDeserialize(values);
-        Assert.assertNotNull(revived);
+        assertNotNull(revived);
         Verify.assertSize(values.size(), revived);
-        Assert.assertTrue(revived.containsAll(values));
+        assertTrue(revived.containsAll(values));
     }
 
     @Test
@@ -326,16 +334,16 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         {
             MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(i);
 
-            Assert.assertTrue(map.containsKey(COLLISIONS.get(i - 1)));
-            Assert.assertTrue(map.containsValue(COLLISIONS.get(i - 1)));
-            Assert.assertFalse(map.containsKey(COLLISION_10));
-            Assert.assertFalse(map.containsValue(COLLISION_10));
-            Assert.assertFalse(map.containsKey(null));
-            Assert.assertFalse(map.containsValue(null));
+            assertTrue(map.containsKey(COLLISIONS.get(i - 1)));
+            assertTrue(map.containsValue(COLLISIONS.get(i - 1)));
+            assertFalse(map.containsKey(COLLISION_10));
+            assertFalse(map.containsValue(COLLISION_10));
+            assertFalse(map.containsKey(null));
+            assertFalse(map.containsValue(null));
 
             map.put(null, null);
-            Assert.assertTrue(map.containsKey(null));
-            Assert.assertTrue(map.containsValue(null));
+            assertTrue(map.containsKey(null));
+            assertTrue(map.containsValue(null));
         }
     }
 
@@ -345,11 +353,11 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         for (int i = 1; i < COLLISIONS.size(); i++)
         {
             MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(i);
-            Assert.assertNull(map.put(null, null));
-            Assert.assertNull(map.remove(null));
-            Assert.assertNull(map.remove(COLLISION_10));
+            assertNull(map.put(null, null));
+            assertNull(map.remove(null));
+            assertNull(map.remove(COLLISION_10));
             Integer biggestValue = COLLISIONS.get(i - 1);
-            Assert.assertEquals(biggestValue, map.remove(biggestValue));
+            assertEquals(biggestValue, map.remove(biggestValue));
         }
     }
 
@@ -357,24 +365,24 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void getIfAbsentPutValueWithCollisions()
     {
         MutableMap<Integer, Object> map = this.newMapWithKeyValue(COLLISION_1, null);
-        Assert.assertNull(map.getIfAbsentPut(COLLISION_1, 5));
-        Assert.assertNull(map.getIfAbsentPut(COLLISION_3, (Integer) null));
-        Assert.assertNull(map.getIfAbsentPut(COLLISION_3, 7));
-        Assert.assertEquals(Integer.valueOf(9), map.getIfAbsentPut(COLLISION_2, 9));
-        Assert.assertEquals(Integer.valueOf(10), map.getIfAbsentPut(COLLISION_4, 10));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(COLLISION_1, null, COLLISION_2, 9, COLLISION_3, null, COLLISION_4, 10), map);
+        assertNull(map.getIfAbsentPut(COLLISION_1, 5));
+        assertNull(map.getIfAbsentPut(COLLISION_3, (Integer) null));
+        assertNull(map.getIfAbsentPut(COLLISION_3, 7));
+        assertEquals(Integer.valueOf(9), map.getIfAbsentPut(COLLISION_2, 9));
+        assertEquals(Integer.valueOf(10), map.getIfAbsentPut(COLLISION_4, 10));
+        assertEquals(UnifiedMap.newWithKeysValues(COLLISION_1, null, COLLISION_2, 9, COLLISION_3, null, COLLISION_4, 10), map);
     }
 
     @Test
     public void getIfAbsentPutWithWithCollisions()
     {
         MutableMap<Integer, Object> map = this.newMapWithKeyValue(COLLISION_1, null);
-        Assert.assertNull(map.getIfAbsentPutWith(COLLISION_1, String::valueOf, 5));
-        Assert.assertNull(map.getIfAbsentPutWith(COLLISION_3, Functions.getPassThru(), null));
-        Assert.assertNull(map.getIfAbsentPutWith(COLLISION_3, String::valueOf, 7));
-        Assert.assertEquals("9", map.getIfAbsentPutWith(COLLISION_2, String::valueOf, 9));
-        Assert.assertEquals(Integer.valueOf(10), map.getIfAbsentPutWith(COLLISION_4, Functions.getIntegerPassThru(), 10));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(COLLISION_1, null, COLLISION_2, "9", COLLISION_3, null, COLLISION_4, 10), map);
+        assertNull(map.getIfAbsentPutWith(COLLISION_1, String::valueOf, 5));
+        assertNull(map.getIfAbsentPutWith(COLLISION_3, Functions.getPassThru(), null));
+        assertNull(map.getIfAbsentPutWith(COLLISION_3, String::valueOf, 7));
+        assertEquals("9", map.getIfAbsentPutWith(COLLISION_2, String::valueOf, 9));
+        assertEquals(Integer.valueOf(10), map.getIfAbsentPutWith(COLLISION_4, Functions.getIntegerPassThru(), 10));
+        assertEquals(UnifiedMap.newWithKeysValues(COLLISION_1, null, COLLISION_2, "9", COLLISION_3, null, COLLISION_4, 10), map);
     }
 
     @Override
@@ -389,13 +397,13 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
 
             Integer biggestValue = COLLISIONS.get(i - 1);
 
-            Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of(biggestValue, biggestValue)));
-            Assert.assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
+            assertTrue(map.entrySet().remove(ImmutableEntry.of(biggestValue, biggestValue)));
+            assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
 
-            Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of(COLLISION_10, COLLISION_10)));
-            Assert.assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
+            assertFalse(map.entrySet().remove(ImmutableEntry.of(COLLISION_10, COLLISION_10)));
+            assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
 
-            Assert.assertFalse(map.entrySet().remove(null));
+            assertFalse(map.entrySet().remove(null));
         }
     }
 
@@ -409,12 +417,12 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         {
             MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(i);
 
-            Assert.assertFalse(map.entrySet().retainAll(
+            assertFalse(map.entrySet().retainAll(
                     FastList.newList(map.entrySet()).with(ImmutableEntry.of(COLLISION_10, COLLISION_10))));
 
-            Assert.assertTrue(map.entrySet().retainAll(
+            assertTrue(map.entrySet().retainAll(
                     this.mapWithCollisionsOfSize(i - 1).entrySet()));
-            Assert.assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
+            assertEquals(this.mapWithCollisionsOfSize(i - 1), map);
         }
 
         for (Integer item : MORE_COLLISIONS)
@@ -422,15 +430,15 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
             MutableMap<Integer, Integer> integers = this.mapWithCollisionsOfSize(9);
             @SuppressWarnings("BoxingBoxedValue")
             Integer keyCopy = new Integer(item);
-            Assert.assertTrue(integers.entrySet().retainAll(mList(ImmutableEntry.of(keyCopy, keyCopy))));
-            Assert.assertEquals(iMap(keyCopy, keyCopy), integers);
-            Assert.assertNotSame(keyCopy, Iterate.getOnly(integers.entrySet()).getKey());
+            assertTrue(integers.entrySet().retainAll(mList(ImmutableEntry.of(keyCopy, keyCopy))));
+            assertEquals(iMap(keyCopy, keyCopy), integers);
+            assertNotSame(keyCopy, Iterate.getOnly(integers.entrySet()).getKey());
         }
 
         // simple map, collection to retain contains non-entry element
         MutableMap<Integer, String> map4 = this.newMapWithKeysValues(1, "One", 2, "Two");
         FastList<Object> toRetain = FastList.newListWith(ImmutableEntry.of(1, "One"), "explosion!", ImmutableEntry.of(2, "Two"));
-        Assert.assertFalse(map4.entrySet().retainAll(toRetain));
+        assertFalse(map4.entrySet().retainAll(toRetain));
     }
 
     @Override
@@ -445,10 +453,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
             Object sentinel = new Object();
             UnifiedSet<Integer> result = UnifiedSet.newSet();
             map.forEachWith((argument1, argument2) -> {
-                Assert.assertSame(sentinel, argument2);
+                assertSame(sentinel, argument2);
                 result.add(argument1);
             }, sentinel);
-            Assert.assertEquals(map.keySet(), result);
+            assertEquals(map.keySet(), result);
         }
     }
 
@@ -460,21 +468,21 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
 
         MutableList<Object> retained = Lists.mutable.of();
         retained.add(null);
-        Assert.assertFalse(map.keySet().retainAll(retained));
+        assertFalse(map.keySet().retainAll(retained));
         Verify.assertContains(null, map.keySet());
 
         // a map with a chain containing empty slots
         MutableMap<Integer, Integer> map2 = this.mapWithCollisionsOfSize(5);
-        Assert.assertFalse(map2.keySet().retainAll(FastList.newListWith(0, 17, 34, 51, 68)));
+        assertFalse(map2.keySet().retainAll(FastList.newListWith(0, 17, 34, 51, 68)));
         Verify.assertContainsAll(map2.keySet(), 0, 17, 34, 51, 68);
 
         // a map with no chaining, nothing retained
         MutableMap<Integer, String> map3 = this.newMapWithKeyValue(1, "One");
-        Assert.assertTrue(map3.keySet().retainAll(FastList.newListWith(9)));
+        assertTrue(map3.keySet().retainAll(FastList.newListWith(9)));
         Verify.assertEmpty(map3);
 
         Set<Integer> keys = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four").keySet();
-        Assert.assertTrue(keys.retainAll(FastList.newListWith(1, 2, 3)));
+        assertTrue(keys.retainAll(FastList.newListWith(1, 2, 3)));
         Verify.assertContainsAll(keys, 1, 2, 3);
     }
 
@@ -482,15 +490,15 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void keySet_containsAll()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Assert.assertFalse(map.keySet().containsAll(FastList.newListWith(5)));
-        Assert.assertTrue(map.keySet().containsAll(FastList.newListWith(1, 2, 4)));
+        assertFalse(map.keySet().containsAll(FastList.newListWith(5)));
+        assertTrue(map.keySet().containsAll(FastList.newListWith(1, 2, 4)));
     }
 
     @Test
     public void keySet_equals()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
-        Assert.assertNotEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), map.keySet());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -558,10 +566,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         Iterator<Integer> iterator = this.mapWithCollisionsOfSize(9).iterator();
         for (Integer collision : MORE_COLLISIONS)
         {
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(collision, iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(collision, iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -570,13 +578,13 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One");
         Map.Entry<Integer, String> entry = Iterate.getFirst(map.entrySet());
         String value = "Ninety-Nine";
-        Assert.assertEquals("One", entry.setValue(value));
-        Assert.assertEquals(value, entry.getValue());
+        assertEquals("One", entry.setValue(value));
+        assertEquals(value, entry.getValue());
         Verify.assertContainsKeyValue(1, value, map);
 
         map.remove(1);
         Verify.assertEmpty(map);
-        Assert.assertNull(entry.setValue("Ignored"));
+        assertNull(entry.setValue("Ignored"));
     }
 
     @Test
@@ -585,7 +593,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, String> map = this.newMapWithKeyValue(null, null);
         Map.Entry<Integer, String> entry = Iterate.getFirst(map.entrySet());
 
-        Assert.assertEquals(0, entry.hashCode());
+        assertEquals(0, entry.hashCode());
     }
 
     @Test
@@ -594,7 +602,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, String> map = this.newMapWithKeyValue(null, null);
         Map.Entry<Integer, String> entry = Iterate.getFirst(map.entrySet());
 
-        Assert.assertNotEquals(entry, new Object());
+        assertNotEquals(entry, new Object());
     }
 
     @Test
@@ -603,22 +611,22 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         // map with chaining, attempt to remove non-existent entry
         MutableMap<Integer, Integer> chainedMap = this.mapWithCollisionsOfSize(3);
         Set<Map.Entry<Integer, Integer>> chainedEntries = chainedMap.entrySet();
-        Assert.assertFalse(chainedEntries.remove(ImmutableEntry.of(5, 5)));
+        assertFalse(chainedEntries.remove(ImmutableEntry.of(5, 5)));
 
         // map with chaining, attempt to remove non-existent collding entry
         MutableMap<Integer, Integer> chainedMap2 = this.mapWithCollisionsOfSize(2);
         Set<Map.Entry<Integer, Integer>> chainedEntries2 = chainedMap2.entrySet();
-        Assert.assertFalse(chainedEntries2.remove(ImmutableEntry.of(COLLISION_4, COLLISION_4)));
+        assertFalse(chainedEntries2.remove(ImmutableEntry.of(COLLISION_4, COLLISION_4)));
 
         // map with chaining, attempt to remove non-existent colliding entry (key exists, but value does not)
         MutableMap<Integer, Integer> chainedMap3 = this.mapWithCollisionsOfSize(3);
         Set<Map.Entry<Integer, Integer>> chainedEntries3 = chainedMap3.entrySet();
-        Assert.assertFalse(chainedEntries3.remove(ImmutableEntry.of(COLLISION_2, COLLISION_4)));
+        assertFalse(chainedEntries3.remove(ImmutableEntry.of(COLLISION_2, COLLISION_4)));
 
         // map with no chaining, attempt to remove non-existent entry
         MutableMap<Integer, String> unchainedMap = this.newMapWithKeyValue(1, "One");
         Set<Map.Entry<Integer, String>> unchainedEntries = unchainedMap.entrySet();
-        Assert.assertFalse(unchainedEntries.remove(ImmutableEntry.of(5, "Five")));
+        assertFalse(unchainedEntries.remove(ImmutableEntry.of(5, "Five")));
     }
 
     @Test
@@ -641,9 +649,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         // simple map, test for non-existent entries
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 3, "Three");
         Set<Map.Entry<Integer, String>> entries = map.entrySet();
-        Assert.assertFalse(entries.containsAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
+        assertFalse(entries.containsAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
 
-        Assert.assertTrue(entries.containsAll(FastList.newListWith(ImmutableEntry.of(1, "One"), ImmutableEntry.of(3, "Three"))));
+        assertTrue(entries.containsAll(FastList.newListWith(ImmutableEntry.of(1, "One"), ImmutableEntry.of(3, "Three"))));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -666,7 +674,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void entrySet_equals()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", null, null);
-        Assert.assertNotEquals(UnifiedSet.newSetWith(ImmutableEntry.of(5, "Five")), map.entrySet());
+        assertNotEquals(UnifiedSet.newSetWith(ImmutableEntry.of(5, "Five")), map.entrySet());
 
         UnifiedSet<ImmutableEntry<Integer, String>> expected = UnifiedSet.newSetWith(
                 ImmutableEntry.of(1, "One"),
@@ -703,7 +711,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
     public void valueCollection_equals()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three", null, null);
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.values());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.values());
     }
 
     @Override
@@ -717,14 +725,14 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         // map with a chain and no empty slots
         MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(2);
         map.forEachWithIndex((each, index) -> set.add(index + ":" + each));
-        Assert.assertEquals(UnifiedSet.newSetWith("0:0", "1:17"), set);
+        assertEquals(UnifiedSet.newSetWith("0:0", "1:17"), set);
 
         set.clear();
 
         // map with a chain and empty slots
         MutableMap<Integer, Integer> map2 = this.mapWithCollisionsOfSize(5);
         map2.forEachWithIndex((each, index) -> set.add(index + ":" + each));
-        Assert.assertEquals(UnifiedSet.newSetWith("0:0", "1:17", "2:34", "3:51", "4:68"), set);
+        assertEquals(UnifiedSet.newSetWith("0:0", "1:17", "2:34", "3:51", "4:68"), set);
     }
 
     @Override
@@ -738,7 +746,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         // map with a chain and empty slots
         MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(5);
         map.forEachKey(each -> set.add(each.toString()));
-        Assert.assertEquals(UnifiedSet.newSetWith("0", "17", "34", "51", "68"), set);
+        assertEquals(UnifiedSet.newSetWith("0", "17", "34", "51", "68"), set);
     }
 
     @Override
@@ -750,10 +758,10 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(9).withKeyValue(null, null);
         MutableSet<Integer> result = UnifiedSet.newSet();
         map.forEachValue(each -> {
-            Assert.assertTrue(each == null || each.getClass() == Integer.class);
+            assertTrue(each == null || each.getClass() == Integer.class);
             result.add(each);
         });
-        Assert.assertEquals(MORE_COLLISIONS.toSet().with(null), result);
+        assertEquals(MORE_COLLISIONS.toSet().with(null), result);
     }
 
     @Override
@@ -770,17 +778,17 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
             Verify.assertEqualsAndHashCode(expectedMap, map);
             MutableMap<Integer, Integer> clone1 = map.clone();
             clone1.put(COLLISION_10, COLLISION_10);
-            Assert.assertNotEquals(expectedMap, clone1);
+            assertNotEquals(expectedMap, clone1);
             MutableMap<Integer, Integer> clone2 = map.clone();
             clone2.put(null, null);
-            Assert.assertNotEquals(expectedMap, clone2);
+            assertNotEquals(expectedMap, clone2);
 
             expectedMap.put(null, null);
-            Assert.assertNotEquals(expectedMap, map);
+            assertNotEquals(expectedMap, map);
             expectedMap.remove(null);
 
             expectedMap.put(COLLISION_10, COLLISION_10);
-            Assert.assertNotEquals(expectedMap, map);
+            assertNotEquals(expectedMap, map);
         }
 
         MutableMap<Integer, Integer> mapA = this.mapWithCollisionsOfSize(3);
@@ -789,31 +797,31 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         // map with a chain, compare the null key (and value) with a non-null key
         mapA.put(null, null);
         mapB.put(42, 84);
-        Assert.assertNotEquals(mapA, mapB);
-        Assert.assertNotEquals(mapA.hashCode(), mapB.hashCode());
+        assertNotEquals(mapA, mapB);
+        assertNotEquals(mapA.hashCode(), mapB.hashCode());
 
         // map with a chain, compare the two null keys with different values (one null, one not)
         mapB.remove(42);
         mapB.put(null, 42);
-        Assert.assertNotEquals(mapA, mapB);
+        assertNotEquals(mapA, mapB);
 
         // map with a chain, compare a non-null key (null value) with a non-null key and value
         mapB.remove(null);
         mapB.remove(42);
         mapA.remove(null);
         mapA.put(17, null);
-        Assert.assertNotEquals(mapA, mapB);
+        assertNotEquals(mapA, mapB);
 
         MutableMap<Integer, String> mapC = this.newMapWithKeysValues(1, "One", 2, "Two", null, null);
         MutableMap<Integer, String> mapD = this.newMapWithKeysValues(1, "One", 2, "Two", 3, "Three");
 
         // compare the null key (and value) with a non-null key
-        Assert.assertNotEquals(mapC, mapD);
+        assertNotEquals(mapC, mapD);
 
         // compare a non-null key (and null value) with a non-null key
         mapC.remove(null);
         mapC.put(3, null);
-        Assert.assertNotEquals(mapC, mapD);
+        assertNotEquals(mapC, mapD);
 
         // reset
         mapC.remove(3);
@@ -824,9 +832,9 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
         mapD.put(null, "Three");
 
         // compare the two null keys with different values (one null, one not)
-        Assert.assertNotEquals(mapC, mapD);
+        assertNotEquals(mapC, mapD);
 
-        Assert.assertEquals(0, this.newMapWithKeyValue(null, null).hashCode());
+        assertEquals(0, this.newMapWithKeyValue(null, null).hashCode());
     }
 
     @Test
@@ -849,7 +857,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
             }
         }
 
-        Assert.assertArrayEquals(expected, map.keysView().toArray());
+        assertArrayEquals(expected, map.keysView().toArray());
     }
 
     @Override
@@ -859,7 +867,7 @@ public abstract class UnifiedMapTestCase extends MutableMapTestCase
 
         MutableMap<String, String> map = this.newMap();
         map.collectKeysAndValues(Arrays.asList(FREQUENT_COLLISIONS), Functions.identity(), Functions.identity());
-        Assert.assertEquals(FREQUENT_COLLISIONS[0], map.getFirst());
+        assertEquals(FREQUENT_COLLISIONS[0], map.getFirst());
     }
 
     private static final class NoInstanceOfInEquals

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
@@ -22,6 +22,9 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
 /**
  * JUnit test for {@link UnmodifiableMutableMap}.
  */
@@ -65,7 +68,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeObject()
     {
         MutableMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.remove("One"));
+        assertThrows(UnsupportedOperationException.class, () -> map.remove("One"));
     }
 
     @Override
@@ -73,14 +76,14 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeKey()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.removeKey(1));
+        assertThrows(UnsupportedOperationException.class, () -> map.removeKey(1));
     }
 
     @Override
     @Test
     public void removeAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(null));
     }
 
     @Override
@@ -88,7 +91,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeIf()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.removeIf(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.removeIf(null));
     }
 
     @Override
@@ -96,7 +99,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeFromEntrySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(ImmutableEntry.of(2, "Two")));
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(ImmutableEntry.of(2, "Two")));
     }
 
     @Override
@@ -104,7 +107,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeAllFromEntrySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
     }
 
     @Override
@@ -112,7 +115,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void retainAllFromEntrySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().retainAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().retainAll(FastList.newListWith(ImmutableEntry.of(2, "Two"))));
     }
 
     @Override
@@ -120,7 +123,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void clearEntrySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().clear());
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().clear());
     }
 
     @Override
@@ -128,7 +131,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeFromKeySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.keySet().remove(2));
+        assertThrows(UnsupportedOperationException.class, () -> map.keySet().remove(2));
     }
 
     @Override
@@ -136,7 +139,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeNullFromKeySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.keySet().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.keySet().remove(null));
     }
 
     @Override
@@ -144,7 +147,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeAllFromKeySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.keySet().removeAll(FastList.newListWith(1, 2)));
+        assertThrows(UnsupportedOperationException.class, () -> map.keySet().removeAll(FastList.newListWith(1, 2)));
     }
 
     @Override
@@ -152,7 +155,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void retainAllFromKeySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.keySet().retainAll(Lists.mutable.of()));
+        assertThrows(UnsupportedOperationException.class, () -> map.keySet().retainAll(Lists.mutable.of()));
     }
 
     @Override
@@ -160,7 +163,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void clearKeySet()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.keySet().clear());
+        assertThrows(UnsupportedOperationException.class, () -> map.keySet().clear());
     }
 
     @Override
@@ -168,7 +171,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeFromValues()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().remove("Two"));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().remove("Two"));
     }
 
     @Override
@@ -176,7 +179,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeAllFromValues()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().removeAll(FastList.newListWith("One", "Two")));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().removeAll(FastList.newListWith("One", "Two")));
     }
 
     @Override
@@ -184,7 +187,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void removeNullFromValues()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().remove(null));
     }
 
     @Override
@@ -192,7 +195,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void retainAllFromValues()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "Two");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.values().retainAll(Lists.mutable.of()));
+        assertThrows(UnsupportedOperationException.class, () -> map.values().retainAll(Lists.mutable.of()));
     }
 
     @Override
@@ -200,7 +203,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void getIfAbsentPut()
     {
         Assert.assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, (Function0<String>) () -> ""));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, (Function0<String>) () -> ""));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, (Function0<String>) () -> ""));
     }
 
     @Override
@@ -208,7 +211,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void getIfAbsentPutValue()
     {
         Assert.assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, ""));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, ""));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, ""));
     }
 
     @Override
@@ -244,7 +247,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void putAll()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.putAll(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.putAll(null));
     }
 
     @Override
@@ -252,7 +255,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void collectKeysAndValues()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.collectKeysAndValues(null, null, null));
+        assertThrows(UnsupportedOperationException.class, () -> map.collectKeysAndValues(null, null, null));
     }
 
     @Override
@@ -260,7 +263,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void clear()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, map::clear);
+        assertThrows(UnsupportedOperationException.class, map::clear);
     }
 
     @Override
@@ -288,105 +291,105 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     @Test
     public void withMap()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(null));
     }
 
     @Override
     @Test
     public void withMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.empty()));
     }
 
     @Test
     @Override
     public void withMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
     }
 
     @Override
     @Test
     public void putAllMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void putAllMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Test
     @Override
     public void putAllMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
     }
 
     @Override
@@ -423,7 +426,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void asUnmodifiable()
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertSame(map, map.asUnmodifiable());
+        assertSame(map, map.asUnmodifiable());
     }
 
     @Test
@@ -431,9 +434,9 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2").asUnmodifiable();
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(null));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> Iterate.getFirst(map.entrySet()).setValue("Three"));
+        assertThrows(UnsupportedOperationException.class, () -> Iterate.getFirst(map.entrySet()).setValue("Three"));
 
         Assert.assertEquals(this.newMapWithKeysValues(1, "One", 2, "2"), map);
     }
@@ -458,7 +461,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     @Test
     public void put()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, super::put);
+        assertThrows(UnsupportedOperationException.class, super::put);
     }
 
     @Override
@@ -467,7 +470,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
         MutableMap<Integer, String> clone = map.clone();
-        Assert.assertSame(map, clone);
+        assertSame(map, clone);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableObjectBooleanMapTestCase.java
@@ -21,8 +21,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractObjectBooleanMapTestCase
 {
@@ -52,13 +57,13 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         super.get();
         MutableObjectBooleanMap<String> map1 = this.classUnderTest();
         map1.put("0", false);
-        Assert.assertFalse(map1.get("0"));
+        assertFalse(map1.get("0"));
 
         map1.put("5", true);
-        Assert.assertTrue(map1.get("5"));
+        assertTrue(map1.get("5"));
 
         map1.put(null, true);
-        Assert.assertTrue(map1.get(null));
+        assertTrue(map1.get(null));
     }
 
     @Override
@@ -67,17 +72,17 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         super.getIfAbsent();
         MutableObjectBooleanMap<String> map1 = this.classUnderTest();
         map1.removeKey("0");
-        Assert.assertTrue(map1.getIfAbsent("0", true));
-        Assert.assertFalse(map1.getIfAbsent("0", false));
+        assertTrue(map1.getIfAbsent("0", true));
+        assertFalse(map1.getIfAbsent("0", false));
 
         map1.put("0", false);
-        Assert.assertFalse(map1.getIfAbsent("0", true));
+        assertFalse(map1.getIfAbsent("0", true));
 
         map1.put("5", true);
-        Assert.assertTrue(map1.getIfAbsent("5", false));
+        assertTrue(map1.getIfAbsent("5", false));
 
         map1.put(null, false);
-        Assert.assertFalse(map1.getIfAbsent(null, true));
+        assertFalse(map1.getIfAbsent(null, true));
     }
 
     @Override
@@ -86,26 +91,26 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         super.getOrThrow();
         MutableObjectBooleanMap<String> map1 = this.classUnderTest();
         map1.removeKey("0");
-        Assert.assertThrows(IllegalStateException.class, () -> map1.getOrThrow("0"));
+        assertThrows(IllegalStateException.class, () -> map1.getOrThrow("0"));
         map1.put("0", false);
-        Assert.assertFalse(map1.getOrThrow("0"));
+        assertFalse(map1.getOrThrow("0"));
 
         map1.put("5", true);
-        Assert.assertTrue(map1.getOrThrow("5"));
+        assertTrue(map1.getOrThrow("5"));
 
         map1.put(null, false);
-        Assert.assertFalse(map1.getOrThrow(null));
+        assertFalse(map1.getOrThrow(null));
     }
 
     @Test
     public void getAndPut()
     {
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getAndPut(Integer.valueOf(1), false, true));
-        Assert.assertFalse(map1.getAndPut(Integer.valueOf(2), false, false));
-        Assert.assertFalse(map1.getAndPut(Integer.valueOf(1), true, true));
+        assertTrue(map1.getAndPut(Integer.valueOf(1), false, true));
+        assertFalse(map1.getAndPut(Integer.valueOf(2), false, false));
+        assertFalse(map1.getAndPut(Integer.valueOf(1), true, true));
         map1.remove(Integer.valueOf(1));
-        Assert.assertFalse(map1.getAndPut(Integer.valueOf(1), true, false));
+        assertFalse(map1.getAndPut(Integer.valueOf(1), true, false));
     }
 
     @Override
@@ -114,27 +119,27 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         super.containsKey();
         MutableObjectBooleanMap<String> map1 = this.classUnderTest();
         map1.removeKey("0");
-        Assert.assertFalse(map1.containsKey("0"));
-        Assert.assertFalse(map1.get("0"));
+        assertFalse(map1.containsKey("0"));
+        assertFalse(map1.get("0"));
         map1.removeKey("0");
-        Assert.assertFalse(map1.containsKey("0"));
-        Assert.assertFalse(map1.get("0"));
+        assertFalse(map1.containsKey("0"));
+        assertFalse(map1.get("0"));
 
         map1.removeKey("1");
-        Assert.assertFalse(map1.containsKey("1"));
-        Assert.assertFalse(map1.get("1"));
+        assertFalse(map1.containsKey("1"));
+        assertFalse(map1.get("1"));
 
         map1.removeKey("2");
-        Assert.assertFalse(map1.containsKey("2"));
-        Assert.assertFalse(map1.get("2"));
+        assertFalse(map1.containsKey("2"));
+        assertFalse(map1.get("2"));
 
         map1.removeKey("3");
-        Assert.assertFalse(map1.containsKey("3"));
-        Assert.assertFalse(map1.get("3"));
+        assertFalse(map1.containsKey("3"));
+        assertFalse(map1.get("3"));
         map1.put(null, true);
-        Assert.assertTrue(map1.containsKey(null));
+        assertTrue(map1.containsKey(null));
         map1.removeKey(null);
-        Assert.assertFalse(map1.containsKey(null));
+        assertFalse(map1.containsKey(null));
     }
 
     @Override
@@ -144,10 +149,10 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         this.classUnderTest().clear();
 
         this.classUnderTest().put("5", true);
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
+        assertTrue(this.classUnderTest().containsValue(true));
 
         this.classUnderTest().put(null, false);
-        Assert.assertTrue(this.classUnderTest().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(false));
     }
 
     @Override
@@ -170,17 +175,17 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         map1.clear();
 
         map1.put("5", true);
-        Assert.assertTrue(map1.contains(true));
+        assertTrue(map1.contains(true));
 
         map1.put(null, false);
-        Assert.assertTrue(map1.contains(false));
+        assertTrue(map1.contains(false));
 
         map1.removeKey("5");
-        Assert.assertFalse(map1.contains(true));
-        Assert.assertTrue(map1.contains(false));
+        assertFalse(map1.contains(true));
+        assertTrue(map1.contains(false));
 
         map1.removeKey(null);
-        Assert.assertFalse(map1.contains(false));
+        assertFalse(map1.contains(false));
     }
 
     @Override
@@ -191,21 +196,21 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         map1.clear();
 
         map1.put("5", true);
-        Assert.assertTrue(map1.containsAll(true));
-        Assert.assertFalse(map1.containsAll(true, false));
-        Assert.assertFalse(map1.containsAll(false, false));
+        assertTrue(map1.containsAll(true));
+        assertFalse(map1.containsAll(true, false));
+        assertFalse(map1.containsAll(false, false));
 
         map1.put(null, false);
-        Assert.assertTrue(map1.containsAll(false));
-        Assert.assertTrue(map1.containsAll(true, false));
+        assertTrue(map1.containsAll(false));
+        assertTrue(map1.containsAll(true, false));
 
         map1.removeKey("5");
-        Assert.assertFalse(map1.containsAll(true));
-        Assert.assertFalse(map1.containsAll(true, false));
-        Assert.assertTrue(map1.containsAll(false, false));
+        assertFalse(map1.containsAll(true));
+        assertFalse(map1.containsAll(true, false));
+        assertTrue(map1.containsAll(false, false));
 
         map1.removeKey(null);
-        Assert.assertFalse(map1.containsAll(false, true));
+        assertFalse(map1.containsAll(false, true));
     }
 
     @Override
@@ -216,21 +221,21 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         map1.clear();
 
         map1.put("5", true);
-        Assert.assertTrue(map1.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(map1.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(map1.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(map1.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(map1.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(map1.containsAll(BooleanArrayList.newListWith(false, false)));
 
         map1.put(null, false);
-        Assert.assertTrue(map1.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(map1.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(map1.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(map1.containsAll(BooleanArrayList.newListWith(true, false)));
 
         map1.removeKey("5");
-        Assert.assertFalse(map1.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(map1.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(map1.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(map1.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(map1.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(map1.containsAll(BooleanArrayList.newListWith(false, false)));
 
         map1.removeKey(null);
-        Assert.assertFalse(map1.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(map1.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     protected static MutableList<String> generateCollisions()
@@ -253,15 +258,15 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         MutableObjectBooleanMap<String> hashMap = this.getEmptyMap();
         hashMap.put("0", true);
         hashMap.clear();
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
 
         hashMap.put("1", false);
         hashMap.clear();
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
 
         hashMap.put(null, true);
         hashMap.clear();
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap);
     }
 
     @Test
@@ -269,34 +274,34 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
     {
         MutableObjectBooleanMap<String> map0 = this.newWithKeysValues("0", true, "1", false);
         map0.removeKey("1");
-        Assert.assertEquals(this.newWithKeysValues("0", true), map0);
+        assertEquals(this.newWithKeysValues("0", true), map0);
         map0.removeKey("0");
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), map0);
+        assertEquals(ObjectBooleanHashMap.newMap(), map0);
 
         MutableObjectBooleanMap<String> map1 = this.newWithKeysValues("0", false, "1", true);
         map1.removeKey("0");
-        Assert.assertEquals(this.newWithKeysValues("1", true), map1);
+        assertEquals(this.newWithKeysValues("1", true), map1);
         map1.removeKey("1");
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), map1);
+        assertEquals(ObjectBooleanHashMap.newMap(), map1);
 
         this.map.removeKey("5");
-        Assert.assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.map);
+        assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.map);
         this.map.removeKey("0");
-        Assert.assertEquals(this.newWithKeysValues("1", true, "2", false), this.map);
+        assertEquals(this.newWithKeysValues("1", true, "2", false), this.map);
         this.map.removeKey("1");
-        Assert.assertEquals(this.newWithKeysValues("2", false), this.map);
+        assertEquals(this.newWithKeysValues("2", false), this.map);
         this.map.removeKey("2");
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), this.map);
+        assertEquals(ObjectBooleanHashMap.newMap(), this.map);
         this.map.removeKey("0");
         this.map.removeKey("1");
         this.map.removeKey("2");
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), this.map);
+        assertEquals(ObjectBooleanHashMap.newMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(null, true);
-        Assert.assertTrue(this.map.get(null));
+        assertTrue(this.map.get(null));
         this.map.removeKey(null);
-        Assert.assertFalse(this.map.get(null));
+        assertFalse(this.map.get(null));
     }
 
     @Test
@@ -306,15 +311,15 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         this.map.put("1", false);
         this.map.put("2", true);
         ObjectBooleanHashMap<String> expected = ObjectBooleanHashMap.newWithKeysValues("0", false, "1", false, "2", true);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put("5", true);
         expected.put("5", true);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
 
         this.map.put(null, false);
         expected.put(null, false);
-        Assert.assertEquals(expected, this.map);
+        assertEquals(expected, this.map);
     }
 
     @Test
@@ -329,74 +334,74 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         hashMap.put(collision1, true);
         hashMap.put(collision2, false);
         hashMap.put(collision3, true);
-        Assert.assertFalse(hashMap.get(collision2));
+        assertFalse(hashMap.get(collision2));
         hashMap.removeKey(collision2);
         hashMap.put(collision4, false);
-        Assert.assertEquals(this.newWithKeysValues(collision1, true, collision3, true, collision4, false), hashMap);
+        assertEquals(this.newWithKeysValues(collision1, true, collision3, true, collision4, false), hashMap);
 
         MutableObjectBooleanMap<String> hashMap1 = this.getEmptyMap();
         hashMap1.put(collision1, false);
         hashMap1.put(collision2, false);
         hashMap1.put(collision3, true);
-        Assert.assertFalse(hashMap1.get(collision1));
+        assertFalse(hashMap1.get(collision1));
         hashMap1.removeKey(collision1);
         hashMap1.put(collision4, true);
-        Assert.assertEquals(this.newWithKeysValues(collision2, false, collision3, true, collision4, true), hashMap1);
+        assertEquals(this.newWithKeysValues(collision2, false, collision3, true, collision4, true), hashMap1);
 
         MutableObjectBooleanMap<String> hashMap2 = this.getEmptyMap();
         hashMap2.put(collision1, true);
         hashMap2.put(collision2, true);
         hashMap2.put(collision3, false);
-        Assert.assertFalse(hashMap2.get(collision3));
+        assertFalse(hashMap2.get(collision3));
         hashMap2.removeKey(collision3);
         hashMap2.put(collision4, false);
-        Assert.assertEquals(this.newWithKeysValues(collision1, true, collision2, true, collision4, false), hashMap2);
+        assertEquals(this.newWithKeysValues(collision1, true, collision2, true, collision4, false), hashMap2);
 
         MutableObjectBooleanMap<String> hashMap3 = this.getEmptyMap();
         hashMap3.put(collision1, true);
         hashMap3.put(collision2, true);
         hashMap3.put(collision3, false);
-        Assert.assertTrue(hashMap3.get(collision2));
-        Assert.assertFalse(hashMap3.get(collision3));
+        assertTrue(hashMap3.get(collision2));
+        assertFalse(hashMap3.get(collision3));
         hashMap3.removeKey(collision2);
         hashMap3.removeKey(collision3);
         hashMap3.put(collision4, false);
-        Assert.assertEquals(this.newWithKeysValues(collision1, true, collision4, false), hashMap3);
+        assertEquals(this.newWithKeysValues(collision1, true, collision4, false), hashMap3);
 
         MutableObjectBooleanMap<String> hashMap4 = this.getEmptyMap();
         hashMap4.put(null, false);
-        Assert.assertEquals(this.newWithKeysValues(null, false), hashMap4);
+        assertEquals(this.newWithKeysValues(null, false), hashMap4);
         hashMap4.put(null, true);
-        Assert.assertEquals(this.newWithKeysValues(null, true), hashMap4);
+        assertEquals(this.newWithKeysValues(null, true), hashMap4);
     }
 
     @Test
     public void getIfAbsentPut_Function()
     {
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPut(0, () -> true));
+        assertTrue(map1.getIfAbsentPut(0, () -> true));
         BooleanFunction0 factoryThrows = () ->
         {
             throw new AssertionError();
         };
-        Assert.assertTrue(map1.getIfAbsentPut(0, factoryThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, true), map1);
-        Assert.assertTrue(map1.getIfAbsentPut(1, () -> true));
-        Assert.assertTrue(map1.getIfAbsentPut(1, factoryThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, true), map1);
+        assertTrue(map1.getIfAbsentPut(0, factoryThrows));
+        assertEquals(this.newWithKeysValues(0, true), map1);
+        assertTrue(map1.getIfAbsentPut(1, () -> true));
+        assertTrue(map1.getIfAbsentPut(1, factoryThrows));
+        assertEquals(this.newWithKeysValues(0, true, 1, true), map1);
 
         MutableObjectBooleanMap<Integer> map2 = this.getEmptyMap();
-        Assert.assertFalse(map2.getIfAbsentPut(1, () -> false));
-        Assert.assertFalse(map2.getIfAbsentPut(1, factoryThrows));
-        Assert.assertEquals(this.newWithKeysValues(1, false), map2);
-        Assert.assertFalse(map2.getIfAbsentPut(0, () -> false));
-        Assert.assertFalse(map2.getIfAbsentPut(0, factoryThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
+        assertFalse(map2.getIfAbsentPut(1, () -> false));
+        assertFalse(map2.getIfAbsentPut(1, factoryThrows));
+        assertEquals(this.newWithKeysValues(1, false), map2);
+        assertFalse(map2.getIfAbsentPut(0, () -> false));
+        assertFalse(map2.getIfAbsentPut(0, factoryThrows));
+        assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
 
         MutableObjectBooleanMap<Integer> map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPut(null, () -> true));
-        Assert.assertTrue(map3.getIfAbsentPut(null, factoryThrows));
-        Assert.assertEquals(this.newWithKeysValues(null, true), map3);
+        assertTrue(map3.getIfAbsentPut(null, () -> true));
+        assertTrue(map3.getIfAbsentPut(null, factoryThrows));
+        assertEquals(this.newWithKeysValues(null, true), map3);
     }
 
     @Test
@@ -405,29 +410,29 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         BooleanFunction<String> functionLengthEven = string -> (string.length() & 1) == 0;
 
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertFalse(map1.getIfAbsentPutWith(0, functionLengthEven, "123456789"));
+        assertFalse(map1.getIfAbsentPutWith(0, functionLengthEven, "123456789"));
         BooleanFunction<String> functionThrows = string ->
         {
             throw new AssertionError();
         };
-        Assert.assertFalse(map1.getIfAbsentPutWith(0, functionThrows, "unused"));
-        Assert.assertEquals(this.newWithKeysValues(0, false), map1);
-        Assert.assertFalse(map1.getIfAbsentPutWith(1, functionLengthEven, "123456789"));
-        Assert.assertFalse(map1.getIfAbsentPutWith(1, functionThrows, "unused"));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, false), map1);
+        assertFalse(map1.getIfAbsentPutWith(0, functionThrows, "unused"));
+        assertEquals(this.newWithKeysValues(0, false), map1);
+        assertFalse(map1.getIfAbsentPutWith(1, functionLengthEven, "123456789"));
+        assertFalse(map1.getIfAbsentPutWith(1, functionThrows, "unused"));
+        assertEquals(this.newWithKeysValues(0, false, 1, false), map1);
 
         MutableObjectBooleanMap<Integer> map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.getIfAbsentPutWith(1, functionLengthEven, "1234567890"));
-        Assert.assertTrue(map2.getIfAbsentPutWith(1, functionThrows, "unused0"));
-        Assert.assertEquals(this.newWithKeysValues(1, true), map2);
-        Assert.assertTrue(map2.getIfAbsentPutWith(0, functionLengthEven, "1234567890"));
-        Assert.assertTrue(map2.getIfAbsentPutWith(0, functionThrows, "unused0"));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, true), map2);
+        assertTrue(map2.getIfAbsentPutWith(1, functionLengthEven, "1234567890"));
+        assertTrue(map2.getIfAbsentPutWith(1, functionThrows, "unused0"));
+        assertEquals(this.newWithKeysValues(1, true), map2);
+        assertTrue(map2.getIfAbsentPutWith(0, functionLengthEven, "1234567890"));
+        assertTrue(map2.getIfAbsentPutWith(0, functionThrows, "unused0"));
+        assertEquals(this.newWithKeysValues(0, true, 1, true), map2);
 
         MutableObjectBooleanMap<Integer> map3 = this.getEmptyMap();
-        Assert.assertFalse(map3.getIfAbsentPutWith(null, functionLengthEven, "123456789"));
-        Assert.assertFalse(map3.getIfAbsentPutWith(null, functionThrows, "unused"));
-        Assert.assertEquals(this.newWithKeysValues(null, false), map3);
+        assertFalse(map3.getIfAbsentPutWith(null, functionLengthEven, "123456789"));
+        assertFalse(map3.getIfAbsentPutWith(null, functionThrows, "unused"));
+        assertEquals(this.newWithKeysValues(null, false), map3);
     }
 
     @Test
@@ -436,29 +441,29 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         BooleanFunction<Integer> function = anObject -> anObject == null || (anObject & 1) == 0;
 
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPutWithKey(0, function));
+        assertTrue(map1.getIfAbsentPutWithKey(0, function));
         BooleanFunction<Integer> functionThrows = anObject ->
         {
             throw new AssertionError();
         };
-        Assert.assertTrue(map1.getIfAbsentPutWithKey(0, functionThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, true), map1);
-        Assert.assertFalse(map1.getIfAbsentPutWithKey(1, function));
-        Assert.assertFalse(map1.getIfAbsentPutWithKey(1, functionThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, false), map1);
+        assertTrue(map1.getIfAbsentPutWithKey(0, functionThrows));
+        assertEquals(this.newWithKeysValues(0, true), map1);
+        assertFalse(map1.getIfAbsentPutWithKey(1, function));
+        assertFalse(map1.getIfAbsentPutWithKey(1, functionThrows));
+        assertEquals(this.newWithKeysValues(0, true, 1, false), map1);
 
         MutableObjectBooleanMap<Integer> map2 = this.getEmptyMap();
-        Assert.assertFalse(map2.getIfAbsentPutWithKey(1, function));
-        Assert.assertFalse(map2.getIfAbsentPutWithKey(1, functionThrows));
-        Assert.assertEquals(this.newWithKeysValues(1, false), map2);
-        Assert.assertTrue(map2.getIfAbsentPutWithKey(0, function));
-        Assert.assertTrue(map2.getIfAbsentPutWithKey(0, functionThrows));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, false), map2);
+        assertFalse(map2.getIfAbsentPutWithKey(1, function));
+        assertFalse(map2.getIfAbsentPutWithKey(1, functionThrows));
+        assertEquals(this.newWithKeysValues(1, false), map2);
+        assertTrue(map2.getIfAbsentPutWithKey(0, function));
+        assertTrue(map2.getIfAbsentPutWithKey(0, functionThrows));
+        assertEquals(this.newWithKeysValues(0, true, 1, false), map2);
 
         MutableObjectBooleanMap<Integer> map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPutWithKey(null, function));
-        Assert.assertTrue(map3.getIfAbsentPutWithKey(null, functionThrows));
-        Assert.assertEquals(this.newWithKeysValues(null, true), map3);
+        assertTrue(map3.getIfAbsentPutWithKey(null, function));
+        assertTrue(map3.getIfAbsentPutWithKey(null, functionThrows));
+        assertEquals(this.newWithKeysValues(null, true), map3);
     }
 
     @Test
@@ -466,8 +471,8 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
     {
         MutableObjectBooleanMap<Integer> emptyMap = this.getEmptyMap();
         MutableObjectBooleanMap<Integer> hashMap = emptyMap.withKeyValue(1, true);
-        Assert.assertEquals(this.newWithKeysValues(1, true), hashMap);
-        Assert.assertSame(emptyMap, hashMap);
+        assertEquals(this.newWithKeysValues(1, true), hashMap);
+        assertSame(emptyMap, hashMap);
     }
 
     @Test
@@ -475,13 +480,13 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
     {
         MutableObjectBooleanMap<Integer> hashMap = this.newWithKeysValues(1, true, 2, true, 3, false, 4, false);
         MutableObjectBooleanMap<Integer> actual = hashMap.withoutKey(5);
-        Assert.assertSame(hashMap, actual);
-        Assert.assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false, 4, false), actual);
-        Assert.assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false), hashMap.withoutKey(4));
-        Assert.assertEquals(this.newWithKeysValues(1, true, 2, true), hashMap.withoutKey(3));
-        Assert.assertEquals(this.newWithKeysValues(1, true), hashMap.withoutKey(2));
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutKey(1));
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutKey(1));
+        assertSame(hashMap, actual);
+        assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false, 4, false), actual);
+        assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false), hashMap.withoutKey(4));
+        assertEquals(this.newWithKeysValues(1, true, 2, true), hashMap.withoutKey(3));
+        assertEquals(this.newWithKeysValues(1, true), hashMap.withoutKey(2));
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutKey(1));
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutKey(1));
     }
 
     @Test
@@ -489,12 +494,12 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
     {
         MutableObjectBooleanMap<Integer> hashMap = this.newWithKeysValues(1, true, 2, true, 3, false, 4, false);
         MutableObjectBooleanMap<Integer> actual = hashMap.withoutAllKeys(FastList.newListWith(5, 6, 7));
-        Assert.assertSame(hashMap, actual);
-        Assert.assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false, 4, false), actual);
-        Assert.assertEquals(this.newWithKeysValues(1, true, 2, true), hashMap.withoutAllKeys(FastList.newListWith(5, 4, 3)));
-        Assert.assertEquals(this.newWithKeysValues(1, true), hashMap.withoutAllKeys(FastList.newListWith(2)));
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutAllKeys(FastList.newListWith(1)));
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutAllKeys(FastList.newListWith(5, 6)));
+        assertSame(hashMap, actual);
+        assertEquals(this.newWithKeysValues(1, true, 2, true, 3, false, 4, false), actual);
+        assertEquals(this.newWithKeysValues(1, true, 2, true), hashMap.withoutAllKeys(FastList.newListWith(5, 4, 3)));
+        assertEquals(this.newWithKeysValues(1, true), hashMap.withoutAllKeys(FastList.newListWith(2)));
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutAllKeys(FastList.newListWith(1)));
+        assertEquals(ObjectBooleanHashMap.newMap(), hashMap.withoutAllKeys(FastList.newListWith(5, 6)));
     }
 
     @Test
@@ -509,29 +514,29 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         Iterable<ObjectBooleanPair<Integer>> completeIterable = Iterables.iList(
                 PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), true),
                 PrimitiveTuples.pair(Integer.valueOf(3), false), PrimitiveTuples.pair(Integer.valueOf(4), false));
-        Assert.assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
-        Assert.assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
+        assertEquals(emptyMap, emptyMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, emptyMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, emptyMap.withAllKeyValues(completeIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(emptyIterable));
+        assertEquals(partialMap, partialMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, partialMap.withAllKeyValues(completeIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(emptyIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(partialIterable));
+        assertEquals(completeMap, completeMap.withAllKeyValues(completeIterable));
     }
 
     @Test
     public void asUnmodifiable()
     {
         Verify.assertInstanceOf(UnmodifiableObjectBooleanMap.class, this.map.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableObjectBooleanMap<>(this.map), this.map.asUnmodifiable());
+        assertEquals(new UnmodifiableObjectBooleanMap<>(this.map), this.map.asUnmodifiable());
     }
 
     @Test
     public void asSynchronized()
     {
         Verify.assertInstanceOf(SynchronizedObjectBooleanMap.class, this.map.asSynchronized());
-        Assert.assertEquals(new SynchronizedObjectBooleanMap<>(this.map), this.map.asSynchronized());
+        assertEquals(new SynchronizedObjectBooleanMap<>(this.map), this.map.asSynchronized());
     }
 
     @Test
@@ -555,10 +560,10 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
         MutableObjectBooleanMap<String> map = this.classUnderTest();
         Verify.assertNotEmpty(map);
         MutableBooleanIterator booleanIterator = map.booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
         booleanIterator.remove();
-        Assert.assertThrows(IllegalStateException.class, booleanIterator::remove);
+        assertThrows(IllegalStateException.class, booleanIterator::remove);
     }
 
     @Test
@@ -566,7 +571,7 @@ public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractOb
     {
         MutableObjectBooleanMap<String> map = this.classUnderTest();
         MutableBooleanIterator booleanIterator = map.booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(IllegalStateException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(IllegalStateException.class, booleanIterator::remove);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapKeyValuesViewTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapKeyValuesViewTestCase.java
@@ -49,8 +49,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ObjectBooleanMap#keyValuesView()}.
@@ -89,16 +94,16 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void containsAllIterable()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false))));
-        Assert.assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(1.0, Integer.valueOf(5)))));
+        assertTrue(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false))));
+        assertFalse(collection.containsAllIterable(FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(1.0, Integer.valueOf(5)))));
     }
 
     @Test
     public void containsAllArray()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false)));
-        Assert.assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(1.0, Integer.valueOf(5))));
+        assertTrue(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertFalse(collection.containsAllArguments(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(1.0, Integer.valueOf(5))));
     }
 
     @Test
@@ -123,8 +128,8 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
             result2.add(argument2);
         }, 0);
 
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
-        Assert.assertEquals(Bags.immutable.of(0, 0, 0), result2);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
+        assertEquals(Bags.immutable.of(0, 0, 0), result2);
     }
 
     @Test
@@ -138,8 +143,8 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
             elements.add(object);
             indexes.add(index);
         });
-        Assert.assertEquals(Bags.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false), PrimitiveTuples.pair(Integer.valueOf(3), true)), elements);
-        Assert.assertEquals(Bags.mutable.of(0, 1, 2), indexes);
+        assertEquals(Bags.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), false), PrimitiveTuples.pair(Integer.valueOf(3), true)), elements);
+        assertEquals(Bags.mutable.of(0, 1, 2), indexes);
     }
 
     @Test
@@ -164,7 +169,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void selectWith_target()
     {
         HashBag<ObjectBooleanPair<Integer>> result = this.newWith(1, true, 2, false, 3, true).selectWith(Predicates2.notEqual(), PrimitiveTuples.pair(Integer.valueOf(2), false), HashBag.newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
     }
 
     @Test
@@ -189,7 +194,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void rejectWith_target()
     {
         HashBag<ObjectBooleanPair<Integer>> result = this.newWith(1, true, 2, false, 3, true).rejectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false), HashBag.newBag());
-        Assert.assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
+        assertEquals(Bags.immutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(3), true)), result);
     }
 
     @Test
@@ -205,7 +210,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<Integer> result1 = this.newWith(2, true, 3, false, 4, true).collect(ObjectBooleanPair::getOne);
 
-        Assert.assertEquals(HashBag.newBagWith(2, 3, 4), result1.toBag());
+        assertEquals(HashBag.newBagWith(2, 3, 4), result1.toBag());
     }
 
     @Test
@@ -227,8 +232,8 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detect(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
-        Assert.assertNull(this.newWith(1, true, 2, false, 3, true).detect(PrimitiveTuples.pair(true, Integer.valueOf(4))::equals));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detect(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
+        assertNull(this.newWith(1, true, 2, false, 3, true).detect(PrimitiveTuples.pair(true, Integer.valueOf(4))::equals));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -246,65 +251,65 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true, 2, false, 3, true).min(ObjectBooleanPair::compareTo));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true, 2, false, 3, true).min(ObjectBooleanPair::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), true), this.newWith(1, true, 2, false, 3, true).max(ObjectBooleanPair::compareTo));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), true), this.newWith(1, true, 2, false, 3, true).max(ObjectBooleanPair::compareTo));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true, 2, false, 3, true).min(ObjectBooleanPair::compareTo));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true, 2, false, 3, true).min(ObjectBooleanPair::compareTo));
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), true), this.newWith(1, true, 2, false, 3, true).max(ObjectBooleanPair::compareTo));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), true), this.newWith(1, true, 2, false, 3, true).max(ObjectBooleanPair::compareTo));
     }
 
     @Test
     public void minBy()
     {
         Function<ObjectBooleanPair<Integer>, Integer> function = ObjectBooleanPair::getOne;
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), true), this.newWith(2, true, 3, false, 4, true).minBy(function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), true), this.newWith(2, true, 3, false, 4, true).minBy(function));
     }
 
     @Test
     public void maxBy()
     {
         Function<ObjectBooleanPair<Integer>, Integer> function = object -> object.getOne() & 1;
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), false), this.newWith(2, true, 3, false, 4, true).maxBy(function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(3), false), this.newWith(2, true, 3, false, 4, true).maxBy(function));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
-        Assert.assertNull(this.newWith(1, true, 2, false, 3, true).detectWith(Object::equals, PrimitiveTuples.pair(true, Integer.valueOf(4))));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertNull(this.newWith(1, true, 2, false, 3, true).detectWith(Object::equals, PrimitiveTuples.pair(true, Integer.valueOf(4))));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0<ObjectBooleanPair<Integer>> function = () -> PrimitiveTuples.pair(Integer.valueOf(5), true);
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectIfNone(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals, function));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), true), this.newWith(1, true, 2, false, 3, true).detectIfNone(PrimitiveTuples.pair(true, Integer.valueOf(4))::equals, function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectIfNone(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals, function));
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), true), this.newWith(1, true, 2, false, 3, true).detectIfNone(PrimitiveTuples.pair(true, Integer.valueOf(4))::equals, function));
     }
 
     @Test
     public void detectWithIfNoneBlock()
     {
         Function0<ObjectBooleanPair<Integer>> function = () -> PrimitiveTuples.pair(Integer.valueOf(5), true);
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(2), false), this.newWith(1, true, 2, false, 3, true).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(Integer.valueOf(2), false),
                 function));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), true), this.newWith(1, true, 2, false, 3, true).detectWithIfNone(
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(5), true), this.newWith(1, true, 2, false, 3, true).detectWithIfNone(
                 Object::equals,
                 PrimitiveTuples.pair(true, Integer.valueOf(4)),
                 function));
@@ -313,59 +318,59 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).allSatisfy(ObjectBooleanPair.class::isInstance));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).allSatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).allSatisfy(ObjectBooleanPair.class::isInstance));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).allSatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).allSatisfyWith(Predicates2.instanceOf(), ObjectBooleanPair.class));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).allSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).allSatisfyWith(Predicates2.instanceOf(), ObjectBooleanPair.class));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).allSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).noneSatisfy(Boolean.class::isInstance));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).noneSatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).noneSatisfy(Boolean.class::isInstance));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).noneSatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).noneSatisfyWith(Predicates2.instanceOf(), Boolean.class));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).noneSatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).anySatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).anySatisfy(PrimitiveTuples.pair(true, Integer.valueOf(5))::equals));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).anySatisfy(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).anySatisfy(PrimitiveTuples.pair(true, Integer.valueOf(5))::equals));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(this.newWith(1, true, 2, false, 3, true).anySatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
-        Assert.assertFalse(this.newWith(1, true, 2, false, 3, true).anySatisfyWith(Object::equals, PrimitiveTuples.pair(true, Integer.valueOf(5))));
+        assertTrue(this.newWith(1, true, 2, false, 3, true).anySatisfyWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertFalse(this.newWith(1, true, 2, false, 3, true).anySatisfyWith(Object::equals, PrimitiveTuples.pair(true, Integer.valueOf(5))));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.newWith(1, true, 2, false, 3, true).count(Boolean.class::isInstance));
-        Assert.assertEquals(3, this.newWith(1, true, 2, false, 3, true).count(ObjectBooleanPair.class::isInstance));
-        Assert.assertEquals(1, this.newWith(1, true, 2, false, 3, true).count(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
+        assertEquals(0, this.newWith(1, true, 2, false, 3, true).count(Boolean.class::isInstance));
+        assertEquals(3, this.newWith(1, true, 2, false, 3, true).count(ObjectBooleanPair.class::isInstance));
+        assertEquals(1, this.newWith(1, true, 2, false, 3, true).count(PrimitiveTuples.pair(Integer.valueOf(2), false)::equals));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(0, this.newWith(1, true, 2, false, 3, true).countWith(Predicates2.instanceOf(), Boolean.class));
-        Assert.assertEquals(3, this.newWith(1, true, 2, false, 3, true).countWith(Predicates2.instanceOf(), ObjectBooleanPair.class));
-        Assert.assertEquals(1, this.newWith(1, true, 2, false, 3, true).countWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertEquals(0, this.newWith(1, true, 2, false, 3, true).countWith(Predicates2.instanceOf(), Boolean.class));
+        assertEquals(3, this.newWith(1, true, 2, false, 3, true).countWith(Predicates2.instanceOf(), ObjectBooleanPair.class));
+        assertEquals(1, this.newWith(1, true, 2, false, 3, true).countWith(Object::equals, PrimitiveTuples.pair(Integer.valueOf(2), false)));
     }
 
     @Test
@@ -387,7 +392,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(5L, 7L, 9L),
                 this.newWith(2, true, 3, false, 4, true).collectWith((argument1, argument2) -> argument1.getOne() + argument1.getOne() + argument2, 1L).toBag());
     }
@@ -395,7 +400,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     @Test
     public void collectWith_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(5L, 7L, 9L),
                 this.newWith(2, true, 3, false, 4, true).collectWith((argument1, argument2) -> argument1.getOne() + argument1.getOne() + argument2, 1L, HashBag.newBag()));
     }
@@ -404,20 +409,20 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void getFirst()
     {
         ObjectBooleanPair<Integer> first = this.newWith(1, true, 2, false, 3, true).getFirst();
-        Assert.assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), true).equals(first)
+        assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), true).equals(first)
                 || PrimitiveTuples.pair(Integer.valueOf(2), false).equals(first)
                 || PrimitiveTuples.pair(Integer.valueOf(3), true).equals(first));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true).getFirst());
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true).getFirst());
     }
 
     @Test
     public void getLast()
     {
         ObjectBooleanPair<Integer> last = this.newWith(1, true, 2, false, 3, true).getLast();
-        Assert.assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), true).equals(last)
+        assertTrue(PrimitiveTuples.pair(Integer.valueOf(1), true).equals(last)
                 || PrimitiveTuples.pair(Integer.valueOf(2), false).equals(last)
                 || PrimitiveTuples.pair(Integer.valueOf(3), true).equals(last));
-        Assert.assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true).getLast());
+        assertEquals(PrimitiveTuples.pair(Integer.valueOf(1), true), this.newWith(1, true).getLast());
     }
 
     @Test
@@ -425,7 +430,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         Verify.assertIterableEmpty(this.newWith());
         Verify.assertIterableNotEmpty(this.newWith(1, true));
-        Assert.assertTrue(this.newWith(1, true).notEmpty());
+        assertTrue(this.newWith(1, true).notEmpty());
     }
 
     @Test
@@ -436,13 +441,13 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Iterator<ObjectBooleanPair<Integer>> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
 
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertEquals(objects.toBag(), actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertEquals(objects.toBag(), actual);
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -452,10 +457,10 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Iterator<ObjectBooleanPair<Integer>> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             iterator.next();
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
         iterator.next();
     }
 
@@ -464,7 +469,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         Long result = objects.injectInto(1L, (Long argument1, ObjectBooleanPair<Integer> argument2) -> argument1 + argument2.getOne() + argument2.getOne());
-        Assert.assertEquals(Long.valueOf(19), result);
+        assertEquals(Long.valueOf(19), result);
     }
 
     @Test
@@ -472,7 +477,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         int result = objects.injectInto(1, (int intParameter, ObjectBooleanPair<Integer> argument2) -> intParameter + argument2.getOne() + argument2.getOne());
-        Assert.assertEquals(19, result);
+        assertEquals(19, result);
     }
 
     @Test
@@ -480,7 +485,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         long result = objects.injectInto(1L, (long parameter, ObjectBooleanPair<Integer> argument2) -> parameter + argument2.getOne() + argument2.getOne());
-        Assert.assertEquals(19, result);
+        assertEquals(19, result);
     }
 
     @Test
@@ -488,7 +493,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         double result = objects.injectInto(1.0, (parameter, argument2) -> parameter + argument2.getOne() + argument2.getOne());
-        Assert.assertEquals(19.0, result, 0.0);
+        assertEquals(19.0, result, 0.0);
     }
 
     @Test
@@ -496,7 +501,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         float result = objects.injectInto(1.0f, (float parameter, ObjectBooleanPair<Integer> argument2) -> parameter + argument2.getOne() + argument2.getOne());
-        Assert.assertEquals(19.0, result, 0.0);
+        assertEquals(19.0, result, 0.0);
     }
 
     @Test
@@ -504,7 +509,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         double actual = objects.sumOfFloat(each -> (float) (each.getOne() + each.getOne()));
-        Assert.assertEquals(18.0, actual, 0.0);
+        assertEquals(18.0, actual, 0.0);
     }
 
     @Test
@@ -512,7 +517,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         double actual = objects.sumOfDouble(each -> (double) (each.getOne() + each.getOne()));
-        Assert.assertEquals(18.0, actual, 0.0);
+        assertEquals(18.0, actual, 0.0);
     }
 
     @Test
@@ -520,7 +525,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         long actual = objects.sumOfInt(each -> each.getOne() + each.getOne());
-        Assert.assertEquals(18, actual);
+        assertEquals(18, actual);
     }
 
     @Test
@@ -528,7 +533,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> objects = this.newWith(2, true, 3, false, 4, true);
         long actual = objects.sumOfLong(each -> (long) (each.getOne() + each.getOne()));
-        Assert.assertEquals(18, actual);
+        assertEquals(18, actual);
     }
 
     @Test
@@ -571,7 +576,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(5, false, 1, true, 2, true);
         MutableList<ObjectBooleanPair<Integer>> list = pairs.toSortedList();
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(5), false)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(5), false)), list);
     }
 
     @Test
@@ -579,7 +584,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(5, false, 1, true, 2, true);
         MutableList<ObjectBooleanPair<Integer>> list = pairs.toSortedList(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(5), false), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(1), true)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(5), false), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(1), true)), list);
     }
 
     @Test
@@ -587,7 +592,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(5, false, 1, true, 2, true);
         MutableList<ObjectBooleanPair<Integer>> list = pairs.toSortedListBy(String::valueOf);
-        Assert.assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(5), false)), list);
+        assertEquals(Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true), PrimitiveTuples.pair(Integer.valueOf(2), true), PrimitiveTuples.pair(Integer.valueOf(5), false)), list);
     }
 
     @Test
@@ -658,7 +663,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(1, true, 2, false, 3, true);
         MutableMap<String, String> map =
                 pairs.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
     }
 
     @Test
@@ -667,7 +672,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(1, true, 2, false, 3, true);
         MutableSortedMap<String, String> map =
                 pairs.toSortedMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith("1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
+        assertEquals(TreeSortedMap.newMapWith("1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
     }
 
     @Test
@@ -676,7 +681,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(1, true, 2, false, 3, true);
         MutableSortedMap<String, String> map =
                 pairs.toSortedMap(Comparators.reverseNaturalOrder(), String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), "1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
     }
 
     @Test
@@ -685,14 +690,14 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> pairs = this.newWith(1, true, 2, false, 3, true);
         MutableSortedMap<String, String> map =
                 pairs.toSortedMapBy(String::valueOf, String::valueOf, String::valueOf);
-        Assert.assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
+        assertEquals(TreeSortedMap.newMapWith(Comparators.naturalOrder(), "1:true", "1:true", "2:false", "2:false", "3:true", "3:true"), map);
     }
 
     @Test
     public void testToString()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false);
-        Assert.assertTrue("[1:true, 2:false]".equals(collection.toString())
+        assertTrue("[1:true, 2:false]".equals(collection.toString())
                 || "[2:false, 1:true]".equals(collection.toString()));
     }
 
@@ -700,21 +705,21 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void makeString()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Test
     public void makeStringWithSeparator()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString(", ") + ']');
     }
 
     @Test
     public void makeStringWithSeparatorAndStartAndEnd()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
+        assertEquals(collection.toString(), collection.makeString("[", ", ", "]"));
     }
 
     @Test
@@ -723,7 +728,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -732,7 +737,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, ", ");
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Test
@@ -741,7 +746,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
         Appendable builder = new StringBuilder();
         collection.appendString(builder, "[", ", ", "]");
-        Assert.assertEquals(collection.toString(), builder.toString());
+        assertEquals(collection.toString(), builder.toString());
     }
 
     @Test
@@ -751,10 +756,10 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Function<ObjectBooleanPair<Integer>, Boolean> function = object -> PrimitiveTuples.pair(Integer.valueOf(1), true).equals(object);
 
         Multimap<Boolean, ObjectBooleanPair<Integer>> multimap = collection.groupBy(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), true)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), false)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), true)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), true)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), true)));
     }
 
     @Test
@@ -764,10 +769,10 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Function<ObjectBooleanPair<Integer>, MutableList<Boolean>> function = object -> Lists.mutable.of(PrimitiveTuples.pair(Integer.valueOf(1), true).equals(object));
 
         Multimap<Boolean, ObjectBooleanPair<Integer>> multimap = collection.groupByEach(function);
-        Assert.assertEquals(3, multimap.size());
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), true)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), false)));
-        Assert.assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), true)));
+        assertEquals(3, multimap.size());
+        assertTrue(multimap.containsKeyAndValue(Boolean.TRUE, PrimitiveTuples.pair(Integer.valueOf(1), true)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(2), false)));
+        assertTrue(multimap.containsKeyAndValue(Boolean.FALSE, PrimitiveTuples.pair(Integer.valueOf(3), true)));
     }
 
     @Test
@@ -776,7 +781,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false);
         RichIterable<Pair<ObjectBooleanPair<Integer>, Integer>> result = collection.zip(Interval.oneTo(5));
 
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 2)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 2)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 1), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 2)).equals(result.toBag()));
     }
 
@@ -785,7 +790,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false);
         RichIterable<Pair<ObjectBooleanPair<Integer>, Integer>> result = collection.zipWithIndex();
-        Assert.assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 1)).equals(result.toBag())
+        assertTrue(Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 1)).equals(result.toBag())
                 || Bags.mutable.of(Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(2), false), 0), Tuples.pair(PrimitiveTuples.pair(Integer.valueOf(1), true), 1)).equals(result.toBag()));
     }
 
@@ -793,7 +798,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void chunk()
     {
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, true, 2, false, 3, true);
-        Assert.assertEquals(
+        assertEquals(
                 Bags.immutable.of(
                         FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(1), true)),
                         FastList.newListWith(PrimitiveTuples.pair(Integer.valueOf(2), false)),
@@ -819,8 +824,8 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
     public void empty()
     {
         Verify.assertIterableEmpty(this.newWith());
-        Assert.assertTrue(this.newWith().isEmpty());
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertTrue(this.newWith().isEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Test
@@ -836,9 +841,9 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Procedure2<AtomicInteger, ObjectBooleanPair<Integer>> sumAggregator = (aggregate, value) -> aggregate.addAndGet(value.getOne());
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(2, true, 3, false, 4, true);
         MapIterable<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, AtomicInteger::new, sumAggregator);
-        Assert.assertEquals(4, aggregation.get("4:true").intValue());
-        Assert.assertEquals(3, aggregation.get("3:false").intValue());
-        Assert.assertEquals(2, aggregation.get("2:true").intValue());
+        assertEquals(4, aggregation.get("4:true").intValue());
+        assertEquals(3, aggregation.get("3:false").intValue());
+        assertEquals(2, aggregation.get("2:true").intValue());
     }
 
     @Test
@@ -847,7 +852,7 @@ public abstract class AbstractObjectBooleanMapKeyValuesViewTestCase
         Function2<Integer, ObjectBooleanPair<Integer>, Integer> sumAggregator = (aggregate, value) -> aggregate + value.getOne();
         RichIterable<ObjectBooleanPair<Integer>> collection = this.newWith(1, false, 1, false, 2, true);
         MapIterable<String, Integer> aggregation = collection.aggregateBy(String::valueOf, () -> 0, sumAggregator);
-        Assert.assertEquals(2, aggregation.get("2:true").intValue());
-        Assert.assertEquals(1, aggregation.get("1:false").intValue());
+        assertEquals(2, aggregation.get("2:true").intValue());
+        assertEquals(1, aggregation.get("1:false").intValue());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapTestCase.java
@@ -23,8 +23,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractObjectBooleanMapTestCase
 {
@@ -43,53 +48,53 @@ public abstract class AbstractObjectBooleanMapTestCase
     @Test
     public void get()
     {
-        Assert.assertTrue(this.classUnderTest().get("0"));
-        Assert.assertTrue(this.classUnderTest().get("1"));
-        Assert.assertFalse(this.classUnderTest().get("2"));
+        assertTrue(this.classUnderTest().get("0"));
+        assertTrue(this.classUnderTest().get("1"));
+        assertFalse(this.classUnderTest().get("2"));
 
-        Assert.assertFalse(this.classUnderTest().get("5"));
+        assertFalse(this.classUnderTest().get("5"));
     }
 
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("0", false));
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("1", false));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("2", true));
+        assertTrue(this.classUnderTest().getIfAbsent("0", false));
+        assertTrue(this.classUnderTest().getIfAbsent("1", false));
+        assertFalse(this.classUnderTest().getIfAbsent("2", true));
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsent("5", true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent("5", false));
+        assertTrue(this.classUnderTest().getIfAbsent("5", true));
+        assertFalse(this.classUnderTest().getIfAbsent("5", false));
 
-        Assert.assertTrue(this.classUnderTest().getIfAbsent(null, true));
-        Assert.assertFalse(this.classUnderTest().getIfAbsent(null, false));
+        assertTrue(this.classUnderTest().getIfAbsent(null, true));
+        assertFalse(this.classUnderTest().getIfAbsent(null, false));
     }
 
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.classUnderTest().getOrThrow("0"));
-        Assert.assertTrue(this.classUnderTest().getOrThrow("1"));
-        Assert.assertFalse(this.classUnderTest().getOrThrow("2"));
+        assertTrue(this.classUnderTest().getOrThrow("0"));
+        assertTrue(this.classUnderTest().getOrThrow("1"));
+        assertFalse(this.classUnderTest().getOrThrow("2"));
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOrThrow(null));
     }
 
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.classUnderTest().containsKey("0"));
-        Assert.assertTrue(this.classUnderTest().containsKey("1"));
-        Assert.assertTrue(this.classUnderTest().containsKey("2"));
-        Assert.assertFalse(this.classUnderTest().containsKey("3"));
-        Assert.assertFalse(this.classUnderTest().containsKey(null));
+        assertTrue(this.classUnderTest().containsKey("0"));
+        assertTrue(this.classUnderTest().containsKey("1"));
+        assertTrue(this.classUnderTest().containsKey("2"));
+        assertFalse(this.classUnderTest().containsKey("3"));
+        assertFalse(this.classUnderTest().containsKey(null));
     }
 
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.classUnderTest().containsValue(true));
-        Assert.assertTrue(this.classUnderTest().containsValue(false));
+        assertTrue(this.classUnderTest().containsValue(true));
+        assertTrue(this.classUnderTest().containsValue(false));
     }
 
     @Test
@@ -108,22 +113,22 @@ public abstract class AbstractObjectBooleanMapTestCase
     public void isEmpty()
     {
         Verify.assertEmpty(this.getEmptyMap());
-        Assert.assertFalse(this.classUnderTest().isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(null, false).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(1, true).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(0, false).isEmpty());
-        Assert.assertFalse(this.newWithKeysValues(50, true).isEmpty());
+        assertFalse(this.classUnderTest().isEmpty());
+        assertFalse(this.newWithKeysValues(null, false).isEmpty());
+        assertFalse(this.newWithKeysValues(1, true).isEmpty());
+        assertFalse(this.newWithKeysValues(0, false).isEmpty());
+        assertFalse(this.newWithKeysValues(50, true).isEmpty());
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.getEmptyMap().notEmpty());
-        Assert.assertTrue(this.classUnderTest().notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(1, true).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(null, false).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(0, true).notEmpty());
-        Assert.assertTrue(this.newWithKeysValues(50, false).notEmpty());
+        assertFalse(this.getEmptyMap().notEmpty());
+        assertTrue(this.classUnderTest().notEmpty());
+        assertTrue(this.newWithKeysValues(1, true).notEmpty());
+        assertTrue(this.newWithKeysValues(null, false).notEmpty());
+        assertTrue(this.newWithKeysValues(0, true).notEmpty());
+        assertTrue(this.newWithKeysValues(50, false).notEmpty());
     }
 
     @Test
@@ -140,47 +145,47 @@ public abstract class AbstractObjectBooleanMapTestCase
 
         Verify.assertEqualsAndHashCode(map1, map2);
         Verify.assertPostSerializedEqualsAndHashCode(map1);
-        Assert.assertNotEquals(map1, map3);
-        Assert.assertNotEquals(map1, map4);
-        Assert.assertNotEquals(map1, map5);
-        Assert.assertNotEquals(map7, map6);
-        Assert.assertNotEquals(map7, map8);
+        assertNotEquals(map1, map3);
+        assertNotEquals(map1, map4);
+        assertNotEquals(map1, map5);
+        assertNotEquals(map7, map6);
+        assertNotEquals(map7, map8);
     }
 
     @Test
     public void testHashCode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, false, 1, true, 32, true).hashCode(),
                 this.newWithKeysValues(32, true, 0, false, 1, true).hashCode());
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(50, true, 60, true, null, false).hashCode(),
                 this.newWithKeysValues(50, true, 60, true, null, false).hashCode());
-        Assert.assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
+        assertEquals(UnifiedMap.newMap().hashCode(), this.getEmptyMap().hashCode());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{}", this.getEmptyMap().toString());
-        Assert.assertEquals("{0=false}", this.newWithKeysValues(0, false).toString());
-        Assert.assertEquals("{1=true}", this.newWithKeysValues(1, true).toString());
-        Assert.assertEquals("{5=true}", this.newWithKeysValues(5, true).toString());
+        assertEquals("{}", this.getEmptyMap().toString());
+        assertEquals("{0=false}", this.newWithKeysValues(0, false).toString());
+        assertEquals("{1=true}", this.newWithKeysValues(1, true).toString());
+        assertEquals("{5=true}", this.newWithKeysValues(5, true).toString());
 
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(0, true, 1, false);
-        Assert.assertTrue(
+        assertTrue(
                 map1.toString(),
                 "{0=true, 1=false}".equals(map1.toString())
                         || "{1=false, 0=true}".equals(map1.toString()));
 
         ObjectBooleanMap<Integer> map2 = this.newWithKeysValues(1, false, null, true);
-        Assert.assertTrue(
+        assertTrue(
                 map2.toString(),
                 "{1=false, null=true}".equals(map2.toString())
                         || "{null=true, 1=false}".equals(map2.toString()));
 
         ObjectBooleanMap<Integer> map3 = this.newWithKeysValues(1, true, null, true);
-        Assert.assertTrue(
+        assertTrue(
                 map3.toString(),
                 "{1=true, null=true}".equals(map3.toString())
                         || "{null=true, 1=true}".equals(map3.toString()));
@@ -193,19 +198,19 @@ public abstract class AbstractObjectBooleanMapTestCase
         String[] sum01 = new String[1];
         sum01[0] = "";
         map01.forEachValue(each -> sum01[0] += String.valueOf(each));
-        Assert.assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
+        assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
 
         ObjectBooleanMap<Integer> map = this.newWithKeysValues(3, true, 4, true);
         String[] sum = new String[1];
         sum[0] = "";
         map.forEachValue(each -> sum[0] += String.valueOf(each));
-        Assert.assertEquals("truetrue", sum[0]);
+        assertEquals("truetrue", sum[0]);
 
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(3, false, null, true);
         String[] sum1 = new String[1];
         sum1[0] = "";
         map1.forEachValue(each -> sum1[0] += String.valueOf(each));
-        Assert.assertTrue("truefalse".equals(sum1[0]) || "falsetrue".equals(sum1[0]));
+        assertTrue("truefalse".equals(sum1[0]) || "falsetrue".equals(sum1[0]));
     }
 
     @Test
@@ -215,19 +220,19 @@ public abstract class AbstractObjectBooleanMapTestCase
         String[] sum01 = new String[1];
         sum01[0] = "";
         map01.forEach(each -> sum01[0] += String.valueOf(each));
-        Assert.assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
+        assertTrue("truefalse".equals(sum01[0]) || "falsetrue".equals(sum01[0]));
 
         ObjectBooleanMap<Integer> map = this.newWithKeysValues(3, true, 4, true);
         String[] sum = new String[1];
         sum[0] = "";
         map.forEach(each -> sum[0] += String.valueOf(each));
-        Assert.assertEquals("truetrue", sum[0]);
+        assertEquals("truetrue", sum[0]);
 
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(3, false, null, true);
         String[] sum1 = new String[1];
         sum1[0] = "";
         map1.forEach(each -> sum1[0] += String.valueOf(each));
-        Assert.assertTrue("truefalse".equals(sum1[0]) || "falsetrue".equals(sum1[0]));
+        assertTrue("truefalse".equals(sum1[0]) || "falsetrue".equals(sum1[0]));
     }
 
     @Test
@@ -236,13 +241,13 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<Integer> map01 = this.newWithKeysValues(0, true, 1, false);
         int[] sum01 = new int[1];
         map01.forEachKey(each -> sum01[0] += each);
-        Assert.assertEquals(1, sum01[0]);
+        assertEquals(1, sum01[0]);
 
         ObjectBooleanMap<Integer> map = this.newWithKeysValues(3, false, null, true);
         String[] sum = new String[1];
         sum[0] = "";
         map.forEachKey(each -> sum[0] += String.valueOf(each));
-        Assert.assertTrue("3null".equals(sum[0]) || "null3".equals(sum[0]));
+        assertTrue("3null".equals(sum[0]) || "null3".equals(sum[0]));
     }
 
     @Test
@@ -257,8 +262,8 @@ public abstract class AbstractObjectBooleanMapTestCase
             sumKey01[0] += eachKey;
             sumValue01[0] += eachValue;
         });
-        Assert.assertEquals(1, sumKey01[0]);
-        Assert.assertTrue("truefalse".equals(sumValue01[0]) || "falsetrue".equals(sumValue01[0]));
+        assertEquals(1, sumKey01[0]);
+        assertTrue("truefalse".equals(sumValue01[0]) || "falsetrue".equals(sumValue01[0]));
 
         ObjectBooleanMap<Integer> map = this.newWithKeysValues(3, true, null, false);
         String[] sumKey = new String[1];
@@ -270,25 +275,25 @@ public abstract class AbstractObjectBooleanMapTestCase
             sumKey[0] += String.valueOf(eachKey);
             sumValue[0] += eachValue;
         });
-        Assert.assertTrue(sumKey[0], "3null".equals(sumKey[0]) || "null3".equals(sumKey[0]));
-        Assert.assertTrue("truefalse".equals(sumValue[0]) || "falsetrue".equals(sumValue[0]));
+        assertTrue(sumKey[0], "3null".equals(sumKey[0]) || "null3".equals(sumKey[0]));
+        assertTrue("truefalse".equals(sumValue[0]) || "falsetrue".equals(sumValue[0]));
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals("", this.<String>getEmptyMap().makeString());
-        Assert.assertEquals("true", this.newWithKeysValues(0, true).makeString());
-        Assert.assertEquals("false", this.newWithKeysValues(1, false).makeString());
-        Assert.assertEquals("true", this.newWithKeysValues(null, true).makeString());
+        assertEquals("", this.<String>getEmptyMap().makeString());
+        assertEquals("true", this.newWithKeysValues(0, true).makeString());
+        assertEquals("false", this.newWithKeysValues(1, false).makeString());
+        assertEquals("true", this.newWithKeysValues(null, true).makeString());
 
         ObjectBooleanMap<Integer> map2 = this.newWithKeysValues(1, true, 32, false);
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("[", "/", "]"),
                 "[true/false]".equals(map2.makeString("[", "/", "]"))
                         || "[false/true]".equals(map2.makeString("[", "/", "]")));
 
-        Assert.assertTrue(
+        assertTrue(
                 map2.makeString("/"),
                 "true/false".equals(map2.makeString("/"))
                         || "false/true".equals(map2.makeString("/")));
@@ -299,38 +304,38 @@ public abstract class AbstractObjectBooleanMapTestCase
     {
         Appendable appendable = new StringBuilder();
         this.getEmptyMap().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         Appendable appendable0 = new StringBuilder();
         this.newWithKeysValues(0, true).appendString(appendable0);
-        Assert.assertEquals("true", appendable0.toString());
+        assertEquals("true", appendable0.toString());
 
         Appendable appendable1 = new StringBuilder();
         this.newWithKeysValues(1, false).appendString(appendable1);
-        Assert.assertEquals("false", appendable1.toString());
+        assertEquals("false", appendable1.toString());
 
         Appendable appendable2 = new StringBuilder();
         this.newWithKeysValues(null, false).appendString(appendable2);
-        Assert.assertEquals("false", appendable2.toString());
+        assertEquals("false", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(0, true, 1, false);
         map1.appendString(appendable3);
-        Assert.assertTrue(
+        assertTrue(
                 appendable3.toString(),
                 "true, false".equals(appendable3.toString())
                         || "false, true".equals(appendable3.toString()));
 
         Appendable appendable4 = new StringBuilder();
         map1.appendString(appendable4, "/");
-        Assert.assertTrue(
+        assertTrue(
                 appendable4.toString(),
                 "true/false".equals(appendable4.toString())
                         || "false/true".equals(appendable4.toString()));
 
         Appendable appendable5 = new StringBuilder();
         map1.appendString(appendable5, "[", "/", "]");
-        Assert.assertTrue(
+        assertTrue(
                 appendable5.toString(),
                 "[true/false]".equals(appendable5.toString())
                         || "[false/true]".equals(appendable5.toString()));
@@ -339,71 +344,71 @@ public abstract class AbstractObjectBooleanMapTestCase
     @Test
     public void select()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true), this.classUnderTest().select(BooleanPredicates.isTrue()).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false), this.classUnderTest().select(BooleanPredicates.isFalse()).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true, false), this.classUnderTest().select(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().select(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, true), this.classUnderTest().select(BooleanPredicates.isTrue()).toBag());
+        assertEquals(BooleanHashBag.newBagWith(false), this.classUnderTest().select(BooleanPredicates.isFalse()).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, true, false), this.classUnderTest().select(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().select(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
 
-        Assert.assertEquals(this.newWithKeysValues("0", true), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) == 0 && value));
-        Assert.assertEquals(this.newWithKeysValues("2", false), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) == 0 && !value));
-        Assert.assertEquals(ObjectBooleanHashMap.newMap(), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) != 0 && !value));
+        assertEquals(this.newWithKeysValues("0", true), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) == 0 && value));
+        assertEquals(this.newWithKeysValues("2", false), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) == 0 && !value));
+        assertEquals(ObjectBooleanHashMap.newMap(), this.classUnderTest().select((object, value) -> (Integer.parseInt(object) & 1) != 0 && !value));
     }
 
     @Test
     public void reject()
     {
-        Assert.assertEquals(BooleanHashBag.newBagWith(false), this.classUnderTest().reject(BooleanPredicates.isTrue()).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true), this.classUnderTest().reject(BooleanPredicates.isFalse()).toBag());
-        Assert.assertEquals(new BooleanHashBag(), this.classUnderTest().reject(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true, false), this.classUnderTest().reject(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
+        assertEquals(BooleanHashBag.newBagWith(false), this.classUnderTest().reject(BooleanPredicates.isTrue()).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, true), this.classUnderTest().reject(BooleanPredicates.isFalse()).toBag());
+        assertEquals(new BooleanHashBag(), this.classUnderTest().reject(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, true, false), this.classUnderTest().reject(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())).toBag());
 
-        Assert.assertEquals(this.newWithKeysValues("1", true, "2", false), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) == 0 && value));
-        Assert.assertEquals(this.newWithKeysValues("0", true, "1", true), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) == 0 && !value));
-        Assert.assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) != 0 && !value));
+        assertEquals(this.newWithKeysValues("1", true, "2", false), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) == 0 && value));
+        assertEquals(this.newWithKeysValues("0", true, "1", true), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) == 0 && !value));
+        assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.classUnderTest().reject((object, value) -> (Integer.parseInt(object) & 1) != 0 && !value));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(2L, this.classUnderTest().count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(1L, this.classUnderTest().count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(3L, this.classUnderTest().count(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertEquals(0L, this.classUnderTest().count(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertEquals(2L, this.classUnderTest().count(BooleanPredicates.isTrue()));
+        assertEquals(1L, this.classUnderTest().count(BooleanPredicates.isFalse()));
+        assertEquals(3L, this.classUnderTest().count(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertEquals(0L, this.classUnderTest().count(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().anySatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().allSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.classUnderTest().noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertTrue(this.classUnderTest().detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(this.classUnderTest().detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.newWithKeysValues("0", true, "1", true).detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
+        assertTrue(this.classUnderTest().detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(this.classUnderTest().detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.newWithKeysValues("0", true, "1", true).detectIfNone(BooleanPredicates.and(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
     }
 
     @Test
@@ -412,9 +417,9 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map1 = this.newWithKeysValues("0", true, "1", false);
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
-        Assert.assertTrue(FastList.newListWith("true", "false").equals(map1.collect(String::valueOf)) || FastList.newListWith("false", "true").equals(map1.collect(String::valueOf)));
-        Assert.assertEquals(FastList.newListWith("true"), map2.collect(String::valueOf));
-        Assert.assertEquals(FastList.newListWith("false"), map3.collect(String::valueOf));
+        assertTrue(FastList.newListWith("true", "false").equals(map1.collect(String::valueOf)) || FastList.newListWith("false", "true").equals(map1.collect(String::valueOf)));
+        assertEquals(FastList.newListWith("true"), map2.collect(String::valueOf));
+        assertEquals(FastList.newListWith("false"), map3.collect(String::valueOf));
     }
 
     @Test
@@ -424,10 +429,10 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        Assert.assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray())
+        assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray())
                 || Arrays.equals(new boolean[]{false, true}, map1.toArray()));
-        Assert.assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray()));
-        Assert.assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray()));
+        assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray()));
+        assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray()));
     }
 
     @Test
@@ -437,37 +442,37 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        Assert.assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray(new boolean[]{}))
+        assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray(new boolean[]{}))
                 || Arrays.equals(new boolean[]{false, true}, map1.toArray(new boolean[]{})));
-        Assert.assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray(new boolean[map1.size()]))
+        assertTrue(Arrays.equals(new boolean[]{true, false}, map1.toArray(new boolean[map1.size()]))
                 || Arrays.equals(new boolean[]{false, true}, map1.toArray(new boolean[map1.size()])));
-        Assert.assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray(new boolean[]{})));
-        Assert.assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray(new boolean[map2.size()])));
-        Assert.assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray(new boolean[]{})));
-        Assert.assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray(new boolean[map3.size()])));
+        assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray(new boolean[]{})));
+        assertTrue(Arrays.equals(new boolean[]{true}, map2.toArray(new boolean[map2.size()])));
+        assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray(new boolean[]{})));
+        assertTrue(Arrays.equals(new boolean[]{false}, map3.toArray(new boolean[map3.size()])));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.classUnderTest().contains(true));
-        Assert.assertTrue(this.classUnderTest().contains(false));
+        assertTrue(this.classUnderTest().contains(true));
+        assertTrue(this.classUnderTest().contains(false));
     }
 
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(true, false));
-        Assert.assertTrue(this.classUnderTest().containsAll(true, true));
-        Assert.assertTrue(this.classUnderTest().containsAll(false, false));
+        assertTrue(this.classUnderTest().containsAll(true, false));
+        assertTrue(this.classUnderTest().containsAll(true, true));
+        assertTrue(this.classUnderTest().containsAll(false, false));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.classUnderTest().containsAll(BooleanArrayList.newListWith(false, false)));
     }
 
     @Test
@@ -477,10 +482,10 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        Assert.assertTrue(map1.toList().toString(), BooleanArrayList.newListWith(true, false).equals(map1.toList())
+        assertTrue(map1.toList().toString(), BooleanArrayList.newListWith(true, false).equals(map1.toList())
                 || BooleanArrayList.newListWith(false, true).equals(map1.toList()));
-        Assert.assertEquals(BooleanArrayList.newListWith(true), map2.toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(false), map3.toList());
+        assertEquals(BooleanArrayList.newListWith(true), map2.toList());
+        assertEquals(BooleanArrayList.newListWith(false), map3.toList());
     }
 
     @Test
@@ -491,10 +496,10 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        Assert.assertEquals(BooleanHashSet.newSetWith(false, true), map1.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false, true), map0.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), map2.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), map3.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false, true), map1.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false, true), map0.toSet());
+        assertEquals(BooleanHashSet.newSetWith(true), map2.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false), map3.toSet());
     }
 
     @Test
@@ -505,17 +510,17 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, false, true), map1.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true, true), map0.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), map2.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false), map3.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, false, true), map1.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true, true), map0.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), map2.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false), map3.toBag());
     }
 
     @Test
     public void asLazy()
     {
         Verify.assertSize(this.classUnderTest().toList().size(), this.classUnderTest().asLazy().toList());
-        Assert.assertTrue(this.classUnderTest().asLazy().toList().containsAll(this.classUnderTest().toList()));
+        assertTrue(this.classUnderTest().asLazy().toList().containsAll(this.classUnderTest().toList()));
     }
 
     @Test
@@ -526,31 +531,31 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
         BooleanIterator iterator1 = map1.booleanIterator();
-        Assert.assertTrue(iterator1.hasNext());
+        assertTrue(iterator1.hasNext());
         boolean first = iterator1.next();
-        Assert.assertTrue(iterator1.hasNext());
+        assertTrue(iterator1.hasNext());
         boolean second = iterator1.next();
-        Assert.assertEquals(first, !second);
-        Assert.assertFalse(iterator1.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator1::next);
+        assertEquals(first, !second);
+        assertFalse(iterator1.hasNext());
+        assertThrows(NoSuchElementException.class, iterator1::next);
 
         BooleanIterator iterator2 = map2.booleanIterator();
-        Assert.assertTrue(iterator2.hasNext());
-        Assert.assertTrue(iterator2.next());
-        Assert.assertFalse(iterator2.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator2::next);
+        assertTrue(iterator2.hasNext());
+        assertTrue(iterator2.next());
+        assertFalse(iterator2.hasNext());
+        assertThrows(NoSuchElementException.class, iterator2::next);
 
         BooleanIterator iterator3 = map3.booleanIterator();
-        Assert.assertTrue(iterator3.hasNext());
-        Assert.assertFalse(iterator3.next());
-        Assert.assertFalse(iterator3.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator3::next);
+        assertTrue(iterator3.hasNext());
+        assertFalse(iterator3.next());
+        assertFalse(iterator3.hasNext());
+        assertThrows(NoSuchElementException.class, iterator3::next);
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(ImmutableObjectBooleanMap.class, this.classUnderTest().toImmutable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeySetTestCase.java
@@ -19,8 +19,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ObjectBooleanHashMapKeySetTestCase
 {
@@ -51,15 +56,15 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true, null, false);
         Set<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.contains("One"));
-        Assert.assertTrue(keySet.contains("Two"));
-        Assert.assertTrue(keySet.contains("Three"));
-        Assert.assertFalse(keySet.contains("Four"));
-        Assert.assertTrue(keySet.contains(null));
+        assertTrue(keySet.contains("One"));
+        assertTrue(keySet.contains("Two"));
+        assertTrue(keySet.contains("Three"));
+        assertFalse(keySet.contains("Four"));
+        assertTrue(keySet.contains(null));
         keySet.remove(null);
-        Assert.assertFalse(keySet.contains(null));
+        assertFalse(keySet.contains(null));
         map.removeKey("One");
-        Assert.assertFalse(keySet.contains("One"));
+        assertFalse(keySet.contains("One"));
     }
 
     @Test
@@ -67,17 +72,17 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true, null, false);
         Set<String> keySet = map.keySet();
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith(null, null)));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Four")));
+        assertFalse(keySet.containsAll(FastList.newListWith("Five", "Four")));
         keySet.remove(null);
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two", "Three", null)));
+        assertTrue(keySet.containsAll(FastList.newListWith("One", "Two", "Three")));
         map.removeKey("One");
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
+        assertFalse(keySet.containsAll(FastList.newListWith("One", "Two")));
+        assertTrue(keySet.containsAll(FastList.newListWith("Three", "Two")));
     }
 
     @Test
@@ -85,12 +90,12 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true, null, false);
         Set<String> keySet = map.keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         MutableObjectBooleanMap<String> map1 = this.newEmptyMap();
         Set<String> keySet1 = map1.keySet();
-        Assert.assertTrue(keySet1.isEmpty());
+        assertTrue(keySet1.isEmpty());
         map1.put("One", true);
-        Assert.assertFalse(keySet1.isEmpty());
+        assertFalse(keySet1.isEmpty());
     }
 
     @Test
@@ -120,28 +125,28 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
 
         HashBag<String> expected = HashBag.newBagWith("One", "Two", "Three", null);
         HashBag<String> actual = HashBag.newBag();
-        Assert.assertThrows(IllegalStateException.class, iterator::remove);
+        assertThrows(IllegalStateException.class, iterator::remove);
         for (int i = 0; i < 4; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
-        Assert.assertEquals(expected, actual);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
 
         Iterator<String> iterator1 = keySet.iterator();
         for (int i = 4; i > 0; i--)
         {
-            Assert.assertTrue(iterator1.hasNext());
+            assertTrue(iterator1.hasNext());
             iterator1.next();
             iterator1.remove();
-            Assert.assertThrows(IllegalStateException.class, iterator1::remove);
+            assertThrows(IllegalStateException.class, iterator1::remove);
             Verify.assertSize(i - 1, keySet);
             Verify.assertSize(i - 1, map);
         }
 
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
         Verify.assertEmpty(map);
         Verify.assertEmpty(keySet);
     }
@@ -150,50 +155,50 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
     public void removeFromKeySet()
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true);
-        Assert.assertFalse(map.keySet().remove("Four"));
+        assertFalse(map.keySet().remove("Four"));
 
-        Assert.assertTrue(map.keySet().remove("Two"));
-        Assert.assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().remove("Two"));
+        assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void removeNullFromKeySet()
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true);
-        Assert.assertFalse(map.keySet().remove(null));
-        Assert.assertEquals(this.newMapWithKeysValues("One", true, "Two", false, "Three", true), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().remove(null));
+        assertEquals(this.newMapWithKeysValues("One", true, "Two", false, "Three", true), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
         map.put(null, true);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertTrue(map.keySet().remove(null));
-        Assert.assertEquals(this.newMapWithKeysValues("One", true, "Two", false, "Three", true), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
+        assertTrue(map.keySet().remove(null));
+        assertEquals(this.newMapWithKeysValues("One", true, "Two", false, "Three", true), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
     }
 
     @Test
     public void removeAllFromKeySet()
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true);
-        Assert.assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().removeAll(FastList.newListWith("Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().removeAll(FastList.newListWith("Two", "Four")));
+        assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
     public void retainAllFromKeySet()
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true);
-        Assert.assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertFalse(map.keySet().retainAll(FastList.newListWith("One", "Two", "Three", "Four")));
+        assertEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
 
-        Assert.assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
-        Assert.assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
+        assertTrue(map.keySet().retainAll(FastList.newListWith("One", "Three")));
+        assertEquals(this.newMapWithKeysValues("One", true, "Three", true), map);
+        assertEquals(UnifiedSet.newSetWith("One", "Three"), map.keySet());
     }
 
     @Test
@@ -210,8 +215,8 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
     {
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true, null, false);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("One", "Two", "Three", null), map.keySet());
-        Assert.assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
-        Assert.assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
+        assertNotEquals(UnifiedSet.newSetWith("One", "Two", "Three"), map.keySet());
+        assertNotEquals(FastList.newListWith("One", "Two", "Three", null), map.keySet());
     }
 
     @Test
@@ -220,10 +225,10 @@ public abstract class ObjectBooleanHashMapKeySetTestCase
         MutableObjectBooleanMap<String> map = this.newMapWithKeysValues("One", true, "Two", false, "Three", true);
         HashBag<String> expected = HashBag.newBagWith("One", "Two", "Three");
         Set<String> keySet = map.keySet();
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray()));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size()])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[0])));
         expected.add(null);
-        Assert.assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
+        assertEquals(expected, HashBag.newBagWith(keySet.toArray(new String[keySet.size() + 1])));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeysViewTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeysViewTest.java
@@ -17,8 +17,12 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMap#keysView()}.
@@ -44,16 +48,16 @@ public class ObjectBooleanHashMapKeysViewTest extends AbstractLazyIterableTestCa
         MutableSet<String> actual = UnifiedSet.newSet();
 
         Iterator<String> iterator = ObjectBooleanHashMap.newWithKeysValues("zero", true, "thirtyOne", false, "thirtyTwo", true).keysView().iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapTestCase.java
@@ -19,8 +19,11 @@ import org.eclipse.collections.api.block.function.primitive.BooleanFunction0;
 import org.eclipse.collections.api.block.function.primitive.BooleanToBooleanFunction;
 import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObjectBooleanMapTestCase
 {
@@ -41,8 +44,8 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         values.setAccessible(true);
 
         MutableObjectBooleanMap<String> hashMap = this.getEmptyMap();
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test
@@ -54,12 +57,12 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         values.setAccessible(true);
 
         MutableObjectBooleanMap<String> hashMap = this.newMapWithInitialCapacity(3);
-        Assert.assertEquals(8L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(8L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
 
         MutableObjectBooleanMap<String> hashMap2 = this.newMapWithInitialCapacity(15);
-        Assert.assertEquals(32L, ((Object[]) keys.get(hashMap2)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(32L, ((Object[]) keys.get(hashMap2)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -77,49 +80,49 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         values.setAccessible(true);
 
         MutableObjectBooleanMap<String> hashMap = this.getEmptyMap();
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
-        Assert.assertEquals(this.getEmptyMap(), hashMap);
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(this.getEmptyMap(), hashMap);
     }
 
     @Test
     public void removeKeyIfAbsent()
     {
         MutableObjectBooleanMap<String> map0 = this.newWithKeysValues("0", false, "1", true);
-        Assert.assertTrue(map0.removeKeyIfAbsent("1", false));
-        Assert.assertEquals(this.newWithKeysValues("0", false), map0);
-        Assert.assertFalse(map0.removeKeyIfAbsent("0", true));
-        Assert.assertEquals(this.getEmptyMap(), map0);
-        Assert.assertFalse(map0.removeKeyIfAbsent("1", false));
-        Assert.assertTrue(map0.removeKeyIfAbsent("0", true));
+        assertTrue(map0.removeKeyIfAbsent("1", false));
+        assertEquals(this.newWithKeysValues("0", false), map0);
+        assertFalse(map0.removeKeyIfAbsent("0", true));
+        assertEquals(this.getEmptyMap(), map0);
+        assertFalse(map0.removeKeyIfAbsent("1", false));
+        assertTrue(map0.removeKeyIfAbsent("0", true));
 
         MutableObjectBooleanMap<String> map1 = this.newWithKeysValues("0", true, "1", false);
-        Assert.assertTrue(map1.removeKeyIfAbsent("0", false));
-        Assert.assertEquals(this.newWithKeysValues("1", false), map1);
-        Assert.assertFalse(map1.removeKeyIfAbsent("1", true));
-        Assert.assertEquals(this.getEmptyMap(), map1);
-        Assert.assertFalse(map1.removeKeyIfAbsent("0", false));
-        Assert.assertTrue(map1.removeKeyIfAbsent("1", true));
+        assertTrue(map1.removeKeyIfAbsent("0", false));
+        assertEquals(this.newWithKeysValues("1", false), map1);
+        assertFalse(map1.removeKeyIfAbsent("1", true));
+        assertEquals(this.getEmptyMap(), map1);
+        assertFalse(map1.removeKeyIfAbsent("0", false));
+        assertTrue(map1.removeKeyIfAbsent("1", true));
 
-        Assert.assertTrue(this.map.removeKeyIfAbsent("5", true));
-        Assert.assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.map);
-        Assert.assertTrue(this.map.removeKeyIfAbsent("0", false));
-        Assert.assertEquals(this.newWithKeysValues("1", true, "2", false), this.map);
-        Assert.assertTrue(this.map.removeKeyIfAbsent("1", false));
-        Assert.assertEquals(this.newWithKeysValues("2", false), this.map);
-        Assert.assertFalse(this.map.removeKeyIfAbsent("2", true));
-        Assert.assertEquals(this.getEmptyMap(), this.map);
-        Assert.assertFalse(this.map.removeKeyIfAbsent("0", false));
-        Assert.assertFalse(this.map.removeKeyIfAbsent("1", false));
-        Assert.assertTrue(this.map.removeKeyIfAbsent("2", true));
-        Assert.assertEquals(this.getEmptyMap(), this.map);
+        assertTrue(this.map.removeKeyIfAbsent("5", true));
+        assertEquals(this.newWithKeysValues("0", true, "1", true, "2", false), this.map);
+        assertTrue(this.map.removeKeyIfAbsent("0", false));
+        assertEquals(this.newWithKeysValues("1", true, "2", false), this.map);
+        assertTrue(this.map.removeKeyIfAbsent("1", false));
+        assertEquals(this.newWithKeysValues("2", false), this.map);
+        assertFalse(this.map.removeKeyIfAbsent("2", true));
+        assertEquals(this.getEmptyMap(), this.map);
+        assertFalse(this.map.removeKeyIfAbsent("0", false));
+        assertFalse(this.map.removeKeyIfAbsent("1", false));
+        assertTrue(this.map.removeKeyIfAbsent("2", true));
+        assertEquals(this.getEmptyMap(), this.map);
         Verify.assertEmpty(this.map);
 
         this.map.put(null, true);
 
-        Assert.assertTrue(this.map.get(null));
-        Assert.assertTrue(this.map.removeKeyIfAbsent(null, false));
-        Assert.assertFalse(this.map.get(null));
+        assertTrue(this.map.get(null));
+        assertTrue(this.map.removeKeyIfAbsent(null, false));
+        assertFalse(this.map.get(null));
     }
 
     @Test
@@ -128,7 +131,7 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         ObjectBooleanHashMap<Integer> hashMap = ObjectBooleanHashMap.newMap();
         for (int i = 2; i < 10; i++)
         {
-            Assert.assertFalse(hashMap.containsKey(i));
+            assertFalse(hashMap.containsKey(i));
             hashMap.put(i, (i & 1) == 0);
         }
 
@@ -136,52 +139,52 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         Field values = ObjectBooleanHashMap.class.getDeclaredField("values");
         keys.setAccessible(true);
         values.setAccessible(true);
-        Assert.assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(16L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
         Verify.assertSize(8, hashMap);
         for (int i = 2; i < 10; i++)
         {
-            Assert.assertTrue(hashMap.containsKey(i));
+            assertTrue(hashMap.containsKey(i));
         }
 
-        Assert.assertTrue(hashMap.containsValue(false));
-        Assert.assertTrue(hashMap.containsValue(true));
+        assertTrue(hashMap.containsValue(false));
+        assertTrue(hashMap.containsValue(true));
         hashMap.put(10, true);
-        Assert.assertEquals(32L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(64L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(32L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(64L, ((BitSet) values.get(hashMap)).size());
 
         for (int i = 11; i < 75; i++)
         {
-            Assert.assertFalse(String.valueOf(i), hashMap.containsKey(i));
+            assertFalse(String.valueOf(i), hashMap.containsKey(i));
             hashMap.put(i, (i & 1) == 0);
         }
-        Assert.assertEquals(256L, ((Object[]) keys.get(hashMap)).length);
-        Assert.assertEquals(256L, ((BitSet) values.get(hashMap)).size());
+        assertEquals(256L, ((Object[]) keys.get(hashMap)).length);
+        assertEquals(256L, ((BitSet) values.get(hashMap)).size());
     }
 
     @Test
     public void getIfAbsentPut()
     {
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.getIfAbsentPut(0, true));
-        Assert.assertTrue(map1.getIfAbsentPut(0, false));
-        Assert.assertEquals(this.newWithKeysValues(0, true), map1);
-        Assert.assertTrue(map1.getIfAbsentPut(1, true));
-        Assert.assertTrue(map1.getIfAbsentPut(1, false));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, true), map1);
+        assertTrue(map1.getIfAbsentPut(0, true));
+        assertTrue(map1.getIfAbsentPut(0, false));
+        assertEquals(this.newWithKeysValues(0, true), map1);
+        assertTrue(map1.getIfAbsentPut(1, true));
+        assertTrue(map1.getIfAbsentPut(1, false));
+        assertEquals(this.newWithKeysValues(0, true, 1, true), map1);
 
         MutableObjectBooleanMap<Integer> map2 = this.getEmptyMap();
-        Assert.assertFalse(map2.getIfAbsentPut(1, false));
-        Assert.assertFalse(map2.getIfAbsentPut(1, true));
-        Assert.assertEquals(this.newWithKeysValues(1, false), map2);
-        Assert.assertFalse(map2.getIfAbsentPut(0, false));
-        Assert.assertFalse(map2.getIfAbsentPut(0, true));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
+        assertFalse(map2.getIfAbsentPut(1, false));
+        assertFalse(map2.getIfAbsentPut(1, true));
+        assertEquals(this.newWithKeysValues(1, false), map2);
+        assertFalse(map2.getIfAbsentPut(0, false));
+        assertFalse(map2.getIfAbsentPut(0, true));
+        assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
 
         MutableObjectBooleanMap<Integer> map3 = this.getEmptyMap();
-        Assert.assertTrue(map3.getIfAbsentPut(null, true));
-        Assert.assertTrue(map3.getIfAbsentPut(null, false));
-        Assert.assertEquals(this.newWithKeysValues(null, true), map3);
+        assertTrue(map3.getIfAbsentPut(null, true));
+        assertTrue(map3.getIfAbsentPut(null, false));
+        assertEquals(this.newWithKeysValues(null, true), map3);
     }
 
     @Test
@@ -190,30 +193,30 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         BooleanToBooleanFunction flip = value -> !value;
 
         MutableObjectBooleanMap<Integer> map1 = this.getEmptyMap();
-        Assert.assertTrue(map1.updateValue(0, false, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, true), map1);
-        Assert.assertFalse(map1.updateValue(0, false, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, false), map1);
-        Assert.assertFalse(map1.updateValue(1, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, false), map1);
-        Assert.assertTrue(map1.updateValue(1, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, true), map1);
+        assertTrue(map1.updateValue(0, false, flip));
+        assertEquals(this.newWithKeysValues(0, true), map1);
+        assertFalse(map1.updateValue(0, false, flip));
+        assertEquals(this.newWithKeysValues(0, false), map1);
+        assertFalse(map1.updateValue(1, true, flip));
+        assertEquals(this.newWithKeysValues(0, false, 1, false), map1);
+        assertTrue(map1.updateValue(1, true, flip));
+        assertEquals(this.newWithKeysValues(0, false, 1, true), map1);
 
         MutableObjectBooleanMap<Integer> map2 = this.getEmptyMap();
-        Assert.assertTrue(map2.updateValue(1, false, flip));
-        Assert.assertEquals(this.newWithKeysValues(1, true), map2);
-        Assert.assertFalse(map2.updateValue(1, false, flip));
-        Assert.assertEquals(this.newWithKeysValues(1, false), map2);
-        Assert.assertFalse(map2.updateValue(0, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
-        Assert.assertTrue(map2.updateValue(0, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(0, true, 1, false), map2);
+        assertTrue(map2.updateValue(1, false, flip));
+        assertEquals(this.newWithKeysValues(1, true), map2);
+        assertFalse(map2.updateValue(1, false, flip));
+        assertEquals(this.newWithKeysValues(1, false), map2);
+        assertFalse(map2.updateValue(0, true, flip));
+        assertEquals(this.newWithKeysValues(0, false, 1, false), map2);
+        assertTrue(map2.updateValue(0, true, flip));
+        assertEquals(this.newWithKeysValues(0, true, 1, false), map2);
 
         MutableObjectBooleanMap<Integer> map3 = this.getEmptyMap();
-        Assert.assertFalse(map3.updateValue(null, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(null, false), map3);
-        Assert.assertTrue(map3.updateValue(null, true, flip));
-        Assert.assertEquals(this.newWithKeysValues(null, true), map3);
+        assertFalse(map3.updateValue(null, true, flip));
+        assertEquals(this.newWithKeysValues(null, false), map3);
+        assertTrue(map3.updateValue(null, true, flip));
+        assertEquals(this.newWithKeysValues(null, true), map3);
     }
 
     @Override
@@ -224,9 +227,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         ObjectBooleanHashMap<Integer> hashMap0 = new ObjectBooleanHashMap<Integer>().withKeysValues(1, true, 2, false);
         ObjectBooleanHashMap<Integer> hashMap1 = new ObjectBooleanHashMap<Integer>().withKeysValues(1, false, 2, false, 3, true);
         ObjectBooleanHashMap<Integer> hashMap2 = new ObjectBooleanHashMap<Integer>().withKeysValues(1, true, 2, true, 3, false, 4, false);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, true, 2, false), hashMap0);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, false, 2, false, 3, true), hashMap1);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, true, 2, true, 3, false, 4, false), hashMap2);
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, true, 2, false), hashMap0);
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, false, 2, false, 3, true), hashMap1);
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues(1, true, 2, true, 3, false, 4, false), hashMap2);
     }
 
     @Test
@@ -243,7 +246,7 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
             return result;
         });
 
-        Assert.assertEquals(Integer.valueOf(4), total);
+        assertEquals(Integer.valueOf(4), total);
     }
 
     @Test
@@ -252,11 +255,11 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         ObjectBooleanHashMap<String> hashMap = ObjectBooleanHashMap.newMap();
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
             hashMap.put(String.valueOf(each), each % 2 == 0);
-            Assert.assertEquals(each % 2 == 0, hashMap.get(String.valueOf(each)));
+            assertEquals(each % 2 == 0, hashMap.get(String.valueOf(each)));
             hashMap.remove(String.valueOf(each));
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
         }
     }
 
@@ -266,13 +269,13 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         ObjectBooleanHashMap<String> hashMap = ObjectBooleanHashMap.newMap();
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
             hashMap.put(String.valueOf(each), false);
             Iterator<String> iterator = hashMap.keySet().iterator();
-            Assert.assertTrue(iterator.hasNext());
-            Assert.assertEquals(String.valueOf(each), iterator.next());
+            assertTrue(iterator.hasNext());
+            assertEquals(String.valueOf(each), iterator.next());
             iterator.remove();
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
         }
     }
 
@@ -282,9 +285,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
         ObjectBooleanHashMap<String> hashMap = ObjectBooleanHashMap.newMap();
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
             hashMap.getIfAbsentPut(String.valueOf(each), each % 2 == 0);
-            Assert.assertEquals(each % 2 == 0, hashMap.get(String.valueOf(each)));
+            assertEquals(each % 2 == 0, hashMap.get(String.valueOf(each)));
         }
     }
 
@@ -297,9 +300,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
 
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
-            Assert.assertTrue(hashMap.getIfAbsentPutWith(String.valueOf(each), functionLength, ""));
-            Assert.assertTrue(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
+            assertTrue(hashMap.getIfAbsentPutWith(String.valueOf(each), functionLength, ""));
+            assertTrue(hashMap.get(String.valueOf(each)));
         }
     }
 
@@ -312,9 +315,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
 
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(each));
-            Assert.assertEquals(each % 2 == 0, hashMap.getIfAbsentPutWithKey(each, function));
-            Assert.assertEquals(each % 2 == 0, hashMap.get(each));
+            assertFalse(hashMap.get(each));
+            assertEquals(each % 2 == 0, hashMap.getIfAbsentPutWithKey(each, function));
+            assertEquals(each % 2 == 0, hashMap.get(each));
         }
     }
 
@@ -327,9 +330,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
 
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
-            Assert.assertTrue(hashMap.getIfAbsentPut(String.valueOf(each), factory));
-            Assert.assertTrue(hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
+            assertTrue(hashMap.getIfAbsentPut(String.valueOf(each), factory));
+            assertTrue(hashMap.get(String.valueOf(each)));
         }
     }
 
@@ -342,9 +345,9 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
 
         for (int each = 2; each < 100; each++)
         {
-            Assert.assertFalse(hashMap.get(String.valueOf(each)));
-            Assert.assertEquals(each % 2 != 0, hashMap.updateValue(String.valueOf(each), each % 2 == 0, function));
-            Assert.assertEquals(each % 2 != 0, hashMap.get(String.valueOf(each)));
+            assertFalse(hashMap.get(String.valueOf(each)));
+            assertEquals(each % 2 != 0, hashMap.updateValue(String.valueOf(each), each % 2 == 0, function));
+            assertEquals(each % 2 != 0, hashMap.get(String.valueOf(each)));
         }
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapValuesTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapValuesTestCase.java
@@ -25,8 +25,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBoo
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutableBooleanCollectionTestCase
 {
@@ -39,13 +43,13 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
         BooleanIterator iterator1 = bag.booleanIterator();
         for (int i = 0; i < 4; i++)
         {
-            Assert.assertTrue(iterator1.hasNext());
-            Assert.assertTrue(list.remove(iterator1.next()));
+            assertTrue(iterator1.hasNext());
+            assertTrue(list.remove(iterator1.next()));
         }
         Verify.assertEmpty(list);
-        Assert.assertFalse(iterator1.hasNext());
+        assertFalse(iterator1.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, iterator1::next);
+        assertThrows(NoSuchElementException.class, iterator1::next);
 
         ObjectBooleanHashMap<String> map2 = new ObjectBooleanHashMap<>();
         for (int each = 2; each < 100; each++)
@@ -58,7 +62,7 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
             iterator2.next();
             iterator2.remove();
         }
-        Assert.assertTrue(map2.isEmpty());
+        assertTrue(map2.isEmpty());
     }
 
     @Override
@@ -116,141 +120,141 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     {
         ObjectBooleanHashMap<Integer> map = ObjectBooleanHashMap.newWithKeysValues(1, true, 2, false, 3, true);
         MutableBooleanCollection collection = map.values();
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.remove(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
     }
 
     @Override
     @Test
     public void removeAll()
     {
-        Assert.assertFalse(this.newWith().removeAll());
+        assertFalse(this.newWith().removeAll());
 
         ObjectBooleanHashMap<Integer> map = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(true));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(true));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.isEmpty());
     }
 
     @Override
     @Test
     public void removeAll_iterable()
     {
-        Assert.assertFalse(this.newWith().removeAll(new BooleanArrayList()));
+        assertFalse(this.newWith().removeAll(new BooleanArrayList()));
 
         ObjectBooleanHashMap<Integer> map = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertFalse(collection.removeAll());
+        assertFalse(collection.removeAll());
 
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(false)));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.removeAll(BooleanArrayList.newListWith(true)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.isEmpty());
 
         ObjectBooleanHashMap<Integer> map1 = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(collection1.isEmpty());
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertTrue(map1.isEmpty());
+        assertTrue(collection1.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(collection1.isEmpty());
+        assertFalse(collection1.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map1.contains(true));
+        assertFalse(map1.contains(false));
+        assertTrue(map1.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll()
     {
-        Assert.assertFalse(this.newWith().retainAll());
+        assertFalse(this.newWith().retainAll());
 
         ObjectBooleanHashMap<Integer> map = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertFalse(collection.retainAll(false, true));
+        assertFalse(collection.retainAll(false, true));
 
-        Assert.assertTrue(collection.retainAll(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.retainAll(true));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(false));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(false));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.isEmpty());
 
         ObjectBooleanHashMap<Integer> map1 = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll());
-        Assert.assertTrue(collection1.isEmpty());
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertTrue(map1.isEmpty());
+        assertTrue(collection1.retainAll());
+        assertTrue(collection1.isEmpty());
+        assertFalse(collection1.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map1.contains(true));
+        assertFalse(map1.contains(false));
+        assertTrue(map1.isEmpty());
     }
 
     @Override
     @Test
     public void retainAll_iterable()
     {
-        Assert.assertFalse(this.newWith().retainAll(new BooleanArrayList()));
+        assertFalse(this.newWith().retainAll(new BooleanArrayList()));
 
         ObjectBooleanHashMap<Integer> map = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection = map.values();
-        Assert.assertFalse(collection.retainAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(collection.retainAll(BooleanArrayList.newListWith(false, true)));
 
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.contains(true));
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(true)));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.contains(true));
 
-        Assert.assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.isEmpty());
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map.contains(true));
-        Assert.assertFalse(map.contains(false));
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(collection.retainAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.isEmpty());
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map.contains(true));
+        assertFalse(map.contains(false));
+        assertTrue(map.isEmpty());
 
         ObjectBooleanHashMap<Integer> map1 = ObjectBooleanHashMap.newWithKeysValues(1, true, null, false);
         MutableBooleanCollection collection1 = map1.values();
-        Assert.assertTrue(collection1.retainAll(new BooleanArrayList()));
-        Assert.assertTrue(collection1.isEmpty());
-        Assert.assertFalse(collection1.contains(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(map1.contains(true));
-        Assert.assertFalse(map1.contains(false));
-        Assert.assertTrue(map1.isEmpty());
+        assertTrue(collection1.retainAll(new BooleanArrayList()));
+        assertTrue(collection1.isEmpty());
+        assertFalse(collection1.contains(true));
+        assertFalse(collection.contains(false));
+        assertFalse(map1.contains(true));
+        assertFalse(map1.contains(false));
+        assertTrue(map1.isEmpty());
     }
 
     @Override
@@ -267,8 +271,8 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
         Verify.assertEmpty(collection);
         Verify.assertEmpty(map);
         Verify.assertSize(0, collection);
-        Assert.assertFalse(collection.contains(true));
-        Assert.assertFalse(collection.contains(false));
+        assertFalse(collection.contains(true));
+        assertFalse(collection.contains(false));
     }
 
     @Override
@@ -276,45 +280,45 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     public void contains()
     {
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertTrue(collection.contains(false));
-        Assert.assertTrue(collection.remove(false));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.remove(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertTrue(collection.contains(true));
-        Assert.assertTrue(collection.remove(true));
-        Assert.assertFalse(collection.contains(false));
-        Assert.assertFalse(collection.contains(true));
+        assertTrue(collection.contains(true));
+        assertTrue(collection.contains(false));
+        assertTrue(collection.remove(false));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.remove(true));
+        assertFalse(collection.contains(false));
+        assertTrue(collection.contains(true));
+        assertTrue(collection.remove(true));
+        assertFalse(collection.contains(false));
+        assertFalse(collection.contains(true));
     }
 
     @Override
     public void containsAllArray()
     {
         MutableBooleanCollection emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
 
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertTrue(collection.containsAll());
-        Assert.assertTrue(collection.containsAll(true));
-        Assert.assertTrue(collection.containsAll(false));
-        Assert.assertTrue(collection.containsAll(false, true));
+        assertTrue(collection.containsAll());
+        assertTrue(collection.containsAll(true));
+        assertTrue(collection.containsAll(false));
+        assertTrue(collection.containsAll(false, true));
     }
 
     @Override
     public void containsAllIterable()
     {
         MutableBooleanCollection emptyCollection1 = this.newWith();
-        Assert.assertTrue(emptyCollection1.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection1.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection1.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection1.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection1.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection1.containsAll(BooleanArrayList.newListWith(false)));
         MutableBooleanCollection collection = this.classUnderTest();
-        Assert.assertTrue(collection.containsAll(new BooleanArrayList()));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, true)));
+        assertTrue(collection.containsAll(new BooleanArrayList()));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
@@ -340,8 +344,8 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     public void collect()
     {
         BooleanToObjectFunction<Integer> function = parameter -> parameter ? 1 : 0;
-        Assert.assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
-        Assert.assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
+        assertEquals(this.newObjectCollectionWith(1, 0, 1).toBag(), this.newWith(true, false, true).collect(function).toBag());
+        assertEquals(this.newObjectCollectionWith(), this.newWith().collect(function));
     }
 
     @Override
@@ -350,22 +354,22 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     {
         StringBuilder appendable = new StringBuilder();
         this.newWith().appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "/");
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
         this.newWith().appendString(appendable, "[", "/", "]");
-        Assert.assertEquals("[]", appendable.toString());
+        assertEquals("[]", appendable.toString());
         StringBuilder appendable1 = new StringBuilder();
         this.newWith(true).appendString(appendable1);
-        Assert.assertEquals("true", appendable1.toString());
+        assertEquals("true", appendable1.toString());
         StringBuilder appendable2 = new StringBuilder();
         BooleanIterable iterable = this.newWith(true, false);
         iterable.appendString(appendable2);
-        Assert.assertTrue("true, false".equals(appendable2.toString())
+        assertTrue("true, false".equals(appendable2.toString())
                 || "false, true".equals(appendable2.toString()));
         StringBuilder appendable3 = new StringBuilder();
         iterable.appendString(appendable3, "/");
-        Assert.assertTrue("true/false".equals(appendable3.toString())
+        assertTrue("true/false".equals(appendable3.toString())
                 || "false/true".equals(appendable3.toString()));
     }
 
@@ -375,7 +379,7 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     {
         MutableBooleanCollection unmodifiable = this.classUnderTest().asUnmodifiable();
         Verify.assertInstanceOf(UnmodifiableBooleanCollection.class, unmodifiable);
-        Assert.assertTrue(unmodifiable.containsAll(this.classUnderTest()));
+        assertTrue(unmodifiable.containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -384,7 +388,7 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
     {
         MutableBooleanCollection synch = this.classUnderTest().asSynchronized();
         Verify.assertInstanceOf(SynchronizedBooleanCollection.class, synch);
-        Assert.assertTrue(synch.containsAll(this.classUnderTest()));
+        assertTrue(synch.containsAll(this.classUnderTest()));
     }
 
     @Override
@@ -412,8 +416,8 @@ public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutable
                 Lists.mutable.with(BooleanBags.mutable.with(false, true)),
                 iterable3.chunk(3));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(0));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().chunk(-1));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeySetTest.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMapWithHashingStrategy#keySet()}.
@@ -100,6 +101,6 @@ public class ObjectBooleanHashMapWithHashingStrategyKeySetTest extends ObjectBoo
         ObjectBooleanHashMapWithHashingStrategy<Person> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
         Set<Person> people = map.keySet();
         people.remove(JOHNDOE);
-        Assert.assertEquals(map, ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, false));
+        assertEquals(map, ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, false));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeysViewTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeysViewTest.java
@@ -19,7 +19,11 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMapWithHashingStrategy#keysView()}.
@@ -57,16 +61,16 @@ public class ObjectBooleanHashMapWithHashingStrategyKeysViewTest extends Abstrac
         MutableSet<String> actual = UnifiedSet.newSet();
 
         Iterator<String> iterator = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, "zero", true, "thirtyOne", false, "thirtyTwo", true).keysView().iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertThrows(UnsupportedOperationException.class, iterator::remove);
-        Assert.assertTrue(iterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyTest.java
@@ -20,8 +20,12 @@ import org.eclipse.collections.impl.factory.primitive.ObjectBooleanMaps;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHashMapTestCase
 {
@@ -129,7 +133,7 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
 
         ObjectBooleanHashMapWithHashingStrategy<Person> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues(JOHNDOE, false), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues(JOHNDOE, false), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
     }
 
     @Override
@@ -140,7 +144,7 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
 
         ObjectBooleanHashMapWithHashingStrategy<Person> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
-        Assert.assertEquals(ObjectBooleanHashMap.newWithKeysValues(JOHNDOE, false), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
+        assertEquals(ObjectBooleanHashMap.newWithKeysValues(JOHNDOE, false), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
     }
 
     @Override
@@ -152,7 +156,7 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
         ObjectBooleanHashMapWithHashingStrategy<Person> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
         BooleanToObjectFunction<Boolean> f = argument1 -> argument1;
-        Assert.assertEquals(FastList.newListWith(false, false), map.collect(f));
+        assertEquals(FastList.newListWith(false, false), map.collect(f));
     }
 
     @Test
@@ -160,12 +164,12 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
     {
         ObjectBooleanHashMapWithHashingStrategy<Person> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
-        Assert.assertTrue(map.containsKey(JOHNDOE));
-        Assert.assertTrue(map.containsKey(JOHNSMITH));
-        Assert.assertTrue(map.containsKey(JANEDOE));
-        Assert.assertTrue(map.containsKey(JANESMITH));
-        Assert.assertTrue(map.containsValue(false));
-        Assert.assertFalse(map.containsValue(true));
+        assertTrue(map.containsKey(JOHNDOE));
+        assertTrue(map.containsKey(JOHNSMITH));
+        assertTrue(map.containsKey(JANEDOE));
+        assertTrue(map.containsKey(JANESMITH));
+        assertTrue(map.containsValue(false));
+        assertFalse(map.containsValue(true));
     }
 
     @Test
@@ -175,7 +179,7 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
 
         map.remove(JANEDOE);
-        Assert.assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, false), map);
+        assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNSMITH, false), map);
         map.remove(JOHNSMITH);
 
         Verify.assertEmpty(map);
@@ -184,14 +188,14 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
         ObjectBooleanHashMapWithHashingStrategy<String> map2 = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
                 STRING_HASHING_STRATEGY, collidingKeys.get(0), true, collidingKeys.get(1), false, collidingKeys.get(2), true, collidingKeys.get(3), false);
         map2.remove(collidingKeys.get(3));
-        Assert.assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(0), true, collidingKeys.get(1), false, collidingKeys.get(2), true), map2);
+        assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(0), true, collidingKeys.get(1), false, collidingKeys.get(2), true), map2);
         map2.remove(collidingKeys.get(0));
-        Assert.assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(1), false, collidingKeys.get(2), true), map2);
+        assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(STRING_HASHING_STRATEGY, collidingKeys.get(1), false, collidingKeys.get(2), true), map2);
         Verify.assertSize(2, map2);
 
         ObjectBooleanHashMapWithHashingStrategy<Integer> map3 = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, true, null, false, 3, true);
         map3.remove(null);
-        Assert.assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, true, 3, true), map3);
+        assertEquals(ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, true, 3, true), map3);
     }
 
     @Test
@@ -201,13 +205,13 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
         ObjectBooleanHashMapWithHashingStrategy<Person> map2 = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(FIRST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, true, JOHNSMITH, true, JANESMITH, true);
         ObjectBooleanHashMapWithHashingStrategy<Person> mapWithConstantHashCodeStrategy = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(CONSTANT_HASHCODE_STRATEGY, JOHNDOE, true, JANEDOE, true, JOHNSMITH, true, JANESMITH, true);
 
-        Assert.assertEquals(map1, map2);
-        Assert.assertEquals(map2, map1);
-        Assert.assertEquals(mapWithConstantHashCodeStrategy, map2);
-        Assert.assertEquals(map2, mapWithConstantHashCodeStrategy);
-        Assert.assertNotEquals(map1.hashCode(), map2.hashCode());
-        Assert.assertNotEquals(map1.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
-        Assert.assertNotEquals(map2.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
+        assertEquals(map1, map2);
+        assertEquals(map2, map1);
+        assertEquals(mapWithConstantHashCodeStrategy, map2);
+        assertEquals(map2, mapWithConstantHashCodeStrategy);
+        assertNotEquals(map1.hashCode(), map2.hashCode());
+        assertNotEquals(map1.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
+        assertNotEquals(map2.hashCode(), mapWithConstantHashCodeStrategy.hashCode());
 
         ObjectBooleanHashMapWithHashingStrategy<Person> map3 = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(LAST_NAME_HASHING_STRATEGY, JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
 
@@ -215,11 +219,11 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
         ObjectBooleanMap<Person> hashMap = ObjectBooleanMaps.mutable.withAll(map3);
 
         Verify.assertEqualsAndHashCode(map3, map4);
-        Assert.assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
+        assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
 
         ObjectBooleanHashMap<Person> objectMap = ObjectBooleanHashMap.newWithKeysValues(JOHNDOE, true, JANEDOE, false, JOHNSMITH, true, JANESMITH, false);
         ObjectBooleanHashMapWithHashingStrategy<Person> map5 = ObjectBooleanHashMapWithHashingStrategy.newMap(LAST_NAME_HASHING_STRATEGY, objectMap);
-        Assert.assertNotEquals(map5, objectMap);
+        assertNotEquals(map5, objectMap);
     }
 
     @Test
@@ -229,14 +233,14 @@ public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHa
         map.put(null, true);
 
         //Testing getting values from no chains
-        Assert.assertEquals(true, map.get("1"));
-        Assert.assertEquals(false, map.get("2"));
-        Assert.assertEquals(true, map.get(null));
+        assertEquals(true, map.get("1"));
+        assertEquals(false, map.get("2"));
+        assertEquals(true, map.get(null));
 
         ObjectBooleanHashMapWithHashingStrategy<Person> map2 = ObjectBooleanHashMapWithHashingStrategy.newMap(LAST_NAME_HASHING_STRATEGY);
         map2.put(JOHNSMITH, true);
-        Assert.assertEquals(true, map2.get(JOHNSMITH));
+        assertEquals(true, map2.get(JOHNSMITH));
         map2.put(JANESMITH, false);
-        Assert.assertEquals(false, map2.get(JOHNSMITH));
+        assertEquals(false, map2.get(JOHNSMITH));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedObjectBooleanMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedObjectBooleanMapTest.java
@@ -10,8 +10,9 @@
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
 
 public class SynchronizedObjectBooleanMapTest extends AbstractMutableObjectBooleanMapTestCase
 {
@@ -58,6 +59,6 @@ public class SynchronizedObjectBooleanMapTest extends AbstractMutableObjectBoole
     public void asSynchronized()
     {
         super.asSynchronized();
-        Assert.assertSame(this.map, this.map.asSynchronized());
+        assertSame(this.map, this.map.asSynchronized());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableObjectBooleanMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableObjectBooleanMapTest.java
@@ -17,8 +17,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBooleanMapTestCase
 {
@@ -128,30 +132,30 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     @Test
     public void get()
     {
-        Assert.assertTrue(this.map.get("0"));
-        Assert.assertTrue(this.map.get("1"));
-        Assert.assertFalse(this.map.get("2"));
+        assertTrue(this.map.get("0"));
+        assertTrue(this.map.get("1"));
+        assertFalse(this.map.get("2"));
 
-        Assert.assertFalse(this.map.get("5"));
+        assertFalse(this.map.get("5"));
     }
 
     @Override
     @Test
     public void getIfAbsent()
     {
-        Assert.assertTrue(this.map.getIfAbsent("0", false));
-        Assert.assertTrue(this.map.getIfAbsent("1", false));
-        Assert.assertFalse(this.map.getIfAbsent("2", true));
+        assertTrue(this.map.getIfAbsent("0", false));
+        assertTrue(this.map.getIfAbsent("1", false));
+        assertFalse(this.map.getIfAbsent("2", true));
 
-        Assert.assertTrue(this.map.getIfAbsent("33", true));
-        Assert.assertFalse(this.map.getIfAbsent("33", false));
+        assertTrue(this.map.getIfAbsent("33", true));
+        assertFalse(this.map.getIfAbsent("33", false));
     }
 
     @Override
     @Test
     public void getIfAbsentPut_Function()
     {
-        Assert.assertTrue(this.map.getIfAbsentPut("0", () -> false));
+        assertTrue(this.map.getIfAbsentPut("0", () -> false));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -166,7 +170,7 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     {
         BooleanFunction<String> functionLengthEven = string -> (string.length() & 1) == 0;
 
-        Assert.assertTrue(this.map.getIfAbsentPutWith("0", functionLengthEven, "zeroValue"));
+        assertTrue(this.map.getIfAbsentPutWith("0", functionLengthEven, "zeroValue"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -183,7 +187,7 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     {
         BooleanFunction<Integer> function = anObject -> anObject == null || (anObject & 1) == 0;
 
-        Assert.assertTrue(this.newWithKeysValues(0, true).getIfAbsentPutWithKey(0, function));
+        assertTrue(this.newWithKeysValues(0, true).getIfAbsentPutWithKey(0, function));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -198,65 +202,65 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     @Test
     public void getOrThrow()
     {
-        Assert.assertTrue(this.map.getOrThrow("0"));
-        Assert.assertTrue(this.map.getOrThrow("1"));
-        Assert.assertFalse(this.map.getOrThrow("2"));
+        assertTrue(this.map.getOrThrow("0"));
+        assertTrue(this.map.getOrThrow("1"));
+        assertFalse(this.map.getOrThrow("2"));
 
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
-        Assert.assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow("5"));
+        assertThrows(IllegalStateException.class, () -> this.map.getOrThrow(null));
     }
 
     @Override
     @Test
     public void contains()
     {
-        Assert.assertTrue(this.map.contains(true));
-        Assert.assertTrue(this.map.contains(false));
-        Assert.assertFalse(this.getEmptyMap().contains(false));
-        Assert.assertFalse(this.newWithKeysValues("0", true).contains(false));
+        assertTrue(this.map.contains(true));
+        assertTrue(this.map.contains(false));
+        assertFalse(this.getEmptyMap().contains(false));
+        assertFalse(this.newWithKeysValues("0", true).contains(false));
     }
 
     @Override
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.getEmptyMap().containsAll(BooleanArrayList.newListWith(false, true)));
-        Assert.assertFalse(this.newWithKeysValues("0", true).containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.map.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.getEmptyMap().containsAll(BooleanArrayList.newListWith(false, true)));
+        assertFalse(this.newWithKeysValues("0", true).containsAll(BooleanArrayList.newListWith(false)));
     }
 
     @Override
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.map.containsAll(true, false));
-        Assert.assertTrue(this.map.containsAll(true, true));
-        Assert.assertTrue(this.map.containsAll(false, false));
-        Assert.assertFalse(this.getEmptyMap().containsAll(false, true));
-        Assert.assertFalse(this.newWithKeysValues("0", true).containsAll(false));
+        assertTrue(this.map.containsAll(true, false));
+        assertTrue(this.map.containsAll(true, true));
+        assertTrue(this.map.containsAll(false, false));
+        assertFalse(this.getEmptyMap().containsAll(false, true));
+        assertFalse(this.newWithKeysValues("0", true).containsAll(false));
     }
 
     @Override
     @Test
     public void containsKey()
     {
-        Assert.assertTrue(this.map.containsKey("0"));
-        Assert.assertTrue(this.map.containsKey("1"));
-        Assert.assertTrue(this.map.containsKey("2"));
-        Assert.assertFalse(this.map.containsKey("3"));
-        Assert.assertFalse(this.map.containsKey(null));
+        assertTrue(this.map.containsKey("0"));
+        assertTrue(this.map.containsKey("1"));
+        assertTrue(this.map.containsKey("2"));
+        assertFalse(this.map.containsKey("3"));
+        assertFalse(this.map.containsKey(null));
     }
 
     @Override
     @Test
     public void containsValue()
     {
-        Assert.assertTrue(this.map.containsValue(true));
-        Assert.assertTrue(this.map.containsValue(false));
-        Assert.assertFalse(this.getEmptyMap().contains(true));
-        Assert.assertFalse(this.newWithKeysValues("0", false).contains(true));
+        assertTrue(this.map.containsValue(true));
+        assertTrue(this.map.containsValue(false));
+        assertFalse(this.getEmptyMap().contains(true));
+        assertFalse(this.newWithKeysValues("0", false).contains(true));
     }
 
     @Override
@@ -277,7 +281,7 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     public void asUnmodifiable()
     {
         super.asUnmodifiable();
-        Assert.assertSame(this.map, this.map.asUnmodifiable());
+        assertSame(this.map, this.map.asUnmodifiable());
     }
 
     @Override
@@ -287,9 +291,9 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
         UnmodifiableObjectBooleanMap<String> map = this.classUnderTest();
         Verify.assertNotEmpty(map);
         MutableBooleanIterator booleanIterator = map.booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -298,8 +302,8 @@ public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBoole
     {
         UnmodifiableObjectBooleanMap<String> map = this.classUnderTest();
         MutableBooleanIterator booleanIterator = map.booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableEmptySortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableEmptySortedMapTest.java
@@ -28,8 +28,15 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptySortedMap}.
@@ -95,7 +102,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void testToString()
     {
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
-        Assert.assertEquals("{}", map.toString());
+        assertEquals("{}", map.toString());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -120,13 +127,13 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
 
         Integer absentKey = this.size() + 1;
-        Assert.assertNull(classUnderTest.get(absentKey));
+        assertNull(classUnderTest.get(absentKey));
 
         String absentValue = String.valueOf(absentKey);
-        Assert.assertFalse(classUnderTest.containsValue(absentValue));
+        assertFalse(classUnderTest.containsValue(absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -140,10 +147,10 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -157,10 +164,10 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
+        assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -174,10 +181,10 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -189,7 +196,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         Integer absentKey = this.size() + 1;
 
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
+        assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
     }
 
     @Override
@@ -197,7 +204,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void notEmpty()
     {
         //Cannot call super.notEmpty() as map is empty.
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -208,8 +215,8 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         ImmutableSortedMap<String, String> map = new ImmutableEmptySortedMap<>();
 
-        Assert.assertTrue(map.allSatisfy(String.class::isInstance));
-        Assert.assertTrue(map.allSatisfy("Monkey"::equals));
+        assertTrue(map.allSatisfy(String.class::isInstance));
+        assertTrue(map.allSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -220,8 +227,8 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         ImmutableSortedMap<String, String> map = new ImmutableEmptySortedMap<>();
 
-        Assert.assertTrue(map.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertTrue(map.noneSatisfy(Integer.class::isInstance));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -232,8 +239,8 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         ImmutableSortedMap<String, String> map = new ImmutableEmptySortedMap<>();
 
-        Assert.assertFalse(map.anySatisfy(String.class::isInstance));
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertFalse(map.anySatisfy(String.class::isInstance));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Override
@@ -279,12 +286,12 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
         ImmutableSortedMap<Integer, String> actual = map.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableEmptySortedMap.class, actual);
-        Assert.assertSame(ImmutableEmptySortedMap.INSTANCE, actual);
+        assertSame(ImmutableEmptySortedMap.INSTANCE, actual);
 
         ImmutableSortedMap<Integer, String> revMap = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedMap<Integer, String> revActual = revMap.select((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableEmptySortedMap.class, revActual);
-        Assert.assertSame(revMap.comparator(), revActual.comparator());
+        assertSame(revMap.comparator(), revActual.comparator());
     }
 
     @Override
@@ -294,12 +301,12 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
         ImmutableSortedMap<Integer, String> actual = map.reject((ignored1, ignored2) -> false);
         Verify.assertInstanceOf(ImmutableEmptySortedMap.class, actual);
-        Assert.assertSame(ImmutableEmptySortedMap.INSTANCE, actual);
+        assertSame(ImmutableEmptySortedMap.INSTANCE, actual);
 
         ImmutableSortedMap<Integer, String> revMap = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedMap<Integer, String> revActual = revMap.reject((ignored1, ignored2) -> true);
         Verify.assertInstanceOf(ImmutableEmptySortedMap.class, revActual);
-        Assert.assertSame(revMap.comparator(), revActual.comparator());
+        assertSame(revMap.comparator(), revActual.comparator());
     }
 
     @Override
@@ -314,7 +321,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         ImmutableMap<Integer, String> revCollect = revMap.collect(alwaysTrueFunction);
 
         Verify.assertEmpty(collect);
-        Assert.assertSame(collect, revCollect);
+        assertSame(collect, revCollect);
     }
 
     /**
@@ -325,7 +332,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void collectWithIndex()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.collectWithIndex(PrimitiveTuples::pair));
     }
@@ -338,7 +345,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void collectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty()));
     }
@@ -351,7 +358,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void selectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -364,7 +371,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     public void rejectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -376,7 +383,7 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
         super.detect();
 
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.detect((ignored1, ignored2) -> true));
+        assertNull(map.detect((ignored1, ignored2) -> true));
     }
 
     @Override
@@ -387,8 +394,8 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
         ImmutableSortedMap<Integer, String> revMap = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertFalse(map.containsKey(0));
-        Assert.assertFalse(revMap.containsKey(1));
+        assertFalse(map.containsKey(0));
+        assertFalse(revMap.containsKey(1));
     }
 
     @Test
@@ -400,11 +407,11 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
                 this.classUnderTest(Comparators.reverseNaturalOrder());
 
         Verify.assertEmpty(map.values());
-        Assert.assertSame(Lists.immutable.of(), map.values());
+        assertSame(Lists.immutable.of(), map.values());
 
         Verify.assertEmpty(revMap.values());
 
-        Assert.assertSame(Lists.immutable.of(), revMap.values());
+        assertSame(Lists.immutable.of(), revMap.values());
     }
 
     @Override
@@ -415,13 +422,13 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
 
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
         ImmutableSortedMap<Integer, String> deserialized = SerializeTestHelper.serializeDeserialize(map);
-        Assert.assertSame(ImmutableEmptySortedMap.INSTANCE, map);
-        Assert.assertSame(map, deserialized);
+        assertSame(ImmutableEmptySortedMap.INSTANCE, map);
+        assertSame(map, deserialized);
 
         ImmutableSortedMap<Integer, String> revMap = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableSortedMap<Integer, String> revDeserialized = SerializeTestHelper.serializeDeserialize(revMap);
         Verify.assertInstanceOf(ImmutableSortedMap.class, revDeserialized);
-        Assert.assertNotNull(revDeserialized.comparator());
+        assertNotNull(revDeserialized.comparator());
     }
 
     @Override
@@ -430,26 +437,26 @@ public class ImmutableEmptySortedMapTest extends ImmutableSortedMapTestCase
     {
         super.keyValuesView();
 
-        Assert.assertTrue(this.classUnderTest().keyValuesView().isEmpty());
+        assertTrue(this.classUnderTest().keyValuesView().isEmpty());
     }
 
     @Override
     @Test
     public void take()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
     }
 
     @Override
     @Test
     public void drop()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableSortedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableSortedMapTestCase.java
@@ -41,8 +41,14 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link ImmutableSortedMap}.
@@ -68,13 +74,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     {
         ImmutableSortedMap<Integer, String> immutable = this.classUnderTest();
         SortedMap<Integer, String> map = immutable.castToSortedMap();
-        Assert.assertSame(immutable, map);
-        Assert.assertEquals(immutable, new HashMap<>(map));
+        assertSame(immutable, map);
+        assertEquals(immutable, new HashMap<>(map));
 
         ImmutableSortedMap<Integer, String> revImmutable = this.classUnderTest(REV_INT_COMPARATOR);
         SortedMap<Integer, String> revMap = revImmutable.castToSortedMap();
-        Assert.assertSame(revImmutable, revMap);
-        Assert.assertEquals(revImmutable, new HashMap<>(revMap));
+        assertSame(revImmutable, revMap);
+        assertEquals(revImmutable, new HashMap<>(revMap));
     }
 
     @Override
@@ -85,13 +91,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         ImmutableSortedMap<Integer, String> immutable = this.classUnderTest();
         MutableSortedMap<Integer, String> map = immutable.toSortedMap();
-        Assert.assertNotSame(immutable, map);
-        Assert.assertEquals(immutable, map);
+        assertNotSame(immutable, map);
+        assertEquals(immutable, map);
 
         ImmutableSortedMap<Integer, String> revImmutable = this.classUnderTest(REV_INT_COMPARATOR);
         MutableSortedMap<Integer, String> revMap = revImmutable.toSortedMap();
-        Assert.assertNotSame(revImmutable, revMap);
-        Assert.assertEquals(revImmutable, revMap);
+        assertNotSame(revImmutable, revMap);
+        assertEquals(revImmutable, revMap);
     }
 
     @Override
@@ -168,13 +174,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         MutableList<String> tapResult = Lists.mutable.empty();
         ImmutableSortedMap<Integer, String> map = this.classUnderTest();
-        Assert.assertSame(map, map.tap(tapResult::add));
-        Assert.assertEquals(map.toList(), tapResult);
+        assertSame(map, map.tap(tapResult::add));
+        assertEquals(map.toList(), tapResult);
 
         MutableList<String> revTapResult = Lists.mutable.empty();
         ImmutableSortedMap<Integer, String> revMap = this.classUnderTest(REV_INT_COMPARATOR);
-        Assert.assertSame(revMap, revMap.tap(revTapResult::add));
-        Assert.assertEquals(revMap.toList(), revTapResult);
+        assertSame(revMap, revMap.tap(revTapResult::add));
+        assertEquals(revMap.toList(), revTapResult);
     }
 
     @Override
@@ -216,7 +222,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     @Test
     public void iteratorThrows()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () ->
+        assertThrows(UnsupportedOperationException.class, () ->
         {
             Iterator<String> iterator = this.classUnderTest().iterator();
             iterator.remove();
@@ -245,16 +251,16 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
 
         Integer absentKey = this.size() + 1;
-        Assert.assertNull(classUnderTest.get(absentKey));
+        assertNull(classUnderTest.get(absentKey));
 
         String absentValue = String.valueOf(absentKey);
-        Assert.assertFalse(classUnderTest.containsValue(absentValue));
+        assertFalse(classUnderTest.containsValue(absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.get(1));
+        assertEquals("1", classUnderTest.get(1));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -268,13 +274,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getOrDefault(1, absentValue));
+        assertEquals("1", classUnderTest.getOrDefault(1, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -288,13 +294,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
+        assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsent(1, new PassThruFunction0<>(absentValue)));
+        assertEquals("1", classUnderTest.getIfAbsent(1, new PassThruFunction0<>(absentValue)));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Test
@@ -305,13 +311,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsentValue(1, absentValue));
+        assertEquals("1", classUnderTest.getIfAbsentValue(1, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -325,13 +331,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
 
         // Absent key behavior
         ImmutableSortedMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
 
         // Present key behavior
-        Assert.assertEquals("1", classUnderTest.getIfAbsentWith(1, String::valueOf, absentValue));
+        assertEquals("1", classUnderTest.getIfAbsentWith(1, String::valueOf, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -444,7 +450,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     @Test
     public void putAll()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Map<Integer, String>) this.classUnderTest()).putAll(null));
     }
@@ -452,7 +458,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     @Test
     public void clear()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Map<Integer, String>) this.classUnderTest()).clear());
     }
@@ -462,13 +468,13 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     {
         ImmutableSortedMap<Integer, String> immutableSortedMap = this.classUnderTest();
         Map<Integer, String> map = new HashMap<>(immutableSortedMap.castToSortedMap());
-        Assert.assertEquals(map.entrySet(), immutableSortedMap.castToSortedMap().entrySet());
+        assertEquals(map.entrySet(), immutableSortedMap.castToSortedMap().entrySet());
 
         Set<Map.Entry<Integer, String>> entries = immutableSortedMap.castToSortedMap().entrySet();
         MutableList<Map.Entry<Integer, String>> entriesList = FastList.newList(entries);
         MutableList<Map.Entry<Integer, String>> sortedEntryList =
                 entriesList.toSortedListBy(Functions.getKeyFunction());
-        Assert.assertEquals(sortedEntryList, entriesList);
+        assertEquals(sortedEntryList, entriesList);
     }
 
     @Override
@@ -560,7 +566,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void collectWithIndex()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair("1", 0),
                         PrimitiveTuples.pair("2", 1),
@@ -576,7 +582,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void collectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair("1", 0),
                         PrimitiveTuples.pair("2", 1),
@@ -592,7 +598,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void selectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "3"),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -604,7 +610,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void rejectWithIndexWithTarget()
     {
         ImmutableSortedMap<Integer, String> integers = this.classUnderTest();
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("2", "4"),
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -677,21 +683,21 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
         ImmutableSortedMap<Integer, String> immutable = this.classUnderTest();
         ImmutableSortedMap<Integer, String> immutable2 = immutable.newWithoutAllKeys(immutable.keysView());
         ImmutableSortedMap<Integer, String> immutable3 = immutable.newWithoutAllKeys(Lists.immutable.of());
-        Assert.assertEquals(immutable, immutable3);
-        Assert.assertEquals(Maps.immutable.of(), immutable2);
+        assertEquals(immutable, immutable3);
+        assertEquals(Maps.immutable.of(), immutable2);
     }
 
     @Test
     public void toImmutable()
     {
         ImmutableSortedMap<Integer, String> immutableSortedMap = this.classUnderTest();
-        Assert.assertSame(immutableSortedMap, immutableSortedMap.toImmutable());
+        assertSame(immutableSortedMap, immutableSortedMap.toImmutable());
     }
 
     @Test
     public void put()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Map<Integer, String>) this.classUnderTest()).put(null, null));
     }
@@ -699,7 +705,7 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     @Test
     public void remove()
     {
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () -> ((Map<Integer, String>) this.classUnderTest()).remove(null));
     }
@@ -711,18 +717,18 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void take()
     {
         ImmutableSortedMap<Integer, String> strings1 = this.classUnderTest();
-        Assert.assertEquals(SortedMaps.immutable.of(strings1.comparator()), strings1.take(0));
-        Assert.assertSame(strings1.comparator(), strings1.take(0).comparator());
-        Assert.assertEquals(SortedMaps.immutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(3));
-        Assert.assertSame(strings1.comparator(), strings1.take(3).comparator());
-        Assert.assertEquals(
+        assertEquals(SortedMaps.immutable.of(strings1.comparator()), strings1.take(0));
+        assertSame(strings1.comparator(), strings1.take(0).comparator());
+        assertEquals(SortedMaps.immutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(3));
+        assertSame(strings1.comparator(), strings1.take(3).comparator());
+        assertEquals(
                 SortedMaps.immutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"),
                 strings1.take(strings1.size() - 1));
 
         ImmutableSortedMap<Integer, String> strings2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertSame(strings2, strings2.take(strings2.size()));
-        Assert.assertSame(strings2, strings2.take(10));
-        Assert.assertSame(strings2, strings2.take(Integer.MAX_VALUE));
+        assertSame(strings2, strings2.take(strings2.size()));
+        assertSame(strings2, strings2.take(10));
+        assertSame(strings2, strings2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -735,17 +741,17 @@ public abstract class ImmutableSortedMapTestCase extends MapIterableTestCase
     public void drop()
     {
         ImmutableSortedMap<Integer, String> strings1 = this.classUnderTest();
-        Assert.assertSame(strings1, strings1.drop(0));
-        Assert.assertSame(strings1.comparator(), strings1.drop(0).comparator());
-        Assert.assertEquals(SortedMaps.immutable.of(strings1.comparator(), 4, "4"), strings1.drop(3));
-        Assert.assertSame(strings1.comparator(), strings1.drop(3).comparator());
-        Assert.assertEquals(SortedMaps.immutable.of(strings1.comparator(), 4, "4"), strings1.drop(strings1.size() - 1));
+        assertSame(strings1, strings1.drop(0));
+        assertSame(strings1.comparator(), strings1.drop(0).comparator());
+        assertEquals(SortedMaps.immutable.of(strings1.comparator(), 4, "4"), strings1.drop(3));
+        assertSame(strings1.comparator(), strings1.drop(3).comparator());
+        assertEquals(SortedMaps.immutable.of(strings1.comparator(), 4, "4"), strings1.drop(strings1.size() - 1));
 
         ImmutableSortedMap<Integer, String> expectedMap = SortedMaps.immutable.of(Comparators.reverseNaturalOrder());
         ImmutableSortedMap<Integer, String> strings2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(expectedMap, strings2.drop(strings2.size()));
-        Assert.assertEquals(expectedMap, strings2.drop(10));
-        Assert.assertEquals(expectedMap, strings2.drop(Integer.MAX_VALUE));
+        assertEquals(expectedMap, strings2.drop(strings2.size()));
+        assertEquals(expectedMap, strings2.drop(10));
+        assertEquals(expectedMap, strings2.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
@@ -32,8 +32,14 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
 {
@@ -96,16 +102,16 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
         ImmutableSortedMap<String, Integer> immutableSortedMap = mutableSortedMap.toImmutable();
         MutableList<Map.Entry<String, Integer>> entries = FastList.newList(immutableSortedMap.castToSortedMap().entrySet());
         MutableList<Map.Entry<String, Integer>> sortedEntries = entries.toSortedListBy(Map.Entry::getKey);
-        Assert.assertEquals(sortedEntries, entries);
+        assertEquals(sortedEntries, entries);
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
-        Assert.assertEquals("{4=4, 3=3, 2=2, 1=1}", this.classUnderTest(Comparators.reverseNaturalOrder()).toString());
-        Assert.assertEquals("{}", new ImmutableTreeMap<>(new TreeSortedMap<>()).toString());
+        assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
+        assertEquals("{4=4, 3=3, 2=2, 1=1}", this.classUnderTest(Comparators.reverseNaturalOrder()).toString());
+        assertEquals("{}", new ImmutableTreeMap<>(new TreeSortedMap<>()).toString());
     }
 
     @Test(expected = NullPointerException.class)
@@ -117,7 +123,7 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     @Test
     public void firstKey()
     {
-        Assert.assertEquals(Integer.valueOf(1), new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).firstKey());
+        assertEquals(Integer.valueOf(1), new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).firstKey());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -129,7 +135,7 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     @Test
     public void lastKey()
     {
-        Assert.assertEquals(Integer.valueOf(4), new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).lastKey());
+        assertEquals(Integer.valueOf(4), new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).lastKey());
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -150,11 +156,11 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     {
         SortedMap<Integer, String> immutableSortedMap = new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4"));
         Set<Integer> keySet = immutableSortedMap.keySet();
-        Assert.assertTrue(keySet.contains(1));
-        Assert.assertTrue(keySet.contains(2));
-        Assert.assertTrue(keySet.contains(4));
-        Assert.assertFalse(keySet.contains(0));
-        Assert.assertFalse(keySet.contains(5));
+        assertTrue(keySet.contains(1));
+        assertTrue(keySet.contains(2));
+        assertTrue(keySet.contains(4));
+        assertFalse(keySet.contains(0));
+        assertFalse(keySet.contains(5));
     }
 
     @Test
@@ -162,31 +168,31 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     {
         SortedMap<Integer, String> immutableSortedMap = new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4"));
         Set<Integer> keySet = immutableSortedMap.keySet();
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3, 4)));
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 4)));
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(2, 3)));
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3)));
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(2, 3, 4)));
-        Assert.assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1)));
-        Assert.assertTrue(keySet.containsAll(FastList.newListWith(1, 4, 1, 3, 4)));
-        Assert.assertFalse(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
-        Assert.assertFalse(keySet.containsAll(UnifiedSet.newSetWith(0, 1, 2, 3, 4, 5)));
-        Assert.assertFalse(keySet.containsAll(FastList.newListWith(0, 1, 4, 1, 3, 4, 0)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3, 4)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 4)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(2, 3)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(2, 3, 4)));
+        assertTrue(keySet.containsAll(UnifiedSet.newSetWith(1)));
+        assertTrue(keySet.containsAll(FastList.newListWith(1, 4, 1, 3, 4)));
+        assertFalse(keySet.containsAll(UnifiedSet.newSetWith(1, 2, 3, 4, 5)));
+        assertFalse(keySet.containsAll(UnifiedSet.newSetWith(0, 1, 2, 3, 4, 5)));
+        assertFalse(keySet.containsAll(FastList.newListWith(0, 1, 4, 1, 3, 4, 0)));
     }
 
     @Test
     public void keySetIsEmpty()
     {
-        Assert.assertFalse(new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).keySet().isEmpty());
-        Assert.assertTrue(new ImmutableTreeMap<Integer, String>(SortedMaps.mutable.of()).keySet().isEmpty());
+        assertFalse(new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).keySet().isEmpty());
+        assertTrue(new ImmutableTreeMap<Integer, String>(SortedMaps.mutable.of()).keySet().isEmpty());
     }
 
     @Test
     public void keySetToString()
     {
-        Assert.assertEquals("[1, 2, 3, 4]", new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).keySet().toString());
-        Assert.assertEquals("[1, 2, 3, 4]", new ImmutableTreeMap<>(SortedMaps.mutable.of(4, "4", 3, "3", 2, "2", 1, "1")).keySet().toString());
-        Assert.assertEquals("[4, 3, 2, 1]", new ImmutableTreeMap<>(SortedMaps.mutable.of(Comparators.reverseNaturalOrder(), 4, "4", 3, "3", 2, "2", 1, "1")).keySet().toString());
+        assertEquals("[1, 2, 3, 4]", new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4")).keySet().toString());
+        assertEquals("[1, 2, 3, 4]", new ImmutableTreeMap<>(SortedMaps.mutable.of(4, "4", 3, "3", 2, "2", 1, "1")).keySet().toString());
+        assertEquals("[4, 3, 2, 1]", new ImmutableTreeMap<>(SortedMaps.mutable.of(Comparators.reverseNaturalOrder(), 4, "4", 3, "3", 2, "2", 1, "1")).keySet().toString());
     }
 
     @Test
@@ -203,13 +209,13 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
         MutableList<Integer> expected = FastList.newListWith(1, 2, 3, 4).toSortedList();
         Set<Integer> keySet = immutableSortedMap.keySet();
         Object[] array = keySet.toArray();
-        Assert.assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
-        Assert.assertNotSame(array, keySet.toArray());
+        assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
+        assertNotSame(array, keySet.toArray());
         array[3] = 5;
-        Assert.assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 5).toSortedList(), FastList.newListWith(array).toSortedList());
+        assertEquals(expected, FastList.newListWith(keySet.toArray()).toSortedList());
+        assertEquals(FastList.newListWith(1, 2, 3, 5).toSortedList(), FastList.newListWith(array).toSortedList());
 
-        Assert.assertEquals(expected, FastList.newListWith(keySet.toArray(new Integer[keySet.size()])).toSortedList());
+        assertEquals(expected, FastList.newListWith(keySet.toArray(new Integer[keySet.size()])).toSortedList());
     }
 
     @Test
@@ -219,7 +225,7 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
         Integer[] destination = new Integer[2]; // deliberately to small to force the method to allocate one of the correct size
         Integer[] result = immutableSortedMap.keySet().toArray(destination);
         Arrays.sort(result);
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
     }
 
     @Test
@@ -231,7 +237,7 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
         target[5] = 42;
         Integer[] result = immutableSortedMap.keySet().toArray(target);
         ArrayIterate.sort(result, result.length, Comparators.safeNullsHigh(Integer::compareTo));
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4, 42, null}, result);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 42, null}, result);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -292,6 +298,6 @@ public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
     public void ofSortedMap()
     {
         SortedMap<Integer, String> immutableMap = new ImmutableTreeMap<>(SortedMaps.mutable.of(1, "1", 2, "2", 3, "3", 4, "4"));
-        Assert.assertSame(immutableMap, SortedMaps.immutable.ofSortedMap(immutableMap));
+        assertSame(immutableMap, SortedMaps.immutable.ofSortedMap(immutableMap));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
@@ -49,10 +49,17 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit TestCase for {@link MutableSortedMap}s.
@@ -105,7 +112,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         MutableSortedMap<Integer, Integer> revMap = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, 1, 2, 2);
         Verify.assertEmpty(map.newEmpty());
         Verify.assertEmpty(revMap.newEmpty());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), revMap.newEmpty().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), revMap.newEmpty().comparator());
     }
 
     @Override
@@ -130,7 +137,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         MutableSortedMap<Integer, String> sortedMap = this.newMapWithKeyValue(1, "One");
         ImmutableSortedMap<Integer, String> result = sortedMap.toImmutable();
         Verify.assertSize(1, result.castToSortedMap());
-        Assert.assertEquals("One", result.get(1));
+        assertEquals("One", result.get(1));
         Verify.assertInstanceOf(ImmutableTreeMap.class, result);
     }
 
@@ -199,13 +206,13 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     {
         MutableList<String> tapResult = Lists.mutable.empty();
         MapIterable<Integer, String> map = this.newMapWithKeysValues(1, "One", 3, "Three", 2, "Two", 4, "Four");
-        Assert.assertSame(map, map.tap(tapResult::add));
-        Assert.assertEquals(map.toList(), tapResult);
+        assertSame(map, map.tap(tapResult::add));
+        assertEquals(map.toList(), tapResult);
 
         MutableList<String> revTapResult = Lists.mutable.empty();
         MapIterable<Integer, String> revMap = this.newMapWithKeysValues(REV_INT_ORDER, 1, "One", 3, "Three", 2, "Two", 4, "Four");
-        Assert.assertSame(revMap, revMap.tap(revTapResult::add));
-        Assert.assertEquals(revMap.toList(), revTapResult);
+        assertSame(revMap, revMap.tap(revTapResult::add));
+        assertEquals(revMap.toList(), revTapResult);
     }
 
     @Override
@@ -304,7 +311,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         super.collectValues();
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(REV_INT_ORDER, 1, "One", 2, "Two", 3, "Three");
         MutableSortedMap<Integer, String> actual = map.collectValues((argument1, argument2) -> new StringBuilder(argument2).reverse().toString());
-        Assert.assertEquals(TreeSortedMap.<Integer, String>
+        assertEquals(TreeSortedMap.<Integer, String>
                 newMap(REV_INT_ORDER).with(1, "enO", 2, "owT", 3, "eerhT"), actual);
     }
 
@@ -325,7 +332,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
                 Interval.zeroTo(map.size() - 1),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(
+        assertEquals(
                 map.zipWithIndex().toSet(),
                 map.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -371,8 +378,8 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
                 "C", 3,
                 "D", 4);
         PartitionMutableList<Integer> partition = map.partition(IntegerPredicates.isEven());
-        Assert.assertEquals(iList(4, 2), partition.getSelected());
-        Assert.assertEquals(iList(3, 1), partition.getRejected());
+        assertEquals(iList(4, 2), partition.getSelected());
+        assertEquals(iList(3, 1), partition.getRejected());
     }
 
     @Override
@@ -386,8 +393,8 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
                 "C", 3,
                 "D", 4);
         PartitionMutableList<Integer> partition = map.partitionWith(Predicates2.in(), map.select(IntegerPredicates.isEven()));
-        Assert.assertEquals(iList(4, 2), partition.getSelected());
-        Assert.assertEquals(iList(3, 1), partition.getRejected());
+        assertEquals(iList(4, 2), partition.getSelected());
+        assertEquals(iList(3, 1), partition.getRejected());
     }
 
     @Override
@@ -408,7 +415,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void collectWithIndex()
     {
         MutableSortedMap<Integer, String> integers = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair("1", 0),
                         PrimitiveTuples.pair("2", 1),
@@ -424,7 +431,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void collectWithIndexWithTarget()
     {
         MutableSortedMap<Integer, String> integers = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair("1", 0),
                         PrimitiveTuples.pair("2", 1),
@@ -440,7 +447,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void selectWithIndexWithTarget()
     {
         MutableSortedMap<Integer, String> integers = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "3"),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -452,7 +459,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void rejectWithIndexWithTarget()
     {
         MutableSortedMap<Integer, String> integers = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("2", "4"),
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -527,7 +534,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
 
         MutableSortedMap<String, String> map = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), "One", "odd", "Two", "even", "Three", "odd", "Four", "even");
         MutableSortedSetMultimap<String, String> flip = map.flip();
-        Assert.assertEquals(expected, flip);
+        assertEquals(expected, flip);
         Verify.assertSortedSetsEqual(
                 TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), "Two", "Four"),
                 flip.get("even"));
@@ -552,12 +559,12 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
 
         MutableSortedMap<Integer, Integer> map = this.newMapWithKeysValues(REV_INT_ORDER, -1, 1, -2, 2, -3, 3);
         Iterator<Integer> iterator = map.iterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         for (int i = 1; i < 4; ++i)
         {
-            Assert.assertEquals(i, iterator.next().intValue());
+            assertEquals(i, iterator.next().intValue());
         }
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -567,13 +574,13 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         // Test without using null
 
         MutableSortedMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertTrue(map.entrySet().remove(ImmutableEntry.of("Two", 2)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertFalse(map.entrySet().remove(ImmutableEntry.of("Four", 4)));
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
 
-        Assert.assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(null));
     }
 
     @Override
@@ -583,15 +590,15 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         // Test without using null
 
         MutableSortedMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertTrue(map.entrySet().removeAll(FastList.newListWith(
+        assertTrue(map.entrySet().removeAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
+        assertFalse(map.entrySet().removeAll(FastList.newListWith(ImmutableEntry.of("Four", 4))));
+        assertEquals(UnifiedMap.newWithKeysValues("Two", 2), map);
 
-        Assert.assertFalse(map.entrySet().remove(null));
+        assertFalse(map.entrySet().remove(null));
     }
 
     @Override
@@ -603,17 +610,17 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         // TODO: delete?
 
         MutableSortedMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertFalse(map.entrySet().retainAll(FastList.newListWith(
+        assertFalse(map.entrySet().retainAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Two", 2),
                 ImmutableEntry.of("Three", 3),
                 ImmutableEntry.of("Four", 4))));
 
-        Assert.assertTrue(map.entrySet().retainAll(FastList.newListWith(
+        assertTrue(map.entrySet().retainAll(FastList.newListWith(
                 ImmutableEntry.of("One", 1),
                 ImmutableEntry.of("Three", 3),
                 ImmutableEntry.of("Four", 4))));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
+        assertEquals(UnifiedMap.newWithKeysValues("One", 1, "Three", 3), map);
     }
 
     @Test
@@ -623,7 +630,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         MutableSortedMap<String, Integer> mutableSortedMap = new TreeSortedMap<>(pairs.toArray(new Pair[]{}));
         MutableList<Map.Entry<String, Integer>> entries = FastList.newList(mutableSortedMap.entrySet());
         MutableList<Map.Entry<String, Integer>> sortedEntries = entries.toSortedListBy(Functions.getKeyFunction());
-        Assert.assertEquals(sortedEntries, entries);
+        assertEquals(sortedEntries, entries);
     }
 
     @Test
@@ -654,12 +661,12 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         // Only use Comparable objects
 
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertNull(map.put(3, "Three"));
-        Assert.assertEquals(TreeSortedMap.newMapWith(1, "One", 2, "Two", 3, "Three"), map);
+        assertNull(map.put(3, "Three"));
+        assertEquals(TreeSortedMap.newMapWith(1, "One", 2, "Two", 3, "Three"), map);
 
         MutableSortedMap<Integer, String> revMap = this.newMapWithKeysValues(REV_INT_ORDER, 1, "One", 2, "Two");
-        Assert.assertNull(revMap.put(0, "Zero"));
-        Assert.assertEquals(TreeSortedMap.<Integer, String>newMap(REV_INT_ORDER).with(0, "Zero", 1, "One", 2, "Two"), revMap);
+        assertNull(revMap.put(0, "Zero"));
+        assertEquals(TreeSortedMap.<Integer, String>newMap(REV_INT_ORDER).with(0, "Zero", 1, "One", 2, "Two"), revMap);
     }
 
     @Override
@@ -677,7 +684,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
 
         MutableSortedMap<Integer, String> revMap = this.newMapWithKeysValues(REV_INT_ORDER, 1, "One", 2, "2");
         revMap.putAll(toAdd);
-        Assert.assertEquals(TreeSortedMap.<Integer, String>newMap(REV_INT_ORDER).with(1, "One", 2, "Two", 3, "Three"), revMap);
+        assertEquals(TreeSortedMap.<Integer, String>newMap(REV_INT_ORDER).with(1, "One", 2, "Two", 3, "Three"), revMap);
     }
 
     @Test
@@ -706,9 +713,9 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         Verify.assertMapsEqual(revMap1, map2);
         Verify.assertMapsEqual(revMap3, map3);
 
-        Assert.assertNotEquals(map2, map3);
-        Assert.assertNotEquals(revMap1, revMap3);
-        Assert.assertNotEquals(map1, revMap3);
+        assertNotEquals(map2, map3);
+        assertNotEquals(revMap1, revMap3);
+        assertNotEquals(map1, revMap3);
     }
 
     @Test
@@ -730,13 +737,13 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         Verify.assertEqualsAndHashCode(Maps.mutable.of(1, "1", 2, "2", 3, "3"), map);
         Verify.assertEqualsAndHashCode(Maps.immutable.of(1, "1", 2, "2", 3, "3"), map);
 
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(1, "1", 2, "2", 4, "4"));
 
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 3, "3", 4, "4"));
-        Assert.assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2"));
+        assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 3, "3", 4, "4"));
+        assertNotEquals(map, this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 4, "4"));
     }
 
     @Override
@@ -761,7 +768,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     {
         super.asUnmodifiable();
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, 1, 2, 2).asUnmodifiable().put(3, 3));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, 1, 2, 2).asUnmodifiable().put(3, 3));
 
         Verify.assertInstanceOf(UnmodifiableTreeMap.class, this.newMapWithKeysValues(1, "1", 2, "2").asUnmodifiable());
     }
@@ -781,28 +788,28 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void firstKey()
     {
         MutableSortedMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Four", 4);
-        Assert.assertEquals("Four", map.firstKey());
+        assertEquals("Four", map.firstKey());
 
         MutableSortedMap<String, Integer> revMap = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(),
                 "One", 1, "Two", 2, "Four", 4);
-        Assert.assertEquals("Two", revMap.firstKey());
+        assertEquals("Two", revMap.firstKey());
 
         MutableSortedMap<Object, Object> emptyMap = this.newMap();
-        Assert.assertThrows(NoSuchElementException.class, emptyMap::firstKey);
+        assertThrows(NoSuchElementException.class, emptyMap::firstKey);
     }
 
     @Test
     public void lastKey()
     {
         MutableSortedMap<String, Integer> map = this.newMapWithKeysValues("One", 1, "Two", 2, "Four", 4);
-        Assert.assertEquals("Two", map.lastKey());
+        assertEquals("Two", map.lastKey());
 
         MutableSortedMap<String, Integer> revMap = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(),
                 "One", 1, "Two", 2, "Four", 4);
-        Assert.assertEquals("Four", revMap.lastKey());
+        assertEquals("Four", revMap.lastKey());
 
         MutableSortedMap<Object, Object> emptyMap = this.newMap();
-        Assert.assertThrows(NoSuchElementException.class, emptyMap::lastKey);
+        assertThrows(NoSuchElementException.class, emptyMap::lastKey);
     }
 
     @Test
@@ -823,7 +830,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         map.clear();
         Verify.assertEmpty(subMap);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subMap.put(4, "Illegal"));
+        assertThrows(IllegalArgumentException.class, () -> subMap.put(4, "Illegal"));
     }
 
     @Test
@@ -844,7 +851,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         map.clear();
         Verify.assertEmpty(subMap);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subMap.put(1, "Illegal"));
+        assertThrows(IllegalArgumentException.class, () -> subMap.put(1, "Illegal"));
     }
 
     @Test
@@ -868,16 +875,16 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         subMap.removeKey(2);
         Verify.assertNotContainsKey(2, map);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subMap.put(4, "Illegal"));
+        assertThrows(IllegalArgumentException.class, () -> subMap.put(4, "Illegal"));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subMap.put(1, "Illegal"));
+        assertThrows(IllegalArgumentException.class, () -> subMap.put(1, "Illegal"));
     }
 
     @Test
     public void testToString()
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertEquals("{1=One, 2=Two}", map.toString());
+        assertEquals("{1=One, 2=Two}", map.toString());
     }
 
     @Test
@@ -885,7 +892,7 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "Two");
         MutableSortedMap<Integer, String> clone = map.clone();
-        Assert.assertNotSame(map, clone);
+        assertNotSame(map, clone);
         Verify.assertEqualsAndHashCode(map, clone);
     }
 
@@ -893,17 +900,17 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void take()
     {
         MutableSortedMap<Integer, String> strings1 = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(SortedMaps.mutable.of(strings1.comparator()), strings1.take(0));
-        Assert.assertSame(strings1.comparator(), strings1.take(0).comparator());
-        Assert.assertEquals(SortedMaps.mutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(3));
-        Assert.assertSame(strings1.comparator(), strings1.take(3).comparator());
-        Assert.assertEquals(SortedMaps.mutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(strings1.size() - 1));
+        assertEquals(SortedMaps.mutable.of(strings1.comparator()), strings1.take(0));
+        assertSame(strings1.comparator(), strings1.take(0).comparator());
+        assertEquals(SortedMaps.mutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(3));
+        assertSame(strings1.comparator(), strings1.take(3).comparator());
+        assertEquals(SortedMaps.mutable.of(strings1.comparator(), 1, "1", 2, "2", 3, "3"), strings1.take(strings1.size() - 1));
 
         MutableSortedMap<Integer, String> expectedMap = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 3, "3", 4, "4");
         MutableSortedMap<Integer, String> strings2 = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(expectedMap, strings2.take(strings2.size()));
-        Assert.assertEquals(expectedMap, strings2.take(10));
-        Assert.assertEquals(expectedMap, strings2.take(Integer.MAX_VALUE));
+        assertEquals(expectedMap, strings2.take(strings2.size()));
+        assertEquals(expectedMap, strings2.take(10));
+        assertEquals(expectedMap, strings2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -916,18 +923,18 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
     public void drop()
     {
         MutableSortedMap<Integer, String> strings1 = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(strings1, strings1.drop(0));
-        Assert.assertNotSame(strings1, strings1.drop(0));
-        Assert.assertSame(strings1.comparator(), strings1.drop(0).comparator());
-        Assert.assertEquals(SortedMaps.mutable.of(strings1.comparator(), 4, "4"), strings1.drop(3));
-        Assert.assertSame(strings1.comparator(), strings1.drop(3).comparator());
-        Assert.assertEquals(SortedMaps.mutable.of(strings1.comparator(), 4, "4"), strings1.drop(strings1.size() - 1));
+        assertEquals(strings1, strings1.drop(0));
+        assertNotSame(strings1, strings1.drop(0));
+        assertSame(strings1.comparator(), strings1.drop(0).comparator());
+        assertEquals(SortedMaps.mutable.of(strings1.comparator(), 4, "4"), strings1.drop(3));
+        assertSame(strings1.comparator(), strings1.drop(3).comparator());
+        assertEquals(SortedMaps.mutable.of(strings1.comparator(), 4, "4"), strings1.drop(strings1.size() - 1));
 
         MutableSortedMap<Integer, String> expectedMap = SortedMaps.mutable.of(Comparators.reverseNaturalOrder());
         MutableSortedMap<Integer, String> strings2 = this.newMapWithKeysValues(Comparators.reverseNaturalOrder(), 1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(expectedMap, strings2.drop(strings2.size()));
-        Assert.assertEquals(expectedMap, strings2.drop(10));
-        Assert.assertEquals(expectedMap, strings2.drop(Integer.MAX_VALUE));
+        assertEquals(expectedMap, strings2.drop(strings2.size()));
+        assertEquals(expectedMap, strings2.drop(10));
+        assertEquals(expectedMap, strings2.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapterTest.java
@@ -17,8 +17,11 @@ import java.util.TreeMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SortedMapAdapter}.
@@ -96,11 +99,11 @@ public class SortedMapAdapterTest extends MutableSortedMapTestCase
     {
         TreeSortedMap<Integer, String> sortedMap = TreeSortedMap.newMapWith(1, "1", 2, "2");
         MutableSortedMap<Integer, String> adapt = SortedMapAdapter.adapt(sortedMap);
-        Assert.assertSame(sortedMap, adapt);
+        assertSame(sortedMap, adapt);
 
         SortedMap<Integer, String> treeMap = new TreeMap<>(sortedMap);
         MutableSortedMap<Integer, String> treeAdapt = SortedMaps.adapt(treeMap);
-        Assert.assertNotSame(treeMap, treeAdapt);
-        Assert.assertEquals(treeMap, treeAdapt);
+        assertNotSame(treeMap, treeAdapt);
+        assertEquals(treeMap, treeAdapt);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMapTest.java
@@ -18,8 +18,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class TreeSortedMapTest extends MutableSortedMapTestCase
 {
@@ -108,7 +111,7 @@ public class TreeSortedMapTest extends MutableSortedMapTestCase
         Verify.assertListsEqual(FastList.newListWith(3, 2, 1), revSortedMap.keySet().toList());
 
         TreeSortedMap<Integer, String> sortedMap2 = TreeSortedMap.newMap(revSortedMap);
-        Assert.assertEquals(revSortedMap.comparator(), sortedMap2.comparator());
+        assertEquals(revSortedMap.comparator(), sortedMap2.comparator());
         Verify.assertMapsEqual(revSortedMap, sortedMap2);
     }
 
@@ -134,9 +137,9 @@ public class TreeSortedMapTest extends MutableSortedMapTestCase
         super.testClone();
         TreeSortedMap<Integer, Integer> sortedMap = TreeSortedMap.<Integer, Integer>newMapWith(Tuples.pair(1, 4), Tuples.pair(2, 3), Tuples.pair(3, 2), Tuples.pair(4, 1));
         MutableSortedMap<Integer, Integer> clone = sortedMap.clone();
-        Assert.assertNotSame(sortedMap, clone);
-        Assert.assertEquals(sortedMap, clone);
+        assertNotSame(sortedMap, clone);
+        assertEquals(sortedMap, clone);
         sortedMap.removeKey(1);
-        Assert.assertTrue(clone.containsKey(1));
+        assertTrue(clone.containsKey(1));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableSortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableSortedMapTest.java
@@ -16,8 +16,10 @@ import java.util.TreeMap;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class UnmodifiableSortedMapTest
 {
@@ -30,7 +32,7 @@ public class UnmodifiableSortedMapTest
     @Test
     public void comparator()
     {
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), this.revMap.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), this.revMap.comparator());
     }
 
     @Test
@@ -57,25 +59,25 @@ public class UnmodifiableSortedMapTest
     @Test
     public void firstKey()
     {
-        Assert.assertEquals(1, this.map.firstKey().intValue());
-        Assert.assertEquals(4, this.revMap.firstKey().intValue());
+        assertEquals(1, this.map.firstKey().intValue());
+        assertEquals(4, this.revMap.firstKey().intValue());
     }
 
     @Test
     public void lasKey()
     {
-        Assert.assertEquals(4, this.map.lastKey().intValue());
-        Assert.assertEquals(1, this.revMap.lastKey().intValue());
+        assertEquals(4, this.map.lastKey().intValue());
+        assertEquals(1, this.revMap.lastKey().intValue());
     }
 
     private void checkMutability(Map<Integer, String> map)
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(3, "1"));
+        assertThrows(UnsupportedOperationException.class, () -> map.put(3, "1"));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.putAll(SortedMaps.mutable.of(1, "1", 2, "2")));
+        assertThrows(UnsupportedOperationException.class, () -> map.putAll(SortedMaps.mutable.of(1, "1", 2, "2")));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.remove(2));
+        assertThrows(UnsupportedOperationException.class, () -> map.remove(2));
 
-        Assert.assertThrows(UnsupportedOperationException.class, map::clear);
+        assertThrows(UnsupportedOperationException.class, map::clear);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
@@ -22,8 +22,11 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableTreeMap}.
@@ -127,7 +130,7 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     @Test
     public void removeAllKeys()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "Two").removeAllKeys(null));
     }
 
     @Override
@@ -282,7 +285,7 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     public void clear()
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertThrows(UnsupportedOperationException.class, map::clear);
+        assertThrows(UnsupportedOperationException.class, map::clear);
     }
 
     @Override
@@ -290,7 +293,7 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     public void asUnmodifiable()
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2");
-        Assert.assertSame(map, map.asUnmodifiable());
+        assertSame(map, map.asUnmodifiable());
     }
 
     @Test
@@ -298,11 +301,11 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "One", 2, "2").asUnmodifiable();
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(null));
+        assertThrows(UnsupportedOperationException.class, () -> map.entrySet().remove(null));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> Iterate.getFirst(map.entrySet()).setValue("Three"));
+        assertThrows(UnsupportedOperationException.class, () -> Iterate.getFirst(map.entrySet()).setValue("Three"));
 
-        Assert.assertEquals(this.newMapWithKeysValues(1, "One", 2, "2"), map);
+        assertEquals(this.newMapWithKeysValues(1, "One", 2, "2"), map);
     }
 
     @Test
@@ -310,7 +313,7 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeyValue(1, "One").asUnmodifiable();
         Object[] entries = map.entrySet().toArray();
-        Assert.assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
+        assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
     }
 
     @Test
@@ -318,7 +321,7 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeyValue(1, "One").asUnmodifiable();
         Object[] entries = map.entrySet().toArray(new Object[]{});
-        Assert.assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
+        assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
     }
 
     @Override
@@ -353,105 +356,105 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     @Test
     public void withMap()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMap(null));
     }
 
     @Override
     @Test
     public void withMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').withMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void withMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void withMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().withMapIterable(null));
     }
 
     @Override
     @Test
     public void putAllMapIterable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeyValue(1, 'a').putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void putAllMapIterableTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.with(1, Character.valueOf('a'))));
     }
 
     @Override
     @Test
     public void putAllMapIterableEmptyAndTargetEmpty()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.empty()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(Maps.mutable.empty()));
     }
 
     @Override
     @Test
     public void putAllMapIterableNull()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
+        assertThrows(UnsupportedOperationException.class, () -> this.newMap().putAllMapIterable(null));
     }
 
     @Override
@@ -525,21 +528,21 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
     public void testClone()
     {
         MutableSortedMap<Integer, String> map = this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4");
-        Assert.assertSame(map, map.clone());
+        assertSame(map, map.clone());
         Verify.assertInstanceOf(UnmodifiableTreeMap.class, map.clone());
     }
 
     private void checkMutability(MutableSortedMap<Integer, String> map)
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.put(3, "3"));
+        assertThrows(UnsupportedOperationException.class, () -> map.put(3, "3"));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.putAll(TreeSortedMap.newMapWith(1, "1", 2, "2")));
+        assertThrows(UnsupportedOperationException.class, () -> map.putAll(TreeSortedMap.newMapWith(1, "1", 2, "2")));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.remove(2));
+        assertThrows(UnsupportedOperationException.class, () -> map.remove(2));
 
-        Assert.assertThrows(UnsupportedOperationException.class, map::clear);
+        assertThrows(UnsupportedOperationException.class, map::clear);
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> map.with(Tuples.pair(1, "1")));
+        assertThrows(UnsupportedOperationException.class, () -> map.with(Tuples.pair(1, "1")));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEmptyMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEmptyMapWithHashingStrategyTest.java
@@ -19,8 +19,12 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.map.immutable.ImmutableMemoryEfficientMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptyMapWithHashingStrategy}.
@@ -58,7 +62,7 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
     public void testToString()
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertEquals("{}", map.toString());
+        assertEquals("{}", map.toString());
     }
 
     @Override
@@ -76,13 +80,13 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
 
         Integer absentKey = this.size() + 1;
-        Assert.assertNull(classUnderTest.get(absentKey));
+        assertNull(classUnderTest.get(absentKey));
 
         String absentValue = String.valueOf(absentKey);
-        Assert.assertFalse(classUnderTest.containsValue(absentValue));
+        assertFalse(classUnderTest.containsValue(absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -94,10 +98,10 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
+        assertEquals(absentValue, classUnderTest.getIfAbsent(absentKey, new PassThruFunction0<>(absentValue)));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -111,10 +115,10 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getOrDefault(absentKey, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -126,10 +130,10 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentValue(absentKey, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -141,10 +145,10 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
 
         // Absent key behavior
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
+        assertEquals(absentValue, classUnderTest.getIfAbsentWith(absentKey, String::valueOf, absentValue));
 
         // Still unchanged
-        Assert.assertEquals(this.equalUnifiedMap(), classUnderTest);
+        assertEquals(this.equalUnifiedMap(), classUnderTest);
     }
 
     @Override
@@ -154,14 +158,14 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
         Integer absentKey = this.size() + 1;
 
         ImmutableMap<Integer, String> classUnderTest = this.classUnderTest();
-        Assert.assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
+        assertNull(classUnderTest.ifPresentApply(absentKey, Functions.getPassThru()));
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -170,8 +174,8 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
-        Assert.assertTrue(map.allSatisfy(String.class::isInstance));
-        Assert.assertTrue(map.allSatisfy("Monkey"::equals));
+        assertTrue(map.allSatisfy(String.class::isInstance));
+        assertTrue(map.allSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -180,8 +184,8 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
-        Assert.assertTrue(map.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(map.noneSatisfy("Monkey"::equals));
+        assertTrue(map.noneSatisfy(Integer.class::isInstance));
+        assertTrue(map.noneSatisfy("Monkey"::equals));
     }
 
     @Override
@@ -190,8 +194,8 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
 
-        Assert.assertFalse(map.anySatisfy(String.class::isInstance));
-        Assert.assertFalse(map.anySatisfy("Monkey"::equals));
+        assertFalse(map.anySatisfy(String.class::isInstance));
+        assertFalse(map.anySatisfy("Monkey"::equals));
     }
 
     @Override
@@ -256,7 +260,7 @@ public class ImmutableEmptyMapWithHashingStrategyTest extends ImmutableMemoryEff
     public void detect()
     {
         ImmutableMap<Integer, String> map = this.classUnderTest();
-        Assert.assertNull(map.detect((ignored1, ignored2) -> true));
+        assertNull(map.detect((ignored1, ignored2) -> true));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategyTest.java
@@ -20,8 +20,9 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableUnifiedMapWithHashingStrategyTest extends ImmutableMapTestCase
 {
@@ -64,14 +65,14 @@ public class ImmutableUnifiedMapWithHashingStrategyTest extends ImmutableMapTest
     @Override
     public void testToString()
     {
-        Assert.assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
+        assertEquals("{1=1, 2=2, 3=3, 4=4}", this.classUnderTest().toString());
     }
 
     @Test
     public void getBatchCount()
     {
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.classUnderTest();
-        Assert.assertEquals(5, integerBatchIterable.getBatchCount(3));
+        assertEquals(5, integerBatchIterable.getBatchCount(3));
     }
 
     @Test
@@ -80,6 +81,6 @@ public class ImmutableUnifiedMapWithHashingStrategyTest extends ImmutableMapTest
         Sum sum = new IntegerSum(0);
         BatchIterable<String> integerBatchIterable = (BatchIterable<String>) this.classUnderTest();
         integerBatchIterable.batchForEach(each -> sum.add(Integer.valueOf(each)), 0, 1);
-        Assert.assertEquals(10, sum.getValue());
+        assertEquals(10, sum.getValue());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyTest.java
@@ -42,8 +42,16 @@ import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
 {
@@ -123,7 +131,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     @Test
     public void constructorOfPairs()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, "one", 2, "two", 3, "three"),
                 UnifiedMapWithHashingStrategy.newMapWith(INTEGER_HASHING_STRATEGY, Tuples.pair(1, "one"), Tuples.pair(2, "two"), Tuples.pair(3, "three")));
     }
@@ -137,20 +145,20 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         Pair<Integer, String> pair4 = Tuples.pair(4, "Four");
         UnifiedMapWithHashingStrategy<Integer, String> expected = UnifiedMapWithHashingStrategy.newMapWith(INTEGER_HASHING_STRATEGY, pair1, pair2, pair3, pair4);
         UnifiedMapWithHashingStrategy<Integer, String> actual1 = UnifiedMapWithHashingStrategy.newMapWith(INTEGER_HASHING_STRATEGY, FastList.newListWith(pair1, pair2, pair3, pair4));
-        Assert.assertEquals(expected, actual1);
-        Assert.assertEquals(expected.hashingStrategy(), actual1.hashingStrategy());
+        assertEquals(expected, actual1);
+        assertEquals(expected.hashingStrategy(), actual1.hashingStrategy());
 
         UnifiedMapWithHashingStrategy<Integer, String> actual2 = UnifiedMapWithHashingStrategy.newMapWith(INTEGER_HASHING_STRATEGY, UnifiedSet.newSetWith(pair1, pair2, pair3, pair4));
-        Assert.assertEquals(expected, actual2);
-        Assert.assertEquals(expected.hashingStrategy(), actual2.hashingStrategy());
+        assertEquals(expected, actual2);
+        assertEquals(expected.hashingStrategy(), actual2.hashingStrategy());
     }
 
     @Test
     public void newMap_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, -1, 0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, 1, -0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, 1, 1.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, -1, 0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, 1, -0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedMapWithHashingStrategy<Integer, Integer>(INTEGER_HASHING_STRATEGY, 1, 1.5f));
     }
 
     @Override
@@ -161,7 +169,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
 
         UnifiedMapWithHashingStrategy<Person, Integer> map = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 2, JOHNSMITH, 3, JANESMITH, 4);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(JOHNDOE, 2), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
+        assertEquals(UnifiedMap.newWithKeysValues(JOHNDOE, 2), map.select((argument1, argument2) -> "Doe".equals(argument1.getLastName())));
     }
 
     @Override
@@ -172,7 +180,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
 
         UnifiedMapWithHashingStrategy<Person, Integer> map = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 2, JOHNSMITH, 3, JANESMITH, 4);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(JOHNDOE, 2), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
+        assertEquals(UnifiedMap.newWithKeysValues(JOHNDOE, 2), map.reject((argument1, argument2) -> "Smith".equals(argument1.getLastName())));
     }
 
     @Override
@@ -194,15 +202,15 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     {
         UnifiedMapWithHashingStrategy<Person, Integer> map = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 2, JOHNSMITH, 3, JANESMITH, 4);
-        Assert.assertTrue(map.containsKey(JOHNDOE));
-        Assert.assertTrue(map.containsValue(2));
-        Assert.assertTrue(map.containsKey(JOHNSMITH));
-        Assert.assertTrue(map.containsValue(4));
-        Assert.assertTrue(map.containsKey(JANEDOE));
-        Assert.assertTrue(map.containsKey(JANESMITH));
+        assertTrue(map.containsKey(JOHNDOE));
+        assertTrue(map.containsValue(2));
+        assertTrue(map.containsKey(JOHNSMITH));
+        assertTrue(map.containsValue(4));
+        assertTrue(map.containsKey(JANEDOE));
+        assertTrue(map.containsKey(JANESMITH));
 
-        Assert.assertFalse(map.containsValue(1));
-        Assert.assertFalse(map.containsValue(3));
+        assertFalse(map.containsValue(1));
+        assertFalse(map.containsValue(3));
     }
 
     @Test
@@ -212,24 +220,24 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 2, JOHNSMITH, 3, JANESMITH, 4);
 
         //Testing removing people
-        Assert.assertEquals(2, map.remove(JANEDOE).intValue());
-        Assert.assertEquals(4, map.remove(JOHNSMITH).intValue());
+        assertEquals(2, map.remove(JANEDOE).intValue());
+        assertEquals(4, map.remove(JOHNSMITH).intValue());
 
         Verify.assertEmpty(map);
 
         //Testing removing from a chain
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 =
                 UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, COLLISION_4, 4);
-        Assert.assertEquals(4, map2.remove(COLLISION_4).intValue());
-        Assert.assertEquals(1, map2.remove(COLLISION_1).intValue());
+        assertEquals(4, map2.remove(COLLISION_4).intValue());
+        assertEquals(1, map2.remove(COLLISION_1).intValue());
         Verify.assertSize(2, map2);
 
         //Testing removing null from a chain
         UnifiedMapWithHashingStrategy<Integer, Integer> map3 =
                 UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, COLLISION_1, 1, null, 2, 3, 3, 4, null);
-        Assert.assertEquals(2, map3.remove(null).intValue());
+        assertEquals(2, map3.remove(null).intValue());
         Verify.assertSize(3, map3);
-        Assert.assertNull(map3.remove(4));
+        assertNull(map3.remove(4));
         Verify.assertSize(2, map3);
     }
 
@@ -237,7 +245,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     public void keySet_isEmpty()
     {
         Set<Integer> keySet = UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, 1, 2, 2).keySet();
-        Assert.assertFalse(keySet.isEmpty());
+        assertFalse(keySet.isEmpty());
         keySet.clear();
         Verify.assertEmpty(keySet);
     }
@@ -271,7 +279,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     {
         Iterator<Map.Entry<Integer, Integer>> iterator = UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, 1).entrySet().iterator();
         Map.Entry<Integer, Integer> element = iterator.next();
-        Assert.assertEquals("1=1", element.toString());
+        assertEquals("1=1", element.toString());
     }
 
     @Override
@@ -319,10 +327,10 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         Verify.assertNotContains(ImmutableEntry.of(JOHNDOE, 1), entries);
         Verify.assertNotContains(ImmutableEntry.of(JANESMITH, 3), entries);
 
-        Assert.assertTrue(entries.remove(ImmutableEntry.of(JANESMITH, 4)));
+        assertTrue(entries.remove(ImmutableEntry.of(JANESMITH, 4)));
         Verify.assertNotContains(ImmutableEntry.of(JOHNSMITH, 4), entries);
 
-        Assert.assertTrue(entries.remove(ImmutableEntry.of(JOHNDOE, 2)));
+        assertTrue(entries.remove(ImmutableEntry.of(JOHNDOE, 2)));
         Verify.assertEmpty(entries);
     }
 
@@ -330,9 +338,9 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     public void valuesCollection_containsAll()
     {
         Collection<Integer> values = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3, 4, 4).values();
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2)));
-        Assert.assertTrue(values.containsAll(FastList.newListWith(1, 2, 3, 4)));
-        Assert.assertFalse(values.containsAll(FastList.newListWith(1, 2, 3, 4, 5)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2)));
+        assertTrue(values.containsAll(FastList.newListWith(1, 2, 3, 4)));
+        assertFalse(values.containsAll(FastList.newListWith(1, 2, 3, 4, 5)));
     }
 
     @Test
@@ -404,7 +412,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
             {
                 entries.batchForEach(new EntrySumProcedure(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(20, sum.getValue());
+            assertEquals(20, sum.getValue());
         }
     }
 
@@ -423,8 +431,8 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         {
             collisions.batchForEach(new EntrySumProcedure(sum2), i, batchCount);
         }
-        Assert.assertEquals(1, batchCount);
-        Assert.assertEquals(78, sum2.getValue());
+        assertEquals(1, batchCount);
+        assertEquals(78, sum2.getValue());
 
         //Testing 3 batches with chains and uneven last batch
         Sum sum3 = new IntegerSum(0);
@@ -432,7 +440,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         {
             collisions.batchForEach(new EntrySumProcedure(sum3), i, 5);
         }
-        Assert.assertEquals(78, sum3.getValue());
+        assertEquals(78, sum3.getValue());
     }
 
     @Test
@@ -453,7 +461,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                 sum4.add(each.getValue() == null ? 1 : each.getValue());
             }, i, numBatches);
         }
-        Assert.assertEquals(52, sum4.getValue());
+        assertEquals(52, sum4.getValue());
     }
 
     @Test
@@ -464,7 +472,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         BatchIterable<Map.Entry<Integer, Integer>> empty =
                 (BatchIterable<Map.Entry<Integer, Integer>>) UnifiedMapWithHashingStrategy.newMap(INTEGER_HASHING_STRATEGY).entrySet();
         empty.batchForEach(new EntrySumProcedure(sum5), 0, empty.getBatchCount(1));
-        Assert.assertEquals(0, sum5.getValue());
+        assertEquals(0, sum5.getValue());
     }
 
     private void batchForEachTestCases(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -477,7 +485,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
             {
                 batchIterable.batchForEach(new SumProcedure<>(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(expectedValue, sum.getValue());
+            assertEquals(expectedValue, sum.getValue());
         }
     }
 
@@ -491,8 +499,8 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(new SumProcedure<>(sum), i, numBatches);
         }
-        Assert.assertEquals(1, numBatches);
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(1, numBatches);
+        assertEquals(expectedValue, sum.getValue());
 
         //Testing 3 batches with chains and uneven last batch
         Sum sum2 = new IntegerSum(0);
@@ -500,7 +508,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(new SumProcedure<>(sum2), i, 5);
         }
-        Assert.assertEquals(expectedValue, sum2.getValue());
+        assertEquals(expectedValue, sum2.getValue());
     }
 
     private void batchForEachNullHandling(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -512,7 +520,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         {
             batchIterable.batchForEach(each -> sum.add(each == null ? 1 : each), i, batchIterable.getBatchCount(7));
         }
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchForEachEmptyBatchIterable(BatchIterable<Integer> batchIterable)
@@ -520,7 +528,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         //Test batchForEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum = new IntegerSum(0);
         batchIterable.batchForEach(new SumProcedure<>(sum), 0, batchIterable.getBatchCount(1));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     @Test
@@ -586,7 +594,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                         INTEGER_HASHING_STRATEGY, 1, 1, 2, 2, 3, 3, 4, 4).entrySet();
         Sum sum = new IntegerSum(0);
         entries.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(20, sum.getValue());
+        assertEquals(20, sum.getValue());
     }
 
     @Test
@@ -599,7 +607,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
 
         Sum sum = new IntegerSum(0);
         collisions.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(78, sum.getValue());
+        assertEquals(78, sum.getValue());
     }
 
     @Test
@@ -618,7 +626,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
             sum.add(each.getValue() == null ? 0 : each.getValue());
         });
 
-        Assert.assertEquals(48, sum.getValue());
+        assertEquals(48, sum.getValue());
     }
 
     @Test
@@ -629,14 +637,14 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         BatchIterable<Map.Entry<Integer, Integer>> empty =
                 (BatchIterable<Map.Entry<Integer, Integer>>) UnifiedMapWithHashingStrategy.newMap(INTEGER_HASHING_STRATEGY).entrySet();
         empty.forEach(new EntrySumProcedure(sum));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     private void batchIterable_forEach(BatchIterable<Integer> batchIterable, int expectedValue)
     {
         IntegerSum sum = new IntegerSum(0);
         batchIterable.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchIterable_forEachNullHandling(BatchIterable<Integer> batchIterable, int expectedValue)
@@ -644,7 +652,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         //Testing forEach handling null keys and null values
         Sum sum = new IntegerSum(0);
         batchIterable.forEach(each -> sum.add(each == null ? 0 : each));
-        Assert.assertEquals(expectedValue, sum.getValue());
+        assertEquals(expectedValue, sum.getValue());
     }
 
     private void batchIterable_forEachEmptyBatchIterable(BatchIterable<Integer> batchIterable)
@@ -652,7 +660,7 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         //Test forEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum = new IntegerSum(0);
         batchIterable.batchForEach(new SumProcedure<>(sum), 0, batchIterable.getBatchCount(1));
-        Assert.assertEquals(0, sum.getValue());
+        assertEquals(0, sum.getValue());
     }
 
     @Override
@@ -694,36 +702,36 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
     public void getMapMemoryUsedInWords()
     {
         UnifiedMapWithHashingStrategy<String, String> map = UnifiedMapWithHashingStrategy.newMap(STRING_HASHING_STRATEGY);
-        Assert.assertEquals(34, map.getMapMemoryUsedInWords());
+        assertEquals(34, map.getMapMemoryUsedInWords());
         map.put("1", "1");
-        Assert.assertEquals(34, map.getMapMemoryUsedInWords());
+        assertEquals(34, map.getMapMemoryUsedInWords());
 
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 = this.mapWithCollisionsOfSize(2);
-        Assert.assertEquals(16, map2.getMapMemoryUsedInWords());
+        assertEquals(16, map2.getMapMemoryUsedInWords());
     }
 
     @Test
     public void getHashingStrategy()
     {
         UnifiedMapWithHashingStrategy<Integer, Object> map = UnifiedMapWithHashingStrategy.newMap(INTEGER_HASHING_STRATEGY);
-        Assert.assertSame(INTEGER_HASHING_STRATEGY, map.hashingStrategy());
+        assertSame(INTEGER_HASHING_STRATEGY, map.hashingStrategy());
     }
 
     @Test
     public void getCollidingBuckets()
     {
         UnifiedMapWithHashingStrategy<Object, Object> map = UnifiedMapWithHashingStrategy.newMap(HashingStrategies.defaultStrategy());
-        Assert.assertEquals(0, map.getCollidingBuckets());
+        assertEquals(0, map.getCollidingBuckets());
 
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 = this.mapWithCollisionsOfSize(2);
-        Assert.assertEquals(1, map2.getCollidingBuckets());
+        assertEquals(1, map2.getCollidingBuckets());
 
         map2.put(42, 42);
-        Assert.assertEquals(1, map2.getCollidingBuckets());
+        assertEquals(1, map2.getCollidingBuckets());
 
         UnifiedMapWithHashingStrategy<String, String> map3 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 STRING_HASHING_STRATEGY, "Six", "6", "Bar", "-", "Three", "3", "Five", "5");
-        Assert.assertEquals(2, map3.getCollidingBuckets());
+        assertEquals(2, map3.getCollidingBuckets());
     }
 
     @Override
@@ -737,21 +745,21 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                 INTEGER_HASHING_STRATEGY, 2, 0.75f);
         MORE_COLLISIONS.forEach(Procedures.cast(each -> map.getIfAbsentPut(each, new PassThruFunction0<>(each))));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(9), map);
+        assertEquals(this.mapWithCollisionsOfSize(9), map);
 
         //Testing getting element present in chain
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, COLLISION_4, 4);
-        Assert.assertEquals(2, map2.getIfAbsentPut(COLLISION_2, () ->
+        assertEquals(2, map2.getIfAbsentPut(COLLISION_2, () ->
         {
-            Assert.fail();
+            fail();
             return null;
         }).intValue());
 
         //Testing rehashing while creating a new chained key
         UnifiedMapWithHashingStrategy<Integer, Integer> map3 = UnifiedMapWithHashingStrategy.<Integer, Integer>newMap(
                 INTEGER_HASHING_STRATEGY, 2, 0.75f).withKeysValues(COLLISION_1, 1, 2, 2, 3, 3);
-        Assert.assertEquals(4, map3.getIfAbsentPut(COLLISION_2, new PassThruFunction0<>(4)).intValue());
+        assertEquals(4, map3.getIfAbsentPut(COLLISION_2, new PassThruFunction0<>(4)).intValue());
     }
 
     @Override
@@ -765,13 +773,13 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                 INTEGER_HASHING_STRATEGY, 2, 0.75f);
         MORE_COLLISIONS.forEach(Procedures.cast(each -> map.getIfAbsentPut(each, each)));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(9), map);
+        assertEquals(this.mapWithCollisionsOfSize(9), map);
 
         //Testing getting element present in chain
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, COLLISION_4, 4);
-        Assert.assertEquals(Integer.valueOf(2), map2.getIfAbsentPut(COLLISION_2, Integer.valueOf(5)));
-        Assert.assertEquals(Integer.valueOf(5), map2.getIfAbsentPut(5, Integer.valueOf(5)));
+        assertEquals(Integer.valueOf(2), map2.getIfAbsentPut(COLLISION_2, Integer.valueOf(5)));
+        assertEquals(Integer.valueOf(5), map2.getIfAbsentPut(5, Integer.valueOf(5)));
     }
 
     @Override
@@ -785,13 +793,13 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
                 INTEGER_HASHING_STRATEGY, 2, 0.75f);
         MORE_COLLISIONS.forEach(Procedures.cast(each -> map.getIfAbsentPutWith(each, Functions.getIntegerPassThru(), each)));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(9), map);
+        assertEquals(this.mapWithCollisionsOfSize(9), map);
 
         //Testing getting element present in chain
         UnifiedMapWithHashingStrategy<Integer, Integer> map2 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, 1, COLLISION_2, 2, COLLISION_3, 3, COLLISION_4, 4);
-        Assert.assertEquals(Integer.valueOf(2), map2.getIfAbsentPutWith(COLLISION_2, Functions.getIntegerPassThru(), Integer.valueOf(5)));
-        Assert.assertEquals(Integer.valueOf(5), map2.getIfAbsentPutWith(5, Functions.getIntegerPassThru(), Integer.valueOf(5)));
+        assertEquals(Integer.valueOf(2), map2.getIfAbsentPutWith(COLLISION_2, Functions.getIntegerPassThru(), Integer.valueOf(5)));
+        assertEquals(Integer.valueOf(5), map2.getIfAbsentPutWith(5, Functions.getIntegerPassThru(), Integer.valueOf(5)));
     }
 
     @Test
@@ -802,9 +810,9 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         UnifiedMapWithHashingStrategy<Person, Integer> map2 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 FIRST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 1, JOHNSMITH, 1, JANESMITH, 1);
 
-        Assert.assertEquals(map1, map2);
-        Assert.assertEquals(map2, map1);
-        Assert.assertNotEquals(map1.hashCode(), map2.hashCode());
+        assertEquals(map1, map2);
+        assertEquals(map2, map1);
+        assertNotEquals(map1.hashCode(), map2.hashCode());
 
         UnifiedMapWithHashingStrategy<Person, Integer> map3 = UnifiedMapWithHashingStrategy.newWithKeysValues(
                 LAST_NAME_HASHING_STRATEGY, JOHNDOE, 1, JANEDOE, 2, JOHNSMITH, 3, JANESMITH, 4);
@@ -812,11 +820,11 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         Map<Person, Integer> hashMap = new HashMap<>(map3);
 
         Verify.assertEqualsAndHashCode(map3, map4);
-        Assert.assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
+        assertTrue(map3.equals(hashMap) && hashMap.equals(map3) && map3.hashCode() != hashMap.hashCode());
 
         UnifiedMap<Person, Integer> unifiedMap = UnifiedMap.newWithKeysValues(JOHNDOE, 1, JANEDOE, 1, JOHNSMITH, 1, JANESMITH, 1);
         UnifiedMapWithHashingStrategy<Person, Integer> map5 = UnifiedMapWithHashingStrategy.newMap(LAST_NAME_HASHING_STRATEGY, unifiedMap);
-        Assert.assertNotEquals(map5, unifiedMap);
+        assertNotEquals(map5, unifiedMap);
     }
 
     @Override
@@ -828,9 +836,9 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         // this map is deliberately small to force a rehash to occur from the put method, in a map with a chained bucket
         UnifiedMapWithHashingStrategy<Integer, Integer> map = UnifiedMapWithHashingStrategy.newMap(
                 INTEGER_HASHING_STRATEGY, 2, 0.75f);
-        COLLISIONS.forEach(0, 4, each -> Assert.assertNull(map.put(each, each)));
+        COLLISIONS.forEach(0, 4, each -> assertNull(map.put(each, each)));
 
-        Assert.assertEquals(this.mapWithCollisionsOfSize(5), map);
+        assertEquals(this.mapWithCollisionsOfSize(5), map);
     }
 
     @Test
@@ -839,34 +847,34 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         UnifiedMapWithHashingStrategy<Integer, Integer> map = UnifiedMapWithHashingStrategy.newMap(INTEGER_HASHING_STRATEGY);
 
         //Testing putting values in non chains
-        Assert.assertNull(map.put(1, 1));
-        Assert.assertNull(map.put(2, 2));
-        Assert.assertNull(map.put(3, 3));
-        Assert.assertNull(map.put(4, 4));
-        Assert.assertNull(map.put(5, null));
+        assertNull(map.put(1, 1));
+        assertNull(map.put(2, 2));
+        assertNull(map.put(3, 3));
+        assertNull(map.put(4, 4));
+        assertNull(map.put(5, null));
 
         //Testing getting values from no chains
-        Assert.assertEquals(1, map.get(1).intValue());
-        Assert.assertEquals(2, map.get(2).intValue());
-        Assert.assertNull(map.get(5));
+        assertEquals(1, map.get(1).intValue());
+        assertEquals(2, map.get(2).intValue());
+        assertNull(map.get(5));
 
         //Testing putting and getting elements in a chain
-        Assert.assertNull(map.put(COLLISION_1, 1));
-        Assert.assertNull(map.get(COLLISION_2));
+        assertNull(map.put(COLLISION_1, 1));
+        assertNull(map.get(COLLISION_2));
 
-        Assert.assertNull(map.put(COLLISION_2, 2));
-        Assert.assertNull(map.get(COLLISION_3));
+        assertNull(map.put(COLLISION_2, 2));
+        assertNull(map.get(COLLISION_3));
 
-        Assert.assertNull(map.put(COLLISION_3, null));
-        Assert.assertNull(map.put(COLLISION_4, 4));
-        Assert.assertNull(map.put(COLLISION_5, 5));
+        assertNull(map.put(COLLISION_3, null));
+        assertNull(map.put(COLLISION_4, 4));
+        assertNull(map.put(COLLISION_5, 5));
 
-        Assert.assertEquals(1, map.get(COLLISION_1).intValue());
-        Assert.assertEquals(5, map.get(COLLISION_5).intValue());
-        Assert.assertNull(map.get(COLLISION_3));
+        assertEquals(1, map.get(COLLISION_1).intValue());
+        assertEquals(5, map.get(COLLISION_5).intValue());
+        assertNull(map.get(COLLISION_3));
 
         map.remove(COLLISION_2);
-        Assert.assertNull(map.get(COLLISION_2));
+        assertNull(map.get(COLLISION_2));
 
         //Testing for casting exceptions
         HashingStrategy<Person> lastName = new HashingStrategy<Person>()
@@ -883,16 +891,16 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         };
 
         UnifiedMapWithHashingStrategy<Person, Integer> map2 = UnifiedMapWithHashingStrategy.newMap(lastName);
-        Assert.assertNull(map2.put(new Person("abe", "smith"), 1));
-        Assert.assertNull(map2.put(new Person("brad", "smith"), 2));
-        Assert.assertNull(map2.put(new Person("charlie", "smith"), 3));
+        assertNull(map2.put(new Person("abe", "smith"), 1));
+        assertNull(map2.put(new Person("brad", "smith"), 2));
+        assertNull(map2.put(new Person("charlie", "smith"), 3));
     }
 
     @Test
     public void hashingStrategy()
     {
         UnifiedMapWithHashingStrategy<Integer, Integer> map = UnifiedMapWithHashingStrategy.newWithKeysValues(INTEGER_HASHING_STRATEGY, 1, 1, 2, 2);
-        Assert.assertSame(INTEGER_HASHING_STRATEGY, map.hashingStrategy());
+        assertSame(INTEGER_HASHING_STRATEGY, map.hashingStrategy());
     }
 
     @Test
@@ -913,8 +921,8 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
             expected.put(each, each);
         });
 
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(261, map.size());
+        assertEquals(expected, map);
+        assertEquals(261, map.size());
 
         MutableList<Integer> toRemove = Lists.mutable.withAll(Interval.evensFromTo(0, 20));
 
@@ -926,9 +934,9 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         });
 
         // First assertion to verify that trim does not happen since, the table is already at the smallest required power of 2.
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(239, map.size());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        assertEquals(239, map.size());
 
         Interval.evensFromTo(0, 250).each(each ->
         {
@@ -937,68 +945,68 @@ public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
         });
 
         // Second assertion to verify that trim happens since, the table length is less than smallest required power of 2.
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        Assert.assertEquals(124, map.size());
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        assertEquals(124, map.size());
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         integers.each(each ->
         {
             map.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         map.clear();
         expected.clear();
-        Assert.assertTrue(map.trimToSize());
+        assertTrue(map.trimToSize());
 
         Interval.zeroTo(20).each(each ->
         {
             map.put(each.toString(), each.toString());
             expected.put(each.toString(), each.toString());
         });
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         Interval.fromTo(9, 18).each(each ->
         {
             map.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertFalse(map.trimToSize());
-        Assert.assertEquals(expected, map);
-        expected.forEachKey(each -> Assert.assertEquals(each, map.get(each)));
+        assertTrue(map.trimToSize());
+        assertFalse(map.trimToSize());
+        assertEquals(expected, map);
+        expected.forEachKey(each -> assertEquals(each, map.get(each)));
 
         map.clear();
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertTrue(map.isEmpty());
+        assertTrue(map.trimToSize());
+        assertTrue(map.isEmpty());
         Interval.zeroTo(6).each(each -> map.put(each.toString(), each.toString()));
         // Assert that trim does not happen as long as table.size is already as smaller than required
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         map.put("7", "7");
 
         map.removeKey("2");
         map.removeKey("3");
         // Assert that trim does not happen as long as table.size is as small as required
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
         map.removeKey("5");
         map.removeKey("7");
-        Assert.assertTrue(map.trimToSize());
+        assertTrue(map.trimToSize());
         // Inflate the map so that table.length increases to next power of 2 and check that trim does not happen
         map.put("2", "2");
         map.put("5", "5");
         map.put("7", "7");
         // Assert that the resized table due to put is the required size and no need to trim that.
-        Assert.assertFalse(map.trimToSize());
+        assertFalse(map.trimToSize());
 
         Interval.zeroTo(4).each(each -> map.put(each.toString(), each.toString()));
         Interval.oneTo(3).each(each -> map.removeKey(each.toString()));
-        Assert.assertTrue(map.trimToSize());
-        Assert.assertEquals(5, map.size());
+        assertTrue(map.trimToSize());
+        assertEquals(5, map.size());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractImmutableMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractImmutableMultimapTestCase.java
@@ -26,8 +26,12 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableMultimapTestCase
 {
@@ -70,13 +74,13 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         ImmutableMultimap<String, String> empty = this.classUnderTest();
         Verify.assertEmpty(empty);
-        Assert.assertTrue(empty.isEmpty());
-        Assert.assertFalse(empty.notEmpty());
+        assertTrue(empty.isEmpty());
+        assertFalse(empty.notEmpty());
 
         ImmutableMultimap<String, String> notEmpty = empty.newWith("1", "1");
         Verify.assertNotEmpty(notEmpty);
-        Assert.assertTrue(notEmpty.notEmpty());
-        Assert.assertFalse(notEmpty.isEmpty());
+        assertTrue(notEmpty.notEmpty());
+        assertFalse(notEmpty.isEmpty());
     }
 
     @Test
@@ -88,7 +92,7 @@ public abstract class AbstractImmutableMultimapTestCase
                 .newWith("Two", 2)
                 .newWith("Three", 3);
         Verify.assertInstanceOf(UnmodifiableMutableSet.class, multimap.keySet());
-        Assert.assertEquals(Sets.mutable.of("One", "Two", "Three"), multimap.keySet());
+        assertEquals(Sets.mutable.of("One", "Two", "Three"), multimap.keySet());
     }
 
     @Test
@@ -101,19 +105,19 @@ public abstract class AbstractImmutableMultimapTestCase
         ImmutableMultimap<String, String> notEmpty = empty.newWith("1", "1");
         RichIterable<String> notEmptyView = notEmpty.get("1");
         Verify.assertIterableNotEmpty(notEmptyView);
-        Assert.assertEquals(FastList.newListWith("1"), notEmptyView.toList());
+        assertEquals(FastList.newListWith("1"), notEmptyView.toList());
     }
 
     @Test
     public void toMap()
     {
         ImmutableMultimap<String, String> empty = this.classUnderTest();
-        Assert.assertEquals(UnifiedMap.<String, RichIterable<String>>newMap(), empty.toMap());
+        assertEquals(UnifiedMap.<String, RichIterable<String>>newMap(), empty.toMap());
 
         ImmutableMultimap<String, String> notEmpty = empty.newWith("1", "1");
         MutableCollection<String> strings = this.mutableCollection();
         strings.add("1");
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues("1", (RichIterable<String>) strings),
                 notEmpty.toMap());
     }
@@ -138,7 +142,7 @@ public abstract class AbstractImmutableMultimapTestCase
         ImmutableMultimap<String, String> notEmpty = empty.newWith("1", "1").newWith("1", "2");
         Verify.assertNotEmpty(notEmpty);
 
-        Assert.assertEquals(empty.newWithAll("1", FastList.newListWith("1", "2")), notEmpty);
+        assertEquals(empty.newWithAll("1", FastList.newListWith("1", "2")), notEmpty);
         Verify.assertEmpty(notEmpty.newWithoutAll("1"));
     }
 
@@ -146,7 +150,7 @@ public abstract class AbstractImmutableMultimapTestCase
     public void toImmutable()
     {
         ImmutableMultimap<String, String> empty = this.classUnderTest();
-        Assert.assertSame(empty, empty.toImmutable());
+        assertSame(empty, empty.toImmutable());
     }
 
     @Test
@@ -166,7 +170,7 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         ImmutableMultimap<String, String> multimap = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2");
         ImmutableMultimap<String, String> selectedMultimap = multimap.selectKeysValues((key, value) -> "Two".equals(key) && "2".equals(value));
-        Assert.assertEquals(this.classUnderTest().newWith("Two", "2"), selectedMultimap);
+        assertEquals(this.classUnderTest().newWith("Two", "2"), selectedMultimap);
     }
 
     @Test
@@ -174,7 +178,7 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         ImmutableMultimap<String, String> multimap = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2");
         ImmutableMultimap<String, String> rejectedMultimap = multimap.rejectKeysValues((key, value) -> "Two".equals(key) && "2".equals(value));
-        Assert.assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap);
+        assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap);
     }
 
     @Test
@@ -182,11 +186,11 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         ImmutableMultimap<String, String> multimap1 = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2").newWith("Two", "3");
         ImmutableMultimap<String, String> selectedMultimap1 = multimap1.selectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, "2"));
-        Assert.assertEquals(this.classUnderTest().newWith("Two", "2").newWith("Two", "3"), selectedMultimap1);
+        assertEquals(this.classUnderTest().newWith("Two", "2").newWith("Two", "3"), selectedMultimap1);
 
         ImmutableMultimap<String, String> multimap2 = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "3");
         ImmutableMultimap<String, String> selectedMultimap2 = multimap2.selectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, "2"));
-        Assert.assertEquals(this.classUnderTest(), selectedMultimap2);
+        assertEquals(this.classUnderTest(), selectedMultimap2);
     }
 
     @Test
@@ -194,11 +198,11 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         ImmutableMultimap<String, String> multimap1 = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2").newWith("Two", "3");
         ImmutableMultimap<String, String> rejectedMultimap1 = multimap1.rejectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, "2"));
-        Assert.assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap1);
+        assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap1);
 
         ImmutableMultimap<String, String> multimap2 = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "3");
         ImmutableMultimap<String, String> rejectedMultimap2 = multimap2.rejectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, "2"));
-        Assert.assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap2);
+        assertEquals(this.classUnderTest().newWith("One", "1"), rejectedMultimap2);
     }
 
     @Test
@@ -206,7 +210,7 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         Multimap<String, String> multimap = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2");
         Multimap<String, String> collectedMultimap = multimap.collectKeysValues((argument1, argument2) -> Tuples.pair(argument1 + "Key", argument2 + "Value"));
-        Assert.assertEquals(this.classUnderTest().newWith("OneKey", "1Value").newWith("TwoKey", "2Value"), collectedMultimap);
+        assertEquals(this.classUnderTest().newWith("OneKey", "1Value").newWith("TwoKey", "2Value"), collectedMultimap);
     }
 
     @Test
@@ -223,7 +227,7 @@ public abstract class AbstractImmutableMultimapTestCase
         expectedMultimap.putAll("Evens", Lists.mutable.with(3, 4, 5));
         ImmutableBagMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
 
-        Assert.assertEquals(expectedImmutableMultimap, collectedMultimap);
+        assertEquals(expectedImmutableMultimap, collectedMultimap);
     }
 
     @Test
@@ -231,7 +235,7 @@ public abstract class AbstractImmutableMultimapTestCase
     {
         Multimap<String, String> multimap = this.<String, String>classUnderTest().newWith("One", "1").newWith("Two", "2");
         Multimap<String, String> collectedMultimap = multimap.collectValues(value -> value + "Value");
-        Assert.assertEquals(this.classUnderTest().newWith("One", "1Value").newWith("Two", "2Value"), collectedMultimap);
+        assertEquals(this.classUnderTest().newWith("One", "1Value").newWith("Two", "2Value"), collectedMultimap);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMultimapTestCase.java
@@ -34,8 +34,14 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Helper class for testing {@link Multimap}s.
@@ -126,7 +132,7 @@ public abstract class AbstractMultimapTestCase
         Multimap<Integer, String> expected = this.newMultimap(pair1, pair2, pair3, pair4);
 
         Multimap<Integer, String> actual = this.newMultimapFromPairs(pairs);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -136,7 +142,7 @@ public abstract class AbstractMultimapTestCase
                 this.newMultimapWithKeysValues(1, "One", 2, "Two", 3, "Three", 4, "Four");
         Multimap<Integer, String> actual =
                 this.newMultimap(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(3, "Three"), Tuples.pair(4, "Four"));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -144,7 +150,7 @@ public abstract class AbstractMultimapTestCase
     {
         Verify.assertEmpty(this.newMultimap());
         Verify.assertNotEmpty(this.newMultimapWithKeyValue(1, 1));
-        Assert.assertTrue(this.newMultimapWithKeyValue(1, 1).notEmpty());
+        assertTrue(this.newMultimapWithKeyValue(1, 1).notEmpty());
     }
 
     @Test
@@ -154,7 +160,7 @@ public abstract class AbstractMultimapTestCase
         Multimap<Integer, String> multimap =
                 this.newMultimapWithKeysValues(1, "One", 2, "Two", 3, "Three");
         multimap.forEachKeyValue((key, value) -> collection.add(key + value));
-        Assert.assertEquals(HashBag.newBagWith("1One", "2Two", "3Three"), collection);
+        assertEquals(HashBag.newBagWith("1One", "2Two", "3Three"), collection);
     }
 
     @Test
@@ -167,7 +173,7 @@ public abstract class AbstractMultimapTestCase
         MutableSet<Pair<Integer, MutableCollection<String>>> expected = Sets.mutable.with(
                 Tuples.pair(2, this.createCollection("2", "1")),
                 Tuples.pair(3, this.createCollection("3", "3")));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -176,21 +182,21 @@ public abstract class AbstractMultimapTestCase
         MutableBag<String> collection = Bags.mutable.of();
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         multimap.forEachValue(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(HashBag.newBagWith("1", "2", "3"), collection);
+        assertEquals(HashBag.newBagWith("1", "2", "3"), collection);
     }
 
     @Test
     public void valuesView()
     {
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(Bags.mutable.of("1", "2", "3"), multimap.valuesView().toBag());
+        assertEquals(Bags.mutable.of("1", "2", "3"), multimap.valuesView().toBag());
     }
 
     @Test
     public void multiValuesView()
     {
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("1", "2", "3"),
                 multimap.multiValuesView().flatCollect(Functions.getPassThru()).toBag());
     }
@@ -201,25 +207,25 @@ public abstract class AbstractMultimapTestCase
         MutableList<Integer> collection = Lists.mutable.of();
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         multimap.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), collection);
+        assertEquals(FastList.newListWith(1, 2, 3), collection);
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.newMultimap().isEmpty());
-        Assert.assertFalse(this.newMultimap().notEmpty());
-        Assert.assertTrue(this.newMultimapWithKeysValues(1, "1", 2, "2").notEmpty());
+        assertTrue(this.newMultimap().isEmpty());
+        assertFalse(this.newMultimap().notEmpty());
+        assertTrue(this.newMultimapWithKeysValues(1, "1", 2, "2").notEmpty());
     }
 
     @Test
     public void keysWithMultiValuesView()
     {
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(1, 2, 3),
                 multimap.keyMultiValuePairsView().collect(Pair::getOne).toBag());
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("1", "2", "3"),
                 multimap.keyMultiValuePairsView().flatCollect(Functions.secondOfPair()).toBag());
     }
@@ -228,7 +234,7 @@ public abstract class AbstractMultimapTestCase
     public void keyValuePairsView()
     {
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of(Tuples.pair(1, "1"), Tuples.pair(2, "2"), Tuples.pair(3, "3")),
                 multimap.keyValuePairsView().toBag());
     }
@@ -237,8 +243,8 @@ public abstract class AbstractMultimapTestCase
     public void keyBag()
     {
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 2, "2.1");
-        Assert.assertEquals(1, multimap.keyBag().occurrencesOf(1));
-        Assert.assertEquals(2, multimap.keyBag().occurrencesOf(2));
+        assertEquals(1, multimap.keyBag().occurrencesOf(1));
+        assertEquals(2, multimap.keyBag().occurrencesOf(2));
     }
 
     @Test
@@ -247,8 +253,8 @@ public abstract class AbstractMultimapTestCase
         Multimap<Integer, String> map1 = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         Multimap<Integer, String> map2 = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         Multimap<Integer, String> map3 = this.newMultimapWithKeysValues(2, "2", 3, "3", 4, "4");
-        Assert.assertEquals(map1, map2);
-        Assert.assertNotEquals(map2, map3);
+        assertEquals(map1, map2);
+        assertNotEquals(map2, map3);
     }
 
     @Test
@@ -274,7 +280,7 @@ public abstract class AbstractMultimapTestCase
         Multimap<Object, Object> original = this.newMultimap();
         Multimap<Object, Object> newEmpty = original.newEmpty();
         Verify.assertEmpty(newEmpty);
-        Assert.assertSame(original.getClass(), newEmpty.getClass());
+        assertSame(original.getClass(), newEmpty.getClass());
         Verify.assertEqualsAndHashCode(original, newEmpty);
     }
 
@@ -283,7 +289,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Three", 3);
-        Assert.assertEquals(Bags.mutable.of("One", "Two", "Three"), multimap.keysView().toBag());
+        assertEquals(Bags.mutable.of("One", "Two", "Three"), multimap.keysView().toBag());
     }
 
     @Test
@@ -292,9 +298,9 @@ public abstract class AbstractMultimapTestCase
         Multimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "One", 1, "Two", 2, "Three", 3);
         Set<String> keySet = (Set<String>) multimap.keySet();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> keySet.add("Four"));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> keySet.remove("Four"));
-        Assert.assertEquals(Sets.mutable.of("One", "Two", "Three"), keySet);
+        assertThrows(UnsupportedOperationException.class, () -> keySet.add("Four"));
+        assertThrows(UnsupportedOperationException.class, () -> keySet.remove("Four"));
+        assertEquals(Sets.mutable.of("One", "Two", "Three"), keySet);
     }
 
     @Test
@@ -302,7 +308,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("One", 1, "Two", 2, "Two", 3);
         Verify.assertSize(3, multimap);
-        Assert.assertEquals(2, multimap.sizeDistinct());
+        assertEquals(2, multimap.sizeDistinct());
     }
 
     @Test
@@ -310,7 +316,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("One", 1, "One", 12, "Two", 2, "Two", 3);
         Multimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> "Two".equals(key) && (value % 2 == 0));
-        Assert.assertEquals(this.newMultimapWithKeyValue("Two", 2), selectedMultimap);
+        assertEquals(this.newMultimapWithKeyValue("Two", 2), selectedMultimap);
     }
 
     @Test
@@ -318,7 +324,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("One", 1, "One", 12, "Two", 2, "Two", 4);
         Multimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> "Two".equals(key) || (value % 2 == 0));
-        Assert.assertEquals(this.newMultimapWithKeyValue("One", 1), rejectedMultimap);
+        assertEquals(this.newMultimapWithKeyValue("One", 1), rejectedMultimap);
     }
 
     @Test
@@ -326,7 +332,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("One", 1, "One", 12, "Two", 2, "Two", 3);
         Multimap<String, Integer> selectedMultimap = multimap.selectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, 2));
-        Assert.assertEquals(this.newMultimapWithKeysValues("Two", 2, "Two", 3), selectedMultimap);
+        assertEquals(this.newMultimapWithKeysValues("Two", 2, "Two", 3), selectedMultimap);
     }
 
     @Test
@@ -334,7 +340,7 @@ public abstract class AbstractMultimapTestCase
     {
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("One", 1, "One", 12, "Two", 2, "Two", 3);
         Multimap<String, Integer> rejectedMultimap = multimap.rejectKeysMultiValues((key, values) -> "Two".equals(key) && Iterate.contains(values, 2));
-        Assert.assertEquals(this.newMultimapWithKeysValues("One", 1, "One", 12), rejectedMultimap);
+        assertEquals(this.newMultimapWithKeysValues("One", 1, "One", 12), rejectedMultimap);
     }
 
     @Test
@@ -343,7 +349,7 @@ public abstract class AbstractMultimapTestCase
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("1", 1, "1", 12, "2", 2, "3", 3);
         Multimap<Integer, String> collectedMultimap = multimap.collectKeysValues((key, value) -> Tuples.pair(Integer.valueOf(key), value + "Value"));
         Multimap<Integer, String> expectedMultimap = this.newMultimapWithKeysValues(1, "1Value", 1, "12Value", 2, "2Value", 3, "3Value");
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
+        assertEquals(expectedMultimap, collectedMultimap);
     }
 
     @Test
@@ -361,7 +367,7 @@ public abstract class AbstractMultimapTestCase
                 value -> value % 2 == 0 ? value + 1 : value,
                 Multimaps.mutable.set.empty());
         SetMultimap<Integer, Integer> expectedMultimap1 = Multimaps.mutable.set.with(1, 1, 1, 13, 1, 3);
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        assertEquals(expectedMultimap1, collectedMultimap1);
 
         Multimap<Integer, Integer> collectedMultimap2 = multimap.collectKeyMultiValues(
                 key -> 1,
@@ -371,8 +377,8 @@ public abstract class AbstractMultimapTestCase
         expectedMultimap2.put(1, 3);
         expectedMultimap2.put(1, 3);
         expectedMultimap2.put(1, 3);
-        Assert.assertEquals(expectedMultimap2.keySet(), collectedMultimap2.keySet());
-        Assert.assertEquals(expectedMultimap2.get(1).toBag(), collectedMultimap2.get(1).toBag());
+        assertEquals(expectedMultimap2.keySet(), collectedMultimap2.keySet());
+        assertEquals(expectedMultimap2.get(1).toBag(), collectedMultimap2.get(1).toBag());
     }
 
     @Test
@@ -381,7 +387,7 @@ public abstract class AbstractMultimapTestCase
         Multimap<String, Integer> multimap = this.newMultimapWithKeysValues("1", 1, "1", 12, "2", 2, "3", 3);
         Multimap<String, String> collectedMultimap = multimap.collectValues(value -> value + "Value");
         Multimap<String, String> expectedMultimap = this.newMultimapWithKeysValues("1", "1Value", "1", "12Value", "2", "2Value", "3", "3Value");
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
+        assertEquals(expectedMultimap, collectedMultimap);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMutableMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMutableMultimapTestCase.java
@@ -29,8 +29,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Helper class for testing {@link Multimap}s.
@@ -80,13 +86,13 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         Pair<Integer, String> pair2 = Tuples.pair(2, "Two");
         Pair<Integer, String> pair3 = Tuples.pair(3, "Three");
         Pair<Integer, String> pair4 = Tuples.pair(4, "Four");
-        Assert.assertTrue(multimap.add(pair1));
+        assertTrue(multimap.add(pair1));
         Verify.assertContainsEntry(1, "One", multimap);
-        Assert.assertTrue(multimap.add(pair2));
+        assertTrue(multimap.add(pair2));
         Verify.assertContainsEntry(2, "Two", multimap);
-        Assert.assertTrue(multimap.add(pair3));
+        assertTrue(multimap.add(pair3));
         Verify.assertContainsEntry(3, "Three", multimap);
-        Assert.assertTrue(multimap.add(pair4));
+        assertTrue(multimap.add(pair4));
         Verify.assertContainsEntry(4, "Four", multimap);
         Verify.assertSetsEqual(UnifiedSet.newSetWith(pair1, pair2, pair3, pair4), multimap.keyValuePairsView().toSet());
     }
@@ -117,7 +123,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableBag<Integer> collection = Bags.mutable.of();
         Multimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         multimap.forEachKey(CollectionAddProcedure.on(collection));
-        Assert.assertEquals(HashBag.newBagWith(1, 2, 3), collection);
+        assertEquals(HashBag.newBagWith(1, 2, 3), collection);
     }
 
     @Test
@@ -132,19 +138,19 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<Integer, String> expected = this.newMultimap();
         expected.put(1, "A");
         expected.put(1, "B");
-        Assert.assertEquals(expected, multimap);
+        assertEquals(expected, multimap);
 
         multimap.withKeyMultiValues(1, "C");
         Verify.assertSize(3, multimap);
 
         expected.put(1, "C");
-        Verify.assertEquals(expected, multimap);
+        assertEquals(expected, multimap);
 
         multimap.withKeyMultiValues(2, "Z", "K", "Y");
         Verify.assertSize(6, multimap);
 
         expected = expected.withKeyValue(2, "Z").withKeyValue(2, "K").withKeyValue(2, "Y");
-        Verify.assertEquals(expected, multimap);
+        assertEquals(expected, multimap);
     }
 
     @Test (expected = NullPointerException.class)
@@ -159,12 +165,12 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "One", 2, "2");
         Multimap<Integer, String> toAdd = this.newMultimapWithKeysValues(2, "Two", 3, "Three");
         Multimap<Integer, String> toAddImmutable = this.newMultimapWithKeysValues(4, "Four", 5, "Five");
-        Assert.assertTrue(multimap.putAll(toAdd));
-        Assert.assertTrue(multimap.putAll(toAddImmutable));
+        assertTrue(multimap.putAll(toAdd));
+        assertTrue(multimap.putAll(toAddImmutable));
         MutableMultimap<Integer, String> expected = this.newMultimapWithKeysValues(1, "One", 2, "2", 2, "Two", 3, "Three");
         expected.put(4, "Four");
         expected.put(5, "Five");
-        Assert.assertEquals(expected, multimap);
+        assertEquals(expected, multimap);
     }
 
     @Test
@@ -172,36 +178,36 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
     {
         MutableMultimap<Integer, String> multimap1 = this.newMultimapWithKeysValues(1, "One", 2, "2");
         MutableList<Pair<Integer, String>> pairs1 = Lists.mutable.of(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(3, "Three"));
-        Assert.assertTrue(multimap1.putAllPairs(pairs1));
+        assertTrue(multimap1.putAllPairs(pairs1));
         MutableMultimap<Integer, String> expected1 = this.newMultimap();
         expected1.put(1, "One");
         expected1.put(1, "One");
         expected1.put(2, "2");
         expected1.put(2, "Two");
         expected1.put(3, "Three");
-        Assert.assertEquals(expected1, multimap1);
+        assertEquals(expected1, multimap1);
 
         MutableMultimap<Integer, String> multimap2 = this.newMultimapWithKeysValues(1, "One", 2, "2");
         ImmutableList<Pair<Integer, String>> pairs2 = Lists.immutable.of(Tuples.pair(1, "One"), Tuples.pair(2, "Two"), Tuples.pair(3, "Three"));
-        Assert.assertTrue(multimap2.putAllPairs(pairs2));
+        assertTrue(multimap2.putAllPairs(pairs2));
         MutableMultimap<Integer, String> expected2 = this.newMultimap();
         expected2.put(1, "One");
         expected2.put(1, "One");
         expected2.put(2, "2");
         expected2.put(2, "Two");
         expected2.put(3, "Three");
-        Assert.assertEquals(expected2, multimap2);
+        assertEquals(expected2, multimap2);
 
         MutableMultimap<String, Integer> multimap3 = this.newMultimapWithKeysValues("One", 1, "Two", 2);
         MutableSet<Pair<String, Integer>> pairs3 = Sets.mutable.of(Tuples.pair("One", 1), Tuples.pair("Two", 2), Tuples.pair("Three", 3));
-        Assert.assertTrue(multimap3.putAllPairs(pairs3));
+        assertTrue(multimap3.putAllPairs(pairs3));
         MutableMultimap<String, Integer> expected3 = this.newMultimap();
         expected3.put("One", 1);
         expected3.put("One", 1);
         expected3.put("Two", 2);
         expected3.put("Two", 2);
         expected3.put("Three", 3);
-        Assert.assertEquals(expected3, multimap3);
+        assertEquals(expected3, multimap3);
 
         MutableMultimap<Number, String> multimap4 = this.newMultimap();
         MutableList<Pair<Integer, String>> intPairs4 = Lists.mutable.of(Tuples.pair(1, "Integer1"), Tuples.pair(2, "Integer2"));
@@ -209,52 +215,52 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         multimap4.putAllPairs(intPairs4);
         multimap4.putAllPairs(longPairs4);
         MutableMultimap<Number, String> expected4 = this.newMultimapWithKeysValues(1, "Integer1", 2, "Integer2", 1L, "Long1", 2L, "Long2");
-        Assert.assertEquals(expected4, multimap4);
+        assertEquals(expected4, multimap4);
     }
 
     @Test
     public void putAllFromCollection()
     {
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertTrue(multimap.putAll(1, Lists.fixedSize.of("Three", "Four")));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
-        Assert.assertFalse(multimap.putAll(1, UnifiedSet.newSet()));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
+        assertTrue(multimap.putAll(1, Lists.fixedSize.of("Three", "Four")));
+        assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
+        assertFalse(multimap.putAll(1, UnifiedSet.newSet()));
+        assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
     }
 
     @Test
     public void putAllFromIterable()
     {
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertTrue(multimap.putAll(1, Lists.fixedSize.of("Three", "Four").asLazy()));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
+        assertTrue(multimap.putAll(1, Lists.fixedSize.of("Three", "Four").asLazy()));
+        assertEquals(this.newMultimapWithKeysValues(1, "One", 2, "Two", 1, "Three", 1, "Four"), multimap);
     }
 
     @Test
     public void getIfAbsentPutAll()
     {
         MutableMultimap<Integer, Integer> multimap = this.newMultimap();
-        Assert.assertFalse(multimap.containsKey(1));
-        Assert.assertEquals(0, multimap.size());
+        assertFalse(multimap.containsKey(1));
+        assertEquals(0, multimap.size());
 
-        Assert.assertEquals(this.createCollection(), multimap.getIfAbsentPutAll(1, Lists.mutable.with()));
-        Assert.assertFalse(multimap.containsKey(1));
-        Assert.assertEquals(0, multimap.size());
+        assertEquals(this.createCollection(), multimap.getIfAbsentPutAll(1, Lists.mutable.with()));
+        assertFalse(multimap.containsKey(1));
+        assertEquals(0, multimap.size());
 
-        Assert.assertEquals(this.createCollection(1), multimap.getIfAbsentPutAll(1, Lists.mutable.with(1)));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> multimap.getIfAbsentPutAll(1, Lists.mutable.with(1)).add(1));
+        assertEquals(this.createCollection(1), multimap.getIfAbsentPutAll(1, Lists.mutable.with(1)));
+        assertThrows(UnsupportedOperationException.class, () -> multimap.getIfAbsentPutAll(1, Lists.mutable.with(1)).add(1));
 
         multimap.putAll(2, Lists.mutable.with(2, 2));
         multimap.putAll(3, Lists.mutable.with(3, 3, 3));
-        Assert.assertEquals(this.createCollection(1), multimap.getIfAbsentPutAll(1, Lists.mutable.empty()));
-        Assert.assertEquals(this.createCollection(2, 2), multimap.getIfAbsentPutAll(2, Lists.mutable.empty()));
-        Assert.assertEquals(this.createCollection(3, 3, 3), multimap.getIfAbsentPutAll(3, Lists.mutable.empty()));
-        Assert.assertEquals(this.createCollection(4, 4, 4, 4), multimap.getIfAbsentPutAll(4, Lists.mutable.with(4, 4, 4, 4)));
-        Assert.assertEquals(4, multimap.sizeDistinct());
+        assertEquals(this.createCollection(1), multimap.getIfAbsentPutAll(1, Lists.mutable.empty()));
+        assertEquals(this.createCollection(2, 2), multimap.getIfAbsentPutAll(2, Lists.mutable.empty()));
+        assertEquals(this.createCollection(3, 3, 3), multimap.getIfAbsentPutAll(3, Lists.mutable.empty()));
+        assertEquals(this.createCollection(4, 4, 4, 4), multimap.getIfAbsentPutAll(4, Lists.mutable.with(4, 4, 4, 4)));
+        assertEquals(4, multimap.sizeDistinct());
         int multimapSize = this.createCollection(1).size() + this.createCollection(2, 2).size() + this.createCollection(3, 3, 3).size() + this.createCollection(4, 4, 4, 4).size();
-        Assert.assertEquals(multimapSize, multimap.size());
+        assertEquals(multimapSize, multimap.size());
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> multimap.getIfAbsentPutAll(5, Lists.mutable.with(5)).add(5));
+        assertThrows(UnsupportedOperationException.class, () -> multimap.getIfAbsentPutAll(5, Lists.mutable.with(5)).add(5));
     }
 
     @Test
@@ -264,7 +270,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
 
         Verify.assertSetsEqual(UnifiedSet.newSetWith("1"), UnifiedSet.newSet(multimap.removeAll(1)));
         Verify.assertSize(1, multimap);
-        Assert.assertFalse(multimap.containsKey(1));
+        assertFalse(multimap.containsKey(1));
 
         Verify.assertIterableEmpty(multimap.removeAll(42));
         Verify.assertSize(1, multimap);
@@ -277,8 +283,8 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
     public void containsValue()
     {
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "One", 2, "Two");
-        Assert.assertTrue(multimap.containsValue("Two"));
-        Assert.assertFalse(multimap.containsValue("Three"));
+        assertTrue(multimap.containsValue("Two"));
+        assertFalse(multimap.containsValue("Three"));
     }
 
     @Test
@@ -286,7 +292,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
     {
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "1", 2, "2", 3, "3");
         Verify.assertIterableEmpty(multimap.get(4));
-        Assert.assertTrue(multimap.put(4, "4"));
+        assertTrue(multimap.put(4, "4"));
         Verify.assertContainsEntry(4, "4", multimap);
     }
 
@@ -294,12 +300,12 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
     public void remove()
     {
         MutableMultimap<Integer, Integer> map = this.newMultimapWithKeysValues(1, 1, 1, 2, 3, 3, 4, 5);
-        Assert.assertFalse(map.remove(4, 4));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, 1, 1, 2, 3, 3, 4, 5), map);
-        Assert.assertTrue(map.remove(4, 5));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, 1, 1, 2, 3, 3), map);
-        Assert.assertTrue(map.remove(1, 2));
-        Assert.assertEquals(this.newMultimapWithKeysValues(1, 1, 3, 3), map);
+        assertFalse(map.remove(4, 4));
+        assertEquals(this.newMultimapWithKeysValues(1, 1, 1, 2, 3, 3, 4, 5), map);
+        assertTrue(map.remove(4, 5));
+        assertEquals(this.newMultimapWithKeysValues(1, 1, 1, 2, 3, 3), map);
+        assertTrue(map.remove(1, 2));
+        assertEquals(this.newMultimapWithKeysValues(1, 1, 3, 3), map);
     }
 
     @Test
@@ -308,11 +314,11 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Three", 3);
         RichIterable<Integer> oldValues2 = multimap.replaceValues("Two", UnifiedSet.newSetWith(4));
-        Assert.assertEquals(Bags.mutable.of(2), oldValues2.toBag());
+        assertEquals(Bags.mutable.of(2), oldValues2.toBag());
         Verify.assertEqualsAndHashCode(this.newMultimapWithKeysValues("One", 1, "Two", 4, "Three", 3), multimap);
 
         RichIterable<Integer> oldValues3 = multimap.replaceValues("Three", UnifiedSet.newSet());
-        Assert.assertEquals(Bags.mutable.of(3), oldValues3.toBag());
+        assertEquals(Bags.mutable.of(3), oldValues3.toBag());
         Verify.assertEqualsAndHashCode(this.newMultimapWithKeysValues("One", 1, "Two", 4), multimap);
     }
 
@@ -322,7 +328,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Three", 3);
         RichIterable<Integer> oldValues = multimap.replaceValues("Four", UnifiedSet.newSetWith(4));
-        Assert.assertEquals(HashBag.<Integer>newBag(), oldValues.toBag());
+        assertEquals(HashBag.<Integer>newBag(), oldValues.toBag());
         Verify.assertEqualsAndHashCode(this.newMultimapWithKeysValues("One", 1, "Two", 2, "Three", 3, "Four", 4), multimap);
     }
 
@@ -335,10 +341,10 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         expected.put("One", this.createCollection(1));
         expected.put("Two", this.createCollection(2, 2));
         MutableMap<String, RichIterable<Integer>> toMap = multimap.toMap();
-        Assert.assertEquals(expected, toMap);
+        assertEquals(expected, toMap);
         MutableMap<String, RichIterable<Integer>> newToMap = multimap.toMap();
-        Assert.assertEquals(toMap.get("One"), newToMap.get("One"));
-        Assert.assertNotSame(toMap.get("One"), newToMap.get("One"));
+        assertEquals(toMap.get("One"), newToMap.get("One"));
+        assertNotSame(toMap.get("One"), newToMap.get("One"));
     }
 
     @Test
@@ -347,8 +353,8 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Two", 2);
         ImmutableMultimap<String, Integer> actual = multimap.toImmutable();
-        Assert.assertNotNull(actual);
-        Assert.assertEquals(multimap, actual);
+        assertNotNull(actual);
+        assertEquals(multimap, actual);
     }
 
     @Test
@@ -360,7 +366,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         expected.put("One", UnifiedSet.newSetWith(1));
         expected.put("Two", UnifiedSet.newSetWith(2, 2));
         MutableMap<String, MutableSet<Integer>> map = multimap.toMap(UnifiedSet::new);
-        Assert.assertEquals(expected, map);
+        assertEquals(expected, map);
     }
 
     @Test
@@ -369,8 +375,8 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Two", 2);
         MutableMultimap<String, Integer> mutableCopy = multimap.toMutable();
-        Assert.assertNotSame(multimap, mutableCopy);
-        Assert.assertEquals(multimap, mutableCopy);
+        assertNotSame(multimap, mutableCopy);
+        assertEquals(multimap, mutableCopy);
     }
 
     @Test
@@ -378,7 +384,7 @@ public abstract class AbstractMutableMultimapTestCase extends AbstractMultimapTe
     {
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2);
-        Assert.assertTrue(
+        assertTrue(
                 "{One=[1], Two=[2]}".equals(multimap.toString())
                         || "{Two=[2], One=[1]}".equals(multimap.toString()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/UnifiedSetWithHashingStrategyMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/UnifiedSetWithHashingStrategyMultimapTest.java
@@ -32,8 +32,10 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Test of {@link UnifiedSetWithHashingStrategyMultimap}.
@@ -160,7 +162,7 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         UnifiedSetWithHashingStrategyMultimap<Integer, Person> hashingMap2 = UnifiedSetWithHashingStrategyMultimap.newMultimap(map2);
 
         Verify.assertSetsEqual(hashingMap.get(1), hashingMap2.get(1));
-        Assert.assertSame(hashingMap.getValueHashingStrategy(), hashingMap2.getValueHashingStrategy());
+        assertSame(hashingMap.getValueHashingStrategy(), hashingMap2.getValueHashingStrategy());
     }
 
     @Test
@@ -178,8 +180,8 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
 
         Verify.assertMapsEqual(expected, lastNameMap.getMap());
         Verify.assertMapsEqual(expected, newEmptyMap.getMap());
-        Assert.assertSame(LAST_NAME_STRATEGY, lastNameMap.getValueHashingStrategy());
-        Assert.assertSame(LAST_NAME_STRATEGY, newEmptyMap.getValueHashingStrategy());
+        assertSame(LAST_NAME_STRATEGY, lastNameMap.getValueHashingStrategy());
+        assertSame(LAST_NAME_STRATEGY, newEmptyMap.getValueHashingStrategy());
     }
 
     @Override
@@ -219,9 +221,9 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         UnifiedSetWithHashingStrategyMultimap<Integer, Person> expectedMultimap = UnifiedSetWithHashingStrategyMultimap.newMultimap(FIRST_NAME_STRATEGY);
         expectedMultimap.put(2, JANESMITH);
         expectedMultimap.put(2, JANEDOE);
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
+        assertEquals(expectedMultimap, selectedMultimap);
         Verify.assertMapsEqual(expectedMultimap.getMap(), selectedMultimap.getMap());
-        Assert.assertSame(expectedMultimap.getValueHashingStrategy(), selectedMultimap.getValueHashingStrategy());
+        assertSame(expectedMultimap.getValueHashingStrategy(), selectedMultimap.getValueHashingStrategy());
     }
 
     @Override
@@ -242,9 +244,9 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         UnifiedSetWithHashingStrategyMultimap<Integer, Person> expectedMultimap = UnifiedSetWithHashingStrategyMultimap.newMultimap(FIRST_NAME_STRATEGY);
         expectedMultimap.put(1, JOHNSMITH);
         expectedMultimap.put(1, JOHNDOE);
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
+        assertEquals(expectedMultimap, rejectedMultimap);
         Verify.assertMapsEqual(expectedMultimap.getMap(), rejectedMultimap.getMap());
-        Assert.assertSame(expectedMultimap.getValueHashingStrategy(), rejectedMultimap.getValueHashingStrategy());
+        assertSame(expectedMultimap.getValueHashingStrategy(), rejectedMultimap.getValueHashingStrategy());
     }
 
     @Override
@@ -270,9 +272,9 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         expectedMultimap.put(2, JANESMITH);
         expectedMultimap.put(2, JANEDOE);
         expectedMultimap.put(2, JOHNDOE);
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
+        assertEquals(expectedMultimap, selectedMultimap);
         Verify.assertMapsEqual(expectedMultimap.getMap(), selectedMultimap.getMap());
-        Assert.assertSame(expectedMultimap.getValueHashingStrategy(), selectedMultimap.getValueHashingStrategy());
+        assertSame(expectedMultimap.getValueHashingStrategy(), selectedMultimap.getValueHashingStrategy());
     }
 
     @Override
@@ -297,9 +299,9 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         UnifiedSetWithHashingStrategyMultimap<Integer, Person> expectedMultimap = UnifiedSetWithHashingStrategyMultimap.newMultimap(FIRST_NAME_STRATEGY);
         expectedMultimap.put(3, JOHNSMITH);
         expectedMultimap.put(3, JOHNDOE);
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
+        assertEquals(expectedMultimap, rejectedMultimap);
         Verify.assertMapsEqual(expectedMultimap.getMap(), rejectedMultimap.getMap());
-        Assert.assertSame(expectedMultimap.getValueHashingStrategy(), rejectedMultimap.getValueHashingStrategy());
+        assertSame(expectedMultimap.getValueHashingStrategy(), rejectedMultimap.getValueHashingStrategy());
     }
 
     @Override
@@ -325,7 +327,7 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         expectedMultimap1.put("2", 200);
         expectedMultimap1.put("2", 200);
 
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        assertEquals(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<String, Integer> collectedMultimap2 = multimap.collectKeysValues((key, value) -> Tuples.pair("1", key * value.getAge()));
         MutableBagMultimap<String, Integer> expectedMultimap2 = HashBagMultimap.newMultimap();
@@ -334,7 +336,7 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         expectedMultimap2.put("1", 200);
         expectedMultimap2.put("1", 200);
 
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        assertEquals(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -358,14 +360,14 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         expectedMultimap1.put("1", 100);
         expectedMultimap1.put("2", 100);
 
-        Assert.assertEquals(expectedMultimap1, collectedMultimap1);
+        assertEquals(expectedMultimap1, collectedMultimap1);
 
         MutableBagMultimap<String, Integer> collectedMultimap2 = multimap.collectKeyMultiValues(key -> "1", Person::getAge);
         MutableBagMultimap<String, Integer> expectedMultimap2 = HashBagMultimap.newMultimap();
         expectedMultimap2.put("1", 100);
         expectedMultimap2.put("1", 100);
 
-        Assert.assertEquals(expectedMultimap2, collectedMultimap2);
+        assertEquals(expectedMultimap2, collectedMultimap2);
     }
 
     @Override
@@ -387,6 +389,6 @@ public class UnifiedSetWithHashingStrategyMultimapTest extends AbstractMutableSe
         expectedMultimap.put(1, 100);
         expectedMultimap.put(2, 100);
 
-        Assert.assertEquals(expectedMultimap, collectedMultimap);
+        assertEquals(expectedMultimap, collectedMultimap);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
@@ -22,8 +22,10 @@ import org.eclipse.collections.impl.multimap.AbstractMutableMultimapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutableMultimapTestCase
 {
@@ -68,7 +70,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         MutableBag<Pair<Integer, MutableCollection<String>>> expected = Bags.mutable.with(
                 Tuples.pair(2, this.createCollection("2", "1")),
                 Tuples.pair(3, this.createCollection("3", "3")));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -77,8 +79,8 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
     {
         BagMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         BagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -210,7 +212,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
     {
         MutableBagMultimap<String, String> multimap = this.newMultimap();
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> multimap.putOccurrences("1", "a", -1));
+        assertThrows(IllegalArgumentException.class, () -> multimap.putOccurrences("1", "a", -1));
 
         multimap.putOccurrences("1", "a", 0);
         Verify.assertEmpty(multimap);
@@ -227,7 +229,7 @@ public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutable
         Verify.assertSize(3, multimap);
         Verify.assertBagsEqual(HashBag.newBagWith("b", "b", "b"), multimap.get("2"));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> multimap.putOccurrences("2", "b", -1));
+        assertThrows(IllegalArgumentException.class, () -> multimap.putOccurrences("2", "b", -1));
 
         multimap.putOccurrences("2", "c", 2);
         Verify.assertSize(5, multimap);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
@@ -22,8 +22,9 @@ import org.eclipse.collections.impl.multimap.AbstractImmutableMultimapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
 {
@@ -58,7 +59,7 @@ public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
         MutableBag<Pair<String, MutableBag<Integer>>> expected = Bags.mutable.with(
                 Tuples.pair("Two", Bags.mutable.with(2, 1)),
                 Tuples.pair("Three", Bags.mutable.with(3, 3)));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
         ImmutableBag<Pair<String, ImmutableBag<Integer>>> expected = Bags.immutable.with(
                 Tuples.pair("Two", Bags.immutable.with(2, 1)),
                 Tuples.pair("Three", Bags.immutable.with(3, 3)));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -87,8 +88,8 @@ public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
                 .newWith("Less than 3", 2)
                 .newWith("Less than 3", 2);
         ImmutableBagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimapTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.MultiReaderHashBag;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link MultiReaderHashBagMultimap}.
@@ -116,10 +117,10 @@ public class MultiReaderHashBagMultimapTest extends AbstractMutableBagMultimapTe
 
         MultiReaderHashBagMultimap<Integer, String> actual = MultiReaderHashBagMultimap.newMultimap(testBag);
 
-        Assert.assertEquals(HashBag.newBagWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toBag());
-        Assert.assertEquals(HashBag.newBagWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)));
-        Assert.assertEquals(HashBag.newBagWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)));
-        Assert.assertEquals(HashBag.newBagWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)));
-        Assert.assertEquals(HashBag.newBagWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)));
+        assertEquals(HashBag.newBagWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toBag());
+        assertEquals(HashBag.newBagWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)));
+        assertEquals(HashBag.newBagWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)));
+        assertEquals(HashBag.newBagWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)));
+        assertEquals(HashBag.newBagWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimapTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.multimap.bag;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutHashBagMultimap}.
@@ -101,6 +102,6 @@ public class SynchronizedPutHashBagMultimapTest extends AbstractMutableBagMultim
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "One", 2);
         String toString = multimap.toString();
-        Assert.assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
+        assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimapTest.java
@@ -22,8 +22,9 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.
@@ -114,7 +115,7 @@ public class TreeBagMultimapTest extends org.eclipse.collections.impl.multimap.b
         bagMultimap.putAll(1, collection);
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 5, 5, 4, 3, 2, 1), collection);
         bagMultimap.put(1, 0);
-        Assert.assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
+        assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
         bagMultimap.putAll(2, FastList.newListWith(0, 1, 2, 3, 4, 5, 5));
         Verify.assertSortedBagsEqual(bagMultimap.get(1), bagMultimap.get(2));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
@@ -31,8 +31,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Test of {@link TreeBagMultimap}.
@@ -81,8 +83,8 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
     {
         SortedBagMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         BagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -123,7 +125,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2, 2));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -137,7 +139,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1, 1));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, rejectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
     @Override
@@ -153,7 +155,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -169,7 +171,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimapTest.java
@@ -21,8 +21,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.
@@ -147,7 +148,7 @@ public class TreeBagMultimapTest extends AbstractMutableSortedBagMultimapTestCas
         bagMultimap.putAll(1, collection);
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 5, 5, 4, 3, 2, 1), collection);
         bagMultimap.put(1, 0);
-        Assert.assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
+        assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
         bagMultimap.putAll(2, FastList.newListWith(0, 1, 2, 3, 4, 5, 5));
         Verify.assertSortedBagsEqual(bagMultimap.get(1), bagMultimap.get(2));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
@@ -28,8 +28,9 @@ import org.eclipse.collections.impl.multimap.bag.sorted.mutable.TreeBagMultimap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultimapTestCase
 {
@@ -56,8 +57,8 @@ public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultima
         mutableMap.put("Less than 3", 2);
         ImmutableSortedBagMultimap<String, Integer> multimap = mutableMap.toImmutable();
         ImmutableBagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -97,7 +98,7 @@ public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultima
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertEquals(expectedMultimap.toImmutable().comparator(), selectedMultimap.comparator());
+        assertEquals(expectedMultimap.toImmutable().comparator(), selectedMultimap.comparator());
     }
 
     @Test
@@ -105,8 +106,8 @@ public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultima
     {
         ImmutableSortedBagMultimap<Integer, Integer> map = new ImmutableSortedBagMultimapImpl<>(Maps.immutable.empty());
         ImmutableSortedBagMultimap<Integer, Integer> map2 = new ImmutableSortedBagMultimapImpl<>(Maps.immutable.empty(), Comparators.reverseNaturalOrder());
-        Assert.assertEquals(this.classUnderTest(), map);
-        Assert.assertEquals(TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder()), map2);
+        assertEquals(this.classUnderTest(), map);
+        assertEquals(TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder()), map2);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
@@ -32,8 +32,11 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 /**
  * Test of {@link TreeBagMultimap}.
@@ -79,8 +82,8 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
     {
         SortedBagMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         BagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -89,7 +92,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
     {
         Verify.assertInstanceOf(MutableSortedBagMultimap.class, this.newMultimap());
         Verify.assertInstanceOf(ImmutableSortedBagMultimap.class, this.newMultimap().toImmutable());
-        Assert.assertFalse(this.newMultimap().toImmutable() instanceof MutableSortedBagMultimap);
+        assertFalse(this.newMultimap().toImmutable() instanceof MutableSortedBagMultimap);
     }
 
     @Override
@@ -129,7 +132,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2, 2));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -143,7 +146,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<String, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1, 1));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, rejectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
     @Override
@@ -159,7 +162,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -175,7 +178,7 @@ public abstract class AbstractMutableSortedBagMultimapTestCase extends AbstractM
         MutableSortedBagMultimap<Integer, Integer> expectedMultimap = this.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimapTest.java
@@ -24,8 +24,9 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.
@@ -147,7 +148,7 @@ public class TreeBagMultimapTest extends AbstractMutableSortedBagMultimapTestCas
         bagMultimap.putAll(1, collection);
         Verify.assertSortedBagsEqual(TreeBag.newBagWith(Collections.reverseOrder(), 5, 5, 4, 3, 2, 1), collection);
         bagMultimap.put(1, 0);
-        Assert.assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
+        assertEquals(Integer.valueOf(0), bagMultimap.get(1).getLast());
         bagMultimap.putAll(2, FastList.newListWith(0, 1, 2, 3, 4, 5, 5));
         Verify.assertSortedBagsEqual(bagMultimap.get(1), bagMultimap.get(2));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategyTest.java
@@ -26,8 +26,11 @@ import org.eclipse.collections.impl.multimap.bag.AbstractMutableBagMultimapTestC
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Test of {@link HashBagMultimap}.
@@ -108,8 +111,8 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
         MutableBagMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Two", 2);
         ImmutableMultimap<String, Integer> actual = multimap.toImmutable();
-        Assert.assertNotNull(actual);
-        Assert.assertEquals(multimap, actual);
+        assertNotNull(actual);
+        assertEquals(multimap, actual);
         // ideally this should go back to HashBagMultimapWithHashingStrategy
         Verify.assertInstanceOf(HashBagMultimap.class, actual.toMutable());
     }
@@ -123,8 +126,8 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
         MutableBagMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "Two", 2, "Two", 2);
         MutableMultimap<String, Integer> mutableCopy = multimap.toMutable();
-        Assert.assertNotSame(multimap, mutableCopy);
-        Assert.assertEquals(multimap, mutableCopy);
+        assertNotSame(multimap, mutableCopy);
+        assertEquals(multimap, mutableCopy);
         Verify.assertInstanceOf(HashBagMultimapWithHashingStrategy.class, mutableCopy);
     }
 
@@ -141,7 +144,7 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
         expected.put("One", this.createCollection(1));
         expected.put("Two", this.createCollection(2, 2));
         MutableMap<String, RichIterable<Integer>> actual = multimap.toMap();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         Verify.assertInstanceOf(UnifiedMapWithHashingStrategy.class, actual);
     }
 
@@ -158,7 +161,7 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
         expected.put("One", UnifiedSet.newSetWith(1));
         expected.put("Two", UnifiedSet.newSetWith(2, 2));
         MutableMap<String, MutableSet<Integer>> actual = multimap.toMap(UnifiedSet::new);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         Verify.assertInstanceOf(UnifiedMapWithHashingStrategy.class, actual);
     }
 
@@ -172,7 +175,7 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
         multimapWithIdentity.putAll(new Integer(1), Lists.fixedSize.of(2, 20, 1));
         multimapWithIdentity.put(new Integer(1), 3);
 
-        Assert.assertEquals(3, multimapWithIdentity.sizeDistinct());
+        assertEquals(3, multimapWithIdentity.sizeDistinct());
         Verify.assertSize(5, multimapWithIdentity);
 
         HashBagMultimapWithHashingStrategy<Integer, Integer> multimapWithDefault =
@@ -180,7 +183,7 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
                         HashingStrategies.defaultStrategy(),
                         multimapWithIdentity);
 
-        Assert.assertEquals(1, multimapWithDefault.sizeDistinct());
+        assertEquals(1, multimapWithDefault.sizeDistinct());
         Verify.assertSize(5, multimapWithDefault);
 
         Verify.assertIterablesEqual(
@@ -198,6 +201,6 @@ public class HashBagMultimapWithHashingStrategyTest extends AbstractMutableBagMu
     {
         HashBagMultimapWithHashingStrategy<Integer, Integer> multimap =
                 HashBagMultimapWithHashingStrategy.newMultimap(HashingStrategies.identityStrategy());
-        Assert.assertEquals(HashingStrategies.identityStrategy(), multimap.getKeyHashingStrategy());
+        assertEquals(HashingStrategies.identityStrategy(), multimap.getKeyHashingStrategy());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
@@ -27,8 +27,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractMutableListMultimapTestCase extends AbstractMutableMultimapTestCase
 {
@@ -73,7 +74,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableSet<Pair<Integer, MutableList<String>>> expected = Sets.mutable.with(
                 Tuples.pair(2, this.createCollection("2", "1")),
                 Tuples.pair(3, this.createCollection("3", "3")));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -82,8 +83,8 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
     {
         ListMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         UnsortedBagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Test
@@ -92,7 +93,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
     {
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "One", 2);
-        Assert.assertEquals("{One=[1, 2]}", multimap.toString());
+        assertEquals("{One=[1, 2]}", multimap.toString());
     }
 
     @Override
@@ -107,7 +108,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableListMultimap<String, Integer> selectedMultimap = multimap.selectKeysValues((key, value) -> "Two".equals(key) && (value % 2 == 0));
         MutableListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("Two", FastList.newListWith(2, 4, 2));
-        Assert.assertEquals(expectedMultimap, selectedMultimap);
+        assertEquals(expectedMultimap, selectedMultimap);
         Verify.assertListsEqual(expectedMultimap.get("Two"), selectedMultimap.get("Two"));
     }
 
@@ -123,7 +124,7 @@ public abstract class AbstractMutableListMultimapTestCase extends AbstractMutabl
         MutableListMultimap<String, Integer> rejectedMultimap = multimap.rejectKeysValues((key, value) -> "Two".equals(key) || (value % 2 == 0));
         MutableListMultimap<String, Integer> expectedMultimap = FastListMultimap.newMultimap();
         expectedMultimap.putAll("One", FastList.newListWith(1, 3, 1));
-        Assert.assertEquals(expectedMultimap, rejectedMultimap);
+        assertEquals(expectedMultimap, rejectedMultimap);
         Verify.assertListsEqual(expectedMultimap.get("One"), rejectedMultimap.get("One"));
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/FastListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/FastListMultimapTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link FastListMultimap}.
@@ -112,10 +113,10 @@ public class FastListMultimapTest extends AbstractMutableListMultimapTestCase
 
         MutableListMultimap<Integer, String> actual = FastListMultimap.newMultimap(testList);
 
-        Assert.assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
-        Assert.assertEquals(FastList.newListWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
-        Assert.assertEquals(FastList.newListWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
-        Assert.assertEquals(FastList.newListWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
-        Assert.assertEquals(FastList.newListWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
+        assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
+        assertEquals(FastList.newListWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
+        assertEquals(FastList.newListWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
+        assertEquals(FastList.newListWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
+        assertEquals(FastList.newListWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
@@ -29,8 +29,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
 {
@@ -65,7 +66,7 @@ public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSet<Pair<String, MutableList<Integer>>> expected = Sets.mutable.with(
                 Tuples.pair("Two", Lists.mutable.with(2, 1)),
                 Tuples.pair("Three", Lists.mutable.with(3, 3)));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -81,7 +82,7 @@ public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSet<Pair<String, ImmutableList<Integer>>> exptected = Sets.mutable.with(
                 Tuples.pair("Two", Lists.immutable.with(2, 1)),
                 Tuples.pair("Three", Lists.immutable.with(3, 3)));
-        Assert.assertEquals(exptected, collection);
+        assertEquals(exptected, collection);
     }
 
     @Override
@@ -94,8 +95,8 @@ public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
                 .newWith("Less than 3", 2)
                 .newWith("Less than 3", 2);
         ImmutableBagMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
-        Assert.assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Bags.immutable.with("Less than 3", "Less than 3"), flipped.get(2));
+        assertEquals(Bags.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimapTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link MultiReaderFastListMultimap}.
@@ -116,10 +117,10 @@ public class MultiReaderFastListMultimapTest extends AbstractMutableListMultimap
 
         MultiReaderFastListMultimap<Integer, String> actual = MultiReaderFastListMultimap.newMultimap(testList);
 
-        Assert.assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
-        Assert.assertEquals(FastList.newListWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
-        Assert.assertEquals(FastList.newListWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
-        Assert.assertEquals(FastList.newListWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
-        Assert.assertEquals(FastList.newListWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
+        assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
+        assertEquals(FastList.newListWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
+        assertEquals(FastList.newListWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
+        assertEquals(FastList.newListWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
+        assertEquals(FastList.newListWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
@@ -29,8 +29,10 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutableMultimapTestCase
 {
@@ -75,7 +77,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
         MutableSet<Pair<Integer, MutableSet<String>>> expected = Sets.mutable.with(
                 Tuples.pair(2, this.createCollection("2", "1")),
                 Tuples.pair(3, this.createCollection("3", "3")));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -86,9 +88,9 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
 
         MutableMultimap<Integer, String> multimap = this.newMultimapWithKeysValues(1, "One", 2, "2");
         MutableList<Pair<Integer, String>> pairs = Lists.mutable.of(Tuples.pair(1, "One"));
-        Assert.assertFalse(multimap.putAllPairs(pairs));
+        assertFalse(multimap.putAllPairs(pairs));
         MutableMultimap<Integer, String> expected = this.newMultimapWithKeysValues(1, "One", 2, "2");
-        Assert.assertEquals(expected, multimap);
+        assertEquals(expected, multimap);
     }
 
     @Override
@@ -97,8 +99,8 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
     {
         SetMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         SetMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
-        Assert.assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
+        assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -213,7 +215,7 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
                 value -> value % 2 == 0 ? value + 1 : value,
                 Multimaps.mutable.set.empty());
         SetMultimap<Integer, Integer> expectedMultimap3 = Multimaps.mutable.set.with(1, 1, 1, 13, 1, 3);
-        Assert.assertEquals(expectedMultimap3, collectedMultimap3);
+        assertEquals(expectedMultimap3, collectedMultimap3);
 
         Multimap<Integer, Integer> collectedMultimap4 = multimap2.collectKeyMultiValues(
                 key -> 1,
@@ -221,8 +223,8 @@ public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutable
                 Multimaps.mutable.list.empty());
         MutableListMultimap<Integer, Integer> expectedMultimap4 = Multimaps.mutable.list.with(1, 1, 1, 3, 1, 13);
         expectedMultimap4.put(1, 3);
-        Assert.assertEquals(expectedMultimap4.keySet(), collectedMultimap4.keySet());
-        Assert.assertEquals(expectedMultimap4.get(1).toBag(), collectedMultimap4.get(1).toBag());
+        assertEquals(expectedMultimap4.keySet(), collectedMultimap4.keySet());
+        assertEquals(expectedMultimap4.get(1).toBag(), collectedMultimap4.get(1).toBag());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
@@ -26,8 +26,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
 {
@@ -63,7 +64,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSet<Pair<String, MutableSet<Integer>>> expected = Sets.mutable.with(
                 Tuples.pair("Two", Sets.mutable.with(2, 1)),
                 Tuples.pair("Three", Sets.mutable.with(3, 3)));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -80,7 +81,7 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
         MutableSet<Pair<String, MutableSet<Integer>>> expected = Sets.mutable.with(
                 Tuples.pair("Two", Sets.mutable.with(2, 1)),
                 Tuples.pair("Three", Sets.mutable.with(3, 3)));
-        Assert.assertEquals(expected, collection);
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -93,8 +94,8 @@ public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
                 .newWith("Less than 3", 2)
                 .newWith("Less than 3", 2);
         ImmutableSetMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
-        Assert.assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
+        assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimapTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link MultiReaderUnifiedSetMultimap}.
@@ -116,10 +117,10 @@ public class MultiReaderUnifiedSetMultimapTest extends AbstractMutableSetMultima
 
         MultiReaderUnifiedSetMultimap<Integer, String> actual = MultiReaderUnifiedSetMultimap.newMultimap(testBag);
 
-        Assert.assertEquals(UnifiedSet.newSetWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)));
-        Assert.assertEquals(UnifiedSet.newSetWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)));
-        Assert.assertEquals(UnifiedSet.newSetWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)));
-        Assert.assertEquals(UnifiedSet.newSetWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)));
+        assertEquals(UnifiedSet.newSetWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toSet());
+        assertEquals(UnifiedSet.newSetWith("One", "OneOne", "One"), actual.get(Integer.valueOf(1)));
+        assertEquals(UnifiedSet.newSetWith("Two", "TwoTwo", "Two"), actual.get(Integer.valueOf(2)));
+        assertEquals(UnifiedSet.newSetWith("Three", "ThreeThree", "Three"), actual.get(Integer.valueOf(3)));
+        assertEquals(UnifiedSet.newSetWith("Four", "FourFour", "Four"), actual.get(Integer.valueOf(4)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimapTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.multimap.set;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutUnifiedSetMultimap}.
@@ -101,6 +102,6 @@ public class SynchronizedPutUnifiedSetMultimapTest extends AbstractMutableSetMul
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "One", 2);
         String toString = multimap.toString();
-        Assert.assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
+        assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimapTest.java
@@ -16,8 +16,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link UnifiedSetMultimap}.
@@ -113,10 +114,10 @@ public class UnifiedSetMultimapTest extends AbstractMutableSetMultimapTestCase
 
         UnifiedSetMultimap<Integer, String> actual = UnifiedSetMultimap.newMultimap(testList);
 
-        Assert.assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
-        Assert.assertEquals(FastList.newListWith("OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
-        Assert.assertEquals(FastList.newListWith("TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
-        Assert.assertEquals(FastList.newListWith("ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
-        Assert.assertEquals(FastList.newListWith("FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
+        assertEquals(FastList.newListWith(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3), Integer.valueOf(4)), actual.keysView().toList());
+        assertEquals(FastList.newListWith("OneOne", "One"), actual.get(Integer.valueOf(1)).toList());
+        assertEquals(FastList.newListWith("TwoTwo", "Two"), actual.get(Integer.valueOf(2)).toList());
+        assertEquals(FastList.newListWith("ThreeThree", "Three"), actual.get(Integer.valueOf(3)).toList());
+        assertEquals(FastList.newListWith("FourFour", "Four"), actual.get(Integer.valueOf(4)).toList());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
@@ -32,8 +32,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractMutableMultimapTestCase
 {
@@ -76,8 +78,8 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
     {
         SortedSetMultimap<String, Integer> multimap = this.newMultimapWithKeysValues("Less than 2", 1, "Less than 3", 1, "Less than 3", 2, "Less than 3", 2);
         SetMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
-        Assert.assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
+        assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -110,7 +112,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -124,7 +126,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<String, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll("One", FastList.newListWith(3, 1));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap, rejectedMultimap);
-        Assert.assertEquals(expectedMultimap.comparator(), rejectedMultimap.comparator());
+        assertEquals(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
     @Override
@@ -140,7 +142,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -156,7 +158,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
         MutableSortedSetMultimap<Integer, Integer> expectedMultimap = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap.putAll(3, FastList.newListWith(4, 3, 1, 1));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -210,7 +212,7 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
                 value -> value % 2 == 0 ? value + 1 : value,
                 Multimaps.mutable.set.empty());
         SetMultimap<Integer, Integer> expectedMultimap3 = Multimaps.mutable.set.with(1, 1, 1, 13, 1, 3);
-        Assert.assertEquals(expectedMultimap3, collectedMultimap3);
+        assertEquals(expectedMultimap3, collectedMultimap3);
 
         Multimap<Integer, Integer> collectedMultimap4 = multimap2.collectKeyMultiValues(
                 key -> 1,
@@ -218,8 +220,8 @@ public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractM
                 Multimaps.mutable.list.empty());
         MutableListMultimap<Integer, Integer> expectedMultimap4 = Multimaps.mutable.list.with(1, 1, 1, 3, 1, 13);
         expectedMultimap4.put(1, 3);
-        Assert.assertEquals(expectedMultimap4.keySet(), collectedMultimap4.keySet());
-        Assert.assertEquals(expectedMultimap4.get(1).toBag(), collectedMultimap4.get(1).toBag());
+        assertEquals(expectedMultimap4.keySet(), collectedMultimap4.keySet());
+        assertEquals(expectedMultimap4.get(1).toBag(), collectedMultimap4.get(1).toBag());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
@@ -36,8 +36,11 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTestCase
 {
@@ -58,8 +61,8 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     {
         UnifiedMap<Integer, ImmutableSortedSet<Integer>> map = UnifiedMap.newWithKeysValues(1, TreeSortedSet.newSetWith(1).toImmutable());
         ImmutableSortedSetMultimap<Integer, Integer> immutableMap = new ImmutableSortedSetMultimapImpl<>(map, null);
-        Assert.assertEquals(FastList.newListWith(1), immutableMap.get(1).toList());
-        Assert.assertNull(immutableMap.comparator());
+        assertEquals(FastList.newListWith(1), immutableMap.get(1).toList());
+        assertNull(immutableMap.comparator());
         Verify.assertSize(1, immutableMap);
     }
 
@@ -67,7 +70,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
     public void testNewEmpty()
     {
         ImmutableSortedSetMultimap<Integer, Integer> map = new ImmutableSortedSetMultimapImpl<>(UnifiedMap.newMap(), Collections.reverseOrder());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), map.newEmpty().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), map.newEmpty().comparator());
         Verify.assertEmpty(map.newEmpty());
     }
 
@@ -105,7 +108,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
         multimap.put("Three", 3);
         multimap.put("Three", 3);
         multimap.toImmutable().forEachKeyMultiValues((key, values) -> collection.add(Tuples.pair(key, values)));
-        Assert.assertEquals(UnifiedSet.newSetWith(Tuples.pair("Two", TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 2, 1)), Tuples.pair("Three", TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 3, 3))), collection);
+        assertEquals(UnifiedSet.newSetWith(Tuples.pair("Two", TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 2, 1)), Tuples.pair("Three", TreeSortedSet.newSetWith(Comparators.reverseNaturalOrder(), 3, 3))), collection);
     }
 
     @Override
@@ -118,8 +121,8 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
                 .newWith("Less than 3", 2)
                 .newWith("Less than 3", 2);
         UnsortedSetMultimap<Integer, String> flipped = multimap.flip();
-        Assert.assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
-        Assert.assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
+        assertEquals(Sets.immutable.with("Less than 3"), flipped.get(2));
+        assertEquals(Sets.immutable.with("Less than 2", "Less than 3"), flipped.get(1));
     }
 
     @Override
@@ -135,7 +138,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
         expectedMultimap.putAll("Two", FastList.newListWith(4, 2));
         ImmutableSortedSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
         Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -151,7 +154,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
         expectedMultimap.putAll("One", FastList.newListWith(3, 1));
         ImmutableSortedSetMultimap<String, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
         Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, rejectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), rejectedMultimap.comparator());
     }
 
     @Override
@@ -169,7 +172,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
         expectedMultimap.putAll(2, FastList.newListWith(5, 4, 3, 2, 2));
         ImmutableSortedSetMultimap<Integer, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
         Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override
@@ -187,7 +190,7 @@ public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTes
         expectedMultimap.putAll(3, FastList.newListWith(5, 4, 2, 2));
         ImmutableSortedSetMultimap<Integer, Integer> expectedImmutableMultimap = expectedMultimap.toImmutable();
         Verify.assertSortedSetMultimapsEqual(expectedImmutableMultimap, selectedMultimap);
-        Assert.assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
+        assertSame(expectedMultimap.comparator(), selectedMultimap.comparator());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimapTest.java
@@ -17,8 +17,9 @@ import org.eclipse.collections.api.multimap.sortedset.MutableSortedSetMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutTreeSortedSetMultimap}.
@@ -117,6 +118,6 @@ public class SynchronizedPutTreeSortedSetMultimapTest extends AbstractMutableSor
         MutableMultimap<String, Integer> multimap =
                 this.newMultimapWithKeysValues("One", 1, "One", 2);
         String toString = multimap.toString();
-        Assert.assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
+        assertTrue("{One=[1, 2]}".equals(toString) || "{One=[2, 1]}".equals(toString));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimapTest.java
@@ -23,8 +23,9 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of {@link TreeSortedSetMultimap}.
@@ -166,7 +167,7 @@ public class TreeSortedSetMultimapTest extends AbstractMutableSortedSetMultimapT
         setMultimap.putAll(1, collection);
         Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(Collections.reverseOrder(), 5, 4, 3, 2, 1), collection);
         setMultimap.put(1, 0);
-        Assert.assertEquals(Integer.valueOf(0), setMultimap.get(1).getLast());
+        assertEquals(Integer.valueOf(0), setMultimap.get(1).getLast());
         setMultimap.putAll(2, FastList.newListWith(0, 1, 2, 4, 2, 1, 4, 5, 3, 4, 5));
         Verify.assertSortedSetsEqual(setMultimap.get(1), setMultimap.get(2));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunnerTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunnerTest.java
@@ -17,9 +17,10 @@ import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.impl.block.factory.ObjectIntProcedures;
 import org.eclipse.collections.impl.block.procedure.DoNothingProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public class ObjectIntProcedureFJTaskRunnerTest
 {
@@ -38,13 +39,13 @@ public class ObjectIntProcedureFJTaskRunnerTest
     @Test
     public void taskCompletedUsingNonCombineOne()
     {
-        Assert.assertThrows(CountDownCalledException.class, () -> this.undertest.taskCompleted(null));
+        assertThrows(CountDownCalledException.class, () -> this.undertest.taskCompleted(null));
     }
 
     @Test
     public void joinUsingNonCombineOne()
     {
-        Assert.assertThrows(
+        assertThrows(
                 AwaitDownCalledException.class,
                 () -> this.undertest.executeAndCombine(
                         new DoNothingExecutor(),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelArrayIterateTest.java
@@ -19,8 +19,10 @@ import org.eclipse.collections.impl.math.SumCombiner;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ParallelArrayIterateTest
 {
@@ -30,27 +32,27 @@ public class ParallelArrayIterateTest
         Sum sum1 = new IntegerSum(0);
         Integer[] array1 = this.createIntegerArray(16);
         ParallelArrayIterate.forEach(array1, new SumProcedure<>(sum1), new SumCombiner<>(sum1), 1, array1.length / 2);
-        Assert.assertEquals(16, sum1.getValue());
+        assertEquals(16, sum1.getValue());
 
         Sum sum2 = new IntegerSum(0);
         Integer[] array2 = this.createIntegerArray(7);
         ParallelArrayIterate.forEach(array2, new SumProcedure<>(sum2), new SumCombiner<>(sum2));
-        Assert.assertEquals(7, sum2.getValue());
+        assertEquals(7, sum2.getValue());
 
         Sum sum3 = new IntegerSum(0);
         Integer[] array3 = this.createIntegerArray(15);
         ParallelArrayIterate.forEach(array3, new SumProcedure<>(sum3), new SumCombiner<>(sum3), 1, array3.length / 2);
-        Assert.assertEquals(15, sum3.getValue());
+        assertEquals(15, sum3.getValue());
 
         Sum sum4 = new IntegerSum(0);
         Integer[] array4 = this.createIntegerArray(35);
         ParallelArrayIterate.forEach(array4, new SumProcedure<>(sum4), new SumCombiner<>(sum4));
-        Assert.assertEquals(35, sum4.getValue());
+        assertEquals(35, sum4.getValue());
 
         Sum sum5 = new IntegerSum(0);
         Integer[] array5 = this.createIntegerArray(40);
         ParallelArrayIterate.forEach(array5, new SumProcedure<>(sum5), new SumCombiner<>(sum5), 1, array5.length / 2);
-        Assert.assertEquals(40, sum5.getValue());
+        assertEquals(40, sum5.getValue());
     }
 
     private Integer[] createIntegerArray(int size)
@@ -66,7 +68,7 @@ public class ParallelArrayIterateTest
     @Test
     public void parallelForEachException()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> ParallelArrayIterate.forEach(
                         Interval.zeroTo(5).toArray(),
@@ -104,7 +106,7 @@ public class ParallelArrayIterateTest
         this.parallelSum(array, parallelSum);
         Sum linearSum = new LongSum(0);
         this.linearSum(array, linearSum);
-        Assert.assertEquals(parallelSum, linearSum);
+        assertEquals(parallelSum, linearSum);
     }
 
     @Test
@@ -117,8 +119,8 @@ public class ParallelArrayIterateTest
         Sum linearSum1 = new LongSum(0);
         Sum linearSum2 = new LongSum(0);
         this.basicTestLinearSums(array, linearSum1, linearSum2);
-        Assert.assertEquals(parallelSum1, linearSum1);
-        Assert.assertEquals(parallelSum2, linearSum2);
+        assertEquals(parallelSum1, linearSum1);
+        assertEquals(parallelSum2, linearSum2);
     }
 
     private void basicTestLinearSums(

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterate2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterate2Test.java
@@ -17,8 +17,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link ParallelIterate}.
@@ -40,11 +41,11 @@ public class ParallelIterate2Test
 
         ExecutorService executorService1 = ParallelIterate.newPooledExecutor(4, "test pool 2 4", true);
         executorService1.invokeAll(tasks);
-        Assert.assertEquals(howManyTimes, counter.get());
+        assertEquals(howManyTimes, counter.get());
 
         counter.set(0);
         ExecutorService executorService2 = ParallelIterate.newPooledExecutor(2, "test pool 2", true);
         executorService2.invokeAll(tasks);
-        Assert.assertEquals(howManyTimes, counter.get());
+        assertEquals(howManyTimes, counter.get());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterateTest.java
@@ -63,9 +63,14 @@ import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ParallelIterateTest
 {
@@ -142,25 +147,25 @@ public class ParallelIterateTest
         IntegerSum sum = new IntegerSum(0);
         MutableSet<Integer> set = Interval.toSet(1, 100);
         ParallelIterate.forEach(set, new SumProcedure(sum), new SumCombiner(sum));
-        Assert.assertEquals(5050, sum.getSum());
+        assertEquals(5050, sum.getSum());
 
         //Testing batch size 1
         IntegerSum sum2 = new IntegerSum(0);
         UnifiedSet<Integer> set2 = UnifiedSet.newSet(Interval.oneTo(100));
         ParallelIterate.forEach(set2, new SumProcedure(sum2), new SumCombiner(sum2), 1, set2.getBatchCount(set2.size()));
-        Assert.assertEquals(5050, sum2.getSum());
+        assertEquals(5050, sum2.getSum());
 
         //Testing an uneven batch size
         IntegerSum sum3 = new IntegerSum(0);
         UnifiedSet<Integer> set3 = UnifiedSet.newSet(Interval.oneTo(100));
         ParallelIterate.forEach(set3, new SumProcedure(sum3), new SumCombiner(sum3), 1, set3.getBatchCount(13));
-        Assert.assertEquals(5050, sum3.getSum());
+        assertEquals(5050, sum3.getSum());
 
         //Testing divideByZero exception by passing 1 as batchSize
         IntegerSum sum4 = new IntegerSum(0);
         UnifiedSet<Integer> set4 = UnifiedSet.newSet(Interval.oneTo(100));
         ParallelIterate.forEach(set4, new SumProcedure(sum4), new SumCombiner(sum4), 1);
-        Assert.assertEquals(5050, sum4.getSum());
+        assertEquals(5050, sum4.getSum());
     }
 
     @Test
@@ -170,19 +175,19 @@ public class ParallelIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         MutableMap<String, Integer> map1 = Interval.fromTo(1, 100).toMap(String::valueOf, Functions.getIntegerPassThru());
         ParallelIterate.forEach(map1, new SumProcedure(sum1), new SumCombiner(sum1));
-        Assert.assertEquals(5050, sum1.getSum());
+        assertEquals(5050, sum1.getSum());
 
         //Testing batch size 1
         IntegerSum sum2 = new IntegerSum(0);
         UnifiedMap<String, Integer> map2 = (UnifiedMap<String, Integer>) Interval.fromTo(1, 100).toMap(String::valueOf, Functions.getIntegerPassThru());
         ParallelIterate.forEach(map2, new SumProcedure(sum2), new SumCombiner(sum2), 1, map2.getBatchCount(map2.size()));
-        Assert.assertEquals(5050, sum2.getSum());
+        assertEquals(5050, sum2.getSum());
 
         //Testing an uneven batch size
         IntegerSum sum3 = new IntegerSum(0);
         UnifiedMap<String, Integer> set3 = (UnifiedMap<String, Integer>) Interval.fromTo(1, 100).toMap(String::valueOf, Functions.getIntegerPassThru());
         ParallelIterate.forEach(set3, new SumProcedure(sum3), new SumCombiner(sum3), 1, set3.getBatchCount(13));
-        Assert.assertEquals(5050, sum3.getSum());
+        assertEquals(5050, sum3.getSum());
     }
 
     @Test
@@ -191,37 +196,37 @@ public class ParallelIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         List<Integer> list1 = ParallelIterateTest.createIntegerList(16);
         ParallelIterate.forEach(list1, new SumProcedure(sum1), new SumCombiner(sum1), 1, list1.size() / 2);
-        Assert.assertEquals(16, sum1.getSum());
+        assertEquals(16, sum1.getSum());
 
         IntegerSum sum2 = new IntegerSum(0);
         List<Integer> list2 = ParallelIterateTest.createIntegerList(7);
         ParallelIterate.forEach(list2, new SumProcedure(sum2), new SumCombiner(sum2));
-        Assert.assertEquals(7, sum2.getSum());
+        assertEquals(7, sum2.getSum());
 
         IntegerSum sum3 = new IntegerSum(0);
         List<Integer> list3 = ParallelIterateTest.createIntegerList(15);
         ParallelIterate.forEach(list3, new SumProcedure(sum3), new SumCombiner(sum3), 1, list3.size() / 2);
-        Assert.assertEquals(15, sum3.getSum());
+        assertEquals(15, sum3.getSum());
 
         IntegerSum sum4 = new IntegerSum(0);
         List<Integer> list4 = ParallelIterateTest.createIntegerList(35);
         ParallelIterate.forEach(list4, new SumProcedure(sum4), new SumCombiner(sum4));
-        Assert.assertEquals(35, sum4.getSum());
+        assertEquals(35, sum4.getSum());
 
         IntegerSum sum5 = new IntegerSum(0);
         MutableList<Integer> list5 = FastList.newList(list4);
         ParallelIterate.forEach(list5, new SumProcedure(sum5), new SumCombiner(sum5));
-        Assert.assertEquals(35, sum5.getSum());
+        assertEquals(35, sum5.getSum());
 
         IntegerSum sum6 = new IntegerSum(0);
         List<Integer> list6 = ParallelIterateTest.createIntegerList(40);
         ParallelIterate.forEach(list6, new SumProcedure(sum6), new SumCombiner(sum6), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum6.getSum());
+        assertEquals(40, sum6.getSum());
 
         IntegerSum sum7 = new IntegerSum(0);
         MutableList<Integer> list7 = FastList.newList(list6);
         ParallelIterate.forEach(list7, new SumProcedure(sum7), new SumCombiner(sum7), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum7.getSum());
+        assertEquals(40, sum7.getSum());
     }
 
     @Test
@@ -230,43 +235,43 @@ public class ParallelIterateTest
         IntegerSum sum1 = new IntegerSum(0);
         ImmutableList<Integer> list1 = Lists.immutable.ofAll(ParallelIterateTest.createIntegerList(16));
         ParallelIterate.forEach(list1, new SumProcedure(sum1), new SumCombiner(sum1), 1, list1.size() / 2);
-        Assert.assertEquals(16, sum1.getSum());
+        assertEquals(16, sum1.getSum());
 
         IntegerSum sum2 = new IntegerSum(0);
         ImmutableList<Integer> list2 = Lists.immutable.ofAll(ParallelIterateTest.createIntegerList(7));
         ParallelIterate.forEach(list2, new SumProcedure(sum2), new SumCombiner(sum2));
-        Assert.assertEquals(7, sum2.getSum());
+        assertEquals(7, sum2.getSum());
 
         IntegerSum sum3 = new IntegerSum(0);
         ImmutableList<Integer> list3 = Lists.immutable.ofAll(ParallelIterateTest.createIntegerList(15));
         ParallelIterate.forEach(list3, new SumProcedure(sum3), new SumCombiner(sum3), 1, list3.size() / 2);
-        Assert.assertEquals(15, sum3.getSum());
+        assertEquals(15, sum3.getSum());
 
         IntegerSum sum4 = new IntegerSum(0);
         ImmutableList<Integer> list4 = Lists.immutable.ofAll(ParallelIterateTest.createIntegerList(35));
         ParallelIterate.forEach(list4, new SumProcedure(sum4), new SumCombiner(sum4));
-        Assert.assertEquals(35, sum4.getSum());
+        assertEquals(35, sum4.getSum());
 
         IntegerSum sum5 = new IntegerSum(0);
         ImmutableList<Integer> list5 = FastList.newList(list4).toImmutable();
         ParallelIterate.forEach(list5, new SumProcedure(sum5), new SumCombiner(sum5));
-        Assert.assertEquals(35, sum5.getSum());
+        assertEquals(35, sum5.getSum());
 
         IntegerSum sum6 = new IntegerSum(0);
         ImmutableList<Integer> list6 = Lists.immutable.ofAll(ParallelIterateTest.createIntegerList(40));
         ParallelIterate.forEach(list6, new SumProcedure(sum6), new SumCombiner(sum6), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum6.getSum());
+        assertEquals(40, sum6.getSum());
 
         IntegerSum sum7 = new IntegerSum(0);
         ImmutableList<Integer> list7 = FastList.newList(list6).toImmutable();
         ParallelIterate.forEach(list7, new SumProcedure(sum7), new SumCombiner(sum7), 1, list6.size() / 2);
-        Assert.assertEquals(40, sum7.getSum());
+        assertEquals(40, sum7.getSum());
     }
 
     @Test
     public void testForEachWithException()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> ParallelIterate.forEach(
                         ParallelIterateTest.createIntegerList(5),
@@ -281,9 +286,9 @@ public class ParallelIterateTest
     {
         Integer[] array = new Integer[200];
         MutableList<Integer> list = new FastList<>(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         ParallelIterate.forEachWithIndex(list, (each, index) -> array[index] = each);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -291,9 +296,9 @@ public class ParallelIterateTest
     {
         Integer[] array = new Integer[200];
         MutableList<Integer> list = new FastList<>(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         ParallelIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -301,9 +306,9 @@ public class ParallelIterateTest
     {
         Integer[] array = new Integer[200];
         ImmutableList<Integer> list = Interval.oneTo(200).toList().toImmutable();
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         ParallelIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
@@ -311,25 +316,25 @@ public class ParallelIterateTest
     {
         Integer[] array = new Integer[200];
         List<Integer> list = new ArrayList<>(Interval.oneTo(200));
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         ParallelIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 10, 10);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[]{}));
+        assertArrayEquals(array, list.toArray(new Integer[]{}));
     }
 
     @Test
     public void testForEachWithIndexToArrayUsingFixedArrayList()
     {
         Integer[] array = new Integer[10];
-        Assert.assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(array, Predicates.isNull()));
         List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ParallelIterate.forEachWithIndex(list, (each, index) -> array[index] = each, 1, 2);
-        Assert.assertArrayEquals(array, list.toArray(new Integer[list.size()]));
+        assertArrayEquals(array, list.toArray(new Integer[list.size()]));
     }
 
     @Test
     public void testForEachWithIndexException()
     {
-        Assert.assertThrows(
+        assertThrows(
                 RuntimeException.class,
                 () -> ParallelIterate.forEachWithIndex(
                         ParallelIterateTest.createIntegerList(5),
@@ -351,9 +356,9 @@ public class ParallelIterateTest
         Collection<Integer> actual2 = ParallelIterate.select(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = ParallelIterate.select(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -363,10 +368,10 @@ public class ParallelIterateTest
         Collection<Integer> actual1 = ParallelIterate.select(iterable, Predicates.greaterThan(100));
         Collection<Integer> actual2 = ParallelIterate.select(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
-        Assert.assertSame(expected.getClass(), actual1.getClass());
-        Assert.assertSame(expected.getClass(), actual2.getClass());
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
+        assertSame(expected.getClass(), actual1.getClass());
+        assertSame(expected.getClass(), actual2.getClass());
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
     }
 
     @Test
@@ -379,8 +384,8 @@ public class ParallelIterateTest
     {
         int actual1 = ParallelIterate.count(iterable, Predicates.greaterThan(100));
         int actual2 = ParallelIterate.count(iterable, Predicates.greaterThan(100), 6, this.executor);
-        Assert.assertEquals(100, actual1);
-        Assert.assertEquals(100, actual2);
+        assertEquals(100, actual1);
+        assertEquals(100, actual2);
     }
 
     @Test
@@ -395,9 +400,9 @@ public class ParallelIterateTest
         Collection<Integer> actual2 = ParallelIterate.reject(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = ParallelIterate.reject(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.reject(Predicates.greaterThan(100));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -414,9 +419,9 @@ public class ParallelIterateTest
         RichIterable<String> expected = iterable.collect(String::valueOf);
         Verify.assertSize(200, actual1);
         Verify.assertContains(String.valueOf(200), actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected.toBag(), HashBag.newBag(actual3));
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected.toBag(), HashBag.newBag(actual3));
     }
 
     @Test
@@ -436,9 +441,9 @@ public class ParallelIterateTest
         Verify.assertNotContains(String.valueOf(90), actual1);
         Verify.assertNotContains(String.valueOf(210), actual1);
         Verify.assertContains(String.valueOf(159), actual1);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, HashBag.newBag(actual1));
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
-        Assert.assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, HashBag.newBag(actual1));
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
+        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
     }
 
     @Test
@@ -456,15 +461,15 @@ public class ParallelIterateTest
         Multimap<String, Integer> result7 = ParallelIterate.groupBy(iterable.toBag(), String::valueOf, SynchronizedPutHashBagMultimap.newMultimap(), 100);
         Multimap<String, Integer> result8 = ParallelIterate.groupBy(iterable.toBag(), String::valueOf, SynchronizedPutHashBagMultimap.newMultimap());
         Multimap<String, Integer> result9 = ParallelIterate.groupBy(iterable.toList().toImmutable(), String::valueOf);
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result1));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result2));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result9));
-        Assert.assertEquals(expectedAsSet, result3);
-        Assert.assertEquals(expectedAsSet, result4);
-        Assert.assertEquals(expectedAsSet, result5);
-        Assert.assertEquals(expectedAsSet, result6);
-        Assert.assertEquals(expected, result7);
-        Assert.assertEquals(expected, result8);
+        assertEquals(expected, HashBagMultimap.newMultimap(result1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result2));
+        assertEquals(expected, HashBagMultimap.newMultimap(result9));
+        assertEquals(expectedAsSet, result3);
+        assertEquals(expectedAsSet, result4);
+        assertEquals(expectedAsSet, result5);
+        assertEquals(expectedAsSet, result6);
+        assertEquals(expected, result7);
+        assertEquals(expected, result8);
     }
 
     @Test
@@ -486,16 +491,16 @@ public class ParallelIterateTest
         expected.put('M', "Mary");
         expected.put('B', "Bob");
         expected.put('S', "Sara");
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result1));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result2));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result3));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result4));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result5));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result6));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result7));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result8));
-        Assert.assertEquals(expected, HashBagMultimap.newMultimap(result9));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ParallelIterate.groupBy(null, null, 1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result1));
+        assertEquals(expected, HashBagMultimap.newMultimap(result2));
+        assertEquals(expected, HashBagMultimap.newMultimap(result3));
+        assertEquals(expected, HashBagMultimap.newMultimap(result4));
+        assertEquals(expected, HashBagMultimap.newMultimap(result5));
+        assertEquals(expected, HashBagMultimap.newMultimap(result6));
+        assertEquals(expected, HashBagMultimap.newMultimap(result7));
+        assertEquals(expected, HashBagMultimap.newMultimap(result8));
+        assertEquals(expected, HashBagMultimap.newMultimap(result9));
+        assertThrows(IllegalArgumentException.class, () -> ParallelIterate.groupBy(null, null, 1));
     }
 
     @Test
@@ -505,11 +510,11 @@ public class ParallelIterateTest
         List<Integer> list = Interval.oneTo(2000);
         MutableMap<String, AtomicInteger> aggregation =
                 ParallelIterate.aggregateInPlaceBy(list, EVEN_OR_ODD, AtomicInteger::new, countAggregator);
-        Assert.assertEquals(1000, aggregation.get("Even").intValue());
-        Assert.assertEquals(1000, aggregation.get("Odd").intValue());
+        assertEquals(1000, aggregation.get("Even").intValue());
+        assertEquals(1000, aggregation.get("Odd").intValue());
         ParallelIterate.aggregateInPlaceBy(list, EVEN_OR_ODD, AtomicInteger::new, countAggregator, aggregation);
-        Assert.assertEquals(2000, aggregation.get("Even").intValue());
-        Assert.assertEquals(2000, aggregation.get("Odd").intValue());
+        assertEquals(2000, aggregation.get("Even").intValue());
+        assertEquals(2000, aggregation.get("Odd").intValue());
     }
 
     @Test
@@ -522,9 +527,9 @@ public class ParallelIterateTest
                 .shuffleThis();
         MapIterable<String, AtomicInteger> aggregation =
                 ParallelIterate.aggregateInPlaceBy(list, String::valueOf, AtomicInteger::new, AtomicInteger::addAndGet, 50);
-        Assert.assertEquals(100, aggregation.get("1").intValue());
-        Assert.assertEquals(400, aggregation.get("2").intValue());
-        Assert.assertEquals(900, aggregation.get("3").intValue());
+        assertEquals(100, aggregation.get("1").intValue());
+        assertEquals(400, aggregation.get("2").intValue());
+        assertEquals(900, aggregation.get("3").intValue());
     }
 
     @Test
@@ -534,11 +539,11 @@ public class ParallelIterateTest
         List<Integer> list = Interval.oneTo(20000);
         MutableMap<String, Integer> aggregation =
                 ParallelIterate.aggregateBy(list, EVEN_OR_ODD, () -> 0, countAggregator);
-        Assert.assertEquals(10000, aggregation.get("Even").intValue());
-        Assert.assertEquals(10000, aggregation.get("Odd").intValue());
+        assertEquals(10000, aggregation.get("Even").intValue());
+        assertEquals(10000, aggregation.get("Odd").intValue());
         ParallelIterate.aggregateBy(list, EVEN_OR_ODD, () -> 0, countAggregator, aggregation);
-        Assert.assertEquals(20000, aggregation.get("Even").intValue());
-        Assert.assertEquals(20000, aggregation.get("Odd").intValue());
+        assertEquals(20000, aggregation.get("Even").intValue());
+        assertEquals(20000, aggregation.get("Odd").intValue());
     }
 
     @Test
@@ -546,21 +551,21 @@ public class ParallelIterateTest
     {
         Interval interval = Interval.oneTo(100000);
         ObjectDoubleMap<String> sumByCount = ParallelIterate.sumByDouble(interval, EVEN_OR_ODD, i -> 1.0d);
-        Assert.assertEquals(50000.0, sumByCount.get("Even"), 0.0);
-        Assert.assertEquals(50000.0, sumByCount.get("Odd"), 0.0);
+        assertEquals(50000.0, sumByCount.get("Even"), 0.0);
+        assertEquals(50000.0, sumByCount.get("Odd"), 0.0);
         ObjectDoubleMap<String> sumByValue = ParallelIterate.sumByDouble(interval, EVEN_OR_ODD, Integer::doubleValue);
-        Assert.assertEquals(interval.sumByDouble(EVEN_OR_ODD, Integer::doubleValue), sumByValue);
+        assertEquals(interval.sumByDouble(EVEN_OR_ODD, Integer::doubleValue), sumByValue);
         ObjectDoubleMap<Integer> sumByValue2 = ParallelIterate.sumByDouble(interval, i -> i % 1000, Integer::doubleValue);
-        Assert.assertEquals(interval.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue2);
+        assertEquals(interval.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue2);
         Interval interval2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY);
         ObjectDoubleMap<String> sumByValue3 = ParallelIterate.sumByDouble(interval2, EVEN_OR_ODD, Integer::doubleValue);
-        Assert.assertEquals(interval2.sumByDouble(EVEN_OR_ODD, Integer::doubleValue), sumByValue3);
+        assertEquals(interval2.sumByDouble(EVEN_OR_ODD, Integer::doubleValue), sumByValue3);
         ObjectDoubleMap<Integer> sumByValue4 = ParallelIterate.sumByDouble(interval2, i -> i % 1000, Integer::doubleValue);
-        Assert.assertEquals(interval2.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue4);
+        assertEquals(interval2.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue4);
         Interval small = Interval.oneTo(11);
         ObjectDoubleMap<String> smallSumByCount = ParallelIterate.sumByDouble(small, EVEN_OR_ODD, i -> 1.0d);
-        Assert.assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
-        Assert.assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
+        assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
+        assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
     }
 
     @Test
@@ -579,12 +584,12 @@ public class ParallelIterateTest
                     return 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue());
                 });
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(1),
                 1.0e-15);
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(2),
                 1.0e-15);
@@ -595,21 +600,21 @@ public class ParallelIterateTest
     {
         Interval interval = Interval.oneTo(100000);
         ObjectDoubleMap<String> sumByCount = ParallelIterate.sumByFloat(interval, EVEN_OR_ODD, i -> 1.0f);
-        Assert.assertEquals(50000.0, sumByCount.get("Even"), 0.0);
-        Assert.assertEquals(50000.0, sumByCount.get("Odd"), 0.0);
+        assertEquals(50000.0, sumByCount.get("Even"), 0.0);
+        assertEquals(50000.0, sumByCount.get("Odd"), 0.0);
         ObjectDoubleMap<String> sumByValue = ParallelIterate.sumByFloat(interval, EVEN_OR_ODD, Integer::floatValue);
-        Assert.assertEquals(interval.sumByFloat(EVEN_OR_ODD, Integer::floatValue), sumByValue);
+        assertEquals(interval.sumByFloat(EVEN_OR_ODD, Integer::floatValue), sumByValue);
         ObjectDoubleMap<Integer> sumByValue2 = ParallelIterate.sumByFloat(interval, i -> i % 1000, Integer::floatValue);
-        Assert.assertEquals(interval.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue2);
+        assertEquals(interval.sumByDouble(i -> i % 1000, Integer::doubleValue), sumByValue2);
         Interval interval2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY);
         ObjectDoubleMap<String> sumByValue3 = ParallelIterate.sumByFloat(interval2, EVEN_OR_ODD, Integer::floatValue);
-        Assert.assertEquals(interval2.sumByFloat(EVEN_OR_ODD, Integer::floatValue), sumByValue3);
+        assertEquals(interval2.sumByFloat(EVEN_OR_ODD, Integer::floatValue), sumByValue3);
         ObjectDoubleMap<Integer> sumByValue4 = ParallelIterate.sumByFloat(interval2, i -> i % 1000, Integer::floatValue);
-        Assert.assertEquals(interval2.sumByFloat(i -> i % 1000, Integer::floatValue), sumByValue4);
+        assertEquals(interval2.sumByFloat(i -> i % 1000, Integer::floatValue), sumByValue4);
         Interval small = Interval.oneTo(11);
         ObjectDoubleMap<String> smallSumByCount = ParallelIterate.sumByFloat(small, EVEN_OR_ODD, i -> 1.0f);
-        Assert.assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
-        Assert.assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
+        assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
+        assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
     }
 
     @Test
@@ -630,12 +635,12 @@ public class ParallelIterateTest
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(1),
                 1.0e-15);
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(2),
                 1.0e-15);
@@ -646,21 +651,21 @@ public class ParallelIterateTest
     {
         Interval interval = Interval.oneTo(100000);
         ObjectLongMap<String> sumByCount = ParallelIterate.sumByLong(interval, EVEN_OR_ODD, i -> 1L);
-        Assert.assertEquals(50000, sumByCount.get("Even"));
-        Assert.assertEquals(50000, sumByCount.get("Odd"));
+        assertEquals(50000, sumByCount.get("Even"));
+        assertEquals(50000, sumByCount.get("Odd"));
         ObjectLongMap<String> sumByValue = ParallelIterate.sumByLong(interval, EVEN_OR_ODD, Integer::longValue);
-        Assert.assertEquals(interval.sumByLong(EVEN_OR_ODD, Integer::longValue), sumByValue);
+        assertEquals(interval.sumByLong(EVEN_OR_ODD, Integer::longValue), sumByValue);
         ObjectLongMap<Integer> sumByValue2 = ParallelIterate.sumByLong(interval, i -> i % 1000, Integer::longValue);
-        Assert.assertEquals(interval.sumByLong(i -> i % 1000, Integer::longValue), sumByValue2);
+        assertEquals(interval.sumByLong(i -> i % 1000, Integer::longValue), sumByValue2);
         Interval interval2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY);
         ObjectLongMap<String> sumByValue3 = ParallelIterate.sumByLong(interval2, EVEN_OR_ODD, Integer::longValue);
-        Assert.assertEquals(interval2.sumByLong(EVEN_OR_ODD, Integer::longValue), sumByValue3);
+        assertEquals(interval2.sumByLong(EVEN_OR_ODD, Integer::longValue), sumByValue3);
         ObjectLongMap<Integer> sumByValue4 = ParallelIterate.sumByLong(interval2, i -> i % 1000, Integer::longValue);
-        Assert.assertEquals(interval2.sumByLong(i -> i % 1000, Integer::longValue), sumByValue4);
+        assertEquals(interval2.sumByLong(i -> i % 1000, Integer::longValue), sumByValue4);
         Interval small = Interval.oneTo(11);
         ObjectLongMap<String> smallSumByCount = ParallelIterate.sumByLong(small, EVEN_OR_ODD, i -> 1L);
-        Assert.assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
-        Assert.assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
+        assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
+        assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
     }
 
     @Test
@@ -668,21 +673,21 @@ public class ParallelIterateTest
     {
         Interval interval = Interval.oneTo(100000);
         ObjectLongMap<String> sumByCount = ParallelIterate.sumByInt(interval, EVEN_OR_ODD, i -> 1);
-        Assert.assertEquals(50000, sumByCount.get("Even"));
-        Assert.assertEquals(50000, sumByCount.get("Odd"));
+        assertEquals(50000, sumByCount.get("Even"));
+        assertEquals(50000, sumByCount.get("Odd"));
         ObjectLongMap<String> sumByValue = ParallelIterate.sumByInt(interval, EVEN_OR_ODD, Integer::intValue);
-        Assert.assertEquals(interval.sumByInt(EVEN_OR_ODD, Integer::intValue), sumByValue);
+        assertEquals(interval.sumByInt(EVEN_OR_ODD, Integer::intValue), sumByValue);
         ObjectLongMap<Integer> sumByValue2 = ParallelIterate.sumByInt(interval, i -> i % 1000, Integer::intValue);
-        Assert.assertEquals(interval.sumByInt(i -> i % 1000, Integer::intValue), sumByValue2);
+        assertEquals(interval.sumByInt(i -> i % 1000, Integer::intValue), sumByValue2);
         Interval interval2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY);
         ObjectLongMap<String> sumByValue3 = ParallelIterate.sumByInt(interval2, EVEN_OR_ODD, Integer::intValue);
-        Assert.assertEquals(interval2.sumByInt(EVEN_OR_ODD, Integer::intValue), sumByValue3);
+        assertEquals(interval2.sumByInt(EVEN_OR_ODD, Integer::intValue), sumByValue3);
         ObjectLongMap<Integer> sumByValue4 = ParallelIterate.sumByInt(interval2, i -> i % 1000, Integer::intValue);
-        Assert.assertEquals(interval2.sumByInt(i -> i % 1000, Integer::intValue), sumByValue4);
+        assertEquals(interval2.sumByInt(i -> i % 1000, Integer::intValue), sumByValue4);
         Interval small = Interval.oneTo(11);
         ObjectLongMap<String> smallSumByCount = ParallelIterate.sumByInt(small, EVEN_OR_ODD, i -> 1);
-        Assert.assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
-        Assert.assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
+        assertEquals(5.0, smallSumByCount.get("Even"), 0.0);
+        assertEquals(6.0, smallSumByCount.get("Odd"), 0.0);
     }
 
     @Test
@@ -690,21 +695,21 @@ public class ParallelIterateTest
     {
         MutableList<BigDecimal> list = Interval.oneTo(100000).collect(BigDecimal::new).toList().shuffleThis();
         MutableMap<String, BigDecimal> sumByCount = ParallelIterate.sumByBigDecimal(list, EVEN_OR_ODD_BD, bd -> new BigDecimal(1L));
-        Assert.assertEquals(BigDecimal.valueOf(50000L), sumByCount.get("Even"));
-        Assert.assertEquals(BigDecimal.valueOf(50000L), sumByCount.get("Odd"));
+        assertEquals(BigDecimal.valueOf(50000L), sumByCount.get("Even"));
+        assertEquals(BigDecimal.valueOf(50000L), sumByCount.get("Odd"));
         MutableMap<String, BigDecimal> sumByValue = ParallelIterate.sumByBigDecimal(list, EVEN_OR_ODD_BD, bd -> bd);
-        Assert.assertEquals(Iterate.sumByBigDecimal(list, EVEN_OR_ODD_BD, bd -> bd), sumByValue);
+        assertEquals(Iterate.sumByBigDecimal(list, EVEN_OR_ODD_BD, bd -> bd), sumByValue);
         MutableMap<Integer, BigDecimal> sumByValue2 = ParallelIterate.sumByBigDecimal(list, bd -> bd.intValue() % 1000, bd -> bd);
-        Assert.assertEquals(Iterate.sumByBigDecimal(list, bd -> bd.intValue() % 1000, bd -> bd), sumByValue2);
+        assertEquals(Iterate.sumByBigDecimal(list, bd -> bd.intValue() % 1000, bd -> bd), sumByValue2);
         MutableList<BigDecimal> list2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY).collect(BigDecimal::new).toList();
         MutableMap<String, BigDecimal> sumByValue3 = ParallelIterate.sumByBigDecimal(list2, EVEN_OR_ODD_BD, bd -> bd);
-        Assert.assertEquals(Iterate.sumByBigDecimal(list2, EVEN_OR_ODD_BD, bd -> bd), sumByValue3);
+        assertEquals(Iterate.sumByBigDecimal(list2, EVEN_OR_ODD_BD, bd -> bd), sumByValue3);
         MutableMap<Integer, BigDecimal> sumByValue4 = ParallelIterate.sumByBigDecimal(list2, bd -> bd.intValue() % 1000, bd -> bd);
-        Assert.assertEquals(Iterate.sumByBigDecimal(list2, bd -> bd.intValue() % 1000, bd -> bd), sumByValue4);
+        assertEquals(Iterate.sumByBigDecimal(list2, bd -> bd.intValue() % 1000, bd -> bd), sumByValue4);
         Interval small = Interval.oneTo(11);
         MutableMap<String, BigDecimal> smallSumByCount = ParallelIterate.sumByBigDecimal(small, EVEN_OR_ODD, i -> BigDecimal.valueOf(1L));
-        Assert.assertEquals(new BigDecimal(5), smallSumByCount.get("Even"));
-        Assert.assertEquals(new BigDecimal(6), smallSumByCount.get("Odd"));
+        assertEquals(new BigDecimal(5), smallSumByCount.get("Even"));
+        assertEquals(new BigDecimal(6), smallSumByCount.get("Odd"));
     }
 
     @Test
@@ -712,21 +717,21 @@ public class ParallelIterateTest
     {
         MutableList<BigInteger> list = Interval.oneTo(100000).collect(Object::toString).collect(BigInteger::new).toList().shuffleThis();
         MutableMap<String, BigInteger> sumByCount = ParallelIterate.sumByBigInteger(list, EVEN_OR_ODD_BI, bi -> BigInteger.valueOf(1L));
-        Assert.assertEquals(BigInteger.valueOf(50000L), sumByCount.get("Even"));
-        Assert.assertEquals(BigInteger.valueOf(50000L), sumByCount.get("Odd"));
+        assertEquals(BigInteger.valueOf(50000L), sumByCount.get("Even"));
+        assertEquals(BigInteger.valueOf(50000L), sumByCount.get("Odd"));
         MutableMap<String, BigInteger> sumByValue = ParallelIterate.sumByBigInteger(list, EVEN_OR_ODD_BI, bi -> bi);
-        Assert.assertEquals(Iterate.sumByBigInteger(list, EVEN_OR_ODD_BI, bi -> bi), sumByValue);
+        assertEquals(Iterate.sumByBigInteger(list, EVEN_OR_ODD_BI, bi -> bi), sumByValue);
         MutableMap<Integer, BigInteger> sumByValue2 = ParallelIterate.sumByBigInteger(list, bi -> bi.intValue() % 1000, bi -> bi);
-        Assert.assertEquals(Iterate.sumByBigInteger(list, bi -> bi.intValue() % 1000, bi -> bi), sumByValue2);
+        assertEquals(Iterate.sumByBigInteger(list, bi -> bi.intValue() % 1000, bi -> bi), sumByValue2);
         MutableList<BigInteger> list2 = Interval.oneTo(UNEVEN_COUNT_FOR_SUMBY).collect(Object::toString).collect(BigInteger::new).toList();
         MutableMap<String, BigInteger> sumByValue3 = ParallelIterate.sumByBigInteger(list2, EVEN_OR_ODD_BI, bi -> bi);
-        Assert.assertEquals(Iterate.sumByBigInteger(list2, EVEN_OR_ODD_BI, bi -> bi), sumByValue3);
+        assertEquals(Iterate.sumByBigInteger(list2, EVEN_OR_ODD_BI, bi -> bi), sumByValue3);
         MutableMap<Integer, BigInteger> sumByValue4 = ParallelIterate.sumByBigInteger(list2, bi -> bi.intValue() % 1000, bi -> bi);
-        Assert.assertEquals(Iterate.sumByBigInteger(list2, bi -> bi.intValue() % 1000, bi -> bi), sumByValue4);
+        assertEquals(Iterate.sumByBigInteger(list2, bi -> bi.intValue() % 1000, bi -> bi), sumByValue4);
         Interval small = Interval.oneTo(11);
         MutableMap<String, BigInteger> smallSumByCount = ParallelIterate.sumByBigInteger(small, EVEN_OR_ODD, i -> BigInteger.valueOf(1L));
-        Assert.assertEquals(new BigInteger("5"), smallSumByCount.get("Even"));
-        Assert.assertEquals(new BigInteger("6"), smallSumByCount.get("Odd"));
+        assertEquals(new BigInteger("5"), smallSumByCount.get("Even"));
+        assertEquals(new BigInteger("6"), smallSumByCount.get("Odd"));
     }
 
     @Test
@@ -740,9 +745,9 @@ public class ParallelIterateTest
                 .shuffleThis();
         MapIterable<String, Integer> aggregation =
                 ParallelIterate.aggregateBy(list, String::valueOf, () -> 0, sumAggregator, 100);
-        Assert.assertEquals(1000, aggregation.get("1").intValue());
-        Assert.assertEquals(4000, aggregation.get("2").intValue());
-        Assert.assertEquals(9000, aggregation.get("3").intValue());
+        assertEquals(1000, aggregation.get("1").intValue());
+        assertEquals(4000, aggregation.get("2").intValue());
+        assertEquals(9000, aggregation.get("3").intValue());
     }
 
     private static List<Integer> createIntegerList(int size)
@@ -764,9 +769,9 @@ public class ParallelIterateTest
         RichIterable<String> expected1 = iterable.flatCollect(INT_TO_TWO_STRINGS);
         RichIterable<String> expected2 = iterable.flatCollect(INT_TO_TWO_STRINGS, HashBag.newBag());
         Verify.assertContains(String.valueOf(200), actual1);
-        Assert.assertEquals(expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected1, actual1);
-        Assert.assertEquals(expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected2, actual2);
-        Assert.assertEquals(expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected1, actual3);
+        assertEquals(expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected1, actual1);
+        assertEquals(expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected2, actual2);
+        assertEquals(expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected1, actual3);
     }
 
     public static final class IntegerSum

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/PartitionHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/PartitionHashBagTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionHashBagTest
 {
@@ -29,7 +30,7 @@ public class PartitionHashBagTest
         partitionMutableBag.getRejected().withAll(rejected);
 
         PartitionImmutableBag<Integer> partitionImmutableBag = partitionMutableBag.toImmutable();
-        Assert.assertEquals(selected, partitionImmutableBag.getSelected());
-        Assert.assertEquals(rejected, partitionImmutableBag.getRejected());
+        assertEquals(selected, partitionImmutableBag.getSelected());
+        assertEquals(rejected, partitionImmutableBag.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/sorted/PartitionTreeBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/sorted/PartitionTreeBagTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.factory.SortedBags;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionImmutableSortedBag;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionMutableSortedBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionTreeBagTest
 {
@@ -29,7 +30,7 @@ public class PartitionTreeBagTest
         partitionTreeBag.getSelected().addAll(selected);
         partitionTreeBag.getRejected().addAll(rejected);
         PartitionImmutableSortedBag<Integer> immutableSortedBag = partitionTreeBag.toImmutable();
-        Assert.assertEquals(selected, immutableSortedBag.getSelected());
-        Assert.assertEquals(rejected, immutableSortedBag.getRejected());
+        assertEquals(selected, immutableSortedBag.getSelected());
+        assertEquals(rejected, immutableSortedBag.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/list/PartitionFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/list/PartitionFastListTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.partition.list.PartitionImmutableList;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionFastListTest
 {
@@ -28,7 +29,7 @@ public class PartitionFastListTest
         partitionedList.getSelected().addAll(selected);
         partitionedList.getRejected().addAll(rejected);
         PartitionImmutableList<Integer> immutable = partitionedList.toImmutable();
-        Assert.assertEquals(selected, immutable.getSelected());
-        Assert.assertEquals(rejected, immutable.getRejected());
+        assertEquals(selected, immutable.getSelected());
+        assertEquals(rejected, immutable.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/PartitionUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/PartitionUnifiedSetTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
 import org.eclipse.collections.api.set.MutableSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionUnifiedSetTest
 {
@@ -28,7 +29,7 @@ public class PartitionUnifiedSetTest
         partitionMutableSet.getSelected().addAll(selected);
         partitionMutableSet.getRejected().addAll(rejected);
         PartitionImmutableSet<Integer> integerPartitionImmutableSet = partitionMutableSet.toImmutable();
-        Assert.assertEquals(selected, integerPartitionImmutableSet.getSelected());
-        Assert.assertEquals(rejected, integerPartitionImmutableSet.getRejected());
+        assertEquals(selected, integerPartitionImmutableSet.getSelected());
+        assertEquals(rejected, integerPartitionImmutableSet.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/sorted/PartitionTreeSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/sorted/PartitionTreeSortedSetTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.partition.set.sorted.PartitionImmutableSorted
 import org.eclipse.collections.api.partition.set.sorted.PartitionMutableSortedSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionTreeSortedSetTest
 {
@@ -30,7 +31,7 @@ public class PartitionTreeSortedSetTest
         partitionTreeSortedSet.getSelected().addAll(selected);
         partitionTreeSortedSet.getRejected().addAll(rejected);
         PartitionImmutableSortedSet<Integer> immutableSortedSet = partitionTreeSortedSet.toImmutable();
-        Assert.assertEquals(selected, immutableSortedSet.getSelected());
-        Assert.assertEquals(rejected, immutableSortedSet.getRejected());
+        assertEquals(selected, immutableSortedSet.getSelected());
+        assertEquals(rejected, immutableSortedSet.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/strategy/PartitionUnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/strategy/PartitionUnifiedSetWithHashingStrategyTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionUnifiedSetWithHashingStrategyTest
 {
@@ -32,7 +33,7 @@ public class PartitionUnifiedSetWithHashingStrategyTest
         partitionMutableSet.getRejected().addAll(rejected);
 
         PartitionImmutableSet<Integer> partitionImmutableSet = partitionMutableSet.toImmutable();
-        Assert.assertEquals(selected, partitionImmutableSet.getSelected());
-        Assert.assertEquals(rejected, partitionImmutableSet.getRejected());
+        assertEquals(selected, partitionImmutableSet.getSelected());
+        assertEquals(rejected, partitionImmutableSet.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/stack/PartitionArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/stack/PartitionArrayStackTest.java
@@ -14,8 +14,9 @@ import org.eclipse.collections.api.partition.stack.PartitionImmutableStack;
 import org.eclipse.collections.api.partition.stack.PartitionMutableStack;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartitionArrayStackTest
 {
@@ -32,7 +33,7 @@ public class PartitionArrayStackTest
                 ArrayStack.newStackFromTopToBottom(1, 2, 3, 4, 5, 6).partition(Predicates.lessThan(4));
 
         PartitionImmutableStack<Integer> partitionImmutableStack = partitionMutableStack.toImmutable();
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3), partitionImmutableStack.getSelected());
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(4, 5, 6), partitionImmutableStack.getRejected());
+        assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3), partitionImmutableStack.getSelected());
+        assertEquals(ArrayStack.newStackFromTopToBottom(4, 5, 6), partitionImmutableStack.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSetTestCase.java
@@ -44,10 +44,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.UnmodifiableMutableSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link AbstractMemoryEfficientMutableSet}.
@@ -156,10 +161,10 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         for (int i = size; i-- > 0; )
         {
             String integerString = iterator.next();
-            Assert.assertEquals(size, Integer.parseInt(integerString) + i);
+            assertEquals(size, Integer.parseInt(integerString) + i);
         }
 
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -231,8 +236,8 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableMap<Boolean, RichIterable<String>> actualMap = multimap.toMap();
         int halfSize = this.classUnderTest().size() / 2;
         boolean odd = this.classUnderTest().size() % 2 != 0;
-        Assert.assertEquals(halfSize, Iterate.sizeOf(actualMap.getIfAbsent(false, FastList::new)));
-        Assert.assertEquals(halfSize + (odd ? 1 : 0), Iterate.sizeOf(actualMap.get(true)));
+        assertEquals(halfSize, Iterate.sizeOf(actualMap.getIfAbsent(false, FastList::new)));
+        assertEquals(halfSize + (odd ? 1 : 0), Iterate.sizeOf(actualMap.get(true)));
     }
 
     @Test
@@ -245,11 +250,11 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
 
         Multimap<Integer, Integer> actual =
                 set.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 set.groupByEach(new NegativeIntervalFunction(), UnifiedSetMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
@@ -261,18 +266,18 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         List<Object> nullsMinusOne = Collections.nCopies(set.size() - 1, null);
 
         MutableSet<Pair<String, Object>> pairs = set.zip(nulls);
-        Assert.assertEquals(set, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(set, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
+        assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableSet<Pair<String, Object>> pairsPlusOne = set.zip(nullsPlusOne);
-        Assert.assertEquals(set, pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(set, pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableSet<Pair<String, Object>> pairsMinusOne = set.zip(nullsMinusOne);
-        Assert.assertEquals(set.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(set.containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
+        assertEquals(set.size() - 1, pairsMinusOne.size());
+        assertTrue(set.containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
 
-        Assert.assertEquals(
+        assertEquals(
                 set.zip(nulls),
                 set.zip(nulls, UnifiedSet.newSet()));
     }
@@ -283,14 +288,14 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<Pair<String, Integer>> pairs = set.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(set.size() - 1).toSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(
+        assertEquals(
                 set.zipWithIndex(),
                 set.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -300,7 +305,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> clone = set.clone();
-        Assert.assertNotSame(clone, set);
+        assertNotSame(clone, set);
         Verify.assertEqualsAndHashCode(clone, set);
     }
 
@@ -319,37 +324,37 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals("1", this.classUnderTest().min(String::compareTo));
+        assertEquals("1", this.classUnderTest().min(String::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals("1", this.classUnderTest().max(Comparators.reverse(String::compareTo)));
+        assertEquals("1", this.classUnderTest().max(Comparators.reverse(String::compareTo)));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals("1", this.classUnderTest().min());
+        assertEquals("1", this.classUnderTest().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(String.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
+        assertEquals(String.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals("1", this.classUnderTest().minBy(String::valueOf));
+        assertEquals("1", this.classUnderTest().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(String.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(String::valueOf));
+        assertEquals(String.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Test
@@ -364,7 +369,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         {
             hashBag.add(1);
         }
-        Assert.assertEquals(hashBag, sizes.toBag());
+        assertEquals(hashBag, sizes.toBag());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -377,7 +382,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     public void chunk_large_size()
     {
         MutableSet<String> set = this.classUnderTest();
-        Assert.assertEquals(set, set.chunk(10).getFirst());
+        assertEquals(set, set.chunk(10).getFirst());
     }
 
     @Test
@@ -386,10 +391,10 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> union = set.union(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
+        assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
     }
 
     @Test
@@ -398,10 +403,10 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -410,7 +415,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> intersect = set.intersect(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersect(UnifiedSet.newSetWith("not present")));
     }
@@ -421,7 +426,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> intersect = set.intersectInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -431,8 +436,8 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -440,8 +445,8 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -450,7 +455,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> difference = set.symmetricDifference(UnifiedSet.newSetWith("2", "3", "4", "5", "not present"));
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -467,7 +472,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
                 UnifiedSet.newSetWith("2", "3", "4", "5", "not present"),
                 UnifiedSet.newSet());
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -482,15 +487,15 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     public void isSubsetOf()
     {
         MutableSet<String> set = this.classUnderTest();
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         MutableSet<String> set = this.classUnderTest();
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -509,7 +514,7 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))
@@ -520,11 +525,11 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     public void with()
     {
         MutableSet<String> set = this.classUnderTest();
-        Assert.assertFalse(set.contains("11"));
+        assertFalse(set.contains("11"));
         MutableSet<String> setWith = set.with("11");
-        Assert.assertTrue(setWith.containsAll(set));
-        Assert.assertTrue(setWith.contains("11"));
-        Assert.assertSame(setWith, setWith.with("11"));
+        assertTrue(setWith.containsAll(set));
+        assertTrue(setWith.contains("11"));
+        assertSame(setWith, setWith.with("11"));
         assertSetType(set, setWith);
     }
 
@@ -534,21 +539,21 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         Verify.assertContainsNone(set, "11", "12");
         MutableSet<String> setWith = set.withAll(FastList.newListWith("11", "12"));
-        Assert.assertTrue(setWith.containsAll(set));
+        assertTrue(setWith.containsAll(set));
         Verify.assertContainsAll(setWith, "11", "12");
         assertSetType(set, setWith);
-        Assert.assertSame(setWith, setWith.withAll(FastList.newList()));
+        assertSame(setWith, setWith.withAll(FastList.newList()));
     }
 
     @Test
     public void without()
     {
         MutableSet<String> set = this.classUnderTest();
-        Assert.assertSame(set, set.without("11"));
+        assertSame(set, set.without("11"));
         MutableList<String> list = set.toList();
         list.forEach(Procedures.cast(each -> {
             MutableSet<String> setWithout = set.without(each);
-            Assert.assertFalse(setWithout.contains(each));
+            assertFalse(setWithout.contains(each));
             assertSetType(set, setWithout);
         }));
     }
@@ -558,10 +563,10 @@ public abstract class AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest().with("11").with("12");
         MutableSet<String> setWithout = set.withoutAll(FastList.newListWith("11", "12"));
-        Assert.assertTrue(setWithout.containsAll(this.classUnderTest()));
+        assertTrue(setWithout.containsAll(this.classUnderTest()));
         Verify.assertContainsNone(setWithout, "11", "12");
         assertSetType(set, setWithout);
-        Assert.assertSame(setWithout, setWithout.withoutAll(FastList.newList()));
+        assertSame(setWithout, setWithout.withoutAll(FastList.newList()));
     }
 
     protected static void assertSetType(MutableSet<?> original, MutableSet<?> modified)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/DoubletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/DoubletonSetTest.java
@@ -27,11 +27,15 @@ import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link DoubletonSet}.
@@ -67,11 +71,11 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
 
         Twin<String> twin3 = Tuples.twin("1", "1");
         set.with(twin3);
-        Assert.assertSame(set.getFirst(), twin1);
+        assertSame(set.getFirst(), twin1);
 
         Twin<String> twin4 = Tuples.twin("2", "2");
         set.with(twin4);
-        Assert.assertSame(set.getLast(), twin2);
+        assertSame(set.getLast(), twin2);
     }
 
     @Override
@@ -90,7 +94,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.remove("1");
-            Assert.fail("Cannot remove from DoubletonSet");
+            fail("Cannot remove from DoubletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -104,7 +108,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("1");
-            Assert.fail("Cannot add to DoubletonSet");
+            fail("Cannot add to DoubletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -118,7 +122,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("3");
-            Assert.fail("Cannot add to DoubletonSet");
+            fail("Cannot add to DoubletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -158,8 +162,8 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
             }
         }
         MutableSet<String> cloneSet = this.set.clone();
-        Assert.assertNotSame(cloneSet, this.set);
-        Assert.assertEquals(UnifiedSet.newSetWith("1", "2"), cloneSet);
+        assertNotSame(cloneSet, this.set);
+        assertEquals(UnifiedSet.newSetWith("1", "2"), cloneSet);
     }
 
     @Test
@@ -173,7 +177,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void getLast()
     {
-        Assert.assertEquals("2", this.set.getLast());
+        assertEquals("2", this.set.getLast());
     }
 
     @Test
@@ -182,7 +186,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(FastList.newListWith("1", "2"), result);
     }
 
     @Test
@@ -196,8 +200,8 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
-        Assert.assertEquals(1, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(1, indexSum[0]);
     }
 
     @Test
@@ -206,15 +210,15 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2");
         source.forEachWith(Procedures2.fromProcedure(CollectionAddProcedure.on(result)), null);
-        Assert.assertEquals(FastList.newListWith("1", "2"), result);
+        assertEquals(FastList.newListWith("1", "2"), result);
     }
 
     @Test
     public void getFirstGetLast()
     {
         MutableSet<String> source = Sets.fixedSize.of("1", "2");
-        Assert.assertEquals("1", source.getFirst());
-        Assert.assertEquals("2", source.getLast());
+        assertEquals("1", source.getFirst());
+        assertEquals("2", source.getLast());
     }
 
     @Override
@@ -228,16 +232,16 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         set.forEach(Procedures.cast(value -> expected.putAll(-value, Interval.fromTo(value, set.size()))));
         Multimap<Integer, Integer> actual =
                 set.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 set.groupByEach(new NegativeIntervalFunction(), UnifiedSetMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.set.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.set.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/EmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/EmptySetTest.java
@@ -24,9 +24,16 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
@@ -53,10 +60,10 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void testEmpty()
     {
-        Assert.assertTrue(this.emptySet.isEmpty());
-        Assert.assertFalse(this.emptySet.notEmpty());
-        Assert.assertTrue(Sets.fixedSize.of().isEmpty());
-        Assert.assertFalse(Sets.fixedSize.of().notEmpty());
+        assertTrue(this.emptySet.isEmpty());
+        assertFalse(this.emptySet.notEmpty());
+        assertTrue(Sets.fixedSize.of().isEmpty());
+        assertFalse(Sets.fixedSize.of().notEmpty());
     }
 
     @Test
@@ -68,15 +75,15 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void testContains()
     {
-        Assert.assertFalse(this.emptySet.contains("Something"));
-        Assert.assertFalse(this.emptySet.contains(null));
+        assertFalse(this.emptySet.contains("Something"));
+        assertFalse(this.emptySet.contains(null));
     }
 
     @Test
     public void testGetFirstLast()
     {
-        Assert.assertNull(this.emptySet.getFirst());
-        Assert.assertNull(this.emptySet.getLast());
+        assertNull(this.emptySet.getFirst());
+        assertNull(this.emptySet.getLast());
     }
 
     @Test
@@ -90,36 +97,36 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void testClone()
     {
-        Assert.assertSame(Sets.fixedSize.of().clone(), Sets.fixedSize.of());
+        assertSame(Sets.fixedSize.of().clone(), Sets.fixedSize.of());
     }
 
     @Test
     public void testForEach()
     {
-        this.emptySet.forEach(Procedures.cast(each -> Assert.fail()));
+        this.emptySet.forEach(Procedures.cast(each -> fail()));
     }
 
     @Test
     public void testForEachWithIndex()
     {
-        this.emptySet.forEachWithIndex((each, index) -> Assert.fail());
+        this.emptySet.forEachWithIndex((each, index) -> fail());
     }
 
     @Test
     public void testForEachWith()
     {
-        this.emptySet.forEachWith((argument1, argument2) -> Assert.fail(), "param");
+        this.emptySet.forEachWith((argument1, argument2) -> fail(), "param");
     }
 
     @Test
     public void testIterator()
     {
         Iterator<Object> it = this.emptySet.iterator();
-        Assert.assertFalse(it.hasNext());
+        assertFalse(it.hasNext());
 
-        Assert.assertThrows(NoSuchElementException.class, it::next);
+        assertThrows(NoSuchElementException.class, it::next);
 
-        Assert.assertThrows(UnsupportedOperationException.class, it::remove);
+        assertThrows(UnsupportedOperationException.class, it::remove);
     }
 
     @Test
@@ -128,8 +135,8 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSetMultimap<Class<?>, String> multimap = this.classUnderTest().groupBy(Object::getClass);
         Verify.assertSize(this.classUnderTest().size(), multimap);
-        Assert.assertTrue(multimap.keysView().isEmpty());
-        Assert.assertEquals(this.classUnderTest(), multimap.get(String.class));
+        assertTrue(multimap.keysView().isEmpty());
+        assertEquals(this.classUnderTest(), multimap.get(String.class));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -211,14 +218,14 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
         List<Object> nullsPlusOne = Collections.nCopies(set.size() + 1, null);
 
         MutableSet<Pair<String, Object>> pairs = set.zip(nulls);
-        Assert.assertEquals(set, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(set, pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
+        assertEquals(nulls, pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableSet<Pair<String, Object>> pairsPlusOne = set.zip(nullsPlusOne);
-        Assert.assertEquals(set, pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(set, pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
+        assertEquals(nulls, pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
-        Assert.assertEquals(
+        assertEquals(
                 set.zip(nulls),
                 set.zip(nulls, UnifiedSet.newSet()));
     }
@@ -230,14 +237,14 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
         MutableSet<String> set = this.classUnderTest();
         MutableSet<Pair<String, Integer>> pairs = set.zipWithIndex();
 
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(
+        assertEquals(
                 set.zipWithIndex(),
                 set.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -246,14 +253,14 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(10));
+        assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(10));
     }
 
     @Override
     @Test
     public void union()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("a", "b", "c"),
                 this.classUnderTest().union(UnifiedSet.newSetWith("a", "b", "c")));
     }
@@ -262,7 +269,7 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void unionInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("a", "b", "c"),
                 this.classUnderTest().unionInto(UnifiedSet.newSetWith("a", "b", "c"), UnifiedSet.newSet()));
     }
@@ -271,7 +278,7 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void intersect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 this.classUnderTest().intersect(UnifiedSet.newSetWith("1", "2", "3")));
     }
@@ -280,7 +287,7 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void intersectInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 this.classUnderTest().intersectInto(UnifiedSet.newSetWith("1", "2", "3"), UnifiedSet.newSet()));
     }
@@ -291,8 +298,8 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.<String>newSet(), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.<String>newSet(), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Override
@@ -301,15 +308,15 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> set = this.classUnderTest();
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.<String>newSet(), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.<String>newSet(), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Override
     @Test
     public void symmetricDifference()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("not present"),
                 this.classUnderTest().symmetricDifference(UnifiedSet.newSetWith("not present")));
     }
@@ -318,7 +325,7 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void symmetricDifferenceInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("not present"),
                 this.classUnderTest().symmetricDifferenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -326,6 +333,6 @@ public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.emptySet.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.emptySet.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryTest.java
@@ -22,9 +22,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class FixedSizeSetFactoryTest
 {
@@ -58,7 +60,7 @@ public class FixedSizeSetFactoryTest
 
     private void assertCreateSet(FixedSizeSet<String> undertest, String... expected)
     {
-        Assert.assertEquals(UnifiedSet.newSetWith(expected), undertest);
+        assertEquals(UnifiedSet.newSetWith(expected), undertest);
         Verify.assertInstanceOf(FixedSizeSet.class, undertest);
     }
 
@@ -71,35 +73,35 @@ public class FixedSizeSetFactoryTest
         MutableSet<Key> set1 = this.setFactory.of(key, duplicateKey1);
         Verify.assertSize(1, set1);
         Verify.assertContains(key, set1);
-        Assert.assertSame(key, set1.getFirst());
+        assertSame(key, set1.getFirst());
 
         Key duplicateKey2 = new Key("key");
         MutableSet<Key> set2 = this.setFactory.of(key, duplicateKey1, duplicateKey2);
         Verify.assertSize(1, set2);
         Verify.assertContains(key, set2);
-        Assert.assertSame(key, set1.getFirst());
+        assertSame(key, set1.getFirst());
 
         Key duplicateKey3 = new Key("key");
         MutableSet<Key> set3 = this.setFactory.of(key, new Key("not a dupe"), duplicateKey3);
         Verify.assertSize(2, set3);
         Verify.assertContainsAll(set3, key, new Key("not a dupe"));
-        Assert.assertSame(key, set3.detect(key::equals));
+        assertSame(key, set3.detect(key::equals));
 
         Key duplicateKey4 = new Key("key");
         MutableSet<Key> set4 = this.setFactory.of(key, new Key("not a dupe"), duplicateKey3, duplicateKey4);
         Verify.assertSize(2, set4);
         Verify.assertContainsAll(set4, key, new Key("not a dupe"));
-        Assert.assertSame(key, set4.detect(key::equals));
+        assertSame(key, set4.detect(key::equals));
 
         MutableSet<Key> set5 = this.setFactory.of(key, new Key("not a dupe"), new Key("me neither"), duplicateKey4);
         Verify.assertSize(3, set5);
         Verify.assertContainsAll(set5, key, new Key("not a dupe"), new Key("me neither"));
-        Assert.assertSame(key, set5.detect(key::equals));
+        assertSame(key, set5.detect(key::equals));
 
         MutableSet<Key> set6 = this.setFactory.of(key, duplicateKey2, duplicateKey3, duplicateKey4);
         Verify.assertSize(1, set6);
         Verify.assertContains(key, set6);
-        Assert.assertSame(key, set6.detect(key::equals));
+        assertSame(key, set6.detect(key::equals));
     }
 
     @Test
@@ -114,61 +116,61 @@ public class FixedSizeSetFactoryTest
     public void create2()
     {
         FixedSizeSet<String> set = Sets.fixedSize.of("1", "2");
-        Assert.assertEquals(UnifiedSet.newSetWith("1", "2"), set);
+        assertEquals(UnifiedSet.newSetWith("1", "2"), set);
     }
 
     @Test
     public void create3()
     {
         FixedSizeSet<String> set = Sets.fixedSize.of("1", "2", "3");
-        Assert.assertEquals(UnifiedSet.newSetWith("1", "2", "3"), set);
+        assertEquals(UnifiedSet.newSetWith("1", "2", "3"), set);
     }
 
     @Test
     public void create4()
     {
         FixedSizeSet<String> set = Sets.fixedSize.of("1", "2", "3", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("1", "2", "3", "4"), set);
+        assertEquals(UnifiedSet.newSetWith("1", "2", "3", "4"), set);
     }
 
     @Test
     public void createWithDuplicates()
     {
         FixedSizeSet<String> set1 = Sets.fixedSize.of("1", "1");
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), set1);
+        assertEquals(UnifiedSet.newSetWith("1"), set1);
 
         FixedSizeSet<String> set2 = Sets.fixedSize.of("1", "1", "1");
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), set2);
+        assertEquals(UnifiedSet.newSetWith("1"), set2);
 
         FixedSizeSet<String> set3 = Sets.fixedSize.of("2", "3", "2");
-        Assert.assertEquals(UnifiedSet.newSetWith("2", "3"), set3);
+        assertEquals(UnifiedSet.newSetWith("2", "3"), set3);
 
         FixedSizeSet<String> set4 = Sets.fixedSize.of("3", "4", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("3", "4"), set4);
+        assertEquals(UnifiedSet.newSetWith("3", "4"), set4);
 
         FixedSizeSet<String> set5 = Sets.fixedSize.of("4", "4", "4", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4"), set5);
+        assertEquals(UnifiedSet.newSetWith("4"), set5);
 
         FixedSizeSet<String> set6 = Sets.fixedSize.of("4", "3", "4", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3"), set6);
+        assertEquals(UnifiedSet.newSetWith("4", "3"), set6);
 
         FixedSizeSet<String> set7 = Sets.fixedSize.of("4", "2", "3", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set7);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set7);
 
         FixedSizeSet<String> set8 = Sets.fixedSize.of("2", "3", "4", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set8);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set8);
 
         FixedSizeSet<String> set9 = Sets.fixedSize.of("2", "4", "3", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set9);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set9);
 
         FixedSizeSet<String> set10 = Sets.fixedSize.of("2", "4", "3", "4");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set10);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set10);
 
         FixedSizeSet<String> set11 = Sets.fixedSize.of("4", "3", "4", "2");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set11);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set11);
 
         FixedSizeSet<String> set12 = Sets.fixedSize.of("3", "4", "4", "2");
-        Assert.assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set12);
+        assertEquals(UnifiedSet.newSetWith("4", "3", "2"), set12);
     }
 
     @Test
@@ -180,7 +182,7 @@ public class FixedSizeSetFactoryTest
         MutableSet<String> set2 = Sets.fixedSize.of();
         Verify.assertEmpty(set2);
 
-        Assert.assertSame(Sets.fixedSize.of(), Sets.fixedSize.of());
+        assertSame(Sets.fixedSize.of(), Sets.fixedSize.of());
     }
 
     @Test
@@ -189,7 +191,7 @@ public class FixedSizeSetFactoryTest
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3", "4");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
@@ -202,8 +204,8 @@ public class FixedSizeSetFactoryTest
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(6, indexSum[0]);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(6, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
@@ -212,14 +214,14 @@ public class FixedSizeSetFactoryTest
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3", "4");
         source.forEachWith(Procedures2.fromProcedure(CollectionAddProcedure.on(result)), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
     public void ofAllSizeZero()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newList());
-        Assert.assertEquals(UnifiedSet.<Integer>newSetWith(), set);
+        assertEquals(UnifiedSet.<Integer>newSetWith(), set);
         Verify.assertInstanceOf(FixedSizeSet.class, set);
     }
 
@@ -227,7 +229,7 @@ public class FixedSizeSetFactoryTest
     public void ofAllSizeOne()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newListWith(1));
-        Assert.assertEquals(UnifiedSet.newSetWith(1), set);
+        assertEquals(UnifiedSet.newSetWith(1), set);
         Verify.assertInstanceOf(FixedSizeSet.class, set);
     }
 
@@ -235,7 +237,7 @@ public class FixedSizeSetFactoryTest
     public void ofAllSizeTwo()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newListWith(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2), set);
         Verify.assertInstanceOf(FixedSizeSet.class, set);
     }
 
@@ -243,7 +245,7 @@ public class FixedSizeSetFactoryTest
     public void ofAllSizeThree()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newListWith(1, 2, 3));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), set);
         Verify.assertInstanceOf(FixedSizeSet.class, set);
     }
 
@@ -251,7 +253,7 @@ public class FixedSizeSetFactoryTest
     public void ofAllSizeFour()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newListWith(1, 2, 3, 4));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
         Verify.assertInstanceOf(FixedSizeSet.class, set);
     }
 
@@ -259,7 +261,7 @@ public class FixedSizeSetFactoryTest
     public void ofAllSizeFive()
     {
         MutableSet<Integer> set = Sets.fixedSize.ofAll(FastList.newListWith(1, 2, 3, 4, 5));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
         Verify.assertInstanceOf(UnifiedSet.class, set);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetTest.java
@@ -22,9 +22,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
@@ -62,10 +67,10 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
         set.with(Tuples.twin("3", "3"));
         set.with(Tuples.twin("4", "4"));
 
-        Assert.assertSame(set.getFirst(), twin1);
-        Assert.assertSame(set.getSecond(), twin2);
-        Assert.assertSame(set.getThird(), twin3);
-        Assert.assertSame(set.getLast(), twin4);
+        assertSame(set.getFirst(), twin1);
+        assertSame(set.getSecond(), twin2);
+        assertSame(set.getThird(), twin3);
+        assertSame(set.getLast(), twin4);
     }
 
     @Test
@@ -79,7 +84,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
     @Test
     public void remove()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.set.remove("1"));
+        assertThrows(UnsupportedOperationException.class, () -> this.set.remove("1"));
     }
 
     @Test
@@ -88,7 +93,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
         try
         {
             this.set.add("1");
-            Assert.fail("Cannot add to TripletonSet");
+            fail("Cannot add to TripletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -102,7 +107,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
         try
         {
             this.set.add("4");
-            Assert.fail("Cannot add to TripletonSet");
+            fail("Cannot add to TripletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -141,7 +146,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
     {
         MutableSet<String> copyOfSet = SerializeTestHelper.serializeDeserialize(this.set);
         Verify.assertSetsEqual(this.set, copyOfSet);
-        Assert.assertNotSame(this.set, copyOfSet);
+        assertNotSame(this.set, copyOfSet);
     }
 
     @Override
@@ -161,7 +166,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
             }
         }
         MutableSet<String> cloneSet = this.set.clone();
-        Assert.assertNotSame(cloneSet, this.set);
+        assertNotSame(cloneSet, this.set);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("1", "2", "3", "4"), cloneSet);
     }
 
@@ -177,8 +182,8 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
     public void getFirstGetLast()
     {
         MutableSet<String> list5 = Sets.fixedSize.of("1", "2", "3", "4");
-        Assert.assertEquals("1", list5.getFirst());
-        Assert.assertEquals("4", list5.getLast());
+        assertEquals("1", list5.getFirst());
+        assertEquals("4", list5.getLast());
     }
 
     @Test
@@ -187,7 +192,7 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3", "4");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
@@ -201,8 +206,8 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
-        Assert.assertEquals(6, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(6, indexSum[0]);
     }
 
     @Test
@@ -211,12 +216,12 @@ public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCa
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3", "4");
         source.forEachWith(Procedures2.fromProcedure(CollectionAddProcedure.on(result)), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
+        assertEquals(FastList.newListWith("1", "2", "3", "4"), result);
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.set.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.set.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/SingletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/SingletonSetTest.java
@@ -33,12 +33,19 @@ import org.eclipse.collections.impl.set.mutable.SynchronizedMutableSet;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link SingletonSet}.
@@ -74,7 +81,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         Twin<String> twin2 = Tuples.twin("1", "1");
         SingletonSet<Twin<String>> set = new SingletonSet<>(twin1);
         set.with(twin2);
-        Assert.assertSame(set.getFirst(), twin1);
+        assertSame(set.getFirst(), twin1);
     }
 
     @Override
@@ -109,7 +116,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.remove("1");
-            Assert.fail("Should not allow remove from SingletonSet");
+            fail("Should not allow remove from SingletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -123,7 +130,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("1");
-            Assert.fail("Should not allow adding a duplicate to SingletonSet");
+            fail("Should not allow adding a duplicate to SingletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -137,7 +144,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("2");
-            Assert.fail("Should not allow add to SingletonSet");
+            fail("Should not allow add to SingletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -164,8 +171,8 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     public void tap()
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
-        Assert.assertSame(this.intSet, this.intSet.tap(tapResult::add));
-        Assert.assertEquals(this.intSet.toList(), tapResult);
+        assertSame(this.intSet, this.intSet.tap(tapResult::add));
+        assertEquals(this.intSet.toList(), tapResult);
     }
 
     @Test
@@ -234,23 +241,23 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     public void partition()
     {
         PartitionMutableSet<Integer> partition = this.intSet.partition(Predicates.lessThan(3));
-        Assert.assertEquals(mSet(1), partition.getSelected());
-        Assert.assertEquals(mSet(), partition.getRejected());
+        assertEquals(mSet(1), partition.getSelected());
+        assertEquals(mSet(), partition.getRejected());
     }
 
     @Test
     public void partitionWith()
     {
         PartitionMutableSet<Integer> partition = this.intSet.partitionWith(Predicates2.lessThan(), 3);
-        Assert.assertEquals(mSet(1), partition.getSelected());
-        Assert.assertEquals(mSet(), partition.getRejected());
+        assertEquals(mSet(1), partition.getSelected());
+        assertEquals(mSet(), partition.getRejected());
     }
 
     @Test
     public void selectInstancesOf()
     {
         MutableSet<Number> numbers = Sets.fixedSize.of(1);
-        Assert.assertEquals(iSet(1), numbers.selectInstancesOf(Integer.class));
+        assertEquals(iSet(1), numbers.selectInstancesOf(Integer.class));
         Verify.assertEmpty(numbers.selectInstancesOf(Double.class));
     }
 
@@ -276,87 +283,87 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.detect(Integer.valueOf(1)::equals));
-        Assert.assertNull(this.intSet.detect(Integer.valueOf(6)::equals));
+        assertEquals(Integer.valueOf(1), this.intSet.detect(Integer.valueOf(1)::equals));
+        assertNull(this.intSet.detect(Integer.valueOf(6)::equals));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.detectWith(Object::equals, 1));
-        Assert.assertNull(this.intSet.detectWith(Object::equals, 6));
+        assertEquals(Integer.valueOf(1), this.intSet.detectWith(Object::equals, 1));
+        assertNull(this.intSet.detectWith(Object::equals, 6));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.detectIfNone(Integer.valueOf(1)::equals, function));
-        Assert.assertEquals(Integer.valueOf(6), this.intSet.detectIfNone(Integer.valueOf(6)::equals, function));
+        assertEquals(Integer.valueOf(1), this.intSet.detectIfNone(Integer.valueOf(1)::equals, function));
+        assertEquals(Integer.valueOf(6), this.intSet.detectIfNone(Integer.valueOf(6)::equals, function));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
-        Assert.assertEquals(Integer.valueOf(6), this.intSet.detectWithIfNone(Object::equals, Integer.valueOf(6), function));
+        assertEquals(Integer.valueOf(1), this.intSet.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
+        assertEquals(Integer.valueOf(6), this.intSet.detectWithIfNone(Object::equals, Integer.valueOf(6), function));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.intSet.allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(this.intSet.allSatisfy(Integer.valueOf(2)::equals));
+        assertTrue(this.intSet.allSatisfy(Integer.class::isInstance));
+        assertFalse(this.intSet.allSatisfy(Integer.valueOf(2)::equals));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(this.intSet.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(this.intSet.allSatisfyWith(Object::equals, 2));
+        assertTrue(this.intSet.allSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.intSet.allSatisfyWith(Object::equals, 2));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.intSet.anySatisfy(String.class::isInstance));
-        Assert.assertTrue(this.intSet.anySatisfy(Integer.class::isInstance));
+        assertFalse(this.intSet.anySatisfy(String.class::isInstance));
+        assertTrue(this.intSet.anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertFalse(this.intSet.anySatisfyWith(Predicates2.instanceOf(), String.class));
-        Assert.assertTrue(this.intSet.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertFalse(this.intSet.anySatisfyWith(Predicates2.instanceOf(), String.class));
+        assertTrue(this.intSet.anySatisfyWith(Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(this.intSet.noneSatisfy(Integer.class::isInstance));
-        Assert.assertTrue(this.intSet.noneSatisfy(Integer.valueOf(10)::equals));
+        assertFalse(this.intSet.noneSatisfy(Integer.class::isInstance));
+        assertTrue(this.intSet.noneSatisfy(Integer.valueOf(10)::equals));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertFalse(this.intSet.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertTrue(this.intSet.noneSatisfyWith(Object::equals, 10));
+        assertFalse(this.intSet.noneSatisfyWith(Predicates2.instanceOf(), Integer.class));
+        assertTrue(this.intSet.noneSatisfyWith(Object::equals, 10));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(1, this.intSet.count(Integer.class::isInstance));
-        Assert.assertEquals(0, this.intSet.count(String.class::isInstance));
+        assertEquals(1, this.intSet.count(Integer.class::isInstance));
+        assertEquals(0, this.intSet.count(String.class::isInstance));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(1, this.intSet.countWith(Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, this.intSet.countWith(Predicates2.instanceOf(), String.class));
+        assertEquals(1, this.intSet.countWith(Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, this.intSet.countWith(Predicates2.instanceOf(), String.class));
     }
 
     @Test
@@ -374,10 +381,10 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void collectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(2),
                 this.intSet.collectWith(AddFunction.INTEGER, 1));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(2),
                 this.intSet.collectWith(AddFunction.INTEGER, 1, FastList.newList()));
     }
@@ -385,44 +392,44 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.getFirst());
+        assertEquals(Integer.valueOf(1), this.intSet.getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.getLast());
+        assertEquals(Integer.valueOf(1), this.intSet.getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.intSet.getOnly());
+        assertEquals(Integer.valueOf(1), this.intSet.getOnly());
     }
 
     @Test
     public void isEmpty()
     {
         Verify.assertNotEmpty(this.intSet);
-        Assert.assertTrue(this.intSet.notEmpty());
+        assertTrue(this.intSet.notEmpty());
     }
 
     @Test
     public void removeAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.intSet.removeAll(Lists.fixedSize.of(1, 2)));
+        assertThrows(UnsupportedOperationException.class, () -> this.intSet.removeAll(Lists.fixedSize.of(1, 2)));
     }
 
     @Test
     public void retainAll()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.intSet.retainAll(Lists.fixedSize.of(2)));
+        assertThrows(UnsupportedOperationException.class, () -> this.intSet.retainAll(Lists.fixedSize.of(2)));
     }
 
     @Test
     public void clear()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, this.intSet::clear);
+        assertThrows(UnsupportedOperationException.class, this.intSet::clear);
     }
 
     @Override
@@ -434,7 +441,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         for (int i = this.intSet.size(); i-- > 0; )
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(1, integer.intValue() + i);
+            assertEquals(1, integer.intValue() + i);
         }
     }
 
@@ -442,7 +449,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     public void injectInto()
     {
         Integer result = this.intSet.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(2), result);
+        assertEquals(Integer.valueOf(2), result);
     }
 
     @Test
@@ -452,7 +459,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
                 1,
                 (injectedValued, item, parameter) -> injectedValued + item + parameter,
                 0);
-        Assert.assertEquals(Integer.valueOf(2), result);
+        assertEquals(Integer.valueOf(2), result);
     }
 
     @Test
@@ -476,7 +483,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void removeWithPredicate()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.intSet.removeIf(Predicates.isNull()));
+        assertThrows(UnsupportedOperationException.class, () -> this.intSet.removeIf(Predicates.isNull()));
     }
 
     @Test
@@ -492,13 +499,13 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(FastList.newListWith(1), this.intSet.toSortedList(Collections.reverseOrder()));
+        assertEquals(FastList.newListWith(1), this.intSet.toSortedList(Collections.reverseOrder()));
     }
 
     @Test
     public void toSortedListBy()
     {
-        Assert.assertEquals(FastList.newListWith(1), this.intSet.toSortedListBy(Functions.getIntegerPassThru()));
+        assertEquals(FastList.newListWith(1), this.intSet.toSortedListBy(Functions.getIntegerPassThru()));
     }
 
     @Test
@@ -534,7 +541,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
             }
         }
         MutableSet<String> cloneSet = this.set.clone();
-        Assert.assertNotSame(cloneSet, this.set);
+        assertNotSame(cloneSet, this.set);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("1"), cloneSet);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/TripletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/TripletonSetTest.java
@@ -22,9 +22,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link TripletonSet}.
@@ -63,9 +68,9 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         set.with(Tuples.twin("2", "2"));
         set.with(Tuples.twin("3", "3"));
 
-        Assert.assertSame(set.getFirst(), twin1);
-        Assert.assertSame(set.getSecond(), twin2);
-        Assert.assertSame(set.getLast(), twin3);
+        assertSame(set.getFirst(), twin1);
+        assertSame(set.getSecond(), twin2);
+        assertSame(set.getLast(), twin3);
     }
 
     @Override
@@ -92,7 +97,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.remove("1");
-            Assert.fail("Cannot remove from TripletonSet");
+            fail("Cannot remove from TripletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -106,7 +111,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("1");
-            Assert.fail("Cannot add to TripletonSet");
+            fail("Cannot add to TripletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -120,7 +125,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         try
         {
             this.set.add("4");
-            Assert.fail("Cannot add to TripletonSet");
+            fail("Cannot add to TripletonSet");
         }
         catch (UnsupportedOperationException ignored)
         {
@@ -146,7 +151,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     {
         MutableSet<String> copyOfSet = SerializeTestHelper.serializeDeserialize(this.set);
         Verify.assertSetsEqual(this.set, copyOfSet);
-        Assert.assertNotSame(this.set, copyOfSet);
+        assertNotSame(this.set, copyOfSet);
     }
 
     @Override
@@ -166,7 +171,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
             }
         }
         MutableSet<String> cloneSet = this.set.clone();
-        Assert.assertNotSame(cloneSet, this.set);
+        assertNotSame(cloneSet, this.set);
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith("1", "2", "3"), cloneSet);
     }
 
@@ -181,7 +186,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     @Test
     public void getLast()
     {
-        Assert.assertEquals("3", this.set.getLast());
+        assertEquals("3", this.set.getLast());
     }
 
     @Test
@@ -190,7 +195,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3");
         source.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
     }
 
     @Test
@@ -204,8 +209,8 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
             result.add(each);
             indexSum[0] += index;
         });
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
-        Assert.assertEquals(3, indexSum[0]);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(3, indexSum[0]);
     }
 
     @Test
@@ -214,20 +219,20 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
         MutableList<String> result = Lists.mutable.of();
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3");
         source.forEachWith(Procedures2.fromProcedure(CollectionAddProcedure.on(result)), null);
-        Assert.assertEquals(FastList.newListWith("1", "2", "3"), result);
+        assertEquals(FastList.newListWith("1", "2", "3"), result);
     }
 
     @Test
     public void getFirstGetLast()
     {
         MutableSet<String> source = Sets.fixedSize.of("1", "2", "3");
-        Assert.assertEquals("1", source.getFirst());
-        Assert.assertEquals("3", source.getLast());
+        assertEquals("1", source.getFirst());
+        assertEquals("3", source.getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.set.getOnly());
+        assertThrows(IllegalStateException.class, () -> this.set.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableEmptySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableEmptySetTestCase.java
@@ -26,16 +26,22 @@ import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutableSetTestCase
 {
     @Test
     public void containsAll()
     {
-        Assert.assertTrue(this.classUnderTest().castToSet().containsAll(new HashSet<>()));
-        Assert.assertFalse(this.classUnderTest().castToSet().containsAll(UnifiedSet.newSetWith(1)));
+        assertTrue(this.classUnderTest().castToSet().containsAll(new HashSet<>()));
+        assertFalse(this.classUnderTest().castToSet().containsAll(UnifiedSet.newSetWith(1)));
     }
 
     @Override
@@ -51,7 +57,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void detect()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.detect(Integer.valueOf(1)::equals));
+        assertNull(integers.detect(Integer.valueOf(1)::equals));
     }
 
     @Override
@@ -59,7 +65,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void detectWith()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(integers.detectWith(Object::equals, Integer.valueOf(1)));
     }
 
     @Override
@@ -67,14 +73,14 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void anySatisfy()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfy(ERROR_THROWING_PREDICATE));
+        assertFalse(integers.anySatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void anySatisfyWith()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertFalse(integers.anySatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -82,28 +88,28 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void allSatisfy()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(integers.allSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void allSatisfyWith()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(integers.allSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
     public void noneSatisfy()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfy(ERROR_THROWING_PREDICATE));
+        assertTrue(integers.noneSatisfy(ERROR_THROWING_PREDICATE));
     }
 
     @Override
     public void noneSatisfyWith()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
+        assertTrue(integers.noneSatisfyWith(ERROR_THROWING_PREDICATE_2, Integer.class));
     }
 
     @Override
@@ -111,7 +117,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void getFirst()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.getFirst());
+        assertNull(integers.getFirst());
     }
 
     @Override
@@ -119,13 +125,13 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void getLast()
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
-        Assert.assertNull(integers.getLast());
+        assertNull(integers.getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 
     @Override
@@ -133,8 +139,8 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     public void isEmpty()
     {
         ImmutableSet<Integer> list = this.classUnderTest();
-        Assert.assertTrue(list.isEmpty());
-        Assert.assertFalse(list.notEmpty());
+        assertTrue(list.isEmpty());
+        assertFalse(list.notEmpty());
     }
 
     @Override
@@ -220,14 +226,14 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
         List<Object> nullsPlusOne = Collections.nCopies(immutableSet.size() + 1, null);
 
         ImmutableSet<Pair<Integer, Object>> pairs = immutableSet.zip(nulls);
-        Assert.assertEquals(immutableSet, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(UnifiedSet.newSet(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableSet, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(UnifiedSet.newSet(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableSet<Pair<Integer, Object>> pairsPlusOne = immutableSet.zip(nullsPlusOne);
-        Assert.assertEquals(immutableSet, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(UnifiedSet.newSet(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableSet, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(UnifiedSet.newSet(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
-        Assert.assertEquals(immutableSet.zip(nulls), immutableSet.zip(nulls, UnifiedSet.newSet()));
+        assertEquals(immutableSet.zip(nulls), immutableSet.zip(nulls, UnifiedSet.newSet()));
     }
 
     @Override
@@ -237,12 +243,12 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
         ImmutableSet<Integer> immutableSet = this.classUnderTest();
         ImmutableSet<Pair<Integer, Integer>> pairs = immutableSet.zipWithIndex();
 
-        Assert.assertEquals(immutableSet, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(immutableSet, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(
                 UnifiedSet.<Integer>newSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(
+        assertEquals(
                 immutableSet.zipWithIndex(),
                 immutableSet.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -250,7 +256,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void chunk()
     {
-        Assert.assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(2));
+        assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(2));
     }
 
     @Override
@@ -264,14 +270,14 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(10));
+        assertEquals(Lists.mutable.of(), this.classUnderTest().chunk(10));
     }
 
     @Override
     @Test
     public void union()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(1, 2, 3),
                 this.classUnderTest().union(UnifiedSet.newSetWith(1, 2, 3)));
     }
@@ -280,7 +286,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void unionInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(1, 2, 3),
                 this.classUnderTest().unionInto(UnifiedSet.newSetWith(1, 2, 3), UnifiedSet.newSet()));
     }
@@ -289,7 +295,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void intersect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 this.classUnderTest().intersect(UnifiedSet.newSetWith(1, 2, 3)));
     }
@@ -298,7 +304,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void intersectInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 this.classUnderTest().intersectInto(UnifiedSet.newSetWith(1, 2, 3), UnifiedSet.newSet()));
     }
@@ -309,8 +315,8 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     {
         ImmutableSet<Integer> set = this.classUnderTest();
         ImmutableSet<Integer> difference = set.difference(UnifiedSet.newSetWith(1, 2, 3, 999));
-        Assert.assertEquals(UnifiedSet.<Integer>newSet(), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith(999)));
+        assertEquals(UnifiedSet.<Integer>newSet(), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith(999)));
     }
 
     @Override
@@ -319,15 +325,15 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     {
         ImmutableSet<Integer> set = this.classUnderTest();
         MutableSet<Integer> difference = set.differenceInto(UnifiedSet.newSetWith(1, 2, 3, 999), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.<Integer>newSet(), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith(99), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.<Integer>newSet(), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith(99), UnifiedSet.newSet()));
     }
 
     @Override
     @Test
     public void symmetricDifference()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(999),
                 this.classUnderTest().symmetricDifference(UnifiedSet.newSetWith(999)));
     }
@@ -336,7 +342,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
     @Test
     public void symmetricDifferenceInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(999),
                 this.classUnderTest().symmetricDifferenceInto(UnifiedSet.newSetWith(999), UnifiedSet.newSet()));
     }
@@ -359,8 +365,8 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
         {
             throw new AssertionError();
         }, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 
     @Override
@@ -372,7 +378,7 @@ public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutabl
         {
             throw new AssertionError();
         }, 1, targetCollection);
-        Assert.assertEquals(targetCollection, actual);
-        Assert.assertSame(targetCollection, actual);
+        assertEquals(targetCollection, actual);
+        assertSame(targetCollection, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSetTestCase.java
@@ -35,8 +35,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableSetTestCase extends AbstractImmutableCollectionTestCase
 {
@@ -56,14 +61,14 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         MutableSet<Integer> mutable = UnifiedSet.newSet(immutable);
         Verify.assertEqualsAndHashCode(immutable, mutable);
         Verify.assertPostSerializedEqualsAndHashCode(immutable);
-        Assert.assertNotEquals(immutable, FastList.newList(mutable));
+        assertNotEquals(immutable, FastList.newList(mutable));
     }
 
     @Test
     public void newWith()
     {
         ImmutableSet<Integer> immutable = this.classUnderTest();
-        Assert.assertSame(immutable, immutable.newWith(immutable.size()));
+        assertSame(immutable, immutable.newWith(immutable.size()));
         Verify.assertSize(immutable.size() + 1, immutable.newWith(immutable.size() + 1).castToSet());
     }
 
@@ -80,8 +85,8 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<Integer> set = this.classUnderTest();
         ImmutableSet<Integer> withAll = set.newWithAll(UnifiedSet.newSetWith(0));
-        Assert.assertNotEquals(set, withAll);
-        Assert.assertEquals(UnifiedSet.newSet(set).with(0), withAll);
+        assertNotEquals(set, withAll);
+        assertEquals(UnifiedSet.newSet(set).with(0), withAll);
     }
 
     @Test
@@ -89,13 +94,13 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<Integer> set = this.classUnderTest();
         ImmutableSet<Integer> withoutAll = set.newWithoutAll(UnifiedSet.newSet(this.classUnderTest()));
-        Assert.assertEquals(Sets.immutable.<Integer>of(), withoutAll);
+        assertEquals(Sets.immutable.<Integer>of(), withoutAll);
         ImmutableSet<Integer> largeWithoutAll = set.newWithoutAll(Interval.fromTo(101, 150));
-        Assert.assertEquals(set, largeWithoutAll);
+        assertEquals(set, largeWithoutAll);
         ImmutableSet<Integer> largeWithoutAll2 = set.newWithoutAll(UnifiedSet.newSet(Interval.fromTo(151, 199)));
-        Assert.assertEquals(set, largeWithoutAll2);
+        assertEquals(set, largeWithoutAll2);
         ImmutableSet<Integer> largeWithoutAll3 = set.newWithoutAll(FastList.newList(Interval.fromTo(151, 199)));
-        Assert.assertEquals(set, largeWithoutAll3);
+        assertEquals(set, largeWithoutAll3);
     }
 
     @Test
@@ -104,21 +109,21 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<Integer> set = this.classUnderTest();
         for (int i = 1; i <= set.size(); i++)
         {
-            Assert.assertTrue(set.contains(i));
+            assertTrue(set.contains(i));
         }
-        Assert.assertFalse(set.contains(set.size() + 1));
+        assertFalse(set.contains(set.size() + 1));
     }
 
     @Test
     public void containsAllArray()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllArguments(this.classUnderTest().toArray()));
+        assertTrue(this.classUnderTest().containsAllArguments(this.classUnderTest().toArray()));
     }
 
     @Test
     public void containsAllIterable()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(this.classUnderTest()));
+        assertTrue(this.classUnderTest().containsAllIterable(this.classUnderTest()));
     }
 
     @Test
@@ -127,7 +132,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         MutableSet<Integer> result = UnifiedSet.newSet();
         ImmutableSet<Integer> collection = this.classUnderTest();
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Test
@@ -135,7 +140,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         MutableCollection<Integer> result = UnifiedSet.newSet();
         this.classUnderTest().forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 0);
-        Assert.assertEquals(this.classUnderTest(), result);
+        assertEquals(this.classUnderTest(), result);
     }
 
     @Test
@@ -143,14 +148,14 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         MutableCollection<Integer> result = UnifiedSet.newSet();
         this.classUnderTest().forEachWithIndex((object, index) -> result.add(object));
-        Assert.assertEquals(this.classUnderTest(), result);
+        assertEquals(this.classUnderTest(), result);
     }
 
     @Test
     public void select_target()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1), UnifiedSet.newSet()));
+        assertEquals(integers, integers.select(Predicates.lessThan(integers.size() + 1), UnifiedSet.newSet()));
         Verify.assertEmpty(integers.select(Predicates.greaterThan(integers.size()), FastList.newList()));
     }
 
@@ -159,7 +164,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
         Verify.assertEmpty(integers.reject(Predicates.lessThan(integers.size() + 1), FastList.newList()));
-        Assert.assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size()), UnifiedSet.newSet()));
+        assertEquals(integers, integers.reject(Predicates.greaterThan(integers.size()), UnifiedSet.newSet()));
     }
 
     @Test
@@ -169,7 +174,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
 
         ImmutableCollection<String> expected = this.classUnderTest().collect(String::valueOf);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -181,18 +186,18 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         List<Object> nullsMinusOne = Collections.nCopies(immutableCollection.size() - 1, null);
 
         ImmutableCollection<Pair<Integer, Object>> pairs = immutableCollection.zip(nulls);
-        Assert.assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(UnifiedSet.newSet(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(UnifiedSet.newSet(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableCollection<Pair<Integer, Object>> pairsPlusOne = immutableCollection.zip(nullsPlusOne);
-        Assert.assertEquals(immutableCollection, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(UnifiedSet.newSet(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(immutableCollection, pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(UnifiedSet.newSet(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableCollection<Pair<Integer, Object>> pairsMinusOne = immutableCollection.zip(nullsMinusOne);
-        Assert.assertEquals(immutableCollection.size() - 1, pairsMinusOne.size());
-        Assert.assertTrue(immutableCollection.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
+        assertEquals(immutableCollection.size() - 1, pairsMinusOne.size());
+        assertTrue(immutableCollection.containsAllIterable(pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne)));
 
-        Assert.assertEquals(immutableCollection.zip(nulls), immutableCollection.zip(nulls, UnifiedSet.newSet()));
+        assertEquals(immutableCollection.zip(nulls), immutableCollection.zip(nulls, UnifiedSet.newSet()));
     }
 
     @Test
@@ -201,12 +206,12 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableCollection<Integer> immutableCollection = this.classUnderTest();
         ImmutableCollection<Pair<Integer, Integer>> pairs = immutableCollection.zipWithIndex();
 
-        Assert.assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(immutableCollection, pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(
                 Interval.zeroTo(immutableCollection.size() - 1).toSet(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
 
-        Assert.assertEquals(
+        assertEquals(
                 immutableCollection.zipWithIndex(),
                 immutableCollection.zipWithIndex(UnifiedSet.newSet()));
     }
@@ -214,7 +219,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
+        assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
         Verify.assertInstanceOf(ImmutableSet.class, this.classUnderTest().chunk(10).getFirst());
     }
 
@@ -222,7 +227,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     public void collectIfWithTarget()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), UnifiedSet.newSet()));
+        assertEquals(integers, integers.collectIf(Integer.class::isInstance, Functions.getIntegerPassThru(), UnifiedSet.newSet()));
     }
 
     @Test
@@ -238,7 +243,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(this.classUnderTest().toList(), list);
+        assertEquals(this.classUnderTest().toList(), list);
     }
 
     @Test
@@ -247,7 +252,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<Integer> undertest = this.classUnderTest();
         ImmutableSetMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru());
         UnifiedSetMultimap<Integer, Integer> expected = UnifiedSet.newSet(undertest).groupBy(Functions.getPassThru());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -257,7 +262,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         ImmutableSetMultimap<Integer, Integer> actual = undertest.groupByEach(function);
         UnifiedSetMultimap<Integer, Integer> expected = UnifiedSet.newSet(undertest).groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -266,7 +271,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<Integer> undertest = this.classUnderTest();
         UnifiedSetMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru(), UnifiedSetMultimap.newMultimap());
         UnifiedSetMultimap<Integer, Integer> expected = UnifiedSet.newSet(undertest).groupBy(Functions.getPassThru());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -276,7 +281,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         UnifiedSetMultimap<Integer, Integer> actual = undertest.groupByEach(function, UnifiedSetMultimap.newMultimap());
         UnifiedSetMultimap<Integer, Integer> expected = UnifiedSet.newSet(undertest).groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -285,10 +290,10 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         ImmutableSet<String> union = set.union(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
+        assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
     }
 
     @Test
@@ -297,10 +302,10 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -309,7 +314,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         ImmutableSet<String> intersect = set.intersect(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertIterableEmpty(set.intersect(UnifiedSet.newSetWith("not present")));
     }
@@ -320,7 +325,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         MutableSet<String> intersect = set.intersectInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -330,8 +335,8 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         ImmutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -339,8 +344,8 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -349,7 +354,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         ImmutableSet<String> difference = set.symmetricDifference(UnifiedSet.newSetWith("2", "3", "4", "5", "not present"));
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -366,7 +371,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
                 UnifiedSet.newSetWith("2", "3", "4", "5", "not present"),
                 UnifiedSet.newSet());
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -381,15 +386,15 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     public void isSubsetOf()
     {
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -410,7 +415,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
         ImmutableSet<String> set = this.classUnderTest().collect(String::valueOf);
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))
@@ -422,7 +427,7 @@ public abstract class AbstractImmutableSetTestCase extends AbstractImmutableColl
     {
         ImmutableSet<Integer> integers = this.classUnderTest();
         ImmutableSet<Integer> actual = integers.toImmutable();
-        Assert.assertEquals(integers, actual);
-        Assert.assertSame(integers, actual);
+        assertEquals(integers, actual);
+        assertSame(integers, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableUnifiedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableUnifiedSetTestCase.java
@@ -35,8 +35,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableUnifiedSetTestCase
 {
@@ -52,8 +59,8 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     public void newCollection()
     {
         ImmutableSet<Integer> set = this.newSet();
-        Assert.assertTrue(set.isEmpty());
-        Assert.assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
     }
 
     @Test
@@ -61,9 +68,9 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> set = this.newSet(1, 2, 3);
         ImmutableSet<Integer> with = set.newWith(4);
-        Assert.assertNotEquals(set, with);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), with);
-        Assert.assertSame(set, set.newWith(3));
+        assertNotEquals(set, with);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), with);
+        assertSame(set, set.newWith(3));
     }
 
     @Test
@@ -71,8 +78,8 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> set = this.newSet(1, 2, 3);
         ImmutableSet<Integer> withAll = set.newWithAll(UnifiedSet.newSetWith(4, 5));
-        Assert.assertNotEquals(set, withAll);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), withAll);
+        assertNotEquals(set, withAll);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), withAll);
     }
 
     @Test
@@ -80,9 +87,9 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> set = this.newSet(1, 2, 3, 4);
         ImmutableSet<Integer> without = set.newWithout(4);
-        Assert.assertNotEquals(set, without);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), without);
-        Assert.assertSame(set, set.newWithout(5));
+        assertNotEquals(set, without);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), without);
+        assertSame(set, set.newWithout(5));
     }
 
     @Test
@@ -90,34 +97,34 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> set = this.newSet(1, 2, 3, 4, 5);
         ImmutableSet<Integer> withoutAll = set.newWithoutAll(UnifiedSet.newSetWith(4, 5));
-        Assert.assertNotEquals(set, withoutAll);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), withoutAll);
+        assertNotEquals(set, withoutAll);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), withoutAll);
         ImmutableSet<Integer> largeList = this.newSet(Interval.oneTo(200).toArray());
         ImmutableSet<Integer> largeWithoutAll = largeList.newWithoutAll(FastList.newList(Interval.oneTo(100)));
-        Assert.assertEquals(UnifiedSet.newSet(Interval.fromTo(101, 200)), largeWithoutAll);
+        assertEquals(UnifiedSet.newSet(Interval.fromTo(101, 200)), largeWithoutAll);
         ImmutableSet<Integer> largeWithoutAll2 = largeWithoutAll.newWithoutAll(Interval.fromTo(101, 150));
-        Assert.assertEquals(UnifiedSet.newSet(Interval.fromTo(151, 200)), largeWithoutAll2);
+        assertEquals(UnifiedSet.newSet(Interval.fromTo(151, 200)), largeWithoutAll2);
         ImmutableSet<Integer> largeWithoutAll3 = largeWithoutAll2.newWithoutAll(UnifiedSet.newSet(Interval.fromTo(151, 199)));
-        Assert.assertEquals(UnifiedSet.newSetWith(200), largeWithoutAll3);
+        assertEquals(UnifiedSet.newSetWith(200), largeWithoutAll3);
     }
 
     @Test
     public void newSetWith()
     {
         ImmutableSet<Integer> set = this.newSetWith(1);
-        Assert.assertTrue(set.notEmpty());
-        Assert.assertEquals(1, set.size());
-        Assert.assertTrue(set.contains(1));
+        assertTrue(set.notEmpty());
+        assertEquals(1, set.size());
+        assertTrue(set.contains(1));
     }
 
     @Test
     public void newListWithVarArgs()
     {
         ImmutableSet<Integer> set = this.newSetWith(1, 2, 3, 4);
-        Assert.assertTrue(set.notEmpty());
-        Assert.assertEquals(4, set.size());
-        Assert.assertTrue(set.containsAllArguments(1, 2, 3, 4));
-        Assert.assertTrue(set.containsAllIterable(Interval.oneTo(4)));
+        assertTrue(set.notEmpty());
+        assertEquals(4, set.size());
+        assertTrue(set.containsAllArguments(1, 2, 3, 4));
+        assertTrue(set.containsAllIterable(Interval.oneTo(4)));
     }
 
     @Test
@@ -125,8 +132,8 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
         ImmutableSet<Integer> set = this.newSetWith(1, 2, 3, 4);
-        Assert.assertSame(set, set.tap(tapResult::add));
-        Assert.assertEquals(set.toList(), tapResult);
+        assertSame(set, set.tap(tapResult::add));
+        assertEquals(set.toList(), tapResult);
     }
 
     @Test
@@ -151,70 +158,70 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     @Test
     public void select()
     {
-        Assert.assertTrue(this.newSetWith(1, 2, 3, 4, 5).select(Predicates.lessThan(3)).containsAllArguments(1, 2));
-        Assert.assertFalse(this.newSetWith(-1, 2, 3, 4, 5).select(Predicates.lessThan(3)).containsAllArguments(3, 4, 5));
+        assertTrue(this.newSetWith(1, 2, 3, 4, 5).select(Predicates.lessThan(3)).containsAllArguments(1, 2));
+        assertFalse(this.newSetWith(-1, 2, 3, 4, 5).select(Predicates.lessThan(3)).containsAllArguments(3, 4, 5));
     }
 
     @Test
     public void reject()
     {
-        Assert.assertTrue(this.newSetWith(1, 2, 3, 4).reject(Predicates.lessThan(3)).containsAllArguments(3, 4));
+        assertTrue(this.newSetWith(1, 2, 3, 4).reject(Predicates.lessThan(3)).containsAllArguments(3, 4));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertTrue(
+        assertTrue(
                 this.newSetWith(1, 2, 3, 4).collect(String::valueOf).containsAllArguments("1", "2", "3", "4"));
     }
 
     @Test
     public void detect()
     {
-        Assert.assertEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3, 4, 5).detect(Integer.valueOf(3)::equals));
-        Assert.assertNull(this.newSetWith(1, 2, 3, 4, 5).detect(Integer.valueOf(6)::equals));
+        assertEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3, 4, 5).detect(Integer.valueOf(3)::equals));
+        assertNull(this.newSetWith(1, 2, 3, 4, 5).detect(Integer.valueOf(6)::equals));
     }
 
     @Test
     public void detectIfNone()
     {
         Function0<Integer> function = new PassThruFunction0<>(6);
-        Assert.assertEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, function));
-        Assert.assertEquals(Integer.valueOf(6), this.newSetWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, function));
+        assertEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(3)::equals, function));
+        assertEquals(Integer.valueOf(6), this.newSetWith(1, 2, 3, 4, 5).detectIfNone(Integer.valueOf(6)::equals, function));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.newSetWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(this.newSetWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newSetWith(1, 2, 3).allSatisfy(Integer.class::isInstance));
+        assertFalse(this.newSetWith(1, 2, 3).allSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.newSetWith(1, 2, 3).anySatisfy(String.class::isInstance));
-        Assert.assertTrue(this.newSetWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
+        assertFalse(this.newSetWith(1, 2, 3).anySatisfy(String.class::isInstance));
+        assertTrue(this.newSetWith(1, 2, 3).anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.newSetWith(1, 2, 3).noneSatisfy(String.class::isInstance));
-        Assert.assertTrue(this.newSetWith(1, 2, 3).noneSatisfy(Integer.valueOf(100)::equals));
-        Assert.assertFalse(this.newSetWith(1, 2, 3).noneSatisfy(Integer.valueOf(1)::equals));
+        assertTrue(this.newSetWith(1, 2, 3).noneSatisfy(String.class::isInstance));
+        assertTrue(this.newSetWith(1, 2, 3).noneSatisfy(Integer.valueOf(100)::equals));
+        assertFalse(this.newSetWith(1, 2, 3).noneSatisfy(Integer.valueOf(1)::equals));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(3, this.newSetWith(1, 2, 3).count(Integer.class::isInstance));
+        assertEquals(3, this.newSetWith(1, 2, 3).count(Integer.class::isInstance));
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertTrue(this.newSetWith(1, 2, 3).collectIf(
+        assertTrue(this.newSetWith(1, 2, 3).collectIf(
                 Integer.class::isInstance,
                 String::valueOf).containsAllArguments("1", "2", "3"));
     }
@@ -222,20 +229,20 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     @Test
     public void getFirst()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newSetWith(1, 2, 3).getFirst());
-        Assert.assertNotEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(1), this.newSetWith(1, 2, 3).getFirst());
+        assertNotEquals(Integer.valueOf(3), this.newSetWith(1, 2, 3).getFirst());
     }
 
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newSetWith(1, 2, 3).getLast());
+        assertNotNull(this.newSetWith(1, 2, 3).getLast());
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newSetWith(1).getOnly());
+        assertEquals(Integer.valueOf(1), this.newSetWith(1).getOnly());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -253,8 +260,8 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(this.newSet().isEmpty());
-        Assert.assertTrue(this.newSetWith(1, 2).notEmpty());
+        assertTrue(this.newSet().isEmpty());
+        assertTrue(this.newSetWith(1, 2).notEmpty());
     }
 
     @Test
@@ -265,7 +272,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
         for (int i = objects.size(); i-- > 0; )
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(3, integer.intValue() + i);
+            assertEquals(3, integer.intValue() + i);
         }
     }
 
@@ -274,7 +281,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         Integer result = objects.injectInto(1, AddFunction.INTEGER);
-        Assert.assertEquals(Integer.valueOf(7), result);
+        assertEquals(Integer.valueOf(7), result);
     }
 
     @Test
@@ -282,7 +289,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         int result = objects.injectInto(1, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(7, result);
+        assertEquals(7, result);
     }
 
     @Test
@@ -290,7 +297,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         long result = objects.injectInto(1, AddFunction.INTEGER_TO_LONG);
-        Assert.assertEquals(7, result);
+        assertEquals(7, result);
     }
 
     @Test
@@ -298,7 +305,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         double result = objects.injectInto(1, AddFunction.INTEGER_TO_DOUBLE);
-        Assert.assertEquals(7.0d, result, 0.001);
+        assertEquals(7.0d, result, 0.001);
     }
 
     @Test
@@ -306,7 +313,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         float result = objects.injectInto(1, AddFunction.INTEGER_TO_FLOAT);
-        Assert.assertEquals(7.0d, result, 0.001);
+        assertEquals(7.0d, result, 0.001);
     }
 
     @Test
@@ -314,7 +321,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         double actual = objects.sumOfFloat(Integer::floatValue);
-        Assert.assertEquals(6.0f, actual, 0.001);
+        assertEquals(6.0f, actual, 0.001);
     }
 
     @Test
@@ -322,7 +329,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         double actual = objects.sumOfDouble(Integer::doubleValue);
-        Assert.assertEquals(6.0d, actual, 0.001);
+        assertEquals(6.0d, actual, 0.001);
     }
 
     @Test
@@ -330,7 +337,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         long actual = objects.sumOfInt(integer -> integer);
-        Assert.assertEquals(6, actual);
+        assertEquals(6, actual);
     }
 
     @Test
@@ -338,7 +345,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> objects = this.newSetWith(1, 2, 3);
         long actual = objects.sumOfLong(Integer::longValue);
-        Assert.assertEquals(6, actual);
+        assertEquals(6, actual);
     }
 
     @Test
@@ -357,13 +364,13 @@ public abstract class AbstractImmutableUnifiedSetTestCase
         ImmutableSet<Integer> set1 = this.newSetWith(1, 2, 3, 4);
         ImmutableSet<Integer> set2 = this.newSetWith(1, 2, 3, 4);
         ImmutableSet<Integer> set3 = this.newSetWith(2, 3, 4);
-        Assert.assertNotEquals(set1, null);
+        assertNotEquals(set1, null);
         Verify.assertEqualsAndHashCode(set1, set1);
         Verify.assertEqualsAndHashCode(set1, set2);
-        Assert.assertNotEquals(set2, set3);
+        assertNotEquals(set2, set3);
         UnifiedSet<Integer> fastSet = UnifiedSet.newSet(set1);
         Verify.assertEqualsAndHashCode(set1, fastSet);
-        Assert.assertEquals(set1, new HashSet<>(fastSet));
+        assertEquals(set1, new HashSet<>(fastSet));
         Verify.assertEqualsAndHashCode(set1, UnifiedSet.newSetWith(1, 2, 3, 4));
     }
 
@@ -382,7 +389,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> integers = this.newSetWith(1, 2, 3, 4);
         MutableList<Integer> list = integers.toList();
-        Assert.assertTrue(list.containsAllArguments(1, 2, 3, 4));
+        assertTrue(list.containsAllArguments(1, 2, 3, 4));
     }
 
     @Test
@@ -390,7 +397,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> integers = this.newSetWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), list);
+        assertEquals(FastList.newListWith(4, 3, 2, 1), list);
     }
 
     @Test
@@ -398,7 +405,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> integers = this.newSetWith(2, 4, 1, 3);
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4), list);
     }
 
     @Test
@@ -439,7 +446,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
         ImmutableSet<Integer> integers = this.newSetWith(1, 2, 3, 4);
         MutableMap<String, String> map =
                 integers.toMap(String::valueOf, String::valueOf);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "1", "2", "2", "3", "3", "4", "4"), map);
     }
 
     @Test
@@ -447,15 +454,15 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     {
         ImmutableSet<Integer> set = this.newSetWith(1, 2, 3, 4, 5);
         ImmutableSet<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(set);
-        Assert.assertEquals(5, deserializedCollection.size());
-        Assert.assertTrue(deserializedCollection.containsAllArguments(1, 2, 3, 4, 5));
+        assertEquals(5, deserializedCollection.size());
+        assertTrue(deserializedCollection.containsAllArguments(1, 2, 3, 4, 5));
         Verify.assertEqualsAndHashCode(set, deserializedCollection);
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1]", this.newSetWith(1).toString());
+        assertEquals("[1]", this.newSetWith(1).toString());
     }
 
     @Test
@@ -473,7 +480,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newSetWith(1, 2, 3).groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newSetWith(1, 2, 3).groupByUniqueKey(id -> id));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -486,7 +493,7 @@ public abstract class AbstractImmutableUnifiedSetTestCase
     public void groupByUniqueKey_target()
     {
         MutableMap<Integer, Integer> integers = this.newSetWith(1, 2, 3).groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSetTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableDoubletonSetTest
         extends AbstractImmutableSetTestCase
@@ -37,6 +38,6 @@ public class ImmutableDoubletonSetTest
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySetTest.java
@@ -20,8 +20,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 public class ImmutableEmptySetTest extends AbstractImmutableEmptySetTestCase
 {
@@ -35,8 +38,8 @@ public class ImmutableEmptySetTest extends AbstractImmutableEmptySetTestCase
     @Test
     public void newWithout()
     {
-        Assert.assertSame(Sets.immutable.of(), Sets.immutable.of().newWithout(1));
-        Assert.assertSame(Sets.immutable.of(), Sets.immutable.of().newWithoutAll(Interval.oneTo(3)));
+        assertSame(Sets.immutable.of(), Sets.immutable.of().newWithout(1));
+        assertSame(Sets.immutable.of(), Sets.immutable.of().newWithoutAll(Interval.oneTo(3)));
     }
 
     @Override
@@ -47,19 +50,19 @@ public class ImmutableEmptySetTest extends AbstractImmutableEmptySetTestCase
         MutableSet<Integer> mutable = UnifiedSet.newSet(immutable);
         Verify.assertEqualsAndHashCode(mutable, immutable);
         Verify.assertPostSerializedIdentity(immutable);
-        Assert.assertNotEquals(FastList.newList(mutable), immutable);
+        assertNotEquals(FastList.newList(mutable), immutable);
     }
 
     @Test
     public void countByEach()
     {
-        Assert.assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
+        assertEquals(Bags.immutable.empty(), this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i)));
     }
 
     @Test
     public void countByEach_target()
     {
         MutableBag<Integer> target = Bags.mutable.empty();
-        Assert.assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
+        assertEquals(target, this.classUnderTest().countByEach(each -> IntInterval.oneTo(5).collect(i -> each + i), target));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSetTest.java
@@ -12,10 +12,11 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableQuadrupletonSetTest
         extends AbstractImmutableSetTestCase
@@ -42,7 +43,7 @@ public class ImmutableQuadrupletonSetTest
     public void selectInstanceOf()
     {
         ImmutableSet<Number> numbers = new ImmutableQuadrupletonSet<>(1, 2.0, 3, 4.0);
-        Assert.assertEquals(
+        assertEquals(
                 iSet(1, 3),
                 numbers.selectInstancesOf(Integer.class));
     }
@@ -50,6 +51,6 @@ public class ImmutableQuadrupletonSetTest
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSetTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableSingletonSetTest
         extends AbstractImmutableSetTestCase
@@ -60,6 +61,6 @@ public class ImmutableSingletonSetTest
     public void getOnly()
     {
         ImmutableCollection<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.getOnly());
+        assertEquals(Integer.valueOf(1), integers.getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSetTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableTripletonSetTest
         extends AbstractImmutableSetTestCase
@@ -38,6 +39,6 @@ public class ImmutableTripletonSetTest
     @Test
     public void getOnly()
     {
-        Assert.assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
+        assertThrows(IllegalStateException.class, () -> this.classUnderTest().getOnly());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableUnifiedSetTest.java
@@ -17,8 +17,10 @@ import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableUnifiedSet}.
@@ -60,7 +62,7 @@ public class ImmutableUnifiedSetTest extends AbstractImmutableUnifiedSetTestCase
     {
         super.newCollection();
         ImmutableSet<Integer> set = ImmutableUnifiedSet.newSet(UnifiedSet.newSet());
-        Assert.assertTrue(set.isEmpty());
+        assertTrue(set.isEmpty());
         Verify.assertSize(0, set);
     }
 
@@ -68,7 +70,7 @@ public class ImmutableUnifiedSetTest extends AbstractImmutableUnifiedSetTestCase
     public void getBatchCount()
     {
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.newSet(1, 2, 3, 4, 5, 6);
-        Assert.assertEquals(2, integerBatchIterable.getBatchCount(3));
+        assertEquals(2, integerBatchIterable.getBatchCount(3));
     }
 
     @Test
@@ -77,6 +79,6 @@ public class ImmutableUnifiedSetTest extends AbstractImmutableUnifiedSetTestCase
         Sum sum = new IntegerSum(0);
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.newSet(1, 2, 3, 4, 5);
         integerBatchIterable.batchForEach(new SumProcedure<>(sum), 0, 1);
-        Assert.assertEquals(15, sum.getValue());
+        assertEquals(15, sum.getValue());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/AbstractImmutableByteHashSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/AbstractImmutableByteHashSetTestCase.java
@@ -29,8 +29,13 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.ByteHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableByteSet}.
@@ -73,14 +78,14 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     public void isEmpty()
     {
         super.isEmpty();
-        Assert.assertFalse(this.newWith((byte) 0, (byte) 1, (byte) 31).isEmpty());
+        assertFalse(this.newWith((byte) 0, (byte) 1, (byte) 31).isEmpty());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.newWith((byte) 0, (byte) 1, (byte) 31).notEmpty());
+        assertTrue(this.newWith((byte) 0, (byte) 1, (byte) 31).notEmpty());
     }
 
     @Override
@@ -91,15 +96,15 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
         MutableSet<Byte> actual = UnifiedSet.newSet();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
         ByteIterator iterator = set.byteIterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -125,7 +130,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
         set.forEach(each -> sum[0] += each);
 
-        Assert.assertEquals(32L, sum[0]);
+        assertEquals(32L, sum[0]);
     }
 
     @Override
@@ -134,9 +139,9 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     {
         super.count();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 127, (byte) -1, (byte) -31, (byte) -64, (byte) -65, (byte) -128);
-        Assert.assertEquals(3, set.count(BytePredicates.greaterThan((byte) 0)));
-        Assert.assertEquals(8, set.count(BytePredicates.lessThan((byte) 32)));
-        Assert.assertEquals(1, set.count(BytePredicates.greaterThan((byte) 32)));
+        assertEquals(3, set.count(BytePredicates.greaterThan((byte) 0)));
+        assertEquals(8, set.count(BytePredicates.lessThan((byte) 32)));
+        assertEquals(1, set.count(BytePredicates.greaterThan((byte) 32)));
     }
 
     @Override
@@ -165,9 +170,9 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     {
         super.detectIfNone();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals((byte) 0, set.detectIfNone(BytePredicates.lessThan((byte) 1), (byte) 9));
-        Assert.assertEquals((byte) 31, set.detectIfNone(BytePredicates.greaterThan((byte) 1), (byte) 9));
-        Assert.assertEquals((byte) 9, set.detectIfNone(BytePredicates.greaterThan((byte) 31), (byte) 9));
+        assertEquals((byte) 0, set.detectIfNone(BytePredicates.lessThan((byte) 1), (byte) 9));
+        assertEquals((byte) 31, set.detectIfNone(BytePredicates.greaterThan((byte) 1), (byte) 9));
+        assertEquals((byte) 9, set.detectIfNone(BytePredicates.greaterThan((byte) 31), (byte) 9));
     }
 
     @Override
@@ -176,7 +181,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     {
         super.collect();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals(UnifiedSet.newSetWith((byte) -1, (byte) 0, (byte) 30), set.collect(byteParameter -> (byte) (byteParameter - 1)));
+        assertEquals(UnifiedSet.newSetWith((byte) -1, (byte) 0, (byte) 30), set.collect(byteParameter -> (byte) (byteParameter - 1)));
     }
 
     @Override
@@ -185,7 +190,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     {
         super.toSortedArray();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertArrayEquals(new byte[]{(byte) 0, (byte) 1, (byte) 31}, set.toSortedArray());
+        assertArrayEquals(new byte[]{(byte) 0, (byte) 1, (byte) 31}, set.toSortedArray());
     }
 
     @Override
@@ -211,16 +216,16 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
         super.testEquals();
         ImmutableByteSet set1 = this.newWith((byte) 1, (byte) 31, (byte) 32);
         ImmutableByteSet set2 = this.newWith((byte) 32, (byte) 31, (byte) 1);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().toBag());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31), this.newWith((byte) 0, (byte) 1, (byte) 31).toBag());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31, (byte) 32), this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 32).toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31), this.newWith((byte) 0, (byte) 1, (byte) 31).toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31, (byte) 32), this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 32).toBag());
     }
 
     @Override
@@ -229,16 +234,16 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     {
         super.asLazy();
         ImmutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals(set.toSet(), set.asLazy().toSet());
+        assertEquals(set.toSet(), set.asLazy().toSet());
         Verify.assertInstanceOf(LazyByteIterable.class, set.asLazy());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(0, this.newWith().toImmutable().size());
-        Assert.assertEquals(1, this.newWith((byte) 1).toImmutable().size());
-        Assert.assertEquals(3, this.newWith((byte) 1, (byte) 2, (byte) 3).toImmutable().size());
+        assertEquals(0, this.newWith().toImmutable().size());
+        assertEquals(1, this.newWith((byte) 1).toImmutable().size());
+        assertEquals(3, this.newWith((byte) 1, (byte) 2, (byte) 3).toImmutable().size());
     }
 
     @Test
@@ -278,7 +283,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertUnion(ImmutableByteSet set1, ImmutableByteSet set2, ImmutableByteSet expected)
     {
         ImmutableByteSet actual = set1.union(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -318,7 +323,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertIntersect(ImmutableByteSet set1, ImmutableByteSet set2, ImmutableByteSet expected)
     {
         ImmutableByteSet actual = set1.intersect(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -353,7 +358,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertDifference(ImmutableByteSet set1, ImmutableByteSet set2, ImmutableByteSet expected)
     {
         ImmutableByteSet actual = set1.difference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -388,7 +393,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertSymmetricDifference(ImmutableByteSet set1, ImmutableByteSet set2, ImmutableByteSet expected)
     {
         ImmutableByteSet actual = set1.symmetricDifference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -428,7 +433,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertIsSubsetOf(ImmutableByteSet set1, ImmutableByteSet set2, boolean expected)
     {
         boolean actual = set1.isSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -468,7 +473,7 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertIsProperSubsetOf(ImmutableByteSet set1, ImmutableByteSet set2, boolean expected)
     {
         boolean actual = set1.isProperSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -511,6 +516,6 @@ public abstract class AbstractImmutableByteHashSetTestCase extends AbstractImmut
     private void assertCartesianProduct(ImmutableByteSet set1, ImmutableByteSet set2, ImmutableSet<ByteBytePair> expected)
     {
         ImmutableSet<ByteBytePair> actual = set1.cartesianProduct(set2).toSet().toImmutable();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySetTest.java
@@ -22,8 +22,12 @@ import org.eclipse.collections.impl.collection.immutable.primitive.AbstractImmut
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptySet}.
@@ -58,7 +62,7 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -79,14 +83,14 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     @Test
     public void testNewWith()
     {
-        Assert.assertEquals(BooleanSets.immutable.with(true), this.classUnderTest().newWith(true));
+        assertEquals(BooleanSets.immutable.with(true), this.classUnderTest().newWith(true));
     }
 
     @Override
     @Test
     public void newWithAll()
     {
-        Assert.assertEquals(BooleanSets.immutable.with(true), this.classUnderTest().newWithAll(BooleanSets.mutable.with(true)));
+        assertEquals(BooleanSets.immutable.with(true), this.classUnderTest().newWithAll(BooleanSets.mutable.with(true)));
     }
 
     @Override
@@ -95,8 +99,8 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     {
         Verify.assertEqualsAndHashCode(this.newMutableCollectionWith(), this.classUnderTest());
         Verify.assertPostSerializedIdentity(this.newWith());
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(false, false, false, true));
-        Assert.assertNotEquals(this.classUnderTest(), this.newWith(true));
+        assertNotEquals(this.classUnderTest(), this.newWith(false, false, false, true));
+        assertNotEquals(this.classUnderTest(), this.newWith(true));
     }
 
     @Override
@@ -118,7 +122,7 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     @Test
     public void newWithout()
     {
-        Assert.assertEquals(BooleanSets.mutable.empty(), this.classUnderTest().newWithout(true));
+        assertEquals(BooleanSets.mutable.empty(), this.classUnderTest().newWithout(true));
     }
 
     @Override
@@ -134,22 +138,22 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     @Test
     public void toBag()
     {
-        Assert.assertEquals(BooleanBags.mutable.empty(), this.classUnderTest().toBag());
+        assertEquals(BooleanBags.mutable.empty(), this.classUnderTest().toBag());
     }
 
     @Override
     @Test
     public void count()
     {
-        Assert.assertEquals(0, this.classUnderTest().count(BooleanPredicates.alwaysTrue()));
-        Assert.assertEquals(0, this.classUnderTest().count(BooleanPredicates.alwaysFalse()));
+        assertEquals(0, this.classUnderTest().count(BooleanPredicates.alwaysTrue()));
+        assertEquals(0, this.classUnderTest().count(BooleanPredicates.alwaysFalse()));
     }
 
     @Override
     @Test(expected = NoSuchElementException.class)
     public void booleanIterator()
     {
-        Assert.assertFalse(this.classUnderTest().booleanIterator().hasNext());
+        assertFalse(this.classUnderTest().booleanIterator().hasNext());
         this.classUnderTest().booleanIterator().next();
     }
 
@@ -157,16 +161,16 @@ public class ImmutableBooleanEmptySetTest extends AbstractImmutableBooleanCollec
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.alwaysTrue()));
-        Assert.assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.alwaysFalse()));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.alwaysTrue()));
+        assertTrue(this.classUnderTest().noneSatisfy(BooleanPredicates.alwaysFalse()));
     }
 
     @Test
     public void cartesianProduct()
     {
-        Assert.assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(true)).toSet());
-        Assert.assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(false)).toSet());
-        Assert.assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(true, false)).toSet());
-        Assert.assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.empty()).toSet());
+        assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(true)).toSet());
+        assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(false)).toSet());
+        assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.with(true, false)).toSet());
+        assertEquals(Sets.immutable.empty(), this.classUnderTest().cartesianProduct(BooleanSets.immutable.empty()).toSet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
@@ -38,11 +38,19 @@ import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link AbstractMutableSet}.
@@ -87,11 +95,11 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         UnifiedSet<Integer> expected = UnifiedSet.newSetWith(1, 2, 3);
         MutableSet<Integer> collection = this.newWith();
 
-        Assert.assertTrue(collection.addAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertTrue(collection.addAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(expected, collection);
 
-        Assert.assertFalse(collection.addAll(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertFalse(collection.addAll(FastList.newListWith(1, 2, 3)));
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -103,11 +111,11 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         UnifiedSet<Integer> expected = UnifiedSet.newSetWith(1, 2, 3);
         MutableSet<Integer> collection = this.newWith();
 
-        Assert.assertTrue(collection.addAllIterable(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertTrue(collection.addAllIterable(FastList.newListWith(1, 2, 3)));
+        assertEquals(expected, collection);
 
-        Assert.assertFalse(collection.addAllIterable(FastList.newListWith(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertFalse(collection.addAllIterable(FastList.newListWith(1, 2, 3)));
+        assertEquals(expected, collection);
     }
 
     @Test
@@ -116,10 +124,10 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> union = set.union(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
+        assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
     }
 
     @Test
@@ -128,10 +136,10 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -140,7 +148,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> intersect = set.intersect(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersect(UnifiedSet.newSetWith("not present")));
     }
@@ -151,7 +159,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> intersect = set.intersectInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -161,8 +169,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     {
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -170,8 +178,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     {
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -180,7 +188,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> difference = set.symmetricDifference(UnifiedSet.newSetWith("2", "3", "4", "5", "not present"));
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -197,7 +205,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
                 UnifiedSet.newSetWith("2", "3", "4", "5", "not present"),
                 UnifiedSet.newSet());
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -212,15 +220,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     public void isSubsetOf()
     {
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -239,7 +247,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableSet<String> set = this.newWith("1", "2", "3", "4");
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))
@@ -281,16 +289,16 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     {
         super.getFirst();
 
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Test
@@ -302,7 +310,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         Integer[] result = set.toArray(dest);
         Verify.assertSize(4, result);
         Arrays.sort(result);
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4}, result);
     }
 
     @Test
@@ -310,7 +318,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     {
         MutableSet<Integer> set = this.newWith(1, 2);
         String s = set.toString();
-        Assert.assertTrue("[1, 2]".equals(s) || "[2, 1]".equals(s));
+        assertTrue("[1, 2]".equals(s) || "[2, 1]".equals(s));
     }
 
     @Test
@@ -318,7 +326,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
     {
         MutableSet<String> set = this.newWith();
         MutableSet<String> clone = set.clone();
-        Assert.assertNotSame(clone, set);
+        assertNotSame(clone, set);
         Verify.assertEqualsAndHashCode(clone, set);
     }
 
@@ -348,8 +356,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
     private void assertIsEmpty(boolean isEmpty, MutableSet<?> set)
     {
-        Assert.assertEquals(isEmpty, set.isEmpty());
-        Assert.assertEquals(!isEmpty, set.notEmpty());
+        assertEquals(isEmpty, set.isEmpty());
+        assertEquals(!isEmpty, set.notEmpty());
     }
 
     @Test
@@ -361,10 +369,10 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         set.removeAll(collisions);
         for (Integer integer : COLLISIONS)
         {
-            Assert.assertTrue(set.add(new IntegerWithCast(integer)));
-            Assert.assertFalse(set.add(new IntegerWithCast(integer)));
+            assertTrue(set.add(new IntegerWithCast(integer)));
+            assertFalse(set.add(new IntegerWithCast(integer)));
         }
-        Assert.assertEquals(collisions.toSet(), set);
+        assertEquals(collisions.toSet(), set);
     }
 
     @Override
@@ -377,45 +385,45 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         MutableList<IntegerWithCast> collisions = COLLISIONS.collect(IntegerWithCast::new);
         set.addAll(collisions);
         collisions.reverseForEach(each -> {
-            Assert.assertFalse(set.remove(null));
-            Assert.assertTrue(set.remove(each));
-            Assert.assertFalse(set.remove(each));
-            Assert.assertFalse(set.remove(null));
-            Assert.assertFalse(set.remove(new IntegerWithCast(COLLISION_10)));
+            assertFalse(set.remove(null));
+            assertTrue(set.remove(each));
+            assertFalse(set.remove(each));
+            assertFalse(set.remove(null));
+            assertFalse(set.remove(new IntegerWithCast(COLLISION_10)));
         });
 
-        Assert.assertEquals(UnifiedSet.<IntegerWithCast>newSet(), set);
+        assertEquals(UnifiedSet.<IntegerWithCast>newSet(), set);
 
         collisions.forEach(Procedures.cast(each -> {
             MutableSet<IntegerWithCast> set2 = this.newWith();
             set2.addAll(collisions);
 
-            Assert.assertFalse(set2.remove(null));
-            Assert.assertTrue(set2.remove(each));
-            Assert.assertFalse(set2.remove(each));
-            Assert.assertFalse(set2.remove(null));
-            Assert.assertFalse(set2.remove(new IntegerWithCast(COLLISION_10)));
+            assertFalse(set2.remove(null));
+            assertTrue(set2.remove(each));
+            assertFalse(set2.remove(each));
+            assertFalse(set2.remove(null));
+            assertFalse(set2.remove(new IntegerWithCast(COLLISION_10)));
         }));
 
         // remove the second-to-last item in a fully populated single chain to cause the last item to move
         MutableSet<Integer> set3 = this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        Assert.assertTrue(set3.remove(COLLISION_3));
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_4), set3);
+        assertTrue(set3.remove(COLLISION_3));
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_4), set3);
 
-        Assert.assertTrue(set3.remove(COLLISION_2));
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_4), set3);
+        assertTrue(set3.remove(COLLISION_2));
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_4), set3);
 
         // search a chain for a non-existent element
         MutableSet<Integer> chain = this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        Assert.assertFalse(chain.remove(COLLISION_5));
+        assertFalse(chain.remove(COLLISION_5));
 
         // search a deep chain for a non-existent element
         MutableSet<Integer> deepChain = this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6, COLLISION_7);
-        Assert.assertFalse(deepChain.remove(COLLISION_8));
+        assertFalse(deepChain.remove(COLLISION_8));
 
         // search for a non-existent element
         MutableSet<Integer> empty = this.newWith();
-        Assert.assertFalse(empty.remove(COLLISION_1));
+        assertFalse(empty.remove(COLLISION_1));
     }
 
     @Override
@@ -432,8 +440,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableList<Integer> list = MORE_COLLISIONS.subList(0, i);
             MutableSet<Integer> set = this.<Integer>newWith().withAll(list);
-            Assert.assertFalse(set.retainAll(collisions));
-            Assert.assertEquals(list.toSet(), set);
+            assertFalse(set.retainAll(collisions));
+            assertEquals(list.toSet(), set);
         }
 
         for (Integer item : MORE_COLLISIONS)
@@ -441,15 +449,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
             MutableSet<Integer> integers = this.<Integer>newWith().withAll(MORE_COLLISIONS);
             @SuppressWarnings("BoxingBoxedValue")
             Integer keyCopy = new Integer(item);
-            Assert.assertTrue(integers.retainAll(mList(keyCopy)));
-            Assert.assertEquals(iSet(keyCopy), integers);
-            Assert.assertNotSame(keyCopy, Iterate.getOnly(integers));
+            assertTrue(integers.retainAll(mList(keyCopy)));
+            assertEquals(iSet(keyCopy), integers);
+            assertNotSame(keyCopy, Iterate.getOnly(integers));
         }
 
         // retain all on a bucket with a single element
         MutableSet<Integer> singleCollisionBucket = this.newWith(COLLISION_1, COLLISION_2);
         singleCollisionBucket.remove(COLLISION_2);
-        Assert.assertTrue(singleCollisionBucket.retainAll(FastList.newListWith(COLLISION_2)));
+        assertTrue(singleCollisionBucket.retainAll(FastList.newListWith(COLLISION_2)));
     }
 
     @Override
@@ -459,12 +467,12 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         super.equalsAndHashCode();
 
         UnifiedSet<Integer> expected = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        Assert.assertNotEquals(expected, this.newWith(COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5));
-        Assert.assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_3, COLLISION_4, COLLISION_5));
-        Assert.assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_4, COLLISION_5));
-        Assert.assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_5));
+        assertNotEquals(expected, this.newWith(COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5));
+        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_3, COLLISION_4, COLLISION_5));
+        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_4, COLLISION_5));
+        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_5));
 
-        Assert.assertEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4));
+        assertEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4));
     }
 
     @Override
@@ -479,16 +487,16 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
             MutableList<Integer> tapResult = Lists.mutable.of();
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertSame(set, set.tap(tapResult::add));
-            Assert.assertEquals(set.toList(), tapResult);
+            assertSame(set, set.tap(tapResult::add));
+            assertEquals(set.toList(), tapResult);
         }
 
         // test iterating on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
         Counter counter = new Counter();
-        Assert.assertSame(set, set.tap(x -> counter.increment()));
-        Assert.assertEquals(1, counter.getCount());
+        assertSame(set, set.tap(x -> counter.increment()));
+        assertEquals(1, counter.getCount());
     }
 
     @Override
@@ -504,7 +512,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
             set.addAll(MORE_COLLISIONS.subList(0, i));
             MutableSet<Integer> result = UnifiedSet.newSet();
             set.forEach(CollectionAddProcedure.on(result));
-            Assert.assertEquals(set, result);
+            assertEquals(set, result);
         }
 
         // test iterating on a bucket with only one element
@@ -512,7 +520,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         set.remove(COLLISION_2);
         Counter counter = new Counter();
         set.forEach(Procedures.cast(each -> counter.increment()));
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
     }
 
     @Override
@@ -530,10 +538,10 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
             MutableSet<Integer> result = UnifiedSet.newSet();
 
             set.forEachWith((argument1, argument2) -> {
-                Assert.assertSame(sentinel, argument2);
+                assertSame(sentinel, argument2);
                 result.add(argument1);
             }, sentinel);
-            Assert.assertEquals(set, result);
+            assertEquals(set, result);
         }
 
         // test iterating on a bucket with only one element
@@ -541,7 +549,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         set.remove(COLLISION_2);
         Counter counter = new Counter();
         set.forEachWith((argument1, argument2) -> argument2.increment(), counter);
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
     }
 
     @Override
@@ -561,8 +569,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
                 result.add(each);
                 indexes.add(index);
             });
-            Assert.assertEquals(set, result);
-            Assert.assertEquals(Interval.zeroTo(i - 1), indexes);
+            assertEquals(set, result);
+            assertEquals(Interval.zeroTo(i - 1), indexes);
         }
 
         // test iterating on a bucket with only one element
@@ -570,7 +578,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         set.remove(COLLISION_2);
         Counter counter = new Counter();
         set.forEachWithIndex((each, index) -> counter.increment());
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
     }
 
     @Override
@@ -584,15 +592,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.anySatisfy(MORE_COLLISIONS.subList(0, i).getLast()::equals));
-            Assert.assertFalse(set.anySatisfy(Predicates.greaterThan(MORE_COLLISIONS.subList(0, i).getLast())));
+            assertTrue(set.anySatisfy(MORE_COLLISIONS.subList(0, i).getLast()::equals));
+            assertFalse(set.anySatisfy(Predicates.greaterThan(MORE_COLLISIONS.subList(0, i).getLast())));
         }
 
         // test anySatisfy on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertTrue(set.anySatisfy(COLLISION_1::equals));
-        Assert.assertFalse(set.anySatisfy(COLLISION_2::equals));
+        assertTrue(set.anySatisfy(COLLISION_1::equals));
+        assertFalse(set.anySatisfy(COLLISION_2::equals));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -605,7 +613,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.anySatisfy(COLLISION_2::equals));
+        assertTrue(caseA.anySatisfy(COLLISION_2::equals));
     }
 
     @Override
@@ -619,15 +627,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.anySatisfyWith(Object::equals, MORE_COLLISIONS.subList(0, i).getLast()));
-            Assert.assertFalse(set.anySatisfyWith(Predicates2.greaterThan(), MORE_COLLISIONS.subList(0, i).getLast()));
+            assertTrue(set.anySatisfyWith(Object::equals, MORE_COLLISIONS.subList(0, i).getLast()));
+            assertFalse(set.anySatisfyWith(Predicates2.greaterThan(), MORE_COLLISIONS.subList(0, i).getLast()));
         }
 
         // test anySatisfyWith on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertTrue(set.anySatisfyWith(Object::equals, COLLISION_1));
-        Assert.assertFalse(set.anySatisfyWith(Object::equals, COLLISION_2));
+        assertTrue(set.anySatisfyWith(Object::equals, COLLISION_1));
+        assertFalse(set.anySatisfyWith(Object::equals, COLLISION_2));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -640,7 +648,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.anySatisfyWith(Object::equals, COLLISION_2));
+        assertTrue(caseA.anySatisfyWith(Object::equals, COLLISION_2));
     }
 
     @Override
@@ -654,15 +662,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.allSatisfy(Predicates.greaterThanOrEqualTo(MORE_COLLISIONS.subList(0, i).getFirst())));
-            Assert.assertFalse(set.allSatisfy(Predicates.lessThan(MORE_COLLISIONS.subList(0, i).get(i - 1))));
+            assertTrue(set.allSatisfy(Predicates.greaterThanOrEqualTo(MORE_COLLISIONS.subList(0, i).getFirst())));
+            assertFalse(set.allSatisfy(Predicates.lessThan(MORE_COLLISIONS.subList(0, i).get(i - 1))));
         }
 
         // test allSatisfy on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertTrue(set.allSatisfy(COLLISION_1::equals));
-        Assert.assertFalse(set.allSatisfy(COLLISION_2::equals));
+        assertTrue(set.allSatisfy(COLLISION_1::equals));
+        assertFalse(set.allSatisfy(COLLISION_2::equals));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -675,7 +683,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.allSatisfy(Predicates.lessThanOrEqualTo(COLLISION_2)));
+        assertTrue(caseA.allSatisfy(Predicates.lessThanOrEqualTo(COLLISION_2)));
     }
 
     @Override
@@ -689,15 +697,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.allSatisfyWith(Predicates2.greaterThanOrEqualTo(), MORE_COLLISIONS.subList(0, i).getFirst()));
-            Assert.assertFalse(set.allSatisfyWith(Predicates2.lessThan(), MORE_COLLISIONS.subList(0, i).get(i - 1)));
+            assertTrue(set.allSatisfyWith(Predicates2.greaterThanOrEqualTo(), MORE_COLLISIONS.subList(0, i).getFirst()));
+            assertFalse(set.allSatisfyWith(Predicates2.lessThan(), MORE_COLLISIONS.subList(0, i).get(i - 1)));
         }
 
         // test allSatisfyWith on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertTrue(set.allSatisfyWith(Object::equals, COLLISION_1));
-        Assert.assertFalse(set.allSatisfyWith(Object::equals, COLLISION_2));
+        assertTrue(set.allSatisfyWith(Object::equals, COLLISION_1));
+        assertFalse(set.allSatisfyWith(Object::equals, COLLISION_2));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -710,7 +718,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.allSatisfyWith(Predicates2.lessThanOrEqualTo(), COLLISION_2));
+        assertTrue(caseA.allSatisfyWith(Predicates2.lessThanOrEqualTo(), COLLISION_2));
     }
 
     @Override
@@ -724,15 +732,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.noneSatisfy(Predicates.lessThan(MORE_COLLISIONS.subList(0, i).getFirst())));
-            Assert.assertFalse(set.noneSatisfy(Predicates.greaterThanOrEqualTo(MORE_COLLISIONS.subList(0, i).get(i - 1))));
+            assertTrue(set.noneSatisfy(Predicates.lessThan(MORE_COLLISIONS.subList(0, i).getFirst())));
+            assertFalse(set.noneSatisfy(Predicates.greaterThanOrEqualTo(MORE_COLLISIONS.subList(0, i).get(i - 1))));
         }
 
         // test noneSatisfy on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertFalse(set.noneSatisfy(COLLISION_1::equals));
-        Assert.assertTrue(set.noneSatisfy(COLLISION_2::equals));
+        assertFalse(set.noneSatisfy(COLLISION_1::equals));
+        assertTrue(set.noneSatisfy(COLLISION_2::equals));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -745,7 +753,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.noneSatisfy(Predicates.greaterThan(COLLISION_2)));
+        assertTrue(caseA.noneSatisfy(Predicates.greaterThan(COLLISION_2)));
     }
 
     @Override
@@ -759,15 +767,15 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         {
             MutableSet<Integer> set = this.newWith();
             set.addAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertTrue(set.noneSatisfyWith(Predicates2.lessThan(), MORE_COLLISIONS.subList(0, i).getFirst()));
-            Assert.assertFalse(set.noneSatisfyWith(Predicates2.greaterThanOrEqualTo(), MORE_COLLISIONS.subList(0, i).get(i - 1)));
+            assertTrue(set.noneSatisfyWith(Predicates2.lessThan(), MORE_COLLISIONS.subList(0, i).getFirst()));
+            assertFalse(set.noneSatisfyWith(Predicates2.greaterThanOrEqualTo(), MORE_COLLISIONS.subList(0, i).get(i - 1)));
         }
 
         // test noneSatisfyWith on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertFalse(set.noneSatisfyWith(Object::equals, COLLISION_1));
-        Assert.assertTrue(set.noneSatisfyWith(Object::equals, COLLISION_2));
+        assertFalse(set.noneSatisfyWith(Object::equals, COLLISION_1));
+        assertTrue(set.noneSatisfyWith(Object::equals, COLLISION_2));
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
         // set up a chained bucket
@@ -780,7 +788,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         // add the colliding value back and force the rehash
         caseA.add(COLLISION_2);
-        Assert.assertTrue(caseA.noneSatisfyWith(Predicates2.greaterThan(), COLLISION_2));
+        assertTrue(caseA.noneSatisfyWith(Predicates2.greaterThan(), COLLISION_2));
     }
 
     @Override
@@ -800,8 +808,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         // test detect on a bucket with only one element
         MutableSet<Integer> set = this.newWith(COLLISION_1, COLLISION_2);
         set.remove(COLLISION_2);
-        Assert.assertEquals(COLLISION_1, set.detect(COLLISION_1::equals));
-        Assert.assertNull(set.detect(COLLISION_2::equals));
+        assertEquals(COLLISION_1, set.detect(COLLISION_1::equals));
+        assertNull(set.detect(COLLISION_2::equals));
 
         for (int i = 0; i < COLLISIONS.size(); i++)
         {
@@ -817,8 +825,8 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
             }
 
             rehashingSet.add(last);
-            Assert.assertEquals(last, rehashingSet.detect(Predicates.equal(last)));
-            Assert.assertNull(rehashingSet.detect(Integer.valueOf(5)::equals));
+            assertEquals(last, rehashingSet.detect(Predicates.equal(last)));
+            assertNull(rehashingSet.detect(Integer.valueOf(5)::equals));
         }
     }
 
@@ -850,7 +858,7 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
         target[1] = 2;
         target[2] = 2;
         integers.toArray(target);
-        Assert.assertArrayEquals(new Integer[]{1, null, 2}, target);
+        assertArrayEquals(new Integer[]{1, null, 2}, target);
     }
 
     @Override
@@ -910,6 +918,6 @@ public abstract class AbstractMutableSetTestCase extends AbstractCollectionTestC
 
         set1.retainAll(set2);
 
-        Assert.assertArrayEquals(expected, set1.toArray());
+        assertArrayEquals(expected, set1.toArray());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractUnifiedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractUnifiedSetTestCase.java
@@ -15,8 +15,11 @@ import java.util.SortedSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.IntegerWithCast;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractUnifiedSetTestCase extends AbstractMutableSetTestCase
 {
@@ -28,9 +31,9 @@ public abstract class AbstractUnifiedSetTestCase extends AbstractMutableSetTestC
             return;
         }
         MutableSet<IntegerWithCast> mutableSet = this.newWith(new IntegerWithCast(0));
-        Assert.assertFalse(mutableSet.add(new IntegerWithCast(0)));
-        Assert.assertTrue(mutableSet.add(null));
-        Assert.assertFalse(mutableSet.add(null));
+        assertFalse(mutableSet.add(new IntegerWithCast(0)));
+        assertTrue(mutableSet.add(null));
+        assertFalse(mutableSet.add(null));
     }
 
     @Test
@@ -39,9 +42,9 @@ public abstract class AbstractUnifiedSetTestCase extends AbstractMutableSetTestC
         IntegerWithCast key = new IntegerWithCast(0);
         MutableSet<IntegerWithCast> mutableSet = this.newWith(null, key);
 
-        Assert.assertFalse(mutableSet.retainAll(FastList.newListWith(key, null)));
+        assertFalse(mutableSet.retainAll(FastList.newListWith(key, null)));
 
-        Assert.assertEquals(
+        assertEquals(
                 this.newWith(null, key),
                 mutableSet);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsReadUntouchableTest.java
@@ -20,8 +20,11 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {
@@ -37,10 +40,10 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> union = set.union(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
+        assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
     }
 
     @Test
@@ -49,10 +52,10 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -61,7 +64,7 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> intersect = set.intersect(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersect(UnifiedSet.newSetWith("not present")));
     }
@@ -72,7 +75,7 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> intersect = set.intersectInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -82,8 +85,8 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -91,8 +94,8 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -101,7 +104,7 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         MutableSet<String> difference = set.symmetricDifference(UnifiedSet.newSetWith("2", "3", "4", "5", "not present"));
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -118,7 +121,7 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
                 UnifiedSet.newSetWith("2", "3", "4", "5", "not present"),
                 UnifiedSet.newSet());
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -133,15 +136,15 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
     public void isSubsetOf()
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -160,7 +163,7 @@ public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMuta
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4").asReadUntouchable();
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsWriteUntouchableTest.java
@@ -19,8 +19,12 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class MultiReaderUnifiedSetAsWriteUntouchableTest extends AbstractCollectionTestCase
 {
@@ -33,15 +37,15 @@ public class MultiReaderUnifiedSetAsWriteUntouchableTest extends AbstractCollect
     @Override
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
+        assertEquals("1, 2, 3", this.newWith(1, 2, 3).makeString());
     }
 
     @Override
@@ -50,28 +54,28 @@ public class MultiReaderUnifiedSetAsWriteUntouchableTest extends AbstractCollect
     {
         Appendable builder = new StringBuilder();
         this.newWith(1, 2, 3).appendString(builder);
-        Assert.assertEquals("1, 2, 3", builder.toString());
+        assertEquals("1, 2, 3", builder.toString());
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
+        assertEquals("[1, 2, 3]", this.newWith(1, 2, 3).toString());
     }
 
     @Override
     @Test
     public void asSynchronized()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asSynchronized());
     }
 
     @Override
     @Test
     public void asUnmodifiable()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
+        assertThrows(UnsupportedOperationException.class, () -> this.newWith().asUnmodifiable());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetTest.java
@@ -32,8 +32,14 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestCase
 {
@@ -81,23 +87,23 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     @Test
     public void getFirst()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
     @Test
     public void iterator()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> MultiReaderUnifiedSet.newSet().iterator());
+        assertThrows(UnsupportedOperationException.class, () -> MultiReaderUnifiedSet.newSet().iterator());
     }
 
     @Test
@@ -105,7 +111,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     {
         MutableSet<Integer> set = MultiReaderUnifiedSet.newSetWith(1, 2);
         String s = set.toString();
-        Assert.assertTrue("[1, 2]".equals(s) || "[2, 1]".equals(s));
+        assertTrue("[1, 2]".equals(s) || "[2, 1]".equals(s));
     }
 
     @Override
@@ -132,8 +138,8 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
 
     private void assertIsEmpty(boolean isEmpty, MultiReaderUnifiedSet<?> set)
     {
-        Assert.assertEquals(isEmpty, set.isEmpty());
-        Assert.assertEquals(!isEmpty, set.notEmpty());
+        assertEquals(isEmpty, set.isEmpty());
+        assertEquals(!isEmpty, set.notEmpty());
     }
 
     @Override
@@ -141,7 +147,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     public void testToString()
     {
         MutableCollection<Object> collection = this.newWith(1, 2);
-        Assert.assertTrue(
+        assertTrue(
                 "[1, 2]".equals(collection.toString())
                         || "[2, 1]".equals(collection.toString()));
     }
@@ -151,7 +157,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     public void makeString()
     {
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Override
@@ -161,7 +167,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -177,10 +183,10 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> union = set.union(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
+        assertEquals(set, set.union(UnifiedSet.newSetWith("1")));
     }
 
     @Test
@@ -189,10 +195,10 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size()).collect(String::valueOf)));
         Verify.assertContainsAll(union, "a", "b", "c");
 
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -201,7 +207,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> intersect = set.intersect(UnifiedSet.newSetWith("a", "b", "c", "1"));
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersect(UnifiedSet.newSetWith("not present")));
     }
@@ -212,7 +218,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> intersect = set.intersectInto(UnifiedSet.newSetWith("a", "b", "c", "1"), UnifiedSet.newSet());
         Verify.assertSize(1, intersect);
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), intersect);
+        assertEquals(UnifiedSet.newSetWith("1"), intersect);
 
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -222,8 +228,8 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -231,8 +237,8 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -241,7 +247,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         MutableSet<String> difference = set.symmetricDifference(UnifiedSet.newSetWith("2", "3", "4", "5", "not present"));
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -258,7 +264,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
                 UnifiedSet.newSetWith("2", "3", "4", "5", "not present"),
                 UnifiedSet.newSet());
         Verify.assertContains("1", difference);
-        Assert.assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
+        assertTrue(difference.containsAllIterable(Interval.fromTo(set.size() + 1, 5).collect(String::valueOf)));
         for (int i = 2; i <= set.size(); i++)
         {
             Verify.assertNotContains(String.valueOf(i), difference);
@@ -273,15 +279,15 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
     public void isSubsetOf()
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -300,7 +306,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         MutableSet<String> set = MultiReaderUnifiedSet.newSetWith("1", "2", "3", "4");
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))
@@ -314,9 +320,9 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         Function0<AtomicInteger> valueCreator = AtomicInteger::new;
         MutableCollection<Integer> collection = this.newWith(1, 1, 1, 2, 2, 3);
         MapIterable<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, AtomicInteger::addAndGet);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Override
@@ -327,9 +333,9 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
         Function2<Integer, Integer, Integer> sumAggregator = (integer1, integer2) -> integer1 + integer2;
         MutableCollection<Integer> collection = this.newWith(1, 1, 1, 2, 2, 3);
         MapIterable<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(1, aggregation.get("1").intValue());
-        Assert.assertEquals(2, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(1, aggregation.get("1").intValue());
+        assertEquals(2, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Test
@@ -342,7 +348,7 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
             result[0] = delegate.getFirst();
             this.verifyDelegateIsUnmodifiable(delegate);
         });
-        Assert.assertNotNull(result[0]);
+        assertNotNull(result[0]);
     }
 
     @Test
@@ -360,17 +366,17 @@ public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestC
             delegateList.set(delegate);
             iterator.set(delegate.iterator());
         });
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), set);
 
-        Assert.assertThrows(NullPointerException.class, () -> iterator.get().hasNext());
+        assertThrows(NullPointerException.class, () -> iterator.get().hasNext());
 
-        Assert.assertThrows(NullPointerException.class, () -> delegateList.get().iterator());
+        assertThrows(NullPointerException.class, () -> delegateList.get().iterator());
     }
 
     private void verifyDelegateIsUnmodifiable(MutableSet<Integer> delegate)
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
-        Assert.assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.add(2));
+        assertThrows(UnsupportedOperationException.class, () -> delegate.remove(0));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetAdapterTest.java
@@ -25,8 +25,14 @@ import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SetAdapter}.
@@ -47,7 +53,7 @@ public class SetAdapterTest extends AbstractMutableSetTestCase
         collection.add(collection);
         String simpleName = collection.getClass().getSimpleName();
         String string = collection.toString();
-        Assert.assertTrue(
+        assertTrue(
                 ("[1, (this " + simpleName + ")]").equals(string)
                         || ("[(this " + simpleName + "), 1]").equals(string));
     }
@@ -123,10 +129,10 @@ public class SetAdapterTest extends AbstractMutableSetTestCase
         set4.add(2);
         set4.add(3);
         set4.add(4);
-        Assert.assertNotEquals(set1, null);
+        assertNotEquals(set1, null);
         Verify.assertEqualsAndHashCode(set1, set1);
         Verify.assertEqualsAndHashCode(set1, set2);
-        Assert.assertNotEquals(set2, set3);
+        assertNotEquals(set2, set3);
         Verify.assertEqualsAndHashCode(set3, set4);
     }
 
@@ -144,7 +150,7 @@ public class SetAdapterTest extends AbstractMutableSetTestCase
         MutableCollection<Integer> deserializedCollection = SerializeTestHelper.serializeDeserialize(collection);
         Verify.assertSize(5, deserializedCollection);
         Verify.assertContainsAll(deserializedCollection, 1, 2, 3, 4, 5);
-        Assert.assertEquals(collection, deserializedCollection);
+        assertEquals(collection, deserializedCollection);
     }
 
     @Override
@@ -161,16 +167,16 @@ public class SetAdapterTest extends AbstractMutableSetTestCase
     @Test
     public void getFirst()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
@@ -209,8 +215,8 @@ public class SetAdapterTest extends AbstractMutableSetTestCase
     @Test
     public void adaptNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new SetAdapter<>(null));
+        assertThrows(NullPointerException.class, () -> new SetAdapter<>(null));
 
-        Assert.assertThrows(NullPointerException.class, () -> SetAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> SetAdapter.adapt(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetLogicTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetLogicTest.java
@@ -12,9 +12,10 @@ package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class SetLogicTest
 {
@@ -32,7 +33,7 @@ public class SetLogicTest
     public void inOnlyInAMutable()
     {
         MutableSet<Integer> onlyInA = this.setA.reject(Predicates.in(this.setB), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), onlyInA);
+        assertEquals(UnifiedSet.newSetWith(1, 2), onlyInA);
     }
 
     @Test
@@ -40,13 +41,13 @@ public class SetLogicTest
     {
         MutableSet<Integer> onlyInA = UnifiedSet.newSet(this.setA);
         onlyInA.removeAll(this.setB);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), onlyInA);
+        assertEquals(UnifiedSet.newSetWith(1, 2), onlyInA);
     }
 
     @Test
     public void inBothAAndBMutable()
     {
-        Assert.assertEquals(UnifiedSet.newSetWith(3, 4), this.setA.select(Predicates.in(this.setB)));
+        assertEquals(UnifiedSet.newSetWith(3, 4), this.setA.select(Predicates.in(this.setB)));
     }
 
     @Test
@@ -55,6 +56,6 @@ public class SetLogicTest
         MutableSet<Integer> nonOverlappingSet = UnifiedSet.newSet();
         this.setA.select(Predicates.notIn(this.setB), nonOverlappingSet);
         this.setB.select(Predicates.notIn(this.setA), nonOverlappingSet);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 5, 6), nonOverlappingSet);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 5, 6), nonOverlappingSet);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSet2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSet2Test.java
@@ -20,8 +20,13 @@ import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedMutableSet}.
@@ -51,7 +56,7 @@ public class SynchronizedMutableSet2Test extends AbstractMutableSetTestCase
     public void testToString()
     {
         MutableSet<Integer> integer = this.newWith(1);
-        Assert.assertEquals("[1]", integer.toString());
+        assertEquals("[1]", integer.toString());
     }
 
     @Override
@@ -59,7 +64,7 @@ public class SynchronizedMutableSet2Test extends AbstractMutableSetTestCase
     public void makeString()
     {
         MutableSet<Integer> integer = this.newWith(1);
-        Assert.assertEquals("{1}", integer.makeString("{", ",", "}"));
+        assertEquals("{1}", integer.makeString("{", ",", "}"));
     }
 
     @Override
@@ -69,7 +74,7 @@ public class SynchronizedMutableSet2Test extends AbstractMutableSetTestCase
         Appendable stringBuilder = new StringBuilder();
         MutableSet<Integer> integer = this.newWith(1);
         integer.appendString(stringBuilder, "{", ",", "}");
-        Assert.assertEquals("{1}", stringBuilder.toString());
+        assertEquals("{1}", stringBuilder.toString());
     }
 
     @Override
@@ -86,30 +91,30 @@ public class SynchronizedMutableSet2Test extends AbstractMutableSetTestCase
     {
         MutableSet<Number> numbers = new SynchronizedMutableSet<Number>(SetAdapter.adapt(new TreeSet<>((o1, o2) -> Double.compare(o1.doubleValue(), o2.doubleValue())))).withAll(FastList.newListWith(1, 2.0, 3, 4.0, 5));
         MutableSet<Integer> integers = numbers.selectInstancesOf(Integer.class);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
+        assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
+        assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
     }
 
     @Test
     @Override
     public void getFirst()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1).getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1).getFirst());
         int first = this.newWith(1, 2).getFirst().intValue();
-        Assert.assertTrue(first == 1 || first == 2);
+        assertTrue(first == 1 || first == 2);
     }
 
     @Test
     @Override
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1).getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
+        assertEquals(Integer.valueOf(1), this.newWith(1).getLast());
         int last = this.newWith(1, 2).getLast().intValue();
-        Assert.assertTrue(last == 1 || last == 2);
+        assertTrue(last == 1 || last == 2);
     }
 
     @Test
@@ -122,10 +127,10 @@ public class SynchronizedMutableSet2Test extends AbstractMutableSetTestCase
         Iterator<Integer> iterator = objects.iterator();
         for (int i = objects.size(); i-- > 0; )
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             actual.add(iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3), actual);
+        assertFalse(iterator.hasNext());
+        assertEquals(Bags.mutable.of(1, 2, 3), actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSetTest.java
@@ -24,8 +24,10 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.collection.mutable.AbstractSynchronizedCollectionTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedMutableSet}.
@@ -52,7 +54,7 @@ public class SynchronizedMutableSetTest extends AbstractSynchronizedCollectionTe
     public void removeIf()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(2)));
+        assertTrue(objects.removeIf(Predicates.equal(2)));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 3, 4);
     }
@@ -62,7 +64,7 @@ public class SynchronizedMutableSetTest extends AbstractSynchronizedCollectionTe
     public void removeIfWith()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(objects.removeIfWith(Predicates2.equal(), 2));
+        assertTrue(objects.removeIfWith(Predicates2.equal(), 2));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 3, 4);
     }
@@ -80,8 +82,8 @@ public class SynchronizedMutableSetTest extends AbstractSynchronizedCollectionTe
     {
         MutableSet<Number> numbers = new SynchronizedMutableSet<Number>(SetAdapter.adapt(new TreeSet<>((o1, o2) -> Double.compare(o1.doubleValue(), o2.doubleValue())))).withAll(FastList.newListWith(1, 2.0, 3, 4.0, 5));
         MutableSet<Integer> integers = numbers.selectInstancesOf(Integer.class);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
+        assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
+        assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class UnifiedSetAsPoolTest
 {
@@ -21,7 +23,7 @@ public class UnifiedSetAsPoolTest
     @Test
     public void getReturnsNullIfObjectIsNotPooled()
     {
-        Assert.assertNull(this.staticPool.get(1));
+        assertNull(this.staticPool.get(1));
     }
 
     @Test
@@ -29,7 +31,7 @@ public class UnifiedSetAsPoolTest
     {
         Integer firstPooledObject = 1;
         this.staticPool.put(firstPooledObject);
-        Assert.assertSame(firstPooledObject, this.staticPool.get(firstPooledObject));
+        assertSame(firstPooledObject, this.staticPool.get(firstPooledObject));
     }
 
     @Test
@@ -39,7 +41,7 @@ public class UnifiedSetAsPoolTest
         AlwaysEqual firstObject = new AlwaysEqual();
         pool.put(firstObject);
         AlwaysEqual equalObject = new AlwaysEqual();  // deliberate new instance
-        Assert.assertSame(firstObject, pool.get(equalObject));
+        assertSame(firstObject, pool.get(equalObject));
     }
 
     private static final class AlwaysEqual
@@ -62,7 +64,7 @@ public class UnifiedSetAsPoolTest
     {
         Integer firstObject = 1;
         Object returnedObject = this.staticPool.put(firstObject);
-        Assert.assertSame(returnedObject, firstObject);
+        assertSame(returnedObject, firstObject);
     }
 
     @Test
@@ -74,8 +76,8 @@ public class UnifiedSetAsPoolTest
         AlwaysEqual secondObject = new AlwaysEqual();  // deliberate new instance
         Object returnedObject = pool.put(secondObject);
 
-        Assert.assertSame(returnedObject, firstObject);
-        Assert.assertSame(firstObject, pool.get(secondObject));
+        assertSame(returnedObject, firstObject);
+        assertSame(firstObject, pool.get(secondObject));
     }
 
     @Test
@@ -86,7 +88,7 @@ public class UnifiedSetAsPoolTest
         this.staticPool.put(firstObject);
         Integer returnedObject = this.staticPool.removeFromPool(firstObject);
 
-        Assert.assertSame(returnedObject, firstObject);
+        assertSame(returnedObject, firstObject);
         Verify.assertEmpty(this.staticPool);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetTest.java
@@ -31,8 +31,16 @@ import org.eclipse.collections.impl.test.ClassComparer;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test suite for {@link UnifiedSet}.
@@ -72,23 +80,23 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
     @Test
     public void newSet_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(-1, 0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, -0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, 0.0f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, 1.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(-1, 0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, -0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, 0.0f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSet<Integer>(1, 1.5f));
     }
 
     @Test
     public void newSetWithIterable()
     {
         MutableSet<Integer> integers = UnifiedSet.newSet(Interval.oneTo(3));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), integers);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), integers);
     }
 
     @Test
     public void unifiedSetProperSuperSetOfHashSet()
     {
-        Assert.assertTrue(ClassComparer.isProperSupersetOfInstance(UnifiedSet.class, HashSet.class));
+        assertTrue(ClassComparer.isProperSupersetOfInstance(UnifiedSet.class, HashSet.class));
     }
 
     @Override
@@ -111,7 +119,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
                 unifiedSet.add(Integer.valueOf(2));
             }
             Integer value = COLLISIONS.get(i);
-            Assert.assertTrue(unifiedSet.add(value));
+            assertTrue(unifiedSet.add(value));
         }
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element goes in the bucket
@@ -124,7 +132,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         caseA.add(Integer.valueOf(2));
 
         // add the colliding value back and force the rehash
-        Assert.assertTrue(caseA.add(COLLISION_2));
+        assertTrue(caseA.add(COLLISION_2));
 
         // Rehashing Case B: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element is not in the chain
         // set up a chained bucket
@@ -136,7 +144,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         caseB.add(Integer.valueOf(2));
 
         // add a new value and force the rehash
-        Assert.assertTrue(caseB.add(3));
+        assertTrue(caseB.add(3));
     }
 
     @Override
@@ -147,11 +155,11 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
 
         // test adding a fully populated chained bucket
         MutableSet<Integer> expected = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6, COLLISION_7);
-        Assert.assertTrue(UnifiedSet.<Integer>newSet().addAllIterable(expected));
+        assertTrue(UnifiedSet.<Integer>newSet().addAllIterable(expected));
 
         // add an odd-sized collection to a set with a small max to ensure that its capacity is maintained after the operation.
         UnifiedSet<Integer> tiny = UnifiedSet.newSet(0);
-        Assert.assertTrue(tiny.addAllIterable(FastList.newListWith(COLLISION_1)));
+        assertTrue(tiny.addAllIterable(FastList.newListWith(COLLISION_1)));
     }
 
     @Test
@@ -161,23 +169,23 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         set.removeAll(COLLISIONS);
         for (Integer integer : COLLISIONS)
         {
-            Assert.assertNull(set.get(integer));
-            Assert.assertNull(set.get(null));
+            assertNull(set.get(integer));
+            assertNull(set.get(null));
             set.add(integer);
             //noinspection UnnecessaryBoxing,CachedNumberConstructorCall,BoxingBoxedValue
-            Assert.assertSame(integer, set.get(new Integer(integer)));
+            assertSame(integer, set.get(new Integer(integer)));
         }
-        Assert.assertEquals(COLLISIONS.toSet(), set);
+        assertEquals(COLLISIONS.toSet(), set);
 
         // the pool interface supports getting null keys
         UnifiedSet<Integer> chainedWithNull = UnifiedSet.newSetWith(null, COLLISION_1);
         Verify.assertContains(null, chainedWithNull);
-        Assert.assertNull(chainedWithNull.get(null));
+        assertNull(chainedWithNull.get(null));
 
         // getting a non-existent from a chain with one slot should short-circuit to return null
         UnifiedSet<Integer> chainedWithOneSlot = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2);
         chainedWithOneSlot.remove(COLLISION_2);
-        Assert.assertNull(chainedWithOneSlot.get(COLLISION_2));
+        assertNull(chainedWithOneSlot.get(COLLISION_2));
     }
 
     @Test
@@ -189,9 +197,9 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             Pool<Integer> unifiedSet = UnifiedSet.<Integer>newSet(1).withAll(MORE_COLLISIONS.subList(0, i - 1));
             Integer newValue = MORE_COLLISIONS.get(i - 1);
 
-            Assert.assertSame(newValue, unifiedSet.put(newValue));
+            assertSame(newValue, unifiedSet.put(newValue));
             //noinspection UnnecessaryBoxing,CachedNumberConstructorCall,BoxingBoxedValue
-            Assert.assertSame(newValue, unifiedSet.put(new Integer(newValue)));
+            assertSame(newValue, unifiedSet.put(new Integer(newValue)));
         }
 
         // assert that all redundant puts into each position of chain bucket return the original element added
@@ -199,7 +207,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         for (int i = 0; i < set.size(); i++)
         {
             Integer value = COLLISIONS.get(i);
-            Assert.assertSame(value, set.put(value));
+            assertSame(value, set.put(value));
         }
 
         // force rehashing at each step of putting a new colliding entry
@@ -216,7 +224,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
                 pool.put(Integer.valueOf(2));
             }
             Integer value = COLLISIONS.get(i);
-            Assert.assertSame(value, pool.put(value));
+            assertSame(value, pool.put(value));
         }
 
         // cover one case not covered in the above: a bucket with only one entry and a low capacity forcing a rehash
@@ -229,12 +237,12 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         pool.put(Integer.valueOf(2));
 
         // put the colliding value back and force the rehash
-        Assert.assertSame(COLLISION_2, pool.put(COLLISION_2));
+        assertSame(COLLISION_2, pool.put(COLLISION_2));
 
         // put chained items into a pool without causing a rehash
         Pool<Integer> olympicPool = UnifiedSet.newSet();
-        Assert.assertSame(COLLISION_1, olympicPool.put(COLLISION_1));
-        Assert.assertSame(COLLISION_2, olympicPool.put(COLLISION_2));
+        assertSame(COLLISION_1, olympicPool.put(COLLISION_1));
+        assertSame(COLLISION_2, olympicPool.put(COLLISION_2));
     }
 
     @Test
@@ -242,36 +250,36 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
     {
         Pool<Integer> unifiedSet = UnifiedSet.<Integer>newSet(8).withAll(COLLISIONS);
         COLLISIONS.reverseForEach(each -> {
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertSame(each, unifiedSet.removeFromPool(each));
-            Assert.assertNull(unifiedSet.removeFromPool(each));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertNull(unifiedSet.removeFromPool(COLLISION_10));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertSame(each, unifiedSet.removeFromPool(each));
+            assertNull(unifiedSet.removeFromPool(each));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.removeFromPool(COLLISION_10));
         });
 
-        Assert.assertEquals(UnifiedSet.<Integer>newSet(), unifiedSet);
+        assertEquals(UnifiedSet.<Integer>newSet(), unifiedSet);
 
         COLLISIONS.forEach(Procedures.cast(each -> {
             Pool<Integer> unifiedSet2 = UnifiedSet.<Integer>newSet(8).withAll(COLLISIONS);
 
-            Assert.assertNull(unifiedSet2.removeFromPool(null));
-            Assert.assertSame(each, unifiedSet2.removeFromPool(each));
-            Assert.assertNull(unifiedSet2.removeFromPool(each));
-            Assert.assertNull(unifiedSet2.removeFromPool(null));
-            Assert.assertNull(unifiedSet2.removeFromPool(COLLISION_10));
+            assertNull(unifiedSet2.removeFromPool(null));
+            assertSame(each, unifiedSet2.removeFromPool(each));
+            assertNull(unifiedSet2.removeFromPool(each));
+            assertNull(unifiedSet2.removeFromPool(null));
+            assertNull(unifiedSet2.removeFromPool(COLLISION_10));
         }));
 
         // search a chain for a non-existent element
         Pool<Integer> chain = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        Assert.assertNull(chain.removeFromPool(COLLISION_5));
+        assertNull(chain.removeFromPool(COLLISION_5));
 
         // search a deep chain for a non-existent element
         Pool<Integer> deepChain = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6, COLLISION_7);
-        Assert.assertNull(deepChain.removeFromPool(COLLISION_8));
+        assertNull(deepChain.removeFromPool(COLLISION_8));
 
         // search for a non-existent element
         Pool<Integer> empty = UnifiedSet.newSetWith(COLLISION_1);
-        Assert.assertNull(empty.removeFromPool(COLLISION_2));
+        assertNull(empty.removeFromPool(COLLISION_2));
     }
 
     @Test
@@ -299,25 +307,25 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
     {
         UnifiedSet<Integer> unifiedSet = UnifiedSet.<Integer>newSet(10).withAll(MORE_COLLISIONS);
         MORE_COLLISIONS.clone().reverseForEach(each -> {
-            Assert.assertTrue(unifiedSet.add(null));
-            Assert.assertFalse(unifiedSet.add(null));
+            assertTrue(unifiedSet.add(null));
+            assertFalse(unifiedSet.add(null));
             Verify.assertContains(null, unifiedSet);
             Verify.assertPostSerializedEqualsAndHashCode(unifiedSet);
 
-            Assert.assertTrue(unifiedSet.remove(null));
-            Assert.assertFalse(unifiedSet.remove(null));
+            assertTrue(unifiedSet.remove(null));
+            assertFalse(unifiedSet.remove(null));
             Verify.assertNotContains(null, unifiedSet);
 
             Verify.assertPostSerializedEqualsAndHashCode(unifiedSet);
 
-            Assert.assertNull(unifiedSet.put(null));
-            Assert.assertNull(unifiedSet.put(null));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.put(null));
+            assertNull(unifiedSet.put(null));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.removeFromPool(null));
 
             Verify.assertContains(each, unifiedSet);
-            Assert.assertTrue(unifiedSet.remove(each));
-            Assert.assertFalse(unifiedSet.remove(each));
+            assertTrue(unifiedSet.remove(each));
+            assertFalse(unifiedSet.remove(each));
             Verify.assertNotContains(each, unifiedSet);
         });
     }
@@ -330,7 +338,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
 
         UnifiedSet<Integer> singleCollisionBucket = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2);
         singleCollisionBucket.remove(COLLISION_2);
-        Assert.assertEquals(singleCollisionBucket, UnifiedSet.newSetWith(COLLISION_1));
+        assertEquals(singleCollisionBucket, UnifiedSet.newSetWith(COLLISION_1));
 
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith(null, COLLISION_1, COLLISION_2, COLLISION_3), UnifiedSet.newSetWith(null, COLLISION_1, COLLISION_2, COLLISION_3));
         Verify.assertEqualsAndHashCode(UnifiedSet.newSetWith(COLLISION_1, null, COLLISION_2, COLLISION_3), UnifiedSet.newSetWith(COLLISION_1, null, COLLISION_2, COLLISION_3));
@@ -388,19 +396,19 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
                 capacity <<= 1;
             }
 
-            Assert.assertEquals(capacity, table.length, 0.00);
+            assertEquals(capacity, table.length, 0.00);
         }
         catch (SecurityException ignored)
         {
-            Assert.fail("Unable to modify the visibility of the table on UnifiedSet");
+            fail("Unable to modify the visibility of the table on UnifiedSet");
         }
         catch (NoSuchFieldException ignored)
         {
-            Assert.fail("No field named table UnifiedSet");
+            fail("No field named table UnifiedSet");
         }
         catch (IllegalAccessException ignored)
         {
-            Assert.fail("No access the field table in UnifiedSet");
+            fail("No access the field table in UnifiedSet");
         }
     }
 
@@ -416,7 +424,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             {
                 set.batchForEach(new SumProcedure<>(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(55, sum.getValue());
+            assertEquals(55, sum.getValue());
         }
 
         //Testing 1 batch with chains
@@ -427,8 +435,8 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         {
             set2.batchForEach(new SumProcedure<>(sum2), i, numBatches);
         }
-        Assert.assertEquals(1, numBatches);
-        Assert.assertEquals(54, sum2.getValue());
+        assertEquals(1, numBatches);
+        assertEquals(54, sum2.getValue());
 
         //Testing batch size of 3 with chains and uneven last batch
         Sum sum3 = new IntegerSum(0);
@@ -438,13 +446,13 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         {
             set3.batchForEach(new SumProcedure<>(sum3), i, numBatches2);
         }
-        Assert.assertEquals(32, sum3.getValue());
+        assertEquals(32, sum3.getValue());
 
         //Test batchForEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum4 = new IntegerSum(0);
         UnifiedSet<Integer> set4 = UnifiedSet.newSet();
         set4.batchForEach(new SumProcedure<>(sum4), 0, set4.getBatchCount(1));
-        Assert.assertEquals(0, sum4.getValue());
+        assertEquals(0, sum4.getValue());
     }
 
     @Override
@@ -458,21 +466,21 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         {
             MutableSet<Integer> set = UnifiedSet.<Integer>newSet(SIZE).withAll(COLLISIONS.subList(0, i));
             Object[] objects = set.toArray();
-            Assert.assertEquals(set, UnifiedSet.newSetWith(objects));
+            assertEquals(set, UnifiedSet.newSetWith(objects));
         }
 
         MutableSet<Integer> deepChain = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6}, deepChain.toArray());
+        assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6}, deepChain.toArray());
 
         MutableSet<Integer> minimumChain = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2);
         minimumChain.remove(COLLISION_2);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1}, minimumChain.toArray());
+        assertArrayEquals(new Integer[]{COLLISION_1}, minimumChain.toArray());
 
         MutableSet<Integer> set = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
         Integer[] target = {Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1)};
         Integer[] actual = set.toArray(target);
         ArrayIterate.sort(actual, actual.length, Comparators.safeNullsHigh(Integer::compareTo));
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, 1, COLLISION_2, COLLISION_3, COLLISION_4, null}, actual);
+        assertArrayEquals(new Integer[]{COLLISION_1, 1, COLLISION_2, COLLISION_3, COLLISION_4, null}, actual);
     }
 
     @Test
@@ -485,14 +493,14 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             Iterator<Integer> iterator = actual.iterator();
             for (int j = 0; j <= i; j++)
             {
-                Assert.assertTrue(iterator.hasNext());
+                assertTrue(iterator.hasNext());
                 iterator.next();
             }
             iterator.remove();
 
             MutableSet<Integer> expected = UnifiedSet.newSet(MORE_COLLISIONS);
             expected.remove(MORE_COLLISIONS.get(i));
-            Assert.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         // remove the last element from within a 2-level long chain that is fully populated
@@ -503,7 +511,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             iterator1.next();
         }
         iterator1.remove();
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6), set);
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6), set);
 
         // remove the second-to-last element from a 2-level long chain that that has one empty slot
         Iterator<Integer> iterator2 = set.iterator();
@@ -512,7 +520,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             iterator2.next();
         }
         iterator2.remove();
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5), set);
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5), set);
 
         //Testing removing the last element in a fully populated chained bucket
         MutableSet<Integer> set2 = this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
@@ -535,28 +543,28 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         MutableSet<Key> set1 = UnifiedSet.<Key>newSet().with(key, duplicateKey1);
         Verify.assertSize(1, set1);
         Verify.assertContains(key, set1);
-        Assert.assertSame(key, set1.getFirst());
+        assertSame(key, set1.getFirst());
 
         Key duplicateKey2 = new Key("key");
         MutableSet<Key> set2 = UnifiedSet.<Key>newSet().with(key, duplicateKey1, duplicateKey2);
         Verify.assertSize(1, set2);
         Verify.assertContains(key, set2);
-        Assert.assertSame(key, set2.getFirst());
+        assertSame(key, set2.getFirst());
 
         Key duplicateKey3 = new Key("key");
         MutableSet<Key> set3 = UnifiedSet.<Key>newSet().with(key, new Key("not a dupe"), duplicateKey3);
         Verify.assertSize(2, set3);
         Verify.assertContainsAll(set3, key, new Key("not a dupe"));
-        Assert.assertSame(key, set3.detect(key::equals));
+        assertSame(key, set3.detect(key::equals));
     }
 
     @Test
     public void withSameIfNotModified()
     {
         UnifiedSet<Integer> integers = UnifiedSet.newSet();
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), integers.with(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), integers.with(2, 3, 4));
-        Assert.assertSame(integers, integers.with(5, 6, 7));
+        assertEquals(UnifiedSet.newSetWith(1, 2), integers.with(1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), integers.with(2, 3, 4));
+        assertSame(integers, integers.with(5, 6, 7));
     }
 
     @Override
@@ -566,8 +574,8 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         super.retainAll();
 
         MutableSet<Object> setWithNull = this.newWith((Object) null);
-        Assert.assertFalse(setWithNull.retainAll(FastList.newListWith((Object) null)));
-        Assert.assertEquals(UnifiedSet.newSetWith((Object) null), setWithNull);
+        assertFalse(setWithNull.retainAll(FastList.newListWith((Object) null)));
+        assertEquals(UnifiedSet.newSetWith((Object) null), setWithNull);
     }
 
     @Test(expected = NullPointerException.class)
@@ -592,7 +600,7 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         for (int i = 1; i <= size - 1; i++)
         {
             MutableSet<Integer> unifiedSet = UnifiedSet.<Integer>newSet(1).withAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertSame(MORE_COLLISIONS.get(0), unifiedSet.getFirst());
+            assertSame(MORE_COLLISIONS.get(0), unifiedSet.getFirst());
         }
     }
 
@@ -606,12 +614,12 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         for (int i = 1; i <= size - 1; i++)
         {
             MutableSet<Integer> unifiedSet = UnifiedSet.<Integer>newSet(1).withAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertSame(MORE_COLLISIONS.get(i - 1), unifiedSet.getLast());
+            assertSame(MORE_COLLISIONS.get(i - 1), unifiedSet.getLast());
         }
 
         MutableSet<Integer> chainedWithOneSlot = UnifiedSet.newSetWith(COLLISION_1, COLLISION_2);
         chainedWithOneSlot.remove(COLLISION_2);
-        Assert.assertSame(COLLISION_1, chainedWithOneSlot.getLast());
+        assertSame(COLLISION_1, chainedWithOneSlot.getLast());
     }
 
     @Test
@@ -632,8 +640,8 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
             expected.add(each);
         });
 
-        Assert.assertEquals(expected, set);
-        Assert.assertEquals(261, set.size());
+        assertEquals(expected, set);
+        assertEquals(261, set.size());
 
         MutableList<Integer> toRemove = Lists.mutable.withAll(Interval.evensFromTo(0, 20));
 
@@ -645,9 +653,9 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         });
 
         // First assertion to verify that trim does not happen since, the table is already at the smallest required power of 2.
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(239, set.size());
-        Assert.assertEquals(expected, set);
+        assertFalse(set.trimToSize());
+        assertEquals(239, set.size());
+        assertEquals(expected, set);
 
         Interval.evensFromTo(0, 250).each(each ->
         {
@@ -656,38 +664,38 @@ public class UnifiedSetTest extends AbstractMutableSetTestCase
         });
 
         // Second assertion to verify that trim happens since, the table length is less than smallest required power of 2.
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(expected, set);
-        Assert.assertEquals(124, set.size());
-        expected.each(each -> Assert.assertEquals(each, set.get(each)));
+        assertTrue(set.trimToSize());
+        assertFalse(set.trimToSize());
+        assertEquals(expected, set);
+        assertEquals(124, set.size());
+        expected.each(each -> assertEquals(each, set.get(each)));
 
         integers.each(each ->
         {
             set.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(expected, set);
-        expected.each(each -> Assert.assertEquals(each, set.get(each)));
+        assertTrue(set.trimToSize());
+        assertFalse(set.trimToSize());
+        assertEquals(expected, set);
+        expected.each(each -> assertEquals(each, set.get(each)));
 
         set.clear();
-        Assert.assertTrue(set.trimToSize());
+        assertTrue(set.trimToSize());
         Interval.oneTo(4).each(each -> set.add(each.toString()));
         // Assert that trim does not happen after puts
-        Assert.assertFalse(set.trimToSize());
+        assertFalse(set.trimToSize());
         set.remove("1");
         set.remove("2");
-        Assert.assertTrue(set.trimToSize());
+        assertTrue(set.trimToSize());
 
         set.add("1");
         // Assert that the resized table due to put is the required size and no need to trim that.
-        Assert.assertFalse(set.trimToSize());
+        assertFalse(set.trimToSize());
 
         Interval.zeroTo(4).each(each -> set.add(each.toString()));
         Interval.oneTo(3).each(each -> set.remove(each.toString()));
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertEquals(2, set.size());
+        assertTrue(set.trimToSize());
+        assertEquals(2, set.size());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyTest.java
@@ -39,8 +39,16 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test suite for {@link UnifiedSetWithHashingStrategy}.
@@ -91,9 +99,9 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
     @Test
     public void newSet_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, -1, 0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, 1, -0.5f));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, 1, 1.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, -1, 0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, 1, -0.5f));
+        assertThrows(IllegalArgumentException.class, () -> new UnifiedSetWithHashingStrategy<>(INTEGER_HASHING_STRATEGY, 1, 1.5f));
     }
 
     @Override
@@ -104,8 +112,8 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
 
         MutableList<Person> tapResult = Lists.mutable.of();
         UnifiedSetWithHashingStrategy<Person> people = UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).withAll(PEOPLE.castToList());
-        Assert.assertSame(people, people.tap(tapResult::add));
-        Assert.assertEquals(people.toList(), tapResult);
+        assertSame(people, people.tap(tapResult::add));
+        assertEquals(people.toList(), tapResult);
     }
 
     @Override
@@ -161,7 +169,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         LazyIterable<Integer> select = integers.lazyReject(Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(5L, sum.getValue().intValue());
+        assertEquals(5L, sum.getValue().intValue());
     }
 
     /**
@@ -176,7 +184,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         LazyIterable<Integer> select = integers.lazySelect(Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEach(new SumProcedure<>(sum));
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Override
@@ -209,15 +217,15 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
     {
         //testing collection
         MutableSet<Integer> integers = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, Interval.oneTo(3));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(INTEGER_HASHING_STRATEGY, 1, 2, 3), integers);
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(INTEGER_HASHING_STRATEGY, 1, 2, 3), integers);
 
         //testing iterable
         UnifiedSetWithHashingStrategy<Integer> set1 = UnifiedSetWithHashingStrategy.newSet(
                 INTEGER_HASHING_STRATEGY, FastList.newListWith(1, 2, 3).asLazy());
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(INTEGER_HASHING_STRATEGY, 1, 2, 3), set1);
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(INTEGER_HASHING_STRATEGY, 1, 2, 3), set1);
 
         //testing null
-        Assert.assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, null));
+        assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, null));
     }
 
     @Override
@@ -241,7 +249,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 unifiedSet.add(Integer.valueOf(2));
             }
             Integer value = COLLISIONS.get(i);
-            Assert.assertTrue(unifiedSet.add(value));
+            assertTrue(unifiedSet.add(value));
         }
 
         // Rehashing Case A: a bucket with only one entry and a low capacity forcing a rehash, where the trigging element goes in the bucket
@@ -255,7 +263,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         caseA.add(Integer.valueOf(2));
 
         // add the colliding value back and force the rehash
-        Assert.assertTrue(caseA.add(COLLISION_2));
+        assertTrue(caseA.add(COLLISION_2));
 
         // Rehashing Case B: a bucket with only one entry and a low capacity forcing a rehash, where the triggering element is not in the chain
         // set up a chained bucket
@@ -268,7 +276,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         caseB.add(Integer.valueOf(2));
 
         // add a new value and force the rehash
-        Assert.assertTrue(caseB.add(3));
+        assertTrue(caseB.add(3));
     }
 
     @Test
@@ -290,29 +298,29 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         //Same as case A above except with a different hashing strategy
         UnifiedSetWithHashingStrategy<Integer> caseA = UnifiedSetWithHashingStrategy.newSet(hashingStrategy, 2);
         //Adding an element to a slot
-        Assert.assertTrue(caseA.add(COLLISION_1));
+        assertTrue(caseA.add(COLLISION_1));
         //Setting up a chained bucked by forcing a collision
-        Assert.assertTrue(caseA.add(COLLISION_1 + 1000));
+        assertTrue(caseA.add(COLLISION_1 + 1000));
         //Increasing the occupied to the thresh hold
-        Assert.assertTrue(caseA.add(COLLISION_1 + 2000));
+        assertTrue(caseA.add(COLLISION_1 + 2000));
         //Forcing a rehash where the element that forced the rehash goes in the chained bucket
-        Assert.assertTrue(caseA.add(null));
+        assertTrue(caseA.add(null));
         Verify.assertSetsEqual(UnifiedSet.newSetWith(COLLISION_1, COLLISION_1 + 1000, COLLISION_1 + 2000, null), caseA);
 
         //Same as case B above except with a different hashing strategy
         UnifiedSetWithHashingStrategy<Integer> caseB = UnifiedSetWithHashingStrategy.newSet(hashingStrategy, 2);
         //Adding an element to a slot
-        Assert.assertTrue(caseB.add(null));
+        assertTrue(caseB.add(null));
         //Setting up a chained bucked by forcing a collision
-        Assert.assertTrue(caseB.add(1));
+        assertTrue(caseB.add(1));
         //Increasing the occupied to the threshold
-        Assert.assertTrue(caseB.add(2));
+        assertTrue(caseB.add(2));
         //Forcing a rehash where the element that forced the rehash does not go in the chained bucket
-        Assert.assertTrue(caseB.add(3));
+        assertTrue(caseB.add(3));
         Verify.assertSetsEqual(UnifiedSet.newSetWith(null, 1, 2, 3), caseB);
 
         //Testing add throws NullPointerException if the hashingStrategy is not null safe
-        Assert.assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).add(null));
+        assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).add(null));
     }
 
     @Test
@@ -324,16 +332,16 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 person1);
         Person person2 = new Person("f2", "l2", 1);
 
-        Assert.assertEquals(person1, set1.getOnly());
+        assertEquals(person1, set1.getOnly());
         set1.add(person2);
-        Assert.assertEquals(person1, set1.getOnly());
-        Assert.assertEquals(person1, set1.addOrReplace(person2));
-        Assert.assertEquals(person2, set1.getOnly());
+        assertEquals(person1, set1.getOnly());
+        assertEquals(person1, set1.addOrReplace(person2));
+        assertEquals(person2, set1.getOnly());
         set1.remove(person1);
         Verify.assertEmpty(set1);
-        Assert.assertEquals(person1, set1.addOrReplace(person1));
-        Assert.assertEquals(person1, set1.getOnly());
-        Assert.assertEquals(person1, set1.addOrReplace(person1));
+        assertEquals(person1, set1.addOrReplace(person1));
+        assertEquals(person1, set1.getOnly());
+        assertEquals(person1, set1.addOrReplace(person1));
 
         Person person31 = new Person("c1", "l31", COLLISION_1);
         Person person41 = new Person("c2", "l41", COLLISION_2);
@@ -359,51 +367,51 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
 
         UnifiedSetWithHashingStrategy<Person> set2 = UnifiedSetWithHashingStrategy.newSetWith(
                 HashingStrategies.fromFunction(Person::getAge));
-        Assert.assertEquals(person31, set2.addOrReplace(person31));
-        Assert.assertEquals(person41, set2.addOrReplace(person41));
-        Assert.assertEquals(person51, set2.addOrReplace(person51));
-        Assert.assertEquals(person61, set2.addOrReplace(person61));
-        Assert.assertEquals(person61, set2.addOrReplace(person62));
-        Assert.assertEquals(person62, set2.addOrReplace(person61));
-        Assert.assertEquals(person71, set2.addOrReplace(person71));
-        Assert.assertEquals(person81, set2.addOrReplace(person81));
-        Assert.assertEquals(person91, set2.addOrReplace(person91));
-        Assert.assertEquals(person101, set2.addOrReplace(person101));
-        Assert.assertEquals(person111, set2.addOrReplace(person111));
-        Assert.assertEquals(person121, set2.addOrReplace(person121));
-        Assert.assertEquals(person31, set2.addOrReplace(person31));
+        assertEquals(person31, set2.addOrReplace(person31));
+        assertEquals(person41, set2.addOrReplace(person41));
+        assertEquals(person51, set2.addOrReplace(person51));
+        assertEquals(person61, set2.addOrReplace(person61));
+        assertEquals(person61, set2.addOrReplace(person62));
+        assertEquals(person62, set2.addOrReplace(person61));
+        assertEquals(person71, set2.addOrReplace(person71));
+        assertEquals(person81, set2.addOrReplace(person81));
+        assertEquals(person91, set2.addOrReplace(person91));
+        assertEquals(person101, set2.addOrReplace(person101));
+        assertEquals(person111, set2.addOrReplace(person111));
+        assertEquals(person121, set2.addOrReplace(person121));
+        assertEquals(person31, set2.addOrReplace(person31));
 
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 HashingStrategies.fromFunction(Person::getAge),
                 person31, person41, person51, person61, person71, person81, person91, person101, person111, person121),
                 set2);
 
-        Assert.assertEquals(person121, set2.addOrReplace(person122));
-        Assert.assertEquals(person71, set2.addOrReplace(person72));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(person121, set2.addOrReplace(person122));
+        assertEquals(person71, set2.addOrReplace(person72));
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 HashingStrategies.fromFunction(Person::getAge),
                 person31, person41, person51, person61, person72, person81, person91, person101, person111, person122),
                 set2);
-        Assert.assertEquals(person31, set2.addOrReplace(person32));
-        Assert.assertEquals(person41, set2.addOrReplace(person42));
-        Assert.assertEquals(person51, set2.addOrReplace(person52));
-        Assert.assertEquals(person61, set2.addOrReplace(person62));
-        Assert.assertEquals(person72, set2.addOrReplace(person72));
-        Assert.assertEquals(person81, set2.addOrReplace(person82));
-        Assert.assertEquals(person91, set2.addOrReplace(person92));
-        Assert.assertEquals(person101, set2.addOrReplace(person102));
-        Assert.assertEquals(person111, set2.addOrReplace(person112));
-        Assert.assertEquals(person122, set2.addOrReplace(person122));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(person31, set2.addOrReplace(person32));
+        assertEquals(person41, set2.addOrReplace(person42));
+        assertEquals(person51, set2.addOrReplace(person52));
+        assertEquals(person61, set2.addOrReplace(person62));
+        assertEquals(person72, set2.addOrReplace(person72));
+        assertEquals(person81, set2.addOrReplace(person82));
+        assertEquals(person91, set2.addOrReplace(person92));
+        assertEquals(person101, set2.addOrReplace(person102));
+        assertEquals(person111, set2.addOrReplace(person112));
+        assertEquals(person122, set2.addOrReplace(person122));
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 HashingStrategies.fromFunction(Person::getAge),
                 person32, person42, person52, person62, person72, person82, person92, person102, person112, person122),
                 set2);
-        Assert.assertEquals(person1, set2.addOrReplace(person1));
+        assertEquals(person1, set2.addOrReplace(person1));
         Person person3 = new Person("f3", "l3", 3);
         Person person4 = new Person("f4", "l4", 4);
-        Assert.assertEquals(person3, set2.addOrReplace(person3));
-        Assert.assertEquals(person4, set2.addOrReplace(person4));
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(person3, set2.addOrReplace(person3));
+        assertEquals(person4, set2.addOrReplace(person4));
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 HashingStrategies.fromFunction(Person::getAge),
                 person1, person3, person4, person32, person42, person52, person62, person72, person82, person92, person102, person112, person122),
                 set2);
@@ -418,29 +426,29 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         // test adding a fully populated chained bucket
         MutableSet<Integer> expected = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6, COLLISION_7);
-        Assert.assertTrue(UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY).addAllIterable(expected));
+        assertTrue(UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY).addAllIterable(expected));
 
         // add an odd-sized collection to a set with a small max to ensure that its capacity is maintained after the operation.
         UnifiedSetWithHashingStrategy<Integer> tiny = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, 0);
-        Assert.assertTrue(tiny.addAllIterable(FastList.newListWith(COLLISION_1)));
+        assertTrue(tiny.addAllIterable(FastList.newListWith(COLLISION_1)));
 
         //Testing copying set with 3rd slot in chained bucket == null
         UnifiedSetWithHashingStrategy<Integer> integers = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
         UnifiedSetWithHashingStrategy<Integer> set = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY);
         integers.remove(COLLISION_4);
-        Assert.assertTrue(set.addAllIterable(integers));
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3), set);
+        assertTrue(set.addAllIterable(integers));
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3), set);
 
         //Testing copying set with 2nd slot in chained bucket == null
         integers.remove(COLLISION_3);
-        Assert.assertFalse(set.addAllIterable(integers));
+        assertFalse(set.addAllIterable(integers));
 
         //Testing copying set with the 1st slot in chained bucket == null
         integers.remove(COLLISION_2);
-        Assert.assertFalse(set.addAllIterable(integers));
+        assertFalse(set.addAllIterable(integers));
 
-        Assert.assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3), set);
+        assertEquals(UnifiedSet.newSetWith(COLLISION_1, COLLISION_2, COLLISION_3), set);
     }
 
     @Test
@@ -449,20 +457,20 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         UnifiedSetWithHashingStrategy<Person> people = UnifiedSetWithHashingStrategy.newSet(
                 HashingStrategies.nullSafeHashingStrategy(LAST_NAME_HASHING_STRATEGY), 2);
         //Testing adding an iterable
-        Assert.assertTrue(people.addAllIterable(PEOPLE));
+        assertTrue(people.addAllIterable(PEOPLE));
         Verify.assertSetsEqual(UnifiedSet.newSet(LAST_NAME_HASHED_SET), people);
 
         //Testing the set uses its own hashing strategy and not the target sets
-        Assert.assertFalse(people.addAllIterable(UnifiedSetWithHashingStrategy.newSet(FIRST_NAME_HASHING_STRATEGY, PEOPLE)));
+        assertFalse(people.addAllIterable(UnifiedSetWithHashingStrategy.newSet(FIRST_NAME_HASHING_STRATEGY, PEOPLE)));
         Verify.assertSize(2, people);
 
         //Testing adding with null where the call to addALLIterable forces a rehash
         Person notInSet = new Person("Not", "InSet");
-        Assert.assertTrue(people.addAllIterable(UnifiedSet.newSetWith(notInSet, null)));
+        assertTrue(people.addAllIterable(UnifiedSet.newSetWith(notInSet, null)));
         Verify.assertSetsEqual(UnifiedSet.newSet(LAST_NAME_HASHED_SET).with(notInSet, null), people);
 
         //Testing addAllIterable throws NullPointerException if the hashingStrategy is not null safe
-        Assert.assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).addAllIterable(UnifiedSet.newSetWith((Person) null)));
+        assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).addAllIterable(UnifiedSet.newSetWith((Person) null)));
     }
 
     @Test
@@ -473,25 +481,25 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         set.removeAll(COLLISIONS);
         for (Integer integer : COLLISIONS)
         {
-            Assert.assertNull(set.get(integer));
-            Assert.assertNull(set.get(null));
+            assertNull(set.get(integer));
+            assertNull(set.get(null));
             set.add(integer);
             //noinspection UnnecessaryBoxing,CachedNumberConstructorCall,BoxingBoxedValue
-            Assert.assertSame(integer, set.get(new Integer(integer)));
+            assertSame(integer, set.get(new Integer(integer)));
         }
-        Assert.assertEquals(COLLISIONS.toSet(), set);
+        assertEquals(COLLISIONS.toSet(), set);
 
         // the pool interface supports getting null keys
         UnifiedSetWithHashingStrategy<Integer> chainedWithNull = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, null, COLLISION_1);
         Verify.assertContains(null, chainedWithNull);
-        Assert.assertNull(chainedWithNull.get(null));
+        assertNull(chainedWithNull.get(null));
 
         // getting a non-existent from a chain with one slot should short-circuit to return null
         UnifiedSetWithHashingStrategy<Integer> chainedWithOneSlot = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2);
         chainedWithOneSlot.remove(COLLISION_2);
-        Assert.assertNull(chainedWithOneSlot.get(COLLISION_2));
+        assertNull(chainedWithOneSlot.get(COLLISION_2));
     }
 
     @Test
@@ -502,19 +510,19 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
 
         //Putting null then testing geting a null
         Verify.assertSize(3, people.with((Person) null));
-        Assert.assertNull(people.get(null));
+        assertNull(people.get(null));
 
         //Testing it is getting the same reference
-        Assert.assertSame(JOHNSMITH, people.get(JANESMITH));
-        Assert.assertSame(JOHNSMITH, people.get(JOHNSMITH));
-        Assert.assertSame(JOHNDOE, people.get(JANEDOE));
-        Assert.assertSame(JOHNDOE, people.get(JOHNDOE));
+        assertSame(JOHNSMITH, people.get(JANESMITH));
+        assertSame(JOHNSMITH, people.get(JOHNSMITH));
+        assertSame(JOHNDOE, people.get(JANEDOE));
+        assertSame(JOHNDOE, people.get(JOHNDOE));
 
-        Assert.assertSame(JOHNSMITH, people.get(new Person("Anything", "Smith")));
-        Assert.assertNull(people.get(new Person("John", "NotHere")));
+        assertSame(JOHNSMITH, people.get(new Person("Anything", "Smith")));
+        assertNull(people.get(new Person("John", "NotHere")));
 
         //Testing get throws NullPointerException if the hashingStrategy is not null safe
-        Assert.assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).get(null));
+        assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).get(null));
     }
 
     @Test
@@ -527,9 +535,9 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                     INTEGER_HASHING_STRATEGY, 1).withAll(MORE_COLLISIONS.subList(0, i - 1));
             Integer newValue = MORE_COLLISIONS.get(i - 1);
 
-            Assert.assertSame(newValue, unifiedSet.put(newValue));
+            assertSame(newValue, unifiedSet.put(newValue));
             //noinspection UnnecessaryBoxing,CachedNumberConstructorCall,BoxingBoxedValue
-            Assert.assertSame(newValue, unifiedSet.put(new Integer(newValue)));
+            assertSame(newValue, unifiedSet.put(new Integer(newValue)));
         }
 
         // assert that all redundant puts into each position of chain bucket return the original element added
@@ -538,7 +546,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         for (int i = 0; i < set.size(); i++)
         {
             Integer value = COLLISIONS.get(i);
-            Assert.assertSame(value, set.put(value));
+            assertSame(value, set.put(value));
         }
 
         // force rehashing at each step of putting a new colliding entry
@@ -555,7 +563,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 pool.put(Integer.valueOf(2));
             }
             Integer value = COLLISIONS.get(i);
-            Assert.assertSame(value, pool.put(value));
+            assertSame(value, pool.put(value));
         }
 
         // cover one case not covered in the above: a bucket with only one entry and a low capacity forcing a rehash
@@ -568,12 +576,12 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         pool.put(Integer.valueOf(2));
 
         // put the colliding value back and force the rehash
-        Assert.assertSame(COLLISION_2, pool.put(COLLISION_2));
+        assertSame(COLLISION_2, pool.put(COLLISION_2));
 
         // put chained items into a pool without causing a rehash
         Pool<Integer> olympicPool = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY);
-        Assert.assertSame(COLLISION_1, olympicPool.put(COLLISION_1));
-        Assert.assertSame(COLLISION_2, olympicPool.put(COLLISION_2));
+        assertSame(COLLISION_1, olympicPool.put(COLLISION_1));
+        assertSame(COLLISION_2, olympicPool.put(COLLISION_2));
     }
 
     @Test
@@ -582,20 +590,20 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         UnifiedSetWithHashingStrategy<Person> people = UnifiedSetWithHashingStrategy.newSet(
                 HashingStrategies.nullSafeHashingStrategy(LAST_NAME_HASHING_STRATEGY), 2).withAll(PEOPLE.castToList());
         //Testing if element already exists, returns the instance in the set
-        Assert.assertSame(JOHNSMITH, people.put(new Person("Anything", "Smith")));
+        assertSame(JOHNSMITH, people.put(new Person("Anything", "Smith")));
         Verify.assertSize(2, people);
 
         //Testing if the element doesn't exist, returns the element itself
         Person notInSet = new Person("Not", "inSet");
-        Assert.assertSame(notInSet, people.put(notInSet));
+        assertSame(notInSet, people.put(notInSet));
         Verify.assertSize(3, people);
 
         //Testing putting a null to force a rehash
-        Assert.assertNull(people.put(null));
+        assertNull(people.put(null));
         Verify.assertSize(4, people);
 
         //Testing put throws NullPointerException if the hashingStrategy is not null safe
-        Assert.assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).put(null));
+        assertThrows(NullPointerException.class, () -> UnifiedSetWithHashingStrategy.newSet(LAST_NAME_HASHING_STRATEGY).put(null));
     }
 
     @Test
@@ -618,29 +626,29 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 hashingStrategy, 2).with(COLLISION_1, COLLISION_1 + 1000, COLLISION_1 + 2000, null);
 
         //Testing remove null from the end of the chain
-        Assert.assertTrue(integers.remove(null));
+        assertTrue(integers.remove(null));
 
         //Adding null back and creating a deep chain.
         integers.with(null, COLLISION_1 + 3000, COLLISION_1 + 4000, COLLISION_1 + 5000);
 
         //Removing null from the first position of a bucket in the deep chain
-        Assert.assertTrue(integers.remove(null));
-        Assert.assertFalse(integers.remove(null));
+        assertTrue(integers.remove(null));
+        assertFalse(integers.remove(null));
 
         //Removing from the end of the deep chain
-        Assert.assertTrue(integers.remove(COLLISION_1 + 4000));
+        assertTrue(integers.remove(COLLISION_1 + 4000));
 
         //Removing from the first spot of the chain
-        Assert.assertTrue(integers.remove(COLLISION_1));
+        assertTrue(integers.remove(COLLISION_1));
         Verify.assertSize(4, integers);
 
         //Testing removing a non-existent element from a non bucket slot
         integers.add(2);
         integers.add(4);
-        Assert.assertFalse(integers.remove(1002));
+        assertFalse(integers.remove(1002));
 
         //Testing removeIf
-        Assert.assertTrue(integers.removeIf(IntegerPredicates.isEven()));
+        assertTrue(integers.removeIf(IntegerPredicates.isEven()));
         Verify.assertEmpty(integers);
     }
 
@@ -651,41 +659,41 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 INTEGER_HASHING_STRATEGY, 8).withAll(COLLISIONS);
         COLLISIONS.reverseForEach(each ->
         {
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertSame(each, unifiedSet.removeFromPool(each));
-            Assert.assertNull(unifiedSet.removeFromPool(each));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertNull(unifiedSet.removeFromPool(COLLISION_10));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertSame(each, unifiedSet.removeFromPool(each));
+            assertNull(unifiedSet.removeFromPool(each));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.removeFromPool(COLLISION_10));
         });
 
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY), unifiedSet);
+        assertEquals(UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY), unifiedSet);
 
         COLLISIONS.forEach(Procedures.cast(each ->
         {
             Pool<Integer> unifiedSet2 = UnifiedSetWithHashingStrategy.newSet(
                     INTEGER_HASHING_STRATEGY, 8).withAll(COLLISIONS);
 
-            Assert.assertNull(unifiedSet2.removeFromPool(null));
-            Assert.assertSame(each, unifiedSet2.removeFromPool(each));
-            Assert.assertNull(unifiedSet2.removeFromPool(each));
-            Assert.assertNull(unifiedSet2.removeFromPool(null));
-            Assert.assertNull(unifiedSet2.removeFromPool(COLLISION_10));
+            assertNull(unifiedSet2.removeFromPool(null));
+            assertSame(each, unifiedSet2.removeFromPool(each));
+            assertNull(unifiedSet2.removeFromPool(each));
+            assertNull(unifiedSet2.removeFromPool(null));
+            assertNull(unifiedSet2.removeFromPool(COLLISION_10));
         }));
 
         // search a chain for a non-existent element
         Pool<Integer> chain = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        Assert.assertNull(chain.removeFromPool(COLLISION_5));
+        assertNull(chain.removeFromPool(COLLISION_5));
 
         // search a deep chain for a non-existent element
         Pool<Integer> deepChain = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6, COLLISION_7);
-        Assert.assertNull(deepChain.removeFromPool(COLLISION_8));
+        assertNull(deepChain.removeFromPool(COLLISION_8));
 
         // search for a non-existent element
         Pool<Integer> empty = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1);
-        Assert.assertNull(empty.removeFromPool(COLLISION_2));
+        assertNull(empty.removeFromPool(COLLISION_2));
     }
 
     @Test
@@ -708,27 +716,27 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 hashingStrategy, 2).with(COLLISION_1, COLLISION_1 + 1000, COLLISION_1 + 2000, null);
 
         //Testing remove null from the end of the chain
-        Assert.assertNull(integers.removeFromPool(null));
+        assertNull(integers.removeFromPool(null));
 
         Integer collision4000 = COLLISION_1 + 4000;
         //Adding null back and creating a deep chain.
         integers.with(null, COLLISION_1 + 3000, collision4000, COLLISION_1 + 5000);
 
         //Removing null from the first position of a bucket in the deep chain
-        Assert.assertNull(integers.removeFromPool(null));
+        assertNull(integers.removeFromPool(null));
         Verify.assertSize(6, integers);
-        Assert.assertNull(integers.removeFromPool(null));
+        assertNull(integers.removeFromPool(null));
         Verify.assertSize(6, integers);
 
         //Removing from the end of the deep chain
-        Assert.assertSame(collision4000, integers.removeFromPool(COLLISION_1 + 4000));
+        assertSame(collision4000, integers.removeFromPool(COLLISION_1 + 4000));
 
         //Removing from the first spot of the chain
-        Assert.assertSame(COLLISION_1, integers.removeFromPool(COLLISION_1));
+        assertSame(COLLISION_1, integers.removeFromPool(COLLISION_1));
         Verify.assertSize(4, integers);
 
         //Testing removing an element that is not in a chained bucket
-        Assert.assertSame(JOHNSMITH, UnifiedSetWithHashingStrategy.newSetWith(LAST_NAME_HASHING_STRATEGY, JOHNSMITH).removeFromPool(JOHNSMITH));
+        assertSame(JOHNSMITH, UnifiedSetWithHashingStrategy.newSetWith(LAST_NAME_HASHING_STRATEGY, JOHNSMITH).removeFromPool(JOHNSMITH));
     }
 
     @Test
@@ -765,25 +773,25 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 INTEGER_HASHING_STRATEGY, 8).withAll(MORE_COLLISIONS);
         MORE_COLLISIONS.clone().reverseForEach(each ->
         {
-            Assert.assertTrue(unifiedSet.add(null));
-            Assert.assertFalse(unifiedSet.add(null));
+            assertTrue(unifiedSet.add(null));
+            assertFalse(unifiedSet.add(null));
             Verify.assertContains(null, unifiedSet);
             Verify.assertPostSerializedEqualsAndHashCode(unifiedSet);
 
-            Assert.assertTrue(unifiedSet.remove(null));
-            Assert.assertFalse(unifiedSet.remove(null));
+            assertTrue(unifiedSet.remove(null));
+            assertFalse(unifiedSet.remove(null));
             Verify.assertNotContains(null, unifiedSet);
 
             Verify.assertPostSerializedEqualsAndHashCode(unifiedSet);
 
-            Assert.assertNull(unifiedSet.put(null));
-            Assert.assertNull(unifiedSet.put(null));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
-            Assert.assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.put(null));
+            assertNull(unifiedSet.put(null));
+            assertNull(unifiedSet.removeFromPool(null));
+            assertNull(unifiedSet.removeFromPool(null));
 
             Verify.assertContains(each, unifiedSet);
-            Assert.assertTrue(unifiedSet.remove(each));
-            Assert.assertFalse(unifiedSet.remove(each));
+            assertTrue(unifiedSet.remove(each));
+            assertFalse(unifiedSet.remove(each));
             Verify.assertNotContains(each, unifiedSet);
         });
     }
@@ -797,7 +805,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         UnifiedSetWithHashingStrategy<Integer> singleCollisionBucket = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2);
         singleCollisionBucket.remove(COLLISION_2);
-        Assert.assertEquals(singleCollisionBucket, UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(singleCollisionBucket, UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1));
 
         Verify.assertEqualsAndHashCode(
@@ -828,11 +836,11 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
 
         //Checking that a hashing set is symmetrically equal to an identical JDK set
         Set<Person> hashSet = new HashSet<>(setA);
-        Assert.assertTrue(hashSet.equals(setA) && setA.equals(hashSet));
+        assertTrue(hashSet.equals(setA) && setA.equals(hashSet));
 
         //Checking that a hash set is symmetrically equal to an identical Eclipse Collections set
         UnifiedSet<Person> unifiedSet = UnifiedSet.newSet(setA);
-        Assert.assertTrue(unifiedSet.equals(setA) && setA.equals(unifiedSet));
+        assertTrue(unifiedSet.equals(setA) && setA.equals(unifiedSet));
 
         //Testing the asymmetry of equals
         HashingStrategy<String> firstLetterHashingStrategy = new HashingStrategy<String>()
@@ -854,13 +862,13 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         UnifiedSet<String> normalString = UnifiedSet.newSetWith("alpha", "bravo", "charlie");
 
         //Testing hashedString equals normalString
-        Assert.assertTrue(hashedString.equals(normalString) && hashedString.equals(hashedString));
+        assertTrue(hashedString.equals(normalString) && hashedString.equals(hashedString));
         //Testing normalString does not equal a hashedString, note cannot use Assert.notEquals because it assumes symmetric equals behavior
-        Assert.assertFalse(normalString.equals(hashedString) && hashedString.equals(normalString));
+        assertFalse(normalString.equals(hashedString) && hashedString.equals(normalString));
         //Testing 2 sets with same hashing strategies must obey object equals definition
         Verify.assertEqualsAndHashCode(hashedString, anotherHashedString);
         //Testing set size matters
-        Assert.assertNotEquals(hashedString, normalString.remove("alpha"));
+        assertNotEquals(hashedString, normalString.remove("alpha"));
     }
 
     @Test
@@ -906,7 +914,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             {
                 set.batchForEach(new SumProcedure<>(sum), sectionIndex, sectionCount);
             }
-            Assert.assertEquals(55, sum.getValue());
+            assertEquals(55, sum.getValue());
         }
 
         //Testing 1 batch with chains
@@ -918,8 +926,8 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         {
             set2.batchForEach(new SumProcedure<>(sum2), i, numBatches);
         }
-        Assert.assertEquals(1, numBatches);
-        Assert.assertEquals(54, sum2.getValue());
+        assertEquals(1, numBatches);
+        assertEquals(54, sum2.getValue());
 
         //Testing batch size of 3 with chains and uneven last batch
         Sum sum3 = new IntegerSum(0);
@@ -930,13 +938,13 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         {
             set3.batchForEach(new SumProcedure<>(sum3), i, numBatches2);
         }
-        Assert.assertEquals(32, sum3.getValue());
+        assertEquals(32, sum3.getValue());
 
         //Test batchForEach on empty set, it should simply do nothing and not throw any exceptions
         Sum sum4 = new IntegerSum(0);
         UnifiedSetWithHashingStrategy<Integer> set4 = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY);
         set4.batchForEach(new SumProcedure<>(sum4), 0, set4.getBatchCount(1));
-        Assert.assertEquals(0, sum4.getValue());
+        assertEquals(0, sum4.getValue());
     }
 
     @Override
@@ -951,24 +959,24 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             MutableSet<Integer> set = UnifiedSetWithHashingStrategy.newSet(
                     INTEGER_HASHING_STRATEGY, SIZE).withAll(COLLISIONS.subList(0, i));
             Object[] objects = set.toArray();
-            Assert.assertEquals(set, UnifiedSet.newSetWith(objects));
+            assertEquals(set, UnifiedSet.newSetWith(objects));
         }
 
         MutableSet<Integer> deepChain = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6}, deepChain.toArray());
+        assertArrayEquals(new Integer[]{COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6}, deepChain.toArray());
 
         MutableSet<Integer> minimumChain = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2);
         minimumChain.remove(COLLISION_2);
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1}, minimumChain.toArray());
+        assertArrayEquals(new Integer[]{COLLISION_1}, minimumChain.toArray());
 
         MutableSet<Integer> set = UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
         Integer[] target = {Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1), Integer.valueOf(1)};
         Integer[] actual = set.toArray(target);
         ArrayIterate.sort(actual, actual.length, Comparators.safeNullsHigh(Integer::compareTo));
-        Assert.assertArrayEquals(new Integer[]{COLLISION_1, 1, COLLISION_2, COLLISION_3, COLLISION_4, null}, actual);
+        assertArrayEquals(new Integer[]{COLLISION_1, 1, COLLISION_2, COLLISION_3, COLLISION_4, null}, actual);
     }
 
     @Test
@@ -981,14 +989,14 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             Iterator<Integer> iterator = actual.iterator();
             for (int j = 0; j <= i; j++)
             {
-                Assert.assertTrue(iterator.hasNext());
+                assertTrue(iterator.hasNext());
                 iterator.next();
             }
             iterator.remove();
 
             MutableSet<Integer> expected = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, MORE_COLLISIONS);
             expected.remove(MORE_COLLISIONS.get(i));
-            Assert.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         // remove the last element from within a 2-level long chain that is fully populated
@@ -1000,7 +1008,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             iterator1.next();
         }
         iterator1.remove();
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5, COLLISION_6), set);
 
         // remove the second-to-last element from a 2-level long chain that that has one empty slot
@@ -1010,7 +1018,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             iterator2.next();
         }
         iterator2.remove();
-        Assert.assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
+        assertEquals(UnifiedSetWithHashingStrategy.newSetWith(
                 INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5), set);
 
         //Testing removing the last element in a fully populated chained bucket
@@ -1036,30 +1044,30 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
                 HashingStrategies.<Key>defaultStrategy()).with(key, duplicateKey1);
         Verify.assertSize(1, set1);
         Verify.assertContains(key, set1);
-        Assert.assertSame(key, set1.getFirst());
+        assertSame(key, set1.getFirst());
 
         Key duplicateKey2 = new Key("key");
         MutableSet<Key> set2 = UnifiedSetWithHashingStrategy.newSet(
                 HashingStrategies.<Key>defaultStrategy()).with(key, duplicateKey1, duplicateKey2);
         Verify.assertSize(1, set2);
         Verify.assertContains(key, set2);
-        Assert.assertSame(key, set2.getFirst());
+        assertSame(key, set2.getFirst());
 
         Key duplicateKey3 = new Key("key");
         MutableSet<Key> set3 = UnifiedSetWithHashingStrategy.newSet(
                 HashingStrategies.<Key>defaultStrategy()).with(key, new Key("not a dupe"), duplicateKey3);
         Verify.assertSize(2, set3);
         Verify.assertContainsAll(set3, key, new Key("not a dupe"));
-        Assert.assertSame(key, set3.detect(key::equals));
+        assertSame(key, set3.detect(key::equals));
     }
 
     @Test
     public void withSameIfNotModified()
     {
         UnifiedSetWithHashingStrategy<Integer> integers = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2), integers.with(1, 2));
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), integers.with(2, 3, 4));
-        Assert.assertSame(integers, integers.with(5, 6, 7));
+        assertEquals(UnifiedSet.newSetWith(1, 2), integers.with(1, 2));
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4), integers.with(2, 3, 4));
+        assertSame(integers, integers.with(5, 6, 7));
     }
 
     @Override
@@ -1069,8 +1077,8 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         super.retainAll();
 
         MutableSet<Object> setWithNull = this.newWith((Object) null);
-        Assert.assertFalse(setWithNull.retainAll(FastList.newListWith((Object) null)));
-        Assert.assertEquals(UnifiedSet.newSetWith((Object) null), setWithNull);
+        assertFalse(setWithNull.retainAll(FastList.newListWith((Object) null)));
+        assertEquals(UnifiedSet.newSetWith((Object) null), setWithNull);
     }
 
     @Override
@@ -1082,7 +1090,7 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         for (int i = 1; i <= size - 1; i++)
         {
             MutableSet<Integer> unifiedSet = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, 1).withAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertSame(MORE_COLLISIONS.get(0), unifiedSet.getFirst());
+            assertSame(MORE_COLLISIONS.get(0), unifiedSet.getFirst());
         }
     }
 
@@ -1095,12 +1103,12 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         for (int i = 1; i <= size - 1; i++)
         {
             MutableSet<Integer> unifiedSet = UnifiedSetWithHashingStrategy.newSet(INTEGER_HASHING_STRATEGY, 1).withAll(MORE_COLLISIONS.subList(0, i));
-            Assert.assertSame(MORE_COLLISIONS.get(i - 1), unifiedSet.getLast());
+            assertSame(MORE_COLLISIONS.get(i - 1), unifiedSet.getLast());
         }
 
         MutableSet<Integer> chainedWithOneSlot = UnifiedSetWithHashingStrategy.newSetWith(INTEGER_HASHING_STRATEGY, COLLISION_1, COLLISION_2);
         chainedWithOneSlot.remove(COLLISION_2);
-        Assert.assertSame(COLLISION_1, chainedWithOneSlot.getLast());
+        assertSame(COLLISION_1, chainedWithOneSlot.getLast());
     }
 
     @Test
@@ -1122,8 +1130,8 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
             expected.add(each);
         });
 
-        Assert.assertEquals(expected, set);
-        Assert.assertEquals(261, set.size());
+        assertEquals(expected, set);
+        assertEquals(261, set.size());
 
         MutableList<Integer> toRemove = Lists.mutable.withAll(Interval.evensFromTo(0, 20));
 
@@ -1135,9 +1143,9 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         });
 
         // First assertion to verify that trim does not happen since, the table is already at the smallest required power of 2.
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(239, set.size());
-        Assert.assertEquals(expected, set);
+        assertFalse(set.trimToSize());
+        assertEquals(239, set.size());
+        assertEquals(expected, set);
 
         Interval.evensFromTo(0, 250).each(each ->
         {
@@ -1146,38 +1154,38 @@ public class UnifiedSetWithHashingStrategyTest extends AbstractUnifiedSetTestCas
         });
 
         // Second assertion to verify that trim happens since, the table length is less than smallest required power of 2.
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(expected, set);
-        Assert.assertEquals(124, set.size());
-        expected.each(each -> Assert.assertEquals(each, set.get(each)));
+        assertTrue(set.trimToSize());
+        assertFalse(set.trimToSize());
+        assertEquals(expected, set);
+        assertEquals(124, set.size());
+        expected.each(each -> assertEquals(each, set.get(each)));
 
         integers.each(each ->
         {
             set.remove(each.toString());
             expected.remove(each.toString());
         });
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertFalse(set.trimToSize());
-        Assert.assertEquals(expected, set);
-        expected.each(each -> Assert.assertEquals(each, set.get(each)));
+        assertTrue(set.trimToSize());
+        assertFalse(set.trimToSize());
+        assertEquals(expected, set);
+        expected.each(each -> assertEquals(each, set.get(each)));
 
         set.clear();
-        Assert.assertTrue(set.trimToSize());
+        assertTrue(set.trimToSize());
         Interval.oneTo(4).each(each -> set.add(each.toString()));
         // Assert that trim does not happen after puts
-        Assert.assertFalse(set.trimToSize());
+        assertFalse(set.trimToSize());
         set.remove("1");
         set.remove("2");
-        Assert.assertTrue(set.trimToSize());
+        assertTrue(set.trimToSize());
 
         set.add("1");
         // Assert that the resized table due to put is the required size and no need to trim that.
-        Assert.assertFalse(set.trimToSize());
+        assertFalse(set.trimToSize());
 
         Interval.zeroTo(4).each(each -> set.add(each.toString()));
         Interval.oneTo(3).each(each -> set.remove(each.toString()));
-        Assert.assertTrue(set.trimToSize());
-        Assert.assertEquals(2, set.size());
+        assertTrue(set.trimToSize());
+        assertEquals(2, set.size());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnmodifiableMutableSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnmodifiableMutableSetTest.java
@@ -23,9 +23,14 @@ import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCas
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableSet}.
@@ -127,7 +132,7 @@ public class UnmodifiableMutableSetTest extends AbstractCollectionTestCase
     {
         MutableCollection<Object> collection = this.newWith(1, 2);
         String string = collection.toString();
-        Assert.assertTrue("[1, 2]".equals(string) || "[2, 1]".equals(string));
+        assertTrue("[1, 2]".equals(string) || "[2, 1]".equals(string));
     }
 
     @Override
@@ -135,7 +140,7 @@ public class UnmodifiableMutableSetTest extends AbstractCollectionTestCase
     public void makeString()
     {
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Override
@@ -145,23 +150,23 @@ public class UnmodifiableMutableSetTest extends AbstractCollectionTestCase
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
     @Test
     public void getFirst()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
     @Test
     public void getLast()
     {
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
@@ -199,7 +204,7 @@ public class UnmodifiableMutableSetTest extends AbstractCollectionTestCase
     {
         MutableSet<String> set = this.newWith();
         MutableSet<String> clone = set.clone();
-        Assert.assertSame(clone, set);
+        assertSame(clone, set);
     }
 
     @Test(expected = NoSuchElementException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractBooleanSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractBooleanSetTestCase.java
@@ -30,9 +30,15 @@ import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanCollectionTestCase
 {
@@ -74,7 +80,7 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         MutableBooleanSet set = this.classUnderTest();
         Verify.assertSize(2, set);
-        Assert.assertTrue(set.containsAll(true, false, true));
+        assertTrue(set.containsAll(true, false, true));
     }
 
     @Override
@@ -93,10 +99,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertFalse(this.emptySet.notEmpty());
-        Assert.assertTrue(this.setWithFalse.notEmpty());
-        Assert.assertTrue(this.setWithTrue.notEmpty());
-        Assert.assertTrue(this.setWithTrueFalse.notEmpty());
+        assertFalse(this.emptySet.notEmpty());
+        assertTrue(this.setWithFalse.notEmpty());
+        assertTrue(this.setWithTrue.notEmpty());
+        assertTrue(this.setWithTrueFalse.notEmpty());
     }
 
     @Override
@@ -112,10 +118,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         Verify.assertEmpty(this.setWithFalse);
         Verify.assertEmpty(this.setWithTrue);
         Verify.assertEmpty(this.setWithTrueFalse);
-        Assert.assertFalse(this.setWithFalse.contains(false));
-        Assert.assertFalse(this.setWithTrue.contains(true));
-        Assert.assertFalse(this.setWithTrueFalse.contains(true));
-        Assert.assertFalse(this.setWithTrueFalse.contains(false));
+        assertFalse(this.setWithFalse.contains(false));
+        assertFalse(this.setWithTrue.contains(true));
+        assertFalse(this.setWithTrueFalse.contains(true));
+        assertFalse(this.setWithTrueFalse.contains(false));
     }
 
     @Override
@@ -123,14 +129,14 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void contains()
     {
         super.contains();
-        Assert.assertFalse(this.emptySet.contains(true));
-        Assert.assertFalse(this.emptySet.contains(false));
-        Assert.assertTrue(this.setWithFalse.contains(false));
-        Assert.assertFalse(this.setWithFalse.contains(true));
-        Assert.assertTrue(this.setWithTrue.contains(true));
-        Assert.assertFalse(this.setWithTrue.contains(false));
-        Assert.assertTrue(this.setWithTrueFalse.contains(true));
-        Assert.assertTrue(this.setWithTrueFalse.contains(false));
+        assertFalse(this.emptySet.contains(true));
+        assertFalse(this.emptySet.contains(false));
+        assertTrue(this.setWithFalse.contains(false));
+        assertFalse(this.setWithFalse.contains(true));
+        assertTrue(this.setWithTrue.contains(true));
+        assertFalse(this.setWithTrue.contains(false));
+        assertTrue(this.setWithTrueFalse.contains(true));
+        assertTrue(this.setWithTrueFalse.contains(false));
     }
 
     @Override
@@ -138,17 +144,17 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void containsAllArray()
     {
         super.containsAllArray();
-        Assert.assertFalse(this.emptySet.containsAll(true));
-        Assert.assertFalse(this.emptySet.containsAll(true, false));
-        Assert.assertTrue(this.setWithFalse.containsAll(false, false));
-        Assert.assertFalse(this.setWithFalse.containsAll(true, true));
-        Assert.assertFalse(this.setWithFalse.containsAll(true, false, true));
-        Assert.assertTrue(this.setWithTrue.containsAll(true, true));
-        Assert.assertFalse(this.setWithTrue.containsAll(false, false));
-        Assert.assertFalse(this.setWithTrue.containsAll(true, false, false));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(true, true));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(false, false));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(false, true, true));
+        assertFalse(this.emptySet.containsAll(true));
+        assertFalse(this.emptySet.containsAll(true, false));
+        assertTrue(this.setWithFalse.containsAll(false, false));
+        assertFalse(this.setWithFalse.containsAll(true, true));
+        assertFalse(this.setWithFalse.containsAll(true, false, true));
+        assertTrue(this.setWithTrue.containsAll(true, true));
+        assertFalse(this.setWithTrue.containsAll(false, false));
+        assertFalse(this.setWithTrue.containsAll(true, false, false));
+        assertTrue(this.setWithTrueFalse.containsAll(true, true));
+        assertTrue(this.setWithTrueFalse.containsAll(false, false));
+        assertTrue(this.setWithTrueFalse.containsAll(false, true, true));
     }
 
     @Override
@@ -156,89 +162,89 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void containsAllIterable()
     {
         super.containsAllIterable();
-        Assert.assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.setWithFalse.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.setWithFalse.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.setWithFalse.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertTrue(this.setWithTrue.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.setWithTrue.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.setWithTrue.containsAll(BooleanArrayList.newListWith(true, false, false)));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(false, true, true)));
+        assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.setWithFalse.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.setWithFalse.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.setWithFalse.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertTrue(this.setWithTrue.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.setWithTrue.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.setWithTrue.containsAll(BooleanArrayList.newListWith(true, false, false)));
+        assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.setWithTrueFalse.containsAll(BooleanArrayList.newListWith(false, true, true)));
     }
 
     @Override
     @Test
     public void add()
     {
-        Assert.assertTrue(this.emptySet.add(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.emptySet);
+        assertTrue(this.emptySet.add(true));
+        assertEquals(BooleanHashSet.newSetWith(true), this.emptySet);
         MutableBooleanSet set = this.newWith();
-        Assert.assertTrue(set.add(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), set);
-        Assert.assertFalse(this.setWithFalse.add(false));
-        Assert.assertTrue(this.setWithFalse.add(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
-        Assert.assertFalse(this.setWithTrue.add(true));
-        Assert.assertTrue(this.setWithTrue.add(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
-        Assert.assertFalse(this.setWithTrueFalse.add(true));
-        Assert.assertFalse(this.setWithTrueFalse.add(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
+        assertTrue(set.add(false));
+        assertEquals(BooleanHashSet.newSetWith(false), set);
+        assertFalse(this.setWithFalse.add(false));
+        assertTrue(this.setWithFalse.add(true));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
+        assertFalse(this.setWithTrue.add(true));
+        assertTrue(this.setWithTrue.add(false));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
+        assertFalse(this.setWithTrueFalse.add(true));
+        assertFalse(this.setWithTrueFalse.add(false));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
     }
 
     @Override
     @Test
     public void addAllArray()
     {
-        Assert.assertTrue(this.emptySet.addAll(true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.emptySet);
-        Assert.assertFalse(this.setWithFalse.addAll(false, false));
-        Assert.assertTrue(this.setWithFalse.addAll(true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
-        Assert.assertFalse(this.setWithTrue.addAll(true, true));
-        Assert.assertTrue(this.setWithTrue.addAll(true, false, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
-        Assert.assertFalse(this.setWithTrueFalse.addAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
+        assertTrue(this.emptySet.addAll(true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.emptySet);
+        assertFalse(this.setWithFalse.addAll(false, false));
+        assertTrue(this.setWithFalse.addAll(true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
+        assertFalse(this.setWithTrue.addAll(true, true));
+        assertTrue(this.setWithTrue.addAll(true, false, true));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
+        assertFalse(this.setWithTrueFalse.addAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
     }
 
     @Override
     @Test
     public void addAllIterable()
     {
-        Assert.assertTrue(this.emptySet.addAll(BooleanHashSet.newSetWith(true, false, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.emptySet);
-        Assert.assertFalse(this.setWithFalse.addAll(BooleanHashSet.newSetWith(false, false)));
-        Assert.assertTrue(this.setWithFalse.addAll(BooleanHashSet.newSetWith(true, false, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
-        Assert.assertFalse(this.setWithTrue.addAll(BooleanHashSet.newSetWith(true, true)));
-        Assert.assertTrue(this.setWithTrue.addAll(BooleanHashSet.newSetWith(true, false, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
-        Assert.assertFalse(this.setWithTrueFalse.addAll(BooleanHashSet.newSetWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
+        assertTrue(this.emptySet.addAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.emptySet);
+        assertFalse(this.setWithFalse.addAll(BooleanHashSet.newSetWith(false, false)));
+        assertTrue(this.setWithFalse.addAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithFalse);
+        assertFalse(this.setWithTrue.addAll(BooleanHashSet.newSetWith(true, true)));
+        assertTrue(this.setWithTrue.addAll(BooleanHashSet.newSetWith(true, false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrue);
+        assertFalse(this.setWithTrueFalse.addAll(BooleanHashSet.newSetWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse);
     }
 
     @Override
     @Test
     public void remove()
     {
-        Assert.assertTrue(this.setWithTrueFalse.remove(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
+        assertTrue(this.setWithTrueFalse.remove(true));
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
         MutableBooleanSet set = this.newWith(true, false);
-        Assert.assertTrue(set.remove(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), set);
-        Assert.assertFalse(this.setWithTrue.remove(false));
-        Assert.assertTrue(this.setWithTrue.remove(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
-        Assert.assertFalse(this.setWithFalse.remove(true));
-        Assert.assertTrue(this.setWithFalse.remove(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
-        Assert.assertFalse(this.emptySet.remove(true));
-        Assert.assertFalse(this.emptySet.remove(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
+        assertTrue(set.remove(false));
+        assertEquals(BooleanHashSet.newSetWith(true), set);
+        assertFalse(this.setWithTrue.remove(false));
+        assertTrue(this.setWithTrue.remove(true));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
+        assertFalse(this.setWithFalse.remove(true));
+        assertTrue(this.setWithFalse.remove(false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
+        assertFalse(this.emptySet.remove(true));
+        assertFalse(this.emptySet.remove(false));
+        assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
     }
 
     @Override
@@ -246,38 +252,38 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void removeAll()
     {
         super.removeAll();
-        Assert.assertFalse(this.emptySet.removeAll());
-        Assert.assertFalse(this.setWithFalse.removeAll());
-        Assert.assertFalse(this.setWithTrue.removeAll());
-        Assert.assertFalse(this.setWithTrueFalse.removeAll());
+        assertFalse(this.emptySet.removeAll());
+        assertFalse(this.setWithFalse.removeAll());
+        assertFalse(this.setWithTrue.removeAll());
+        assertFalse(this.setWithTrueFalse.removeAll());
 
-        Assert.assertTrue(this.setWithTrueFalse.removeAll(true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
+        assertTrue(this.setWithTrueFalse.removeAll(true, true));
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
         MutableBooleanSet set = this.newWith(true, false);
-        Assert.assertTrue(set.removeAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), set);
+        assertTrue(set.removeAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(), set);
         MutableBooleanSet sett = this.newWith(true, false);
-        Assert.assertTrue(sett.removeAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), sett);
+        assertTrue(sett.removeAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(true), sett);
 
-        Assert.assertFalse(this.setWithTrue.removeAll(false, false));
+        assertFalse(this.setWithTrue.removeAll(false, false));
         MutableBooleanSet sett2 = this.newWith(true);
-        Assert.assertTrue(sett2.removeAll(true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett2);
-        Assert.assertTrue(this.setWithTrue.removeAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
+        assertTrue(sett2.removeAll(true, true));
+        assertEquals(BooleanHashSet.newSetWith(), sett2);
+        assertTrue(this.setWithTrue.removeAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
 
-        Assert.assertFalse(this.setWithFalse.removeAll(true, true));
+        assertFalse(this.setWithFalse.removeAll(true, true));
         MutableBooleanSet sett3 = this.newWith(false);
-        Assert.assertTrue(sett3.removeAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett3);
-        Assert.assertTrue(this.setWithFalse.removeAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
+        assertTrue(sett3.removeAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(), sett3);
+        assertTrue(this.setWithFalse.removeAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
 
-        Assert.assertFalse(this.emptySet.removeAll(true, true));
-        Assert.assertFalse(this.emptySet.removeAll(true, false));
-        Assert.assertFalse(this.emptySet.removeAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
+        assertFalse(this.emptySet.removeAll(true, true));
+        assertFalse(this.emptySet.removeAll(true, false));
+        assertFalse(this.emptySet.removeAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
     }
 
     @Override
@@ -285,38 +291,38 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void removeAll_iterable()
     {
         super.removeAll_iterable();
-        Assert.assertFalse(this.emptySet.removeAll(new BooleanArrayList()));
-        Assert.assertFalse(this.setWithFalse.removeAll(new BooleanArrayList()));
-        Assert.assertFalse(this.setWithTrue.removeAll(new BooleanArrayList()));
-        Assert.assertFalse(this.setWithTrueFalse.removeAll(new BooleanArrayList()));
+        assertFalse(this.emptySet.removeAll(new BooleanArrayList()));
+        assertFalse(this.setWithFalse.removeAll(new BooleanArrayList()));
+        assertFalse(this.setWithTrue.removeAll(new BooleanArrayList()));
+        assertFalse(this.setWithTrueFalse.removeAll(new BooleanArrayList()));
 
-        Assert.assertTrue(this.setWithTrueFalse.removeAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
+        assertTrue(this.setWithTrueFalse.removeAll(BooleanArrayList.newListWith(true, true)));
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithTrueFalse);
         MutableBooleanSet set = this.newWith(true, false);
-        Assert.assertTrue(set.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), set);
+        assertTrue(set.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), set);
         MutableBooleanSet sett = this.newWith(true, false);
-        Assert.assertTrue(sett.removeAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), sett);
+        assertTrue(sett.removeAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(true), sett);
 
-        Assert.assertFalse(this.setWithTrue.removeAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.setWithTrue.removeAll(BooleanArrayList.newListWith(false, false)));
         MutableBooleanSet sett2 = this.newWith(true);
-        Assert.assertTrue(sett2.removeAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett2);
-        Assert.assertTrue(this.setWithTrue.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
+        assertTrue(sett2.removeAll(BooleanArrayList.newListWith(true, true)));
+        assertEquals(BooleanHashSet.newSetWith(), sett2);
+        assertTrue(this.setWithTrue.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
 
-        Assert.assertFalse(this.setWithFalse.removeAll(true, true));
+        assertFalse(this.setWithFalse.removeAll(true, true));
         MutableBooleanSet sett3 = this.newWith(false);
-        Assert.assertTrue(sett3.removeAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett3);
-        Assert.assertTrue(this.setWithFalse.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
+        assertTrue(sett3.removeAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(), sett3);
+        assertTrue(this.setWithFalse.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
 
-        Assert.assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
+        assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.emptySet.removeAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
     }
 
     @Override
@@ -324,34 +330,34 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void retainAll()
     {
         super.retainAll();
-        Assert.assertFalse(this.emptySet.retainAll());
-        Assert.assertTrue(this.setWithTrueFalse.retainAll(true, true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse);
+        assertFalse(this.emptySet.retainAll());
+        assertTrue(this.setWithTrueFalse.retainAll(true, true));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse);
         MutableBooleanSet set = this.newWith(true, false);
-        Assert.assertTrue(set.retainAll());
-        Assert.assertEquals(BooleanHashSet.newSetWith(), set);
+        assertTrue(set.retainAll());
+        assertEquals(BooleanHashSet.newSetWith(), set);
         MutableBooleanSet sett = this.newWith(true, false);
-        Assert.assertTrue(sett.retainAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), sett);
+        assertTrue(sett.retainAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(false), sett);
 
         MutableBooleanSet sett2 = this.newWith(true);
-        Assert.assertTrue(sett2.retainAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett2);
-        Assert.assertTrue(this.setWithTrue.retainAll(false, false));
-        Assert.assertFalse(this.setWithTrue.retainAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
+        assertTrue(sett2.retainAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(), sett2);
+        assertTrue(this.setWithTrue.retainAll(false, false));
+        assertFalse(this.setWithTrue.retainAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
 
         MutableBooleanSet sett3 = this.newWith(false);
-        Assert.assertFalse(sett3.retainAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), sett3);
-        Assert.assertTrue(this.setWithFalse.retainAll(true, true));
-        Assert.assertFalse(this.setWithFalse.retainAll(true, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
+        assertFalse(sett3.retainAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(false), sett3);
+        assertTrue(this.setWithFalse.retainAll(true, true));
+        assertFalse(this.setWithFalse.retainAll(true, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
 
-        Assert.assertFalse(this.emptySet.retainAll(true, true));
-        Assert.assertFalse(this.emptySet.retainAll(true, false));
-        Assert.assertFalse(this.emptySet.retainAll(false, false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
+        assertFalse(this.emptySet.retainAll(true, true));
+        assertFalse(this.emptySet.retainAll(true, false));
+        assertFalse(this.emptySet.retainAll(false, false));
+        assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
     }
 
     @Override
@@ -359,34 +365,34 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void retainAll_iterable()
     {
         super.retainAll_iterable();
-        Assert.assertFalse(this.emptySet.retainAll(new BooleanArrayList()));
-        Assert.assertTrue(this.setWithTrueFalse.retainAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse);
+        assertFalse(this.emptySet.retainAll(new BooleanArrayList()));
+        assertTrue(this.setWithTrueFalse.retainAll(BooleanArrayList.newListWith(true, true)));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse);
         MutableBooleanSet set = this.newWith(true, false);
-        Assert.assertTrue(set.retainAll(BooleanArrayList.newListWith()));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), set);
+        assertTrue(set.retainAll(BooleanArrayList.newListWith()));
+        assertEquals(BooleanHashSet.newSetWith(), set);
         MutableBooleanSet sett = this.newWith(true, false);
-        Assert.assertTrue(sett.retainAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), sett);
+        assertTrue(sett.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(false), sett);
 
         MutableBooleanSet sett2 = this.newWith(true);
-        Assert.assertTrue(sett2.retainAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), sett2);
-        Assert.assertTrue(this.setWithTrue.retainAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.setWithTrue.retainAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
+        assertTrue(sett2.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(), sett2);
+        assertTrue(this.setWithTrue.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.setWithTrue.retainAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue);
 
         MutableBooleanSet sett3 = this.newWith(false);
-        Assert.assertFalse(sett3.retainAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), sett3);
-        Assert.assertTrue(this.setWithFalse.retainAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.setWithFalse.retainAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
+        assertFalse(sett3.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(false), sett3);
+        assertTrue(this.setWithFalse.retainAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.setWithFalse.retainAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse);
 
-        Assert.assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
+        assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(this.emptySet.retainAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.emptySet);
     }
 
     @Override
@@ -399,12 +405,12 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set1 = this.newWith().with(true);
         MutableBooleanSet set2 = this.newWith().with(true).with(false);
         MutableBooleanSet set3 = this.newWith().with(false).with(true);
-        Assert.assertSame(emptySet, set);
-        Assert.assertEquals(this.setWithFalse, set);
-        Assert.assertEquals(this.setWithTrue, set1);
-        Assert.assertEquals(this.setWithTrueFalse, set2);
-        Assert.assertEquals(this.setWithTrueFalse, set3);
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse.with(true));
+        assertSame(emptySet, set);
+        assertEquals(this.setWithFalse, set);
+        assertEquals(this.setWithTrue, set1);
+        assertEquals(this.setWithTrueFalse, set2);
+        assertEquals(this.setWithTrueFalse, set3);
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse.with(true));
     }
 
     @Override
@@ -417,28 +423,28 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set1 = this.newWith().withAll(BooleanArrayList.newListWith(true));
         MutableBooleanSet set2 = this.newWith().withAll(BooleanArrayList.newListWith(true, false));
         MutableBooleanSet set3 = this.newWith().withAll(BooleanArrayList.newListWith(true, false));
-        Assert.assertSame(emptySet, set);
-        Assert.assertEquals(this.setWithFalse, set);
-        Assert.assertEquals(this.setWithTrue, set1);
-        Assert.assertEquals(this.setWithTrueFalse, set2);
-        Assert.assertEquals(this.setWithTrueFalse, set3);
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse.withAll(BooleanHashSet.newSetWith(true, false)));
+        assertSame(emptySet, set);
+        assertEquals(this.setWithFalse, set);
+        assertEquals(this.setWithTrue, set1);
+        assertEquals(this.setWithTrueFalse, set2);
+        assertEquals(this.setWithTrueFalse, set3);
+        assertEquals(BooleanHashSet.newSetWith(true, false), this.setWithTrueFalse.withAll(BooleanHashSet.newSetWith(true, false)));
     }
 
     @Override
     @Test
     public void without()
     {
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse.without(false));
-        Assert.assertSame(this.setWithTrueFalse, this.setWithTrueFalse.without(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.newWith(true, false).without(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrueFalse.without(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.without(false));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue.without(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.without(true));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse.without(false));
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.without(true));
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.without(false));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse.without(false));
+        assertSame(this.setWithTrueFalse, this.setWithTrueFalse.without(false));
+        assertEquals(BooleanHashSet.newSetWith(false), this.newWith(true, false).without(true));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrueFalse.without(true));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.without(false));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue.without(true));
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.without(true));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse.without(false));
+        assertEquals(new BooleanHashSet(), this.emptySet.without(true));
+        assertEquals(new BooleanHashSet(), this.emptySet.without(false));
     }
 
     @Override
@@ -446,20 +452,20 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void withoutAll()
     {
         super.withoutAll();
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertSame(this.setWithTrueFalse, this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.newWith(true, false).withoutAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.newWith(true, false).withoutAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.withoutAll(BooleanArrayList.newListWith(false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue.withoutAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.newWith(true).withoutAll(BooleanArrayList.newListWith(false, true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.withoutAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse.withoutAll(BooleanArrayList.newListWith(false)));
-        Assert.assertEquals(BooleanHashSet.newSetWith(), this.newWith(false).withoutAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(true)));
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(false)));
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(false, true)));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(false, false)));
+        assertSame(this.setWithTrueFalse, this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(false, false)));
+        assertEquals(BooleanHashSet.newSetWith(false), this.newWith(true, false).withoutAll(BooleanArrayList.newListWith(true, true)));
+        assertEquals(BooleanHashSet.newSetWith(), this.newWith(true, false).withoutAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrueFalse.withoutAll(BooleanArrayList.newListWith(true)));
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.withoutAll(BooleanArrayList.newListWith(false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithTrue.withoutAll(BooleanArrayList.newListWith(true)));
+        assertEquals(BooleanHashSet.newSetWith(), this.newWith(true).withoutAll(BooleanArrayList.newListWith(false, true)));
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.withoutAll(BooleanArrayList.newListWith(true)));
+        assertEquals(BooleanHashSet.newSetWith(), this.setWithFalse.withoutAll(BooleanArrayList.newListWith(false)));
+        assertEquals(BooleanHashSet.newSetWith(), this.newWith(false).withoutAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(true)));
+        assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(false)));
+        assertEquals(new BooleanHashSet(), this.emptySet.withoutAll(BooleanArrayList.newListWith(false, true)));
     }
 
     @Override
@@ -467,16 +473,16 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void toArray()
     {
         super.toArray();
-        Assert.assertEquals(0L, this.emptySet.toArray().length);
+        assertEquals(0L, this.emptySet.toArray().length);
 
-        Assert.assertEquals(1L, this.setWithFalse.toArray().length);
-        Assert.assertFalse(this.setWithFalse.toArray()[0]);
+        assertEquals(1L, this.setWithFalse.toArray().length);
+        assertFalse(this.setWithFalse.toArray()[0]);
 
-        Assert.assertEquals(1L, this.setWithTrue.toArray().length);
-        Assert.assertTrue(this.setWithTrue.toArray()[0]);
+        assertEquals(1L, this.setWithTrue.toArray().length);
+        assertTrue(this.setWithTrue.toArray()[0]);
 
-        Assert.assertEquals(2L, this.setWithTrueFalse.toArray().length);
-        Assert.assertTrue(Arrays.equals(new boolean[]{false, true}, this.setWithTrueFalse.toArray())
+        assertEquals(2L, this.setWithTrueFalse.toArray().length);
+        assertTrue(Arrays.equals(new boolean[]{false, true}, this.setWithTrueFalse.toArray())
                 || Arrays.equals(new boolean[]{true, false}, this.setWithTrueFalse.toArray()));
     }
 
@@ -485,10 +491,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(new BooleanArrayList(), this.emptySet.toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(false), this.setWithFalse.toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.setWithTrue.toList());
-        Assert.assertTrue(BooleanArrayList.newListWith(false, true).equals(this.setWithTrueFalse.toList())
+        assertEquals(new BooleanArrayList(), this.emptySet.toList());
+        assertEquals(BooleanArrayList.newListWith(false), this.setWithFalse.toList());
+        assertEquals(BooleanArrayList.newListWith(true), this.setWithTrue.toList());
+        assertTrue(BooleanArrayList.newListWith(false, true).equals(this.setWithTrueFalse.toList())
                 || BooleanArrayList.newListWith(true, false).equals(this.setWithTrueFalse.toList()));
     }
 
@@ -497,32 +503,32 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void toSet()
     {
         super.toSet();
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false, true), this.setWithTrueFalse.toSet());
+        assertEquals(new BooleanHashSet(), this.emptySet.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false), this.setWithFalse.toSet());
+        assertEquals(BooleanHashSet.newSetWith(true), this.setWithTrue.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false, true), this.setWithTrueFalse.toSet());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(new BooleanHashBag(), this.emptySet.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false), this.setWithFalse.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.setWithTrue.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true), this.setWithTrueFalse.toBag());
+        assertEquals(new BooleanHashBag(), this.emptySet.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false), this.setWithFalse.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.setWithTrue.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true), this.setWithTrueFalse.toBag());
     }
 
     @Override
     @Test
     public void testEquals()
     {
-        Assert.assertNotEquals(this.setWithFalse, this.emptySet);
-        Assert.assertNotEquals(this.setWithFalse, this.setWithTrue);
-        Assert.assertNotEquals(this.setWithFalse, this.setWithTrueFalse);
-        Assert.assertNotEquals(this.setWithTrue, this.emptySet);
-        Assert.assertNotEquals(this.setWithTrue, this.setWithTrueFalse);
-        Assert.assertNotEquals(this.setWithTrueFalse, this.emptySet);
+        assertNotEquals(this.setWithFalse, this.emptySet);
+        assertNotEquals(this.setWithFalse, this.setWithTrue);
+        assertNotEquals(this.setWithFalse, this.setWithTrueFalse);
+        assertNotEquals(this.setWithTrue, this.emptySet);
+        assertNotEquals(this.setWithTrue, this.setWithTrueFalse);
+        assertNotEquals(this.setWithTrueFalse, this.emptySet);
         Verify.assertEqualsAndHashCode(this.newWith(false, true), this.setWithTrueFalse);
         Verify.assertEqualsAndHashCode(this.newWith(true, false), this.setWithTrueFalse);
 
@@ -537,12 +543,12 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void testHashCode()
     {
         super.testHashCode();
-        Assert.assertEquals(UnifiedSet.newSet().hashCode(), this.emptySet.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(false).hashCode(), this.setWithFalse.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(true).hashCode(), this.setWithTrue.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(true, false).hashCode(), this.setWithTrueFalse.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(false, true).hashCode(), this.setWithTrueFalse.hashCode());
-        Assert.assertNotEquals(UnifiedSet.newSetWith(false).hashCode(), this.setWithTrueFalse.hashCode());
+        assertEquals(UnifiedSet.newSet().hashCode(), this.emptySet.hashCode());
+        assertEquals(UnifiedSet.newSetWith(false).hashCode(), this.setWithFalse.hashCode());
+        assertEquals(UnifiedSet.newSetWith(true).hashCode(), this.setWithTrue.hashCode());
+        assertEquals(UnifiedSet.newSetWith(true, false).hashCode(), this.setWithTrueFalse.hashCode());
+        assertEquals(UnifiedSet.newSetWith(false, true).hashCode(), this.setWithTrueFalse.hashCode());
+        assertNotEquals(UnifiedSet.newSetWith(false).hashCode(), this.setWithTrueFalse.hashCode());
     }
 
     @Override
@@ -550,30 +556,30 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void booleanIterator()
     {
         BooleanIterator booleanIterator0 = this.emptySet.booleanIterator();
-        Assert.assertFalse(booleanIterator0.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator0::next);
+        assertFalse(booleanIterator0.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator0::next);
 
         BooleanIterator booleanIterator1 = this.setWithFalse.booleanIterator();
-        Assert.assertTrue(booleanIterator1.hasNext());
-        Assert.assertFalse(booleanIterator1.next());
-        Assert.assertFalse(booleanIterator1.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator1::next);
+        assertTrue(booleanIterator1.hasNext());
+        assertFalse(booleanIterator1.next());
+        assertFalse(booleanIterator1.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator1::next);
 
         BooleanIterator booleanIterator2 = this.setWithTrue.booleanIterator();
-        Assert.assertTrue(booleanIterator2.hasNext());
-        Assert.assertTrue(booleanIterator2.next());
-        Assert.assertFalse(booleanIterator2.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator2::next);
+        assertTrue(booleanIterator2.hasNext());
+        assertTrue(booleanIterator2.next());
+        assertFalse(booleanIterator2.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator2::next);
 
         BooleanIterator booleanIterator3 = this.setWithTrueFalse.booleanIterator();
         MutableBooleanSet actual = new BooleanHashSet();
-        Assert.assertTrue(booleanIterator3.hasNext());
+        assertTrue(booleanIterator3.hasNext());
         actual.add(booleanIterator3.next());
-        Assert.assertTrue(booleanIterator3.hasNext());
+        assertTrue(booleanIterator3.hasNext());
         actual.add(booleanIterator3.next());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), actual);
-        Assert.assertFalse(booleanIterator3.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator3::next);
+        assertEquals(BooleanHashSet.newSetWith(true, false), actual);
+        assertFalse(booleanIterator3.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator3::next);
     }
 
     @Override
@@ -590,10 +596,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         this.setWithTrue.forEach(each -> sum[2] += each);
         this.setWithTrueFalse.forEach(each -> sum[3] += each);
 
-        Assert.assertEquals("", sum[0]);
-        Assert.assertEquals("false", sum[1]);
-        Assert.assertEquals("true", sum[2]);
-        Assert.assertTrue("truefalse".equals(sum[3]) || "falsetrue".equals(sum[3]));
+        assertEquals("", sum[0]);
+        assertEquals("false", sum[1]);
+        assertEquals("true", sum[2]);
+        assertTrue("truefalse".equals(sum[3]) || "falsetrue".equals(sum[3]));
     }
 
     @Override
@@ -601,10 +607,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void injectInto()
     {
         ObjectBooleanToObjectFunction<MutableInteger, MutableInteger> function = (object, value) -> object.add(value ? 1 : 0);
-        Assert.assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true, false, true).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(0), BooleanHashSet.newSetWith(false).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(0), new BooleanHashSet().injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true, false, true).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(0), BooleanHashSet.newSetWith(false).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(0), new BooleanHashSet().injectInto(new MutableInteger(0), function));
     }
 
     @Override
@@ -619,15 +625,15 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     @Test
     public void count()
     {
-        Assert.assertEquals(0L, this.emptySet.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.setWithFalse.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(1L, this.setWithFalse.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(0L, this.setWithTrue.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.setWithTrueFalse.count(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(2L, this.setWithTrueFalse.count(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertEquals(0L, this.emptySet.count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.setWithFalse.count(BooleanPredicates.isTrue()));
+        assertEquals(1L, this.setWithFalse.count(BooleanPredicates.isFalse()));
+        assertEquals(0L, this.setWithTrue.count(BooleanPredicates.isFalse()));
+        assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.setWithTrueFalse.count(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isFalse()));
+        assertEquals(1L, this.setWithTrueFalse.count(BooleanPredicates.isTrue()));
+        assertEquals(2L, this.setWithTrueFalse.count(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -635,14 +641,14 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void anySatisfy()
     {
         super.anySatisfy();
-        Assert.assertFalse(this.emptySet.anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.setWithFalse.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.setWithFalse.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.setWithTrue.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.setWithTrue.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.setWithTrueFalse.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.setWithTrueFalse.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.setWithTrueFalse.anySatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertFalse(this.emptySet.anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.setWithFalse.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.setWithFalse.anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.setWithTrue.anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.setWithTrue.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.setWithTrueFalse.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.setWithTrueFalse.anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.setWithTrueFalse.anySatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -650,30 +656,30 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void allSatisfy()
     {
         super.allSatisfy();
-        Assert.assertTrue(this.emptySet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.setWithFalse.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.setWithFalse.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.setWithTrue.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.setWithTrue.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertTrue(this.setWithTrueFalse.allSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.emptySet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.setWithFalse.allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.setWithFalse.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.setWithTrue.allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.setWithTrue.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.setWithTrueFalse.allSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.setWithTrueFalse.allSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.emptySet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.setWithFalse.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.setWithFalse.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.setWithTrue.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.setWithTrue.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.emptySet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.setWithFalse.noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.setWithFalse.noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.setWithTrue.noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.setWithTrue.noneSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertFalse(this.setWithTrueFalse.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -711,20 +717,20 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void detectIfNone()
     {
         super.detectIfNone();
-        Assert.assertTrue(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
-        Assert.assertFalse(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
-        Assert.assertTrue(this.setWithFalse.detectIfNone(BooleanPredicates.isTrue(), true));
-        Assert.assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isFalse(), false));
-        Assert.assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.setWithTrue.detectIfNone(BooleanPredicates.isFalse(), false));
-        Assert.assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isTrue(), true));
-        Assert.assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertTrue(this.setWithTrueFalse.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), true));
-        Assert.assertFalse(this.setWithTrueFalse.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), false));
-        Assert.assertFalse(this.setWithTrueFalse.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertTrue(this.setWithTrueFalse.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertTrue(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
+        assertFalse(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
+        assertTrue(this.setWithFalse.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.setWithFalse.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.setWithTrue.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertTrue(this.setWithTrue.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertTrue(this.setWithTrueFalse.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), true));
+        assertFalse(this.setWithTrueFalse.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), false));
+        assertFalse(this.setWithTrueFalse.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertTrue(this.setWithTrueFalse.detectIfNone(BooleanPredicates.isTrue(), false));
     }
 
     @Override
@@ -733,10 +739,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         super.collect();
         BooleanToObjectFunction<Boolean> function = parameter -> !parameter;
-        Assert.assertEquals(UnifiedSet.newSetWith(true, false), this.setWithTrueFalse.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(false), this.setWithTrue.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(true), this.setWithFalse.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(), this.emptySet.collect(function));
+        assertEquals(UnifiedSet.newSetWith(true, false), this.setWithTrueFalse.collect(function));
+        assertEquals(UnifiedSet.newSetWith(false), this.setWithTrue.collect(function));
+        assertEquals(UnifiedSet.newSetWith(true), this.setWithFalse.collect(function));
+        assertEquals(UnifiedSet.newSetWith(), this.emptySet.collect(function));
     }
 
     @Override
@@ -744,10 +750,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[]", this.emptySet.toString());
-        Assert.assertEquals("[false]", this.setWithFalse.toString());
-        Assert.assertEquals("[true]", this.setWithTrue.toString());
-        Assert.assertTrue("[true, false]".equals(this.setWithTrueFalse.toString())
+        assertEquals("[]", this.emptySet.toString());
+        assertEquals("[false]", this.setWithFalse.toString());
+        assertEquals("[true]", this.setWithTrue.toString());
+        assertTrue("[true, false]".equals(this.setWithTrueFalse.toString())
                 || "[false, true]".equals(this.setWithTrueFalse.toString()));
     }
 
@@ -756,22 +762,22 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("", this.emptySet.makeString());
-        Assert.assertEquals("false", this.setWithFalse.makeString());
-        Assert.assertEquals("true", this.setWithTrue.makeString());
-        Assert.assertTrue("true, false".equals(this.setWithTrueFalse.makeString())
+        assertEquals("", this.emptySet.makeString());
+        assertEquals("false", this.setWithFalse.makeString());
+        assertEquals("true", this.setWithTrue.makeString());
+        assertTrue("true, false".equals(this.setWithTrueFalse.makeString())
                 || "false, true".equals(this.setWithTrueFalse.makeString()));
 
-        Assert.assertEquals("", this.emptySet.makeString("/"));
-        Assert.assertEquals("false", this.setWithFalse.makeString("/"));
-        Assert.assertEquals("true", this.setWithTrue.makeString("/"));
-        Assert.assertTrue(this.setWithTrueFalse.makeString("/"), "true/false".equals(this.setWithTrueFalse.makeString("/"))
+        assertEquals("", this.emptySet.makeString("/"));
+        assertEquals("false", this.setWithFalse.makeString("/"));
+        assertEquals("true", this.setWithTrue.makeString("/"));
+        assertTrue(this.setWithTrueFalse.makeString("/"), "true/false".equals(this.setWithTrueFalse.makeString("/"))
                 || "false/true".equals(this.setWithTrueFalse.makeString("/")));
 
-        Assert.assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
-        Assert.assertEquals("[false]", this.setWithFalse.makeString("[", "/", "]"));
-        Assert.assertEquals("[true]", this.setWithTrue.makeString("[", "/", "]"));
-        Assert.assertTrue(this.setWithTrueFalse.makeString("[", "/", "]"), "[true/false]".equals(this.setWithTrueFalse.makeString("[", "/", "]"))
+        assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
+        assertEquals("[false]", this.setWithFalse.makeString("[", "/", "]"));
+        assertEquals("[true]", this.setWithTrue.makeString("[", "/", "]"));
+        assertTrue(this.setWithTrueFalse.makeString("[", "/", "]"), "[true/false]".equals(this.setWithTrueFalse.makeString("[", "/", "]"))
                 || "[false/true]".equals(this.setWithTrueFalse.makeString("[", "/", "]")));
     }
 
@@ -782,24 +788,24 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         super.appendString();
         StringBuilder appendable = new StringBuilder();
         this.emptySet.appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         StringBuilder appendable1 = new StringBuilder();
         this.setWithFalse.appendString(appendable1);
-        Assert.assertEquals("false", appendable1.toString());
+        assertEquals("false", appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.setWithTrue.appendString(appendable2);
-        Assert.assertEquals("true", appendable2.toString());
+        assertEquals("true", appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.setWithTrueFalse.appendString(appendable3);
-        Assert.assertTrue("true, false".equals(appendable3.toString())
+        assertTrue("true, false".equals(appendable3.toString())
                 || "false, true".equals(appendable3.toString()));
 
         StringBuilder appendable4 = new StringBuilder();
         this.setWithTrueFalse.appendString(appendable4, "[", ", ", "]");
-        Assert.assertTrue("[true, false]".equals(appendable4.toString())
+        assertTrue("[true, false]".equals(appendable4.toString())
                 || "[false, true]".equals(appendable4.toString()));
     }
 
@@ -809,10 +815,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         super.asLazy();
         Verify.assertInstanceOf(LazyBooleanIterable.class, this.emptySet.asLazy());
-        Assert.assertEquals(this.emptySet, this.emptySet.asLazy().toSet());
-        Assert.assertEquals(this.setWithFalse, this.setWithFalse.asLazy().toSet());
-        Assert.assertEquals(this.setWithTrue, this.setWithTrue.asLazy().toSet());
-        Assert.assertEquals(this.setWithTrueFalse, this.setWithTrueFalse.asLazy().toSet());
+        assertEquals(this.emptySet, this.emptySet.asLazy().toSet());
+        assertEquals(this.setWithFalse, this.setWithFalse.asLazy().toSet());
+        assertEquals(this.setWithTrue, this.setWithTrue.asLazy().toSet());
+        assertEquals(this.setWithTrueFalse, this.setWithTrueFalse.asLazy().toSet());
     }
 
     @Override
@@ -821,10 +827,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         super.asSynchronized();
         Verify.assertInstanceOf(SynchronizedBooleanSet.class, this.emptySet.asSynchronized());
-        Assert.assertEquals(new SynchronizedBooleanSet(this.emptySet), this.emptySet.asSynchronized());
-        Assert.assertEquals(new SynchronizedBooleanSet(this.setWithFalse), this.setWithFalse.asSynchronized());
-        Assert.assertEquals(new SynchronizedBooleanSet(this.setWithTrue), this.setWithTrue.asSynchronized());
-        Assert.assertEquals(new SynchronizedBooleanSet(this.setWithTrueFalse), this.setWithTrueFalse.asSynchronized());
+        assertEquals(new SynchronizedBooleanSet(this.emptySet), this.emptySet.asSynchronized());
+        assertEquals(new SynchronizedBooleanSet(this.setWithFalse), this.setWithFalse.asSynchronized());
+        assertEquals(new SynchronizedBooleanSet(this.setWithTrue), this.setWithTrue.asSynchronized());
+        assertEquals(new SynchronizedBooleanSet(this.setWithTrueFalse), this.setWithTrueFalse.asSynchronized());
     }
 
     @Override
@@ -833,10 +839,10 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         super.asUnmodifiable();
         Verify.assertInstanceOf(UnmodifiableBooleanSet.class, this.emptySet.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableBooleanSet(this.emptySet), this.emptySet.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableBooleanSet(this.setWithFalse), this.setWithFalse.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableBooleanSet(this.setWithTrue), this.setWithTrue.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableBooleanSet(this.setWithTrueFalse), this.setWithTrueFalse.asUnmodifiable());
+        assertEquals(new UnmodifiableBooleanSet(this.emptySet), this.emptySet.asUnmodifiable());
+        assertEquals(new UnmodifiableBooleanSet(this.setWithFalse), this.setWithFalse.asUnmodifiable());
+        assertEquals(new UnmodifiableBooleanSet(this.setWithTrue), this.setWithTrue.asUnmodifiable());
+        assertEquals(new UnmodifiableBooleanSet(this.setWithTrueFalse), this.setWithTrueFalse.asUnmodifiable());
     }
 
     @Test
@@ -845,27 +851,27 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
         MutableBooleanSet actual = set11.union(set21);
-        Assert.assertEquals(this.setWithTrueFalse, actual);
+        assertEquals(this.setWithTrueFalse, actual);
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
         MutableBooleanSet actual2 = set12.union(set22);
-        Assert.assertEquals(this.setWithFalse, actual2);
+        assertEquals(this.setWithFalse, actual2);
 
         MutableBooleanSet set13 = this.newWith(true);
         MutableBooleanSet set23 = this.newWith(true);
         MutableBooleanSet actual3 = set13.union(set23);
-        Assert.assertEquals(this.setWithTrue, actual3);
+        assertEquals(this.setWithTrue, actual3);
 
         MutableBooleanSet set14 = this.setWithTrueFalse;
         MutableBooleanSet set24 = this.newWith();
         MutableBooleanSet actual4 = set14.union(set24);
-        Assert.assertEquals(this.setWithTrueFalse, actual4);
+        assertEquals(this.setWithTrueFalse, actual4);
 
         MutableBooleanSet set15 = this.newWith();
         MutableBooleanSet set25 = this.newWith();
         MutableBooleanSet actual5 = set15.union(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
     }
 
     @Test
@@ -874,27 +880,27 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
         MutableBooleanSet actual = set11.intersect(set21);
-        Assert.assertEquals(this.emptySet, actual);
+        assertEquals(this.emptySet, actual);
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
         MutableBooleanSet actual2 = set12.intersect(set22);
-        Assert.assertEquals(this.setWithFalse, actual2);
+        assertEquals(this.setWithFalse, actual2);
 
         MutableBooleanSet set13 = this.newWith(true);
         MutableBooleanSet set23 = this.newWith(true);
         MutableBooleanSet actual3 = set13.intersect(set23);
-        Assert.assertEquals(this.setWithTrue, actual3);
+        assertEquals(this.setWithTrue, actual3);
 
         MutableBooleanSet set14 = this.setWithTrueFalse;
         MutableBooleanSet set24 = this.newWith();
         MutableBooleanSet actual4 = set14.intersect(set24);
-        Assert.assertEquals(this.emptySet, actual4);
+        assertEquals(this.emptySet, actual4);
 
         MutableBooleanSet set15 = this.newWith();
         MutableBooleanSet set25 = this.newWith();
         MutableBooleanSet actual5 = set15.intersect(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
     }
 
     @Test
@@ -903,32 +909,32 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
         MutableBooleanSet actual = set11.difference(set21);
-        Assert.assertEquals(this.setWithTrue, actual);
+        assertEquals(this.setWithTrue, actual);
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
         MutableBooleanSet actual2 = set12.difference(set22);
-        Assert.assertEquals(this.emptySet, actual2);
+        assertEquals(this.emptySet, actual2);
 
         MutableBooleanSet set13 = this.setWithTrueFalse;
         MutableBooleanSet set23 = this.setWithTrueFalse;
         MutableBooleanSet actual3 = set13.difference(set23);
-        Assert.assertEquals(this.emptySet, actual3);
+        assertEquals(this.emptySet, actual3);
 
         MutableBooleanSet set14 = this.setWithTrueFalse;
         MutableBooleanSet set24 = this.newWith();
         MutableBooleanSet actual4 = set14.difference(set24);
-        Assert.assertEquals(this.setWithTrueFalse, actual4);
+        assertEquals(this.setWithTrueFalse, actual4);
 
         MutableBooleanSet set15 = this.newWith();
         MutableBooleanSet set25 = this.setWithTrueFalse;
         MutableBooleanSet actual5 = set15.difference(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
 
         MutableBooleanSet set16 = this.newWith();
         MutableBooleanSet set26 = this.newWith();
         MutableBooleanSet actual6 = set16.difference(set26);
-        Assert.assertEquals(this.emptySet, actual6);
+        assertEquals(this.emptySet, actual6);
     }
 
     @Test
@@ -937,32 +943,32 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
         MutableBooleanSet actual = set11.symmetricDifference(set21);
-        Assert.assertEquals(this.setWithTrueFalse, actual);
+        assertEquals(this.setWithTrueFalse, actual);
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
         MutableBooleanSet actual2 = set12.symmetricDifference(set22);
-        Assert.assertEquals(this.emptySet, actual2);
+        assertEquals(this.emptySet, actual2);
 
         MutableBooleanSet set13 = this.setWithTrueFalse;
         MutableBooleanSet set23 = this.setWithTrueFalse;
         MutableBooleanSet actual3 = set13.symmetricDifference(set23);
-        Assert.assertEquals(this.emptySet, actual3);
+        assertEquals(this.emptySet, actual3);
 
         MutableBooleanSet set14 = this.setWithTrueFalse;
         MutableBooleanSet set24 = this.newWith();
         MutableBooleanSet actual4 = set14.symmetricDifference(set24);
-        Assert.assertEquals(this.setWithTrueFalse, actual4);
+        assertEquals(this.setWithTrueFalse, actual4);
 
         MutableBooleanSet set15 = this.newWith();
         MutableBooleanSet set25 = this.setWithTrueFalse;
         MutableBooleanSet actual5 = set15.symmetricDifference(set25);
-        Assert.assertEquals(this.setWithTrueFalse, actual5);
+        assertEquals(this.setWithTrueFalse, actual5);
 
         MutableBooleanSet set16 = this.newWith();
         MutableBooleanSet set26 = this.newWith();
         MutableBooleanSet actual6 = set16.symmetricDifference(set26);
-        Assert.assertEquals(this.emptySet, actual6);
+        assertEquals(this.emptySet, actual6);
     }
 
     @Test
@@ -970,27 +976,27 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
-        Assert.assertFalse(set11.isSubsetOf(set21));
+        assertFalse(set11.isSubsetOf(set21));
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
-        Assert.assertTrue(set12.isSubsetOf(set22));
+        assertTrue(set12.isSubsetOf(set22));
 
         MutableBooleanSet set13 = this.setWithTrueFalse;
         MutableBooleanSet set23 = this.setWithTrueFalse;
-        Assert.assertTrue(set13.isSubsetOf(set23));
+        assertTrue(set13.isSubsetOf(set23));
 
         MutableBooleanSet set14 = this.setWithTrueFalse;
         MutableBooleanSet set24 = this.newWith();
-        Assert.assertFalse(set14.isSubsetOf(set24));
+        assertFalse(set14.isSubsetOf(set24));
 
         MutableBooleanSet set15 = this.newWith();
         MutableBooleanSet set25 = this.setWithTrueFalse;
-        Assert.assertTrue(set15.isSubsetOf(set25));
+        assertTrue(set15.isSubsetOf(set25));
 
         MutableBooleanSet set16 = this.newWith();
         MutableBooleanSet set26 = this.newWith();
-        Assert.assertTrue(set16.isSubsetOf(set26));
+        assertTrue(set16.isSubsetOf(set26));
     }
 
     @Test
@@ -998,31 +1004,31 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
     {
         MutableBooleanSet set11 = this.newWith(true);
         MutableBooleanSet set21 = this.newWith(false);
-        Assert.assertFalse(set11.isProperSubsetOf(set21));
+        assertFalse(set11.isProperSubsetOf(set21));
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
-        Assert.assertFalse(set12.isProperSubsetOf(set22));
+        assertFalse(set12.isProperSubsetOf(set22));
 
         MutableBooleanSet set13 = this.setWithTrue;
         MutableBooleanSet set23 = this.setWithTrueFalse;
-        Assert.assertTrue(set13.isProperSubsetOf(set23));
+        assertTrue(set13.isProperSubsetOf(set23));
 
         MutableBooleanSet set14 = this.setWithFalse;
         MutableBooleanSet set24 = this.setWithTrueFalse;
-        Assert.assertTrue(set14.isProperSubsetOf(set24));
+        assertTrue(set14.isProperSubsetOf(set24));
 
         MutableBooleanSet set15 = this.setWithTrueFalse;
         MutableBooleanSet set25 = this.newWith();
-        Assert.assertFalse(set15.isProperSubsetOf(set25));
+        assertFalse(set15.isProperSubsetOf(set25));
 
         MutableBooleanSet set16 = this.newWith();
         MutableBooleanSet set26 = this.setWithTrueFalse;
-        Assert.assertTrue(set16.isProperSubsetOf(set26));
+        assertTrue(set16.isProperSubsetOf(set26));
 
         MutableBooleanSet set17 = this.newWith();
         MutableBooleanSet set27 = this.newWith();
-        Assert.assertFalse(set17.isProperSubsetOf(set27));
+        assertFalse(set17.isProperSubsetOf(set27));
     }
 
     @Test
@@ -1032,38 +1038,38 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         MutableBooleanSet set21 = this.setWithFalse;
         MutableSet<BooleanBooleanPair> expected1 = Sets.mutable.with(
                 PrimitiveTuples.pair(true, false));
-        Assert.assertEquals(expected1, set11.cartesianProduct(set21).toSet());
+        assertEquals(expected1, set11.cartesianProduct(set21).toSet());
 
         MutableBooleanSet set12 = this.newWith(false);
         MutableBooleanSet set22 = this.newWith(false);
         MutableSet<BooleanBooleanPair> expected2 = Sets.mutable.with(
                 PrimitiveTuples.pair(false, false));
-        Assert.assertEquals(expected2, set12.cartesianProduct(set22).toSet());
+        assertEquals(expected2, set12.cartesianProduct(set22).toSet());
 
         MutableBooleanSet set13 = this.setWithTrue;
         MutableBooleanSet set23 = this.setWithTrueFalse;
         MutableSet<BooleanBooleanPair> expected3 = Sets.mutable.with(
                 PrimitiveTuples.pair(true, true),
                 PrimitiveTuples.pair(true, false));
-        Assert.assertEquals(expected3, set13.cartesianProduct(set23).toSet());
+        assertEquals(expected3, set13.cartesianProduct(set23).toSet());
 
         MutableBooleanSet set14 = this.setWithFalse;
         MutableBooleanSet set24 = this.setWithTrueFalse;
         MutableSet<BooleanBooleanPair> expected4 = Sets.mutable.with(
                 PrimitiveTuples.pair(false, true),
                 PrimitiveTuples.pair(false, false));
-        Assert.assertEquals(expected4, set14.cartesianProduct(set24).toSet());
+        assertEquals(expected4, set14.cartesianProduct(set24).toSet());
 
         MutableBooleanSet set15 = this.setWithTrueFalse;
         MutableBooleanSet set25 = this.newWith();
-        Assert.assertEquals(Sets.mutable.empty(), set15.cartesianProduct(set25).toSet());
+        assertEquals(Sets.mutable.empty(), set15.cartesianProduct(set25).toSet());
 
         MutableBooleanSet set16 = this.newWith();
         MutableBooleanSet set26 = this.setWithTrueFalse;
-        Assert.assertEquals(Sets.mutable.empty(), set16.cartesianProduct(set26).toSet());
+        assertEquals(Sets.mutable.empty(), set16.cartesianProduct(set26).toSet());
 
         MutableBooleanSet set17 = this.newWith();
         MutableBooleanSet set27 = this.newWith();
-        Assert.assertEquals(Sets.mutable.empty(), set17.cartesianProduct(set27).toSet());
+        assertEquals(Sets.mutable.empty(), set17.cartesianProduct(set27).toSet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
@@ -27,8 +27,13 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.map.mutable.primitive.CollisionGeneratorUtil;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableByteSet}.
@@ -71,14 +76,14 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     public void isEmpty()
     {
         super.isEmpty();
-        Assert.assertFalse(this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128).isEmpty());
+        assertFalse(this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128).isEmpty());
     }
 
     @Override
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128).notEmpty());
+        assertTrue(this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128).notEmpty());
     }
 
     @Override
@@ -89,11 +94,11 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128);
         set.clear();
         Verify.assertSize(0, set);
-        Assert.assertFalse(set.contains((byte) 0));
-        Assert.assertFalse(set.contains((byte) 31));
-        Assert.assertFalse(set.contains((byte) 1));
-        Assert.assertFalse(set.contains((byte) -1));
-        Assert.assertFalse(set.contains((byte) -128));
+        assertFalse(set.contains((byte) 0));
+        assertFalse(set.contains((byte) 31));
+        assertFalse(set.contains((byte) 1));
+        assertFalse(set.contains((byte) -1));
+        assertFalse(set.contains((byte) -128));
     }
 
     @Override
@@ -102,20 +107,20 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.add();
         MutableByteSet set = this.newWith();
-        Assert.assertTrue(set.add((byte) 14));
-        Assert.assertFalse(set.add((byte) 14));
-        Assert.assertTrue(set.add((byte) 2));
-        Assert.assertFalse(set.add((byte) 2));
-        Assert.assertTrue(set.add((byte) 35));
-        Assert.assertFalse(set.add((byte) 35));
-        Assert.assertTrue(set.add((byte) 31));
-        Assert.assertFalse(set.add((byte) 31));
-        Assert.assertTrue(set.add((byte) 32));
-        Assert.assertFalse(set.add((byte) 32));
-        Assert.assertTrue(set.add((byte) 0));
-        Assert.assertFalse(set.add((byte) 0));
-        Assert.assertTrue(set.add((byte) 1));
-        Assert.assertFalse(set.add((byte) 1));
+        assertTrue(set.add((byte) 14));
+        assertFalse(set.add((byte) 14));
+        assertTrue(set.add((byte) 2));
+        assertFalse(set.add((byte) 2));
+        assertTrue(set.add((byte) 35));
+        assertFalse(set.add((byte) 35));
+        assertTrue(set.add((byte) 31));
+        assertFalse(set.add((byte) 31));
+        assertTrue(set.add((byte) 32));
+        assertFalse(set.add((byte) 32));
+        assertTrue(set.add((byte) 0));
+        assertFalse(set.add((byte) 0));
+        assertTrue(set.add((byte) 1));
+        assertFalse(set.add((byte) 1));
     }
 
     @Override
@@ -124,19 +129,19 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.addAllIterable();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128);
-        Assert.assertFalse(set.addAll(new ByteArrayList()));
-        Assert.assertFalse(set.addAll(ByteArrayList.newListWith((byte) 31, (byte) -1, (byte) -128)));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128), set);
+        assertFalse(set.addAll(new ByteArrayList()));
+        assertFalse(set.addAll(ByteArrayList.newListWith((byte) 31, (byte) -1, (byte) -128)));
+        assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -128), set);
 
-        Assert.assertTrue(set.addAll(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 30, (byte) -1, (byte) -128)));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 30, (byte) 31, (byte) -1, (byte) -128), set);
+        assertTrue(set.addAll(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 30, (byte) -1, (byte) -128)));
+        assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 30, (byte) 31, (byte) -1, (byte) -128), set);
 
-        Assert.assertTrue(set.addAll(ByteHashSet.newSetWith((byte) 5)));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 30, (byte) 31, (byte) 31, (byte) -1, (byte) -128), set);
+        assertTrue(set.addAll(ByteHashSet.newSetWith((byte) 5)));
+        assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 2, (byte) 5, (byte) 30, (byte) 31, (byte) 31, (byte) -1, (byte) -128), set);
 
         MutableByteSet set1 = new ByteHashSet();
-        Assert.assertTrue(set1.addAll((byte) 2, (byte) 35));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 2, (byte) 35), set1);
+        assertTrue(set1.addAll((byte) 2, (byte) 35));
+        assertEquals(ByteHashSet.newSetWith((byte) 2, (byte) 35), set1);
     }
 
     @Override
@@ -145,20 +150,20 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.remove();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -8);
-        Assert.assertFalse(this.newWith().remove((byte) 15));
-        Assert.assertFalse(set.remove((byte) 15));
-        Assert.assertTrue(set.remove((byte) 0));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31, (byte) -1, (byte) -8), set);
-        Assert.assertFalse(set.remove((byte) -10));
-        Assert.assertFalse(set.remove((byte) -7));
-        Assert.assertTrue(set.remove((byte) -1));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31, (byte) -8), set);
-        Assert.assertTrue(set.remove((byte) -8));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31), set);
-        Assert.assertTrue(set.remove((byte) 31));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1), set);
-        Assert.assertTrue(set.remove((byte) 1));
-        Assert.assertEquals(ByteHashSet.newSetWith(), set);
+        assertFalse(this.newWith().remove((byte) 15));
+        assertFalse(set.remove((byte) 15));
+        assertTrue(set.remove((byte) 0));
+        assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31, (byte) -1, (byte) -8), set);
+        assertFalse(set.remove((byte) -10));
+        assertFalse(set.remove((byte) -7));
+        assertTrue(set.remove((byte) -1));
+        assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31, (byte) -8), set);
+        assertTrue(set.remove((byte) -8));
+        assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 31), set);
+        assertTrue(set.remove((byte) 31));
+        assertEquals(ByteHashSet.newSetWith((byte) 1), set);
+        assertTrue(set.remove((byte) 1));
+        assertEquals(ByteHashSet.newSetWith(), set);
     }
 
     @Override
@@ -167,17 +172,17 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.removeAll();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128);
-        Assert.assertFalse(set.removeAll());
-        Assert.assertFalse(set.removeAll((byte) 15, (byte) -5, (byte) -32));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128), set);
-        Assert.assertTrue(set.removeAll((byte) 0, (byte) 1, (byte) -1, (byte) -128));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -35, (byte) -64, (byte) -100), set);
-        Assert.assertTrue(set.removeAll((byte) 31, (byte) 63, (byte) 14, (byte) -100));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 100, (byte) 127, (byte) -35, (byte) -64), set);
-        Assert.assertFalse(set.removeAll((byte) -34, (byte) -36, (byte) -63, (byte) -65, (byte) 99, (byte) 101, (byte) 126, (byte) 128));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 100, (byte) 127, (byte) -35, (byte) -64), set);
-        Assert.assertTrue(set.removeAll((byte) -35, (byte) -63, (byte) -64, (byte) 100, (byte) 127));
-        Assert.assertEquals(new ByteHashSet(), set);
+        assertFalse(set.removeAll());
+        assertFalse(set.removeAll((byte) 15, (byte) -5, (byte) -32));
+        assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128), set);
+        assertTrue(set.removeAll((byte) 0, (byte) 1, (byte) -1, (byte) -128));
+        assertEquals(ByteHashSet.newSetWith((byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -35, (byte) -64, (byte) -100), set);
+        assertTrue(set.removeAll((byte) 31, (byte) 63, (byte) 14, (byte) -100));
+        assertEquals(ByteHashSet.newSetWith((byte) 100, (byte) 127, (byte) -35, (byte) -64), set);
+        assertFalse(set.removeAll((byte) -34, (byte) -36, (byte) -63, (byte) -65, (byte) 99, (byte) 101, (byte) 126, (byte) 128));
+        assertEquals(ByteHashSet.newSetWith((byte) 100, (byte) 127, (byte) -35, (byte) -64), set);
+        assertTrue(set.removeAll((byte) -35, (byte) -63, (byte) -64, (byte) 100, (byte) 127));
+        assertEquals(new ByteHashSet(), set);
     }
 
     @Override
@@ -186,15 +191,15 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.removeAll_iterable();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128);
-        Assert.assertFalse(set.removeAll(new ByteArrayList()));
-        Assert.assertFalse(set.removeAll(ByteArrayList.newListWith((byte) 15, (byte) 98, (byte) -98, (byte) -127)));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128), set);
-        Assert.assertTrue(set.removeAll(ByteHashSet.newSetWith((byte) 0, (byte) 31, (byte) -128, (byte) -100)));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64), set);
-        Assert.assertTrue(set.removeAll(ByteHashSet.newSetWith((byte) 1, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64)));
-        Assert.assertEquals(new ByteHashSet(), set);
-        Assert.assertFalse(set.removeAll(ByteHashSet.newSetWith((byte) 1)));
-        Assert.assertEquals(new ByteHashSet(), set);
+        assertFalse(set.removeAll(new ByteArrayList()));
+        assertFalse(set.removeAll(ByteArrayList.newListWith((byte) 15, (byte) 98, (byte) -98, (byte) -127)));
+        assertEquals(ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128), set);
+        assertTrue(set.removeAll(ByteHashSet.newSetWith((byte) 0, (byte) 31, (byte) -128, (byte) -100)));
+        assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64), set);
+        assertTrue(set.removeAll(ByteHashSet.newSetWith((byte) 1, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64)));
+        assertEquals(new ByteHashSet(), set);
+        assertFalse(set.removeAll(ByteHashSet.newSetWith((byte) 1)));
+        assertEquals(new ByteHashSet(), set);
     }
 
     @Override
@@ -205,31 +210,31 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         MutableSet<Byte> actual = UnifiedSet.newSet();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 100, (byte) 127, (byte) -1, (byte) -35, (byte) -64, (byte) -100, (byte) -128);
         ByteIterator iterator = set.byteIterator();
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
         actual.add(iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(expected, actual);
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertEquals(expected, actual);
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -255,7 +260,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 65, (byte) 100, (byte) 127, (byte) 12, (byte) -76, (byte) -1, (byte) -54, (byte) -64, (byte) -63, (byte) -95, (byte) -128, (byte) -127);
         set.forEach(each -> sum[0] += each);
 
-        Assert.assertEquals(-209L, sum[0]);
+        assertEquals(-209L, sum[0]);
     }
 
     @Override
@@ -264,14 +269,14 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.count();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 65, (byte) 100, (byte) 127, (byte) 12, (byte) -76, (byte) -1, (byte) -54, (byte) -64, (byte) -63, (byte) -95, (byte) -128, (byte) -127);
-        Assert.assertEquals(7L, set.count(BytePredicates.greaterThan((byte) 0)));
-        Assert.assertEquals(12L, set.count(BytePredicates.lessThan((byte) 32)));
-        Assert.assertEquals(4L, set.count(BytePredicates.greaterThan((byte) 32)));
-        Assert.assertEquals(1L, set.count(BytePredicates.greaterThan((byte) 100)));
-        Assert.assertEquals(14L, set.count(BytePredicates.lessThan((byte) 100)));
-        Assert.assertEquals(7L, set.count(BytePredicates.lessThan((byte) -50)));
-        Assert.assertEquals(6L, set.count(BytePredicates.lessThan((byte) -54)));
-        Assert.assertEquals(15L, set.count(BytePredicates.greaterThan((byte) -128)));
+        assertEquals(7L, set.count(BytePredicates.greaterThan((byte) 0)));
+        assertEquals(12L, set.count(BytePredicates.lessThan((byte) 32)));
+        assertEquals(4L, set.count(BytePredicates.greaterThan((byte) 32)));
+        assertEquals(1L, set.count(BytePredicates.greaterThan((byte) 100)));
+        assertEquals(14L, set.count(BytePredicates.lessThan((byte) 100)));
+        assertEquals(7L, set.count(BytePredicates.lessThan((byte) -50)));
+        assertEquals(6L, set.count(BytePredicates.lessThan((byte) -54)));
+        assertEquals(15L, set.count(BytePredicates.greaterThan((byte) -128)));
     }
 
     @Override
@@ -280,8 +285,8 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.select();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 63, (byte) 65, (byte) 100, (byte) 127, (byte) 12, (byte) -76, (byte) -1, (byte) -54, (byte) -64, (byte) -63, (byte) -95, (byte) -128, (byte) -127);
-        Assert.assertEquals(this.newWith((byte) 63, (byte) 65, (byte) 100, (byte) 127), set.select(BytePredicates.greaterThan((byte) 32)));
-        Assert.assertEquals(this.newWith((byte) -76, (byte) -1, (byte) -54, (byte) -64, (byte) -63, (byte) -95, (byte) -128, (byte) -127), set.select(BytePredicates.lessThan((byte) 0)));
+        assertEquals(this.newWith((byte) 63, (byte) 65, (byte) 100, (byte) 127), set.select(BytePredicates.greaterThan((byte) 32)));
+        assertEquals(this.newWith((byte) -76, (byte) -1, (byte) -54, (byte) -64, (byte) -63, (byte) -95, (byte) -128, (byte) -127), set.select(BytePredicates.lessThan((byte) 0)));
     }
 
     @Override
@@ -290,8 +295,8 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.reject();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -127, (byte) -63);
-        Assert.assertEquals(this.newWith((byte) 0, (byte) -1, (byte) -127, (byte) -63), set.reject(BytePredicates.greaterThan((byte) 0)));
-        Assert.assertEquals(this.newWith((byte) 0, (byte) 1, (byte) 31), set.reject(BytePredicates.lessThan((byte) 0)));
+        assertEquals(this.newWith((byte) 0, (byte) -1, (byte) -127, (byte) -63), set.reject(BytePredicates.greaterThan((byte) 0)));
+        assertEquals(this.newWith((byte) 0, (byte) 1, (byte) 31), set.reject(BytePredicates.lessThan((byte) 0)));
     }
 
     @Override
@@ -300,12 +305,12 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.detectIfNone();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 64, (byte) 127, (byte) -1, (byte) -67, (byte) -128, (byte) -63);
-        Assert.assertEquals(127, set.detectIfNone(BytePredicates.greaterThan((byte) 126), (byte) 9));
-        Assert.assertEquals(127, set.detectIfNone(BytePredicates.greaterThan((byte) 64), (byte) 9));
-        Assert.assertEquals(-128, set.detectIfNone(BytePredicates.lessThan((byte) -68), (byte) 9));
+        assertEquals(127, set.detectIfNone(BytePredicates.greaterThan((byte) 126), (byte) 9));
+        assertEquals(127, set.detectIfNone(BytePredicates.greaterThan((byte) 64), (byte) 9));
+        assertEquals(-128, set.detectIfNone(BytePredicates.lessThan((byte) -68), (byte) 9));
 
         MutableByteSet set1 = this.newWith((byte) 0, (byte) -1, (byte) 12, (byte) 64);
-        Assert.assertEquals(-1, set1.detectIfNone(BytePredicates.lessThan((byte) 0), (byte) 9));
+        assertEquals(-1, set1.detectIfNone(BytePredicates.lessThan((byte) 0), (byte) 9));
     }
 
     @Override
@@ -315,7 +320,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         super.collect();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -127, (byte) -63);
 
-        Assert.assertEquals(UnifiedSet.newSetWith((byte) -1, (byte) 0, (byte) 30, (byte) -128, (byte) -64), set.collect(byteParameter -> (byte) (byteParameter - 1)));
+        assertEquals(UnifiedSet.newSetWith((byte) -1, (byte) 0, (byte) 30, (byte) -128, (byte) -64), set.collect(byteParameter -> (byte) (byteParameter - 1)));
     }
 
     @Override
@@ -324,7 +329,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.toSortedArray();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -123, (byte) -53);
-        Assert.assertArrayEquals(new byte[]{(byte) -123, (byte) -53, (byte) -1, (byte) 0, (byte) 1, (byte) 31}, set.toSortedArray());
+        assertArrayEquals(new byte[]{(byte) -123, (byte) -53, (byte) -1, (byte) 0, (byte) 1, (byte) 31}, set.toSortedArray());
     }
 
     @Override
@@ -350,16 +355,16 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         super.testEquals();
         MutableByteSet set1 = this.newWith((byte) 1, (byte) 31, (byte) 32);
         MutableByteSet set2 = this.newWith((byte) 32, (byte) 31, (byte) 1);
-        Assert.assertEquals(set1.hashCode(), set2.hashCode());
+        assertEquals(set1.hashCode(), set2.hashCode());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().toBag());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31), this.newWith((byte) 0, (byte) 1, (byte) 31).toBag());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31, (byte) 32), this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 32).toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31), this.newWith((byte) 0, (byte) 1, (byte) 31).toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 0, (byte) 1, (byte) 31, (byte) 32), this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) 32).toBag());
     }
 
     @Override
@@ -368,7 +373,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     {
         super.asLazy();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -31, (byte) -24);
-        Assert.assertEquals(set.toSet(), set.asLazy().toSet());
+        assertEquals(set.toSet(), set.asLazy().toSet());
         Verify.assertInstanceOf(LazyByteIterable.class, set.asLazy());
     }
 
@@ -379,7 +384,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         super.asSynchronized();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -31, (byte) -24);
         Verify.assertInstanceOf(SynchronizedByteSet.class, set.asSynchronized());
-        Assert.assertEquals(new SynchronizedByteSet(set), set.asSynchronized());
+        assertEquals(new SynchronizedByteSet(set), set.asSynchronized());
     }
 
     @Override
@@ -389,7 +394,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
         super.asUnmodifiable();
         MutableByteSet set = this.newWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -31, (byte) -24);
         Verify.assertInstanceOf(UnmodifiableByteSet.class, set.asUnmodifiable());
-        Assert.assertEquals(new UnmodifiableByteSet(set), set.asUnmodifiable());
+        assertEquals(new UnmodifiableByteSet(set), set.asUnmodifiable());
     }
 
     @Test
@@ -435,7 +440,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertUnion(MutableByteSet set1, MutableByteSet set2, MutableByteSet expected)
     {
         MutableByteSet actual = set1.union(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -475,7 +480,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertIntersect(MutableByteSet set1, MutableByteSet set2, MutableByteSet expected)
     {
         MutableByteSet actual = set1.intersect(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -510,7 +515,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertDifference(MutableByteSet set1, MutableByteSet set2, MutableByteSet expected)
     {
         MutableByteSet actual = set1.difference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -545,7 +550,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertSymmetricDifference(MutableByteSet set1, MutableByteSet set2, MutableByteSet expected)
     {
         MutableByteSet actual = set1.symmetricDifference(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -585,7 +590,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertIsSubsetOf(MutableByteSet set1, MutableByteSet set2, boolean expected)
     {
         boolean actual = set1.isSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -625,7 +630,7 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertIsProperSubsetOf(MutableByteSet set1, MutableByteSet set2, boolean expected)
     {
         boolean actual = set1.isProperSubsetOf(set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -668,6 +673,6 @@ public abstract class AbstractByteSetTestCase extends AbstractMutableByteCollect
     private void assertCartesianProduct(MutableByteSet set1, MutableByteSet set2, MutableSet<ByteBytePair> expected)
     {
         MutableSet<ByteBytePair> actual = set1.cartesianProduct(set2).toSet();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSetTest.java
@@ -18,8 +18,12 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class BooleanHashSetTest extends AbstractBooleanSetTestCase
 {
@@ -40,13 +44,13 @@ public class BooleanHashSetTest extends AbstractBooleanSetTestCase
     {
         Field table = BooleanHashSet.class.getDeclaredField("state");
         table.setAccessible(true);
-        Assert.assertEquals(0, table.get(new BooleanHashSet()));
+        assertEquals(0, table.get(new BooleanHashSet()));
     }
 
     @Test
     public void boxed()
     {
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE), this.classUnderTest().boxed());
+        assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE), this.classUnderTest().boxed());
     }
 
     @Override
@@ -64,11 +68,11 @@ public class BooleanHashSetTest extends AbstractBooleanSetTestCase
         BooleanHashSet setFromSet1 = BooleanHashSet.newSet(set1);
         BooleanHashSet setFromSet2 = BooleanHashSet.newSet(set2);
         BooleanHashSet setFromSet3 = BooleanHashSet.newSet(set3);
-        Assert.assertEquals(set3, setFromList);
-        Assert.assertEquals(set0, setFromSet0);
-        Assert.assertEquals(set1, setFromSet1);
-        Assert.assertEquals(set2, setFromSet2);
-        Assert.assertEquals(set3, setFromSet3);
+        assertEquals(set3, setFromList);
+        assertEquals(set0, setFromSet0);
+        assertEquals(set1, setFromSet1);
+        assertEquals(set2, setFromSet2);
+        assertEquals(set3, setFromSet3);
     }
 
     @Override
@@ -79,25 +83,25 @@ public class BooleanHashSetTest extends AbstractBooleanSetTestCase
 
         BooleanHashSet falseSet = this.newWith(false);
         MutableBooleanIterator mutableBooleanIterator = falseSet.booleanIterator();
-        Assert.assertTrue(mutableBooleanIterator.hasNext());
-        Assert.assertFalse(mutableBooleanIterator.next());
+        assertTrue(mutableBooleanIterator.hasNext());
+        assertFalse(mutableBooleanIterator.next());
         mutableBooleanIterator.remove();
         Verify.assertEmpty(falseSet);
-        Assert.assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
-        Assert.assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
+        assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
+        assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
         BooleanHashSet trueSet = this.newWith(true);
         mutableBooleanIterator = trueSet.booleanIterator();
-        Assert.assertTrue(mutableBooleanIterator.hasNext());
-        Assert.assertTrue(mutableBooleanIterator.next());
+        assertTrue(mutableBooleanIterator.hasNext());
+        assertTrue(mutableBooleanIterator.next());
         mutableBooleanIterator.remove();
         Verify.assertEmpty(trueSet);
-        Assert.assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
-        Assert.assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
+        assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
+        assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
         MutableBooleanSet emptySet = new BooleanHashSet();
         mutableBooleanIterator = emptySet.booleanIterator();
-        Assert.assertFalse(mutableBooleanIterator.hasNext());
+        assertFalse(mutableBooleanIterator.hasNext());
         Verify.assertEmpty(emptySet);
-        Assert.assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
-        Assert.assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
+        assertThrows(NoSuchElementException.class, mutableBooleanIterator::next);
+        assertThrows(IllegalStateException.class, mutableBooleanIterator::remove);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BoxedMutableBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BoxedMutableBooleanSetTest.java
@@ -16,8 +16,11 @@ import java.util.HashSet;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BoxedMutableBooleanSetTest
 {
@@ -60,41 +63,41 @@ public class BoxedMutableBooleanSetTest
     {
         MutableSet<Boolean> result = Sets.mutable.empty();
         this.classUnderTest().forEach(result::add);
-        Assert.assertEquals(Sets.mutable.of(true, false), result);
+        assertEquals(Sets.mutable.of(true, false), result);
     }
 
     @Test
     public void add()
     {
         BoxedMutableBooleanSet set = new BoxedMutableBooleanSet(new BooleanHashSet(true));
-        Assert.assertTrue(set.add(Boolean.FALSE));
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
+        assertTrue(set.add(Boolean.FALSE));
+        assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
 
-        Assert.assertFalse(set.add(Boolean.FALSE));
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
+        assertFalse(set.add(Boolean.FALSE));
+        assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
     }
 
     @Test
     public void remove()
     {
         BoxedMutableBooleanSet set = this.classUnderTest();
-        Assert.assertFalse(set.remove("abc"));
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
+        assertFalse(set.remove("abc"));
+        assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), set);
 
-        Assert.assertTrue(set.remove(Boolean.TRUE));
-        Assert.assertEquals(Sets.mutable.of(Boolean.FALSE), set);
+        assertTrue(set.remove(Boolean.TRUE));
+        assertEquals(Sets.mutable.of(Boolean.FALSE), set);
 
-        Assert.assertFalse(set.remove(Boolean.TRUE));
-        Assert.assertEquals(Sets.mutable.of(Boolean.FALSE), set);
+        assertFalse(set.remove(Boolean.TRUE));
+        assertEquals(Sets.mutable.of(Boolean.FALSE), set);
     }
 
     @Test
     public void contains()
     {
         BoxedMutableBooleanSet set = new BoxedMutableBooleanSet(new BooleanHashSet(true));
-        Assert.assertTrue(set.contains(Boolean.TRUE));
-        Assert.assertFalse(set.contains(Boolean.FALSE));
-        Assert.assertFalse(set.contains("abc"));
+        assertTrue(set.contains(Boolean.TRUE));
+        assertFalse(set.contains(Boolean.FALSE));
+        assertFalse(set.contains("abc"));
     }
 
     @Test
@@ -102,7 +105,7 @@ public class BoxedMutableBooleanSetTest
     {
         MutableSet<Boolean> result = Sets.mutable.empty();
         this.classUnderTest().iterator().forEachRemaining(result::add);
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), result);
+        assertEquals(Sets.mutable.of(Boolean.TRUE, Boolean.FALSE), result);
     }
 
     @Test
@@ -134,12 +137,12 @@ public class BoxedMutableBooleanSetTest
         BoxedMutableBooleanSet set = new BoxedMutableBooleanSet(originalSet);
 
         originalSet.remove(true);
-        Assert.assertEquals(Sets.mutable.of(Boolean.FALSE), set);
+        assertEquals(Sets.mutable.of(Boolean.FALSE), set);
 
         originalSet.clear();
         Verify.assertEmpty(set);
 
         originalSet.add(true);
-        Assert.assertEquals(Sets.mutable.of(Boolean.TRUE), set);
+        assertEquals(Sets.mutable.of(Boolean.TRUE), set);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSetTest.java
@@ -18,8 +18,12 @@ import org.eclipse.collections.impl.block.factory.primitive.BytePredicates;
 import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ByteHashSet}.
@@ -52,14 +56,14 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -98, (byte) -64, (byte) -128);
         ByteHashSet hashSetFromList = ByteHashSet.newSet(ByteArrayList.newListWith((byte) 0, (byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -98, (byte) -64, (byte) -128));
         ByteHashSet hashSetFromSet = ByteHashSet.newSet(set);
-        Assert.assertEquals(set, hashSetFromList);
-        Assert.assertEquals(set, hashSetFromSet);
+        assertEquals(set, hashSetFromList);
+        assertEquals(set, hashSetFromSet);
     }
 
     @Test
     public void boxed()
     {
-        Assert.assertEquals(Sets.mutable.of((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().boxed());
+        assertEquals(Sets.mutable.of((byte) 1, (byte) 2, (byte) 3), this.classUnderTest().boxed());
     }
 
     @Override
@@ -70,7 +74,7 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
 
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) -128, (byte) 64);
         Byte sum = set.injectInto(Byte.valueOf((byte) 0), (result, value) -> Byte.valueOf((byte) (result + value)));
-        Assert.assertEquals(Byte.valueOf((byte) -99), sum);
+        assertEquals(Byte.valueOf((byte) -99), sum);
     }
 
     @Override
@@ -84,7 +88,7 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         sb.append("tents");
         set.appendString(sb, "start", ",", "end");
 
-        Assert.assertEquals("contentsstart-128,-64,-2,-1,0,1,31,64end", sb.toString());
+        assertEquals("contentsstart-128,-64,-2,-1,0,1,31,64end", sb.toString());
     }
 
     @Override
@@ -96,27 +100,27 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         MutableByteSet actualSet = set.reject(BytePredicates.greaterThan((byte) 0));
 
         ByteHashSet expectedSet = ByteHashSet.newSetWith((byte) 0, (byte) -1, (byte) -2, (byte) -64, (byte) -128);
-        Assert.assertEquals(expectedSet, actualSet);
+        assertEquals(expectedSet, actualSet);
 
         MutableByteSet actualSet2 = set.reject(BytePredicates.lessThan((byte) 0));
         ByteHashSet expectedSet2 = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) 64);
-        Assert.assertEquals(expectedSet2, actualSet2);
+        assertEquals(expectedSet2, actualSet2);
     }
 
     @Test
     public void hashcode()
     {
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) -128, (byte) 64);
-        Assert.assertEquals(-99, set.hashCode());
+        assertEquals(-99, set.hashCode());
 
         ByteHashSet set1 = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals(32, set1.hashCode());
+        assertEquals(32, set1.hashCode());
 
         ByteHashSet set2 = ByteHashSet.newSetWith((byte) -76, (byte) -128, (byte) -127);
-        Assert.assertEquals(-331, set2.hashCode());
+        assertEquals(-331, set2.hashCode());
 
         ByteHashSet set3 = ByteHashSet.newSetWith((byte) -33, (byte) 127, (byte) 65);
-        Assert.assertEquals(159, set3.hashCode());
+        assertEquals(159, set3.hashCode());
     }
 
     @Override
@@ -130,7 +134,7 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         MutableSet<Byte> actualSet = set.collect(function);
         MutableSet<Byte> expectedSet = UnifiedSet.newSetWith((byte) -1, (byte) 0, (byte) 30, (byte) -2, (byte) -3, (byte) -65, (byte) 110, (byte) 63);
 
-        Assert.assertEquals(expectedSet, actualSet);
+        assertEquals(expectedSet, actualSet);
     }
 
     @Override
@@ -140,12 +144,12 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         super.anySatisfy();
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) -65, (byte) -128, (byte) 111, (byte) 64);
 
-        Assert.assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) 0)));
-        Assert.assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) -2)));
-        Assert.assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) -64)));
-        Assert.assertTrue(set.anySatisfy(BytePredicates.greaterThan((byte) 65)));
-        Assert.assertFalse(set.anySatisfy(BytePredicates.greaterThan((byte) 121)));
-        Assert.assertFalse(set.anySatisfy(BytePredicates.lessThan((byte) -128)));
+        assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) 0)));
+        assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) -2)));
+        assertTrue(set.anySatisfy(BytePredicates.lessThan((byte) -64)));
+        assertTrue(set.anySatisfy(BytePredicates.greaterThan((byte) 65)));
+        assertFalse(set.anySatisfy(BytePredicates.greaterThan((byte) 121)));
+        assertFalse(set.anySatisfy(BytePredicates.lessThan((byte) -128)));
     }
 
     @Override
@@ -156,14 +160,14 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) 111,
                 (byte) 64, (byte) 65, (byte) 125, (byte) -65, (byte) -125);
 
-        Assert.assertTrue(set.allSatisfy(BytePredicates.lessThan((byte) 127)));
-        Assert.assertTrue(set.allSatisfy(BytePredicates.greaterThan((byte) -126)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.lessThan((byte) 0)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.greaterThan((byte) 63)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.equal((byte) 68)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.equal((byte) -124)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.lessThan((byte) 68)));
-        Assert.assertFalse(set.allSatisfy(BytePredicates.greaterThan((byte) -68)));
+        assertTrue(set.allSatisfy(BytePredicates.lessThan((byte) 127)));
+        assertTrue(set.allSatisfy(BytePredicates.greaterThan((byte) -126)));
+        assertFalse(set.allSatisfy(BytePredicates.lessThan((byte) 0)));
+        assertFalse(set.allSatisfy(BytePredicates.greaterThan((byte) 63)));
+        assertFalse(set.allSatisfy(BytePredicates.equal((byte) 68)));
+        assertFalse(set.allSatisfy(BytePredicates.equal((byte) -124)));
+        assertFalse(set.allSatisfy(BytePredicates.lessThan((byte) 68)));
+        assertFalse(set.allSatisfy(BytePredicates.greaterThan((byte) -68)));
     }
 
     @Override
@@ -174,14 +178,14 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) 111,
                 (byte) 64, (byte) 65, (byte) 125, (byte) -65, (byte) -125);
 
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) 127)));
-        Assert.assertTrue(set.noneSatisfy(BytePredicates.greaterThan((byte) 127)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) 65)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) -2)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) -65)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) 124)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) -1)));
-        Assert.assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) -65)));
+        assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) 127)));
+        assertTrue(set.noneSatisfy(BytePredicates.greaterThan((byte) 127)));
+        assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) 65)));
+        assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) -2)));
+        assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) -65)));
+        assertFalse(set.noneSatisfy(BytePredicates.greaterThan((byte) 124)));
+        assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) -1)));
+        assertFalse(set.noneSatisfy(BytePredicates.lessThan((byte) -65)));
     }
 
     @Override
@@ -190,16 +194,16 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     {
         super.sum();
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) -128, (byte) 64);
-        Assert.assertEquals(-99, set.sum());
+        assertEquals(-99, set.sum());
 
         ByteHashSet set1 = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals(32, set1.sum());
+        assertEquals(32, set1.sum());
 
         ByteHashSet set2 = ByteHashSet.newSetWith((byte) -76, (byte) -128, (byte) -127);
-        Assert.assertEquals(-331, set2.sum());
+        assertEquals(-331, set2.sum());
 
         ByteHashSet set3 = ByteHashSet.newSetWith((byte) -33, (byte) 127, (byte) 65);
-        Assert.assertEquals(159, set3.sum());
+        assertEquals(159, set3.sum());
     }
 
     @Override
@@ -208,22 +212,22 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     {
         super.min();
         ByteHashSet set = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31, (byte) -1, (byte) -2, (byte) -64, (byte) -128, (byte) 64, (byte) 127);
-        Assert.assertEquals(-128, set.min());
+        assertEquals(-128, set.min());
 
         ByteHashSet set1 = ByteHashSet.newSetWith((byte) 0, (byte) 1, (byte) 31);
-        Assert.assertEquals(0, set1.min());
+        assertEquals(0, set1.min());
 
         ByteHashSet set2 = ByteHashSet.newSetWith((byte) -76, (byte) -128, (byte) -127);
-        Assert.assertEquals(-128, set2.min());
+        assertEquals(-128, set2.min());
 
         ByteHashSet set3 = ByteHashSet.newSetWith((byte) -33, (byte) 127, (byte) 65);
-        Assert.assertEquals(-33, set3.min());
+        assertEquals(-33, set3.min());
 
         ByteHashSet set4 = ByteHashSet.newSetWith((byte) -65, (byte) -127, (byte) -90);
-        Assert.assertEquals(-127, set4.min());
+        assertEquals(-127, set4.min());
 
         ByteHashSet set5 = ByteHashSet.newSetWith((byte) 75, (byte) 85, (byte) 127);
-        Assert.assertEquals(75, set5.min());
+        assertEquals(75, set5.min());
     }
 
     @Override
@@ -231,10 +235,10 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     public void max()
     {
         super.max();
-        Assert.assertEquals(9L, this.newWith((byte) -1, (byte) -2, (byte) 9).max());
-        Assert.assertEquals(127L, this.newWith((byte) -1, (byte) -2, (byte) 9, (byte) -65, (byte) -127, (byte) 65, (byte) 127).max());
-        Assert.assertEquals(-1L, this.newWith((byte) -1, (byte) -2, (byte) -9, (byte) -65, (byte) -127).max());
-        Assert.assertEquals(-65L, this.newWith((byte) -65, (byte) -87, (byte) -127).max());
+        assertEquals(9L, this.newWith((byte) -1, (byte) -2, (byte) 9).max());
+        assertEquals(127L, this.newWith((byte) -1, (byte) -2, (byte) 9, (byte) -65, (byte) -127, (byte) 65, (byte) 127).max());
+        assertEquals(-1L, this.newWith((byte) -1, (byte) -2, (byte) -9, (byte) -65, (byte) -127).max());
+        assertEquals(-65L, this.newWith((byte) -65, (byte) -87, (byte) -127).max());
     }
 
     @Test
@@ -247,31 +251,31 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     public void addAndCheckField()
     {
         MutableByteSet hashSet = new ByteHashSet();
-        Assert.assertTrue(hashSet.add((byte) 14));
-        Assert.assertFalse(hashSet.add((byte) 14));
-        Assert.assertTrue(hashSet.add((byte) 2));
-        Assert.assertFalse(hashSet.add((byte) 2));
-        Assert.assertTrue(hashSet.add((byte) 35));
-        Assert.assertFalse(hashSet.add((byte) 35));
-        Assert.assertTrue(hashSet.add((byte) 31));
-        Assert.assertFalse(hashSet.add((byte) 31));
-        Assert.assertTrue(hashSet.add((byte) 32));
-        Assert.assertFalse(hashSet.add((byte) 32));
-        Assert.assertTrue(hashSet.add((byte) 0));
-        Assert.assertFalse(hashSet.add((byte) 0));
-        Assert.assertTrue(hashSet.add((byte) 1));
-        Assert.assertFalse(hashSet.add((byte) 1));
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 14, (byte) 2, (byte) 31, (byte) 32, (byte) 35, (byte) 0, (byte) 1), hashSet);
+        assertTrue(hashSet.add((byte) 14));
+        assertFalse(hashSet.add((byte) 14));
+        assertTrue(hashSet.add((byte) 2));
+        assertFalse(hashSet.add((byte) 2));
+        assertTrue(hashSet.add((byte) 35));
+        assertFalse(hashSet.add((byte) 35));
+        assertTrue(hashSet.add((byte) 31));
+        assertFalse(hashSet.add((byte) 31));
+        assertTrue(hashSet.add((byte) 32));
+        assertFalse(hashSet.add((byte) 32));
+        assertTrue(hashSet.add((byte) 0));
+        assertFalse(hashSet.add((byte) 0));
+        assertTrue(hashSet.add((byte) 1));
+        assertFalse(hashSet.add((byte) 1));
+        assertEquals(ByteHashSet.newSetWith((byte) 14, (byte) 2, (byte) 31, (byte) 32, (byte) 35, (byte) 0, (byte) 1), hashSet);
     }
 
     @Test
     public void addWithRehash()
     {
         ByteHashSet hashSet = new ByteHashSet();
-        Assert.assertTrue(hashSet.addAll((byte) 32, (byte) 33, (byte) 34, (byte) 35, (byte) 36, (byte) 37, (byte) 38, (byte) 39));
-        Assert.assertEquals(8, hashSet.size());
-        Assert.assertTrue(hashSet.addAll((byte) 0, (byte) 63, (byte) 64, (byte) 127, (byte) -1, (byte) -64, (byte) -65, (byte) -128));
-        Assert.assertEquals(16, hashSet.size());
+        assertTrue(hashSet.addAll((byte) 32, (byte) 33, (byte) 34, (byte) 35, (byte) 36, (byte) 37, (byte) 38, (byte) 39));
+        assertEquals(8, hashSet.size());
+        assertTrue(hashSet.addAll((byte) 0, (byte) 63, (byte) 64, (byte) 127, (byte) -1, (byte) -64, (byte) -65, (byte) -128));
+        assertEquals(16, hashSet.size());
     }
 
     @Test
@@ -284,9 +288,9 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     {
         for (byte i = (byte) 100; i < (byte) 200; i++)
         {
-            Assert.assertFalse(hashSet.contains(i));
-            Assert.assertTrue(hashSet.add(i));
-            Assert.assertTrue(hashSet.remove(i));
+            assertFalse(hashSet.contains(i));
+            assertTrue(hashSet.add(i));
+            assertTrue(hashSet.remove(i));
         }
     }
 
@@ -312,7 +316,7 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.add((byte) -64);
         hashSet.add((byte) -127);
 
-        Assert.assertEquals(11, hashSet.size());
+        assertEquals(11, hashSet.size());
     }
 
     @Test
@@ -321,30 +325,30 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         ByteHashSet hashSet = ByteHashSet.newSetWith();
         for (byte i = (byte) 0; i <= (byte) 31; i++)
         {
-            Assert.assertTrue(hashSet.add(i));
-            Assert.assertFalse(hashSet.add(i));
+            assertTrue(hashSet.add(i));
+            assertFalse(hashSet.add(i));
         }
         for (byte i = (byte) 0; i <= (byte) 31; i++)
         {
-            Assert.assertTrue(hashSet.contains(i));
+            assertTrue(hashSet.contains(i));
         }
 
         for (byte i = (byte) 0; i <= (byte) 31; i++)
         {
-            Assert.assertTrue(hashSet.contains(i));
-            Assert.assertTrue(hashSet.remove(i));
-            Assert.assertFalse(hashSet.contains(i));
-            Assert.assertFalse(hashSet.remove(i));
+            assertTrue(hashSet.contains(i));
+            assertTrue(hashSet.remove(i));
+            assertFalse(hashSet.contains(i));
+            assertFalse(hashSet.remove(i));
         }
 
-        Assert.assertEquals(new ByteHashSet(), hashSet);
+        assertEquals(new ByteHashSet(), hashSet);
     }
 
     @Test
     public void addDuplicates()
     {
         ByteHashSet hashSet = ByteHashSet.newSetWith();
-        Assert.assertEquals(0, hashSet.size());
+        assertEquals(0, hashSet.size());
 
         hashSet.add((byte) 0);
         hashSet.add((byte) 1);
@@ -356,7 +360,7 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.add((byte) 0);
         hashSet.add((byte) 1);
         hashSet.add((byte) 63);
-        Assert.assertEquals(6, hashSet.size());
+        assertEquals(6, hashSet.size());
     }
 
     @Test
@@ -364,13 +368,13 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
     {
         ByteHashSet hashSet = ByteHashSet.newSetWith();
 
-        Assert.assertFalse(hashSet.contains((byte) 0));
-        Assert.assertFalse(hashSet.contains((byte) 1));
-        Assert.assertFalse(hashSet.contains((byte) 2));
-        Assert.assertFalse(hashSet.contains((byte) 20));
-        Assert.assertFalse(hashSet.contains((byte) 55));
-        Assert.assertFalse(hashSet.contains((byte) 63));
-        Assert.assertFalse(hashSet.contains((byte) 63));
+        assertFalse(hashSet.contains((byte) 0));
+        assertFalse(hashSet.contains((byte) 1));
+        assertFalse(hashSet.contains((byte) 2));
+        assertFalse(hashSet.contains((byte) 20));
+        assertFalse(hashSet.contains((byte) 55));
+        assertFalse(hashSet.contains((byte) 63));
+        assertFalse(hashSet.contains((byte) 63));
 
         hashSet.add((byte) 0);
         hashSet.add((byte) 1);
@@ -379,29 +383,29 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.add((byte) 55);
         hashSet.add((byte) 63);
 
-        Assert.assertTrue(hashSet.contains((byte) 0));
-        Assert.assertTrue(hashSet.contains((byte) 1));
-        Assert.assertTrue(hashSet.contains((byte) 2));
-        Assert.assertTrue(hashSet.contains((byte) 20));
-        Assert.assertTrue(hashSet.contains((byte) 55));
-        Assert.assertTrue(hashSet.contains((byte) 63));
-        Assert.assertTrue(hashSet.contains((byte) 63));
+        assertTrue(hashSet.contains((byte) 0));
+        assertTrue(hashSet.contains((byte) 1));
+        assertTrue(hashSet.contains((byte) 2));
+        assertTrue(hashSet.contains((byte) 20));
+        assertTrue(hashSet.contains((byte) 55));
+        assertTrue(hashSet.contains((byte) 63));
+        assertTrue(hashSet.contains((byte) 63));
 
-        Assert.assertFalse(hashSet.contains((byte) 23));
-        Assert.assertFalse(hashSet.contains((byte) 44));
-        Assert.assertFalse(hashSet.contains((byte) 54));
+        assertFalse(hashSet.contains((byte) 23));
+        assertFalse(hashSet.contains((byte) 44));
+        assertFalse(hashSet.contains((byte) 54));
 
         hashSet.remove((byte) 0);
-        Assert.assertFalse(hashSet.contains((byte) 0));
+        assertFalse(hashSet.contains((byte) 0));
 
         hashSet.remove((byte) 20);
-        Assert.assertFalse(hashSet.contains((byte) 20));
+        assertFalse(hashSet.contains((byte) 20));
 
-        Assert.assertFalse(hashSet.contains((byte) 64));
-        Assert.assertFalse(hashSet.contains((byte) 66));
-        Assert.assertFalse(hashSet.contains((byte) 78));
-        Assert.assertFalse(hashSet.contains((byte) 100));
-        Assert.assertFalse(hashSet.contains((byte) 127));
+        assertFalse(hashSet.contains((byte) 64));
+        assertFalse(hashSet.contains((byte) 66));
+        assertFalse(hashSet.contains((byte) 78));
+        assertFalse(hashSet.contains((byte) 100));
+        assertFalse(hashSet.contains((byte) 127));
 
         hashSet.add((byte) 64);
         hashSet.add((byte) 66);
@@ -409,21 +413,21 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.add((byte) 100);
         hashSet.add((byte) 127);
 
-        Assert.assertTrue(hashSet.contains((byte) 64));
-        Assert.assertTrue(hashSet.contains((byte) 66));
-        Assert.assertTrue(hashSet.contains((byte) 78));
-        Assert.assertTrue(hashSet.contains((byte) 100));
-        Assert.assertTrue(hashSet.contains((byte) 127));
+        assertTrue(hashSet.contains((byte) 64));
+        assertTrue(hashSet.contains((byte) 66));
+        assertTrue(hashSet.contains((byte) 78));
+        assertTrue(hashSet.contains((byte) 100));
+        assertTrue(hashSet.contains((byte) 127));
 
-        Assert.assertFalse(hashSet.contains((byte) 70));
-        Assert.assertFalse(hashSet.contains((byte) 75));
-        Assert.assertFalse(hashSet.contains((byte) 125));
+        assertFalse(hashSet.contains((byte) 70));
+        assertFalse(hashSet.contains((byte) 75));
+        assertFalse(hashSet.contains((byte) 125));
 
         hashSet.remove((byte) 64);
-        Assert.assertFalse(hashSet.contains((byte) 64));
+        assertFalse(hashSet.contains((byte) 64));
 
         hashSet.remove((byte) 100);
-        Assert.assertFalse(hashSet.contains((byte) 100));
+        assertFalse(hashSet.contains((byte) 100));
 
         hashSet.add((byte) -1);
         hashSet.add((byte) -2);
@@ -438,26 +442,26 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.add((byte) -127);
         hashSet.add((byte) -128);
 
-        Assert.assertTrue(hashSet.contains((byte) -1));
-        Assert.assertTrue(hashSet.contains((byte) -2));
-        Assert.assertTrue(hashSet.contains((byte) -33));
-        Assert.assertTrue(hashSet.contains((byte) -34));
-        Assert.assertTrue(hashSet.contains((byte) -50));
-        Assert.assertTrue(hashSet.contains((byte) -64));
+        assertTrue(hashSet.contains((byte) -1));
+        assertTrue(hashSet.contains((byte) -2));
+        assertTrue(hashSet.contains((byte) -33));
+        assertTrue(hashSet.contains((byte) -34));
+        assertTrue(hashSet.contains((byte) -50));
+        assertTrue(hashSet.contains((byte) -64));
 
-        Assert.assertTrue(hashSet.contains((byte) -65));
-        Assert.assertTrue(hashSet.contains((byte) -78));
-        Assert.assertTrue(hashSet.contains((byte) -112));
-        Assert.assertTrue(hashSet.contains((byte) -127));
-        Assert.assertTrue(hashSet.contains((byte) -128));
+        assertTrue(hashSet.contains((byte) -65));
+        assertTrue(hashSet.contains((byte) -78));
+        assertTrue(hashSet.contains((byte) -112));
+        assertTrue(hashSet.contains((byte) -127));
+        assertTrue(hashSet.contains((byte) -128));
 
-        Assert.assertFalse(hashSet.contains((byte) -31));
-        Assert.assertFalse(hashSet.contains((byte) -55));
-        Assert.assertFalse(hashSet.contains((byte) -66));
+        assertFalse(hashSet.contains((byte) -31));
+        assertFalse(hashSet.contains((byte) -55));
+        assertFalse(hashSet.contains((byte) -66));
 
-        Assert.assertFalse(hashSet.contains((byte) -75));
-        Assert.assertFalse(hashSet.contains((byte) -80));
-        Assert.assertFalse(hashSet.contains((byte) -100));
+        assertFalse(hashSet.contains((byte) -75));
+        assertFalse(hashSet.contains((byte) -80));
+        assertFalse(hashSet.contains((byte) -100));
 
         hashSet.remove((byte) -1);
         hashSet.remove((byte) -2);
@@ -465,11 +469,11 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
         hashSet.remove((byte) -127);
         hashSet.remove((byte) -33);
 
-        Assert.assertFalse(hashSet.contains((byte) -1));
-        Assert.assertFalse(hashSet.contains((byte) -2));
-        Assert.assertFalse(hashSet.contains((byte) -65));
-        Assert.assertFalse(hashSet.contains((byte) -127));
-        Assert.assertFalse(hashSet.contains((byte) -33));
+        assertFalse(hashSet.contains((byte) -1));
+        assertFalse(hashSet.contains((byte) -2));
+        assertFalse(hashSet.contains((byte) -65));
+        assertFalse(hashSet.contains((byte) -127));
+        assertFalse(hashSet.contains((byte) -33));
     }
 
     @Test
@@ -509,32 +513,32 @@ public class ByteHashSetTest extends AbstractByteSetTestCase
 
         byte[] expected = {-128, -100, -98, -87, -67, -65, -64, -63, -56, -14, -5, -1, 0, 1, 2, 20, 55, 63, 64, 65, 67, 70, 78, 80, 87, 98, 127};
 
-        Assert.assertArrayEquals(expected, hashSet.toArray());
+        assertArrayEquals(expected, hashSet.toArray());
     }
 
     @Test
     public void toImmutable()
     {
         ByteHashSet hashSet = ByteHashSet.newSetWith();
-        Assert.assertEquals(0, hashSet.toImmutable().size());
+        assertEquals(0, hashSet.toImmutable().size());
 
         ByteHashSet hashSet1 = ByteHashSet.newSetWith((byte) -1);
-        Assert.assertEquals(1, hashSet1.toImmutable().size());
+        assertEquals(1, hashSet1.toImmutable().size());
 
         ByteHashSet hashSet2 = ByteHashSet.newSetWith((byte) -1, (byte) -4);
-        Assert.assertEquals(2, hashSet2.toImmutable().size());
+        assertEquals(2, hashSet2.toImmutable().size());
     }
 
     @Test
     public void freeze()
     {
         ByteHashSet hashSet = ByteHashSet.newSetWith();
-        Assert.assertEquals(0, hashSet.freeze().size());
+        assertEquals(0, hashSet.freeze().size());
 
         ByteHashSet hashSet1 = ByteHashSet.newSetWith((byte) -1);
-        Assert.assertEquals(1, hashSet1.freeze().size());
+        assertEquals(1, hashSet1.freeze().size());
 
         ByteHashSet hashSet2 = ByteHashSet.newSetWith((byte) -1, (byte) -4);
-        Assert.assertEquals(2, hashSet2.freeze().size());
+        assertEquals(2, hashSet2.freeze().size());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ImmutableBooleanHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ImmutableBooleanHashSetTest.java
@@ -31,9 +31,14 @@ import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollectionTestCase
 {
@@ -81,7 +86,7 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     {
         ImmutableBooleanSet set = this.classUnderTest();
         Verify.assertSize(2, set);
-        Assert.assertTrue(set.containsAll(true, false, true));
+        assertTrue(set.containsAll(true, false, true));
     }
 
     @Override
@@ -100,10 +105,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void notEmpty()
     {
         super.notEmpty();
-        Assert.assertFalse(this.emptySet.notEmpty());
-        Assert.assertTrue(this.falseSet.notEmpty());
-        Assert.assertTrue(this.trueSet.notEmpty());
-        Assert.assertTrue(this.trueFalseSet.notEmpty());
+        assertFalse(this.emptySet.notEmpty());
+        assertTrue(this.falseSet.notEmpty());
+        assertTrue(this.trueSet.notEmpty());
+        assertTrue(this.trueFalseSet.notEmpty());
     }
 
     @Override
@@ -111,14 +116,14 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void contains()
     {
         super.contains();
-        Assert.assertFalse(this.emptySet.contains(true));
-        Assert.assertFalse(this.emptySet.contains(false));
-        Assert.assertTrue(this.falseSet.contains(false));
-        Assert.assertFalse(this.falseSet.contains(true));
-        Assert.assertTrue(this.trueSet.contains(true));
-        Assert.assertFalse(this.trueSet.contains(false));
-        Assert.assertTrue(this.trueFalseSet.contains(true));
-        Assert.assertTrue(this.trueFalseSet.contains(false));
+        assertFalse(this.emptySet.contains(true));
+        assertFalse(this.emptySet.contains(false));
+        assertTrue(this.falseSet.contains(false));
+        assertFalse(this.falseSet.contains(true));
+        assertTrue(this.trueSet.contains(true));
+        assertFalse(this.trueSet.contains(false));
+        assertTrue(this.trueFalseSet.contains(true));
+        assertTrue(this.trueFalseSet.contains(false));
     }
 
     @Override
@@ -126,17 +131,17 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void containsAllArray()
     {
         super.containsAllArray();
-        Assert.assertFalse(this.emptySet.containsAll(true));
-        Assert.assertFalse(this.emptySet.containsAll(true, false));
-        Assert.assertTrue(this.falseSet.containsAll(false, false));
-        Assert.assertFalse(this.falseSet.containsAll(true, true));
-        Assert.assertFalse(this.falseSet.containsAll(true, false, true));
-        Assert.assertTrue(this.trueSet.containsAll(true, true));
-        Assert.assertFalse(this.trueSet.containsAll(false, false));
-        Assert.assertFalse(this.trueSet.containsAll(true, false, false));
-        Assert.assertTrue(this.trueFalseSet.containsAll(true, true));
-        Assert.assertTrue(this.trueFalseSet.containsAll(false, false));
-        Assert.assertTrue(this.trueFalseSet.containsAll(false, true, true));
+        assertFalse(this.emptySet.containsAll(true));
+        assertFalse(this.emptySet.containsAll(true, false));
+        assertTrue(this.falseSet.containsAll(false, false));
+        assertFalse(this.falseSet.containsAll(true, true));
+        assertFalse(this.falseSet.containsAll(true, false, true));
+        assertTrue(this.trueSet.containsAll(true, true));
+        assertFalse(this.trueSet.containsAll(false, false));
+        assertFalse(this.trueSet.containsAll(true, false, false));
+        assertTrue(this.trueFalseSet.containsAll(true, true));
+        assertTrue(this.trueFalseSet.containsAll(false, false));
+        assertTrue(this.trueFalseSet.containsAll(false, true, true));
     }
 
     @Override
@@ -144,17 +149,17 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void containsAllIterable()
     {
         super.containsAllIterable();
-        Assert.assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(this.falseSet.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.falseSet.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.falseSet.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertTrue(this.trueSet.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertFalse(this.trueSet.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertFalse(this.trueSet.containsAll(BooleanArrayList.newListWith(true, false, false)));
-        Assert.assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(false, true, true)));
+        assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(this.emptySet.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(this.falseSet.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.falseSet.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.falseSet.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertTrue(this.trueSet.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertFalse(this.trueSet.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertFalse(this.trueSet.containsAll(BooleanArrayList.newListWith(true, false, false)));
+        assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(this.trueFalseSet.containsAll(BooleanArrayList.newListWith(false, true, true)));
     }
 
     @Override
@@ -162,16 +167,16 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void toArray()
     {
         super.toArray();
-        Assert.assertEquals(0L, this.emptySet.toArray().length);
+        assertEquals(0L, this.emptySet.toArray().length);
 
-        Assert.assertEquals(1L, this.falseSet.toArray().length);
-        Assert.assertFalse(this.falseSet.toArray()[0]);
+        assertEquals(1L, this.falseSet.toArray().length);
+        assertFalse(this.falseSet.toArray()[0]);
 
-        Assert.assertEquals(1L, this.trueSet.toArray().length);
-        Assert.assertTrue(this.trueSet.toArray()[0]);
+        assertEquals(1L, this.trueSet.toArray().length);
+        assertTrue(this.trueSet.toArray()[0]);
 
-        Assert.assertEquals(2L, this.trueFalseSet.toArray().length);
-        Assert.assertTrue(Arrays.equals(new boolean[]{false, true}, this.trueFalseSet.toArray())
+        assertEquals(2L, this.trueFalseSet.toArray().length);
+        assertTrue(Arrays.equals(new boolean[]{false, true}, this.trueFalseSet.toArray())
                 || Arrays.equals(new boolean[]{true, false}, this.trueFalseSet.toArray()));
     }
 
@@ -180,10 +185,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void toList()
     {
         super.toList();
-        Assert.assertEquals(new BooleanArrayList(), this.emptySet.toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(false), this.falseSet.toList());
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.trueSet.toList());
-        Assert.assertTrue(BooleanArrayList.newListWith(false, true).equals(this.trueFalseSet.toList())
+        assertEquals(new BooleanArrayList(), this.emptySet.toList());
+        assertEquals(BooleanArrayList.newListWith(false), this.falseSet.toList());
+        assertEquals(BooleanArrayList.newListWith(true), this.trueSet.toList());
+        assertTrue(BooleanArrayList.newListWith(false, true).equals(this.trueFalseSet.toList())
                 || BooleanArrayList.newListWith(true, false).equals(this.trueFalseSet.toList()));
     }
 
@@ -192,32 +197,32 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void toSet()
     {
         super.toSet();
-        Assert.assertEquals(new BooleanHashSet(), this.emptySet.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false), this.falseSet.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true), this.trueSet.toSet());
-        Assert.assertEquals(BooleanHashSet.newSetWith(false, true), this.trueFalseSet.toSet());
+        assertEquals(new BooleanHashSet(), this.emptySet.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false), this.falseSet.toSet());
+        assertEquals(BooleanHashSet.newSetWith(true), this.trueSet.toSet());
+        assertEquals(BooleanHashSet.newSetWith(false, true), this.trueFalseSet.toSet());
     }
 
     @Override
     @Test
     public void toBag()
     {
-        Assert.assertEquals(new BooleanHashBag(), this.emptySet.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false), this.falseSet.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true), this.trueSet.toBag());
-        Assert.assertEquals(BooleanHashBag.newBagWith(false, true), this.trueFalseSet.toBag());
+        assertEquals(new BooleanHashBag(), this.emptySet.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false), this.falseSet.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true), this.trueSet.toBag());
+        assertEquals(BooleanHashBag.newBagWith(false, true), this.trueFalseSet.toBag());
     }
 
     @Override
     @Test
     public void testEquals()
     {
-        Assert.assertNotEquals(this.falseSet, this.emptySet);
-        Assert.assertNotEquals(this.falseSet, this.trueSet);
-        Assert.assertNotEquals(this.falseSet, this.trueFalseSet);
-        Assert.assertNotEquals(this.trueSet, this.emptySet);
-        Assert.assertNotEquals(this.trueSet, this.trueFalseSet);
-        Assert.assertNotEquals(this.trueFalseSet, this.emptySet);
+        assertNotEquals(this.falseSet, this.emptySet);
+        assertNotEquals(this.falseSet, this.trueSet);
+        assertNotEquals(this.falseSet, this.trueFalseSet);
+        assertNotEquals(this.trueSet, this.emptySet);
+        assertNotEquals(this.trueSet, this.trueFalseSet);
+        assertNotEquals(this.trueFalseSet, this.emptySet);
         Verify.assertEqualsAndHashCode(this.newWith(false, true), this.trueFalseSet);
         Verify.assertEqualsAndHashCode(this.newWith(true, false), this.trueFalseSet);
 
@@ -232,12 +237,12 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void testHashCode()
     {
         super.testHashCode();
-        Assert.assertEquals(UnifiedSet.newSet().hashCode(), this.emptySet.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(false).hashCode(), this.falseSet.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(true).hashCode(), this.trueSet.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(true, false).hashCode(), this.trueFalseSet.hashCode());
-        Assert.assertEquals(UnifiedSet.newSetWith(false, true).hashCode(), this.trueFalseSet.hashCode());
-        Assert.assertNotEquals(UnifiedSet.newSetWith(false).hashCode(), this.trueFalseSet.hashCode());
+        assertEquals(UnifiedSet.newSet().hashCode(), this.emptySet.hashCode());
+        assertEquals(UnifiedSet.newSetWith(false).hashCode(), this.falseSet.hashCode());
+        assertEquals(UnifiedSet.newSetWith(true).hashCode(), this.trueSet.hashCode());
+        assertEquals(UnifiedSet.newSetWith(true, false).hashCode(), this.trueFalseSet.hashCode());
+        assertEquals(UnifiedSet.newSetWith(false, true).hashCode(), this.trueFalseSet.hashCode());
+        assertNotEquals(UnifiedSet.newSetWith(false).hashCode(), this.trueFalseSet.hashCode());
     }
 
     @Override
@@ -245,30 +250,30 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void booleanIterator()
     {
         BooleanIterator booleanIterator0 = this.emptySet.booleanIterator();
-        Assert.assertFalse(booleanIterator0.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator0::next);
+        assertFalse(booleanIterator0.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator0::next);
 
         BooleanIterator booleanIterator1 = this.falseSet.booleanIterator();
-        Assert.assertTrue(booleanIterator1.hasNext());
-        Assert.assertFalse(booleanIterator1.next());
-        Assert.assertFalse(booleanIterator1.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator1::next);
+        assertTrue(booleanIterator1.hasNext());
+        assertFalse(booleanIterator1.next());
+        assertFalse(booleanIterator1.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator1::next);
 
         BooleanIterator booleanIterator2 = this.trueSet.booleanIterator();
-        Assert.assertTrue(booleanIterator2.hasNext());
-        Assert.assertTrue(booleanIterator2.next());
-        Assert.assertFalse(booleanIterator2.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator2::next);
+        assertTrue(booleanIterator2.hasNext());
+        assertTrue(booleanIterator2.next());
+        assertFalse(booleanIterator2.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator2::next);
 
         BooleanIterator booleanIterator3 = this.trueFalseSet.booleanIterator();
-        Assert.assertTrue(booleanIterator3.hasNext());
+        assertTrue(booleanIterator3.hasNext());
         MutableBooleanSet actual = new BooleanHashSet();
         actual.add(booleanIterator3.next());
-        Assert.assertTrue(booleanIterator3.hasNext());
+        assertTrue(booleanIterator3.hasNext());
         actual.add(booleanIterator3.next());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false), actual);
-        Assert.assertFalse(booleanIterator3.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, booleanIterator3::next);
+        assertEquals(BooleanHashSet.newSetWith(true, false), actual);
+        assertFalse(booleanIterator3.hasNext());
+        assertThrows(NoSuchElementException.class, booleanIterator3::next);
     }
 
     @Override
@@ -285,10 +290,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         this.trueSet.forEach(each -> sum[2] += each);
         this.trueFalseSet.forEach(each -> sum[3] += each);
 
-        Assert.assertEquals("", sum[0]);
-        Assert.assertEquals("false", sum[1]);
-        Assert.assertEquals("true", sum[2]);
-        Assert.assertTrue("truefalse".equals(sum[3]) || "falsetrue".equals(sum[3]));
+        assertEquals("", sum[0]);
+        assertEquals("false", sum[1]);
+        assertEquals("true", sum[2]);
+        assertTrue("truefalse".equals(sum[3]) || "falsetrue".equals(sum[3]));
     }
 
     @Override
@@ -296,10 +301,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void injectInto()
     {
         ObjectBooleanToObjectFunction<MutableInteger, MutableInteger> function = (object, value) -> object.add(value ? 1 : 0);
-        Assert.assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true, false, true).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(0), BooleanHashSet.newSetWith(false).injectInto(new MutableInteger(0), function));
-        Assert.assertEquals(new MutableInteger(0), new BooleanHashSet().injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true, false, true).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(1), BooleanHashSet.newSetWith(true).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(0), BooleanHashSet.newSetWith(false).injectInto(new MutableInteger(0), function));
+        assertEquals(new MutableInteger(0), new BooleanHashSet().injectInto(new MutableInteger(0), function));
     }
 
     @Override
@@ -314,15 +319,15 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     @Test
     public void count()
     {
-        Assert.assertEquals(0L, this.emptySet.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.falseSet.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(1L, this.falseSet.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(0L, this.trueSet.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(0L, this.trueFalseSet.count(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isFalse()));
-        Assert.assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isTrue()));
-        Assert.assertEquals(2L, this.trueFalseSet.count(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertEquals(0L, this.emptySet.count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.falseSet.count(BooleanPredicates.isTrue()));
+        assertEquals(1L, this.falseSet.count(BooleanPredicates.isFalse()));
+        assertEquals(0L, this.trueSet.count(BooleanPredicates.isFalse()));
+        assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isTrue()));
+        assertEquals(0L, this.trueFalseSet.count(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isFalse()));
+        assertEquals(1L, this.trueFalseSet.count(BooleanPredicates.isTrue()));
+        assertEquals(2L, this.trueFalseSet.count(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -330,14 +335,14 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void anySatisfy()
     {
         super.anySatisfy();
-        Assert.assertFalse(this.emptySet.anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.falseSet.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.falseSet.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.trueSet.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.trueSet.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.trueFalseSet.anySatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.trueFalseSet.anySatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.trueFalseSet.anySatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertFalse(this.emptySet.anySatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.falseSet.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.falseSet.anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.trueSet.anySatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.trueSet.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.trueFalseSet.anySatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.trueFalseSet.anySatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.trueFalseSet.anySatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -345,30 +350,30 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void allSatisfy()
     {
         super.allSatisfy();
-        Assert.assertTrue(this.emptySet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.falseSet.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.falseSet.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.trueSet.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.trueSet.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertTrue(this.trueFalseSet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.emptySet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.falseSet.allSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.falseSet.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.trueSet.allSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.trueSet.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.trueFalseSet.allSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.trueFalseSet.allSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(this.emptySet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
-        Assert.assertFalse(this.falseSet.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.falseSet.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.trueSet.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertTrue(this.trueSet.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.isTrue()));
-        Assert.assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.isFalse()));
-        Assert.assertTrue(this.trueFalseSet.noneSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
-        Assert.assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertTrue(this.emptySet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse())));
+        assertFalse(this.falseSet.noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.falseSet.noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.trueSet.noneSatisfy(BooleanPredicates.isTrue()));
+        assertTrue(this.trueSet.noneSatisfy(BooleanPredicates.isFalse()));
+        assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.isTrue()));
+        assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.isFalse()));
+        assertTrue(this.trueFalseSet.noneSatisfy(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
+        assertFalse(this.trueFalseSet.noneSatisfy(BooleanPredicates.or(BooleanPredicates.isFalse(), BooleanPredicates.isTrue())));
     }
 
     @Override
@@ -406,20 +411,20 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void detectIfNone()
     {
         super.detectIfNone();
-        Assert.assertTrue(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
-        Assert.assertFalse(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
-        Assert.assertTrue(this.falseSet.detectIfNone(BooleanPredicates.isTrue(), true));
-        Assert.assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isFalse(), false));
-        Assert.assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertFalse(this.trueSet.detectIfNone(BooleanPredicates.isFalse(), false));
-        Assert.assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isTrue(), true));
-        Assert.assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isTrue(), false));
-        Assert.assertTrue(this.trueFalseSet.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), true));
-        Assert.assertFalse(this.trueFalseSet.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), false));
-        Assert.assertFalse(this.trueFalseSet.detectIfNone(BooleanPredicates.isFalse(), true));
-        Assert.assertTrue(this.trueFalseSet.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertTrue(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), true));
+        assertFalse(this.emptySet.detectIfNone(BooleanPredicates.or(BooleanPredicates.isTrue(), BooleanPredicates.isFalse()), false));
+        assertTrue(this.falseSet.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.falseSet.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertFalse(this.trueSet.detectIfNone(BooleanPredicates.isFalse(), false));
+        assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isTrue(), true));
+        assertTrue(this.trueSet.detectIfNone(BooleanPredicates.isTrue(), false));
+        assertTrue(this.trueFalseSet.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), true));
+        assertFalse(this.trueFalseSet.detectIfNone(BooleanPredicates.and(BooleanPredicates.isFalse(), BooleanPredicates.isTrue()), false));
+        assertFalse(this.trueFalseSet.detectIfNone(BooleanPredicates.isFalse(), true));
+        assertTrue(this.trueFalseSet.detectIfNone(BooleanPredicates.isTrue(), false));
     }
 
     @Override
@@ -428,10 +433,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     {
         super.collect();
         BooleanToObjectFunction<Boolean> function = parameter -> !parameter;
-        Assert.assertEquals(UnifiedSet.newSetWith(true, false), this.trueFalseSet.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(false), this.trueSet.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(true), this.falseSet.collect(function));
-        Assert.assertEquals(UnifiedSet.newSetWith(), this.emptySet.collect(function));
+        assertEquals(UnifiedSet.newSetWith(true, false), this.trueFalseSet.collect(function));
+        assertEquals(UnifiedSet.newSetWith(false), this.trueSet.collect(function));
+        assertEquals(UnifiedSet.newSetWith(true), this.falseSet.collect(function));
+        assertEquals(UnifiedSet.newSetWith(), this.emptySet.collect(function));
     }
 
     @Override
@@ -439,10 +444,10 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals("[]", this.emptySet.toString());
-        Assert.assertEquals("[false]", this.falseSet.toString());
-        Assert.assertEquals("[true]", this.trueSet.toString());
-        Assert.assertTrue("[true, false]".equals(this.trueFalseSet.toString())
+        assertEquals("[]", this.emptySet.toString());
+        assertEquals("[false]", this.falseSet.toString());
+        assertEquals("[true]", this.trueSet.toString());
+        assertTrue("[true, false]".equals(this.trueFalseSet.toString())
                 || "[false, true]".equals(this.trueFalseSet.toString()));
     }
 
@@ -451,22 +456,22 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals("", this.emptySet.makeString());
-        Assert.assertEquals("false", this.falseSet.makeString());
-        Assert.assertEquals("true", this.trueSet.makeString());
-        Assert.assertTrue("true, false".equals(this.trueFalseSet.makeString())
+        assertEquals("", this.emptySet.makeString());
+        assertEquals("false", this.falseSet.makeString());
+        assertEquals("true", this.trueSet.makeString());
+        assertTrue("true, false".equals(this.trueFalseSet.makeString())
                 || "false, true".equals(this.trueFalseSet.makeString()));
 
-        Assert.assertEquals("", this.emptySet.makeString("/"));
-        Assert.assertEquals("false", this.falseSet.makeString("/"));
-        Assert.assertEquals("true", this.trueSet.makeString("/"));
-        Assert.assertTrue(this.trueFalseSet.makeString("/"), "true/false".equals(this.trueFalseSet.makeString("/"))
+        assertEquals("", this.emptySet.makeString("/"));
+        assertEquals("false", this.falseSet.makeString("/"));
+        assertEquals("true", this.trueSet.makeString("/"));
+        assertTrue(this.trueFalseSet.makeString("/"), "true/false".equals(this.trueFalseSet.makeString("/"))
                 || "false/true".equals(this.trueFalseSet.makeString("/")));
 
-        Assert.assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
-        Assert.assertEquals("[false]", this.falseSet.makeString("[", "/", "]"));
-        Assert.assertEquals("[true]", this.trueSet.makeString("[", "/", "]"));
-        Assert.assertTrue(this.trueFalseSet.makeString("[", "/", "]"), "[true/false]".equals(this.trueFalseSet.makeString("[", "/", "]"))
+        assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
+        assertEquals("[false]", this.falseSet.makeString("[", "/", "]"));
+        assertEquals("[true]", this.trueSet.makeString("[", "/", "]"));
+        assertTrue(this.trueFalseSet.makeString("[", "/", "]"), "[true/false]".equals(this.trueFalseSet.makeString("[", "/", "]"))
                 || "[false/true]".equals(this.trueFalseSet.makeString("[", "/", "]")));
     }
 
@@ -477,24 +482,24 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         super.appendString();
         StringBuilder appendable = new StringBuilder();
         this.emptySet.appendString(appendable);
-        Assert.assertEquals("", appendable.toString());
+        assertEquals("", appendable.toString());
 
         StringBuilder appendable1 = new StringBuilder();
         this.falseSet.appendString(appendable1);
-        Assert.assertEquals("false", appendable1.toString());
+        assertEquals("false", appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.trueSet.appendString(appendable2);
-        Assert.assertEquals("true", appendable2.toString());
+        assertEquals("true", appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.trueFalseSet.appendString(appendable3);
-        Assert.assertTrue("true, false".equals(appendable3.toString())
+        assertTrue("true, false".equals(appendable3.toString())
                 || "false, true".equals(appendable3.toString()));
 
         StringBuilder appendable4 = new StringBuilder();
         this.trueFalseSet.appendString(appendable4, "[", ", ", "]");
-        Assert.assertTrue("[true, false]".equals(appendable4.toString())
+        assertTrue("[true, false]".equals(appendable4.toString())
                 || "[false, true]".equals(appendable4.toString()));
     }
 
@@ -504,18 +509,18 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     {
         super.asLazy();
         Verify.assertInstanceOf(LazyBooleanIterable.class, this.emptySet.asLazy());
-        Assert.assertEquals(this.emptySet, this.emptySet.asLazy().toSet());
-        Assert.assertEquals(this.falseSet, this.falseSet.asLazy().toSet());
-        Assert.assertEquals(this.trueSet, this.trueSet.asLazy().toSet());
-        Assert.assertEquals(this.trueFalseSet, this.trueFalseSet.asLazy().toSet());
+        assertEquals(this.emptySet, this.emptySet.asLazy().toSet());
+        assertEquals(this.falseSet, this.falseSet.asLazy().toSet());
+        assertEquals(this.trueSet, this.trueSet.asLazy().toSet());
+        assertEquals(this.trueFalseSet, this.trueFalseSet.asLazy().toSet());
     }
 
     private void assertSizeAndContains(ImmutableBooleanCollection collection, boolean... elements)
     {
-        Assert.assertEquals(elements.length, collection.size());
+        assertEquals(elements.length, collection.size());
         for (boolean i : elements)
         {
-            Assert.assertTrue(collection.contains(i));
+            assertTrue(collection.contains(i));
         }
     }
 
@@ -577,27 +582,27 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
         ImmutableBooleanSet actual = set11.union(set21);
-        Assert.assertEquals(this.trueFalseSet, actual);
+        assertEquals(this.trueFalseSet, actual);
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
         ImmutableBooleanSet actual2 = set12.union(set22);
-        Assert.assertEquals(this.falseSet, actual2);
+        assertEquals(this.falseSet, actual2);
 
         ImmutableBooleanSet set13 = this.newWith(true);
         ImmutableBooleanSet set23 = this.newWith(true);
         ImmutableBooleanSet actual3 = set13.union(set23);
-        Assert.assertEquals(this.trueSet, actual3);
+        assertEquals(this.trueSet, actual3);
 
         ImmutableBooleanSet set14 = this.trueFalseSet;
         ImmutableBooleanSet set24 = this.newWith();
         ImmutableBooleanSet actual4 = set14.union(set24);
-        Assert.assertEquals(this.trueFalseSet, actual4);
+        assertEquals(this.trueFalseSet, actual4);
 
         ImmutableBooleanSet set15 = this.newWith();
         ImmutableBooleanSet set25 = this.newWith();
         ImmutableBooleanSet actual5 = set15.union(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
     }
 
     @Test
@@ -606,27 +611,27 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
         ImmutableBooleanSet actual = set11.intersect(set21);
-        Assert.assertEquals(this.emptySet, actual);
+        assertEquals(this.emptySet, actual);
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
         ImmutableBooleanSet actual2 = set12.intersect(set22);
-        Assert.assertEquals(this.falseSet, actual2);
+        assertEquals(this.falseSet, actual2);
 
         ImmutableBooleanSet set13 = this.newWith(true);
         ImmutableBooleanSet set23 = this.newWith(true);
         ImmutableBooleanSet actual3 = set13.intersect(set23);
-        Assert.assertEquals(this.trueSet, actual3);
+        assertEquals(this.trueSet, actual3);
 
         ImmutableBooleanSet set14 = this.trueFalseSet;
         ImmutableBooleanSet set24 = this.newWith();
         ImmutableBooleanSet actual4 = set14.intersect(set24);
-        Assert.assertEquals(this.emptySet, actual4);
+        assertEquals(this.emptySet, actual4);
 
         ImmutableBooleanSet set15 = this.newWith();
         ImmutableBooleanSet set25 = this.newWith();
         ImmutableBooleanSet actual5 = set15.intersect(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
     }
 
     @Test
@@ -635,32 +640,32 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
         ImmutableBooleanSet actual = set11.difference(set21);
-        Assert.assertEquals(this.trueSet, actual);
+        assertEquals(this.trueSet, actual);
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
         ImmutableBooleanSet actual2 = set12.difference(set22);
-        Assert.assertEquals(this.emptySet, actual2);
+        assertEquals(this.emptySet, actual2);
 
         ImmutableBooleanSet set13 = this.trueFalseSet;
         ImmutableBooleanSet set23 = this.trueFalseSet;
         ImmutableBooleanSet actual3 = set13.difference(set23);
-        Assert.assertEquals(this.emptySet, actual3);
+        assertEquals(this.emptySet, actual3);
 
         ImmutableBooleanSet set14 = this.trueFalseSet;
         ImmutableBooleanSet set24 = this.newWith();
         ImmutableBooleanSet actual4 = set14.difference(set24);
-        Assert.assertEquals(this.trueFalseSet, actual4);
+        assertEquals(this.trueFalseSet, actual4);
 
         ImmutableBooleanSet set15 = this.newWith();
         ImmutableBooleanSet set25 = this.trueFalseSet;
         ImmutableBooleanSet actual5 = set15.difference(set25);
-        Assert.assertEquals(this.emptySet, actual5);
+        assertEquals(this.emptySet, actual5);
 
         ImmutableBooleanSet set16 = this.newWith();
         ImmutableBooleanSet set26 = this.newWith();
         ImmutableBooleanSet actual6 = set16.difference(set26);
-        Assert.assertEquals(this.emptySet, actual6);
+        assertEquals(this.emptySet, actual6);
     }
 
     @Test
@@ -669,32 +674,32 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
         ImmutableBooleanSet actual = set11.symmetricDifference(set21);
-        Assert.assertEquals(this.trueFalseSet, actual);
+        assertEquals(this.trueFalseSet, actual);
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
         ImmutableBooleanSet actual2 = set12.symmetricDifference(set22);
-        Assert.assertEquals(this.emptySet, actual2);
+        assertEquals(this.emptySet, actual2);
 
         ImmutableBooleanSet set13 = this.trueFalseSet;
         ImmutableBooleanSet set23 = this.trueFalseSet;
         ImmutableBooleanSet actual3 = set13.symmetricDifference(set23);
-        Assert.assertEquals(this.emptySet, actual3);
+        assertEquals(this.emptySet, actual3);
 
         ImmutableBooleanSet set14 = this.trueFalseSet;
         ImmutableBooleanSet set24 = this.newWith();
         ImmutableBooleanSet actual4 = set14.symmetricDifference(set24);
-        Assert.assertEquals(this.trueFalseSet, actual4);
+        assertEquals(this.trueFalseSet, actual4);
 
         ImmutableBooleanSet set15 = this.newWith();
         ImmutableBooleanSet set25 = this.trueFalseSet;
         ImmutableBooleanSet actual5 = set15.symmetricDifference(set25);
-        Assert.assertEquals(this.trueFalseSet, actual5);
+        assertEquals(this.trueFalseSet, actual5);
 
         ImmutableBooleanSet set16 = this.newWith();
         ImmutableBooleanSet set26 = this.newWith();
         ImmutableBooleanSet actual6 = set16.symmetricDifference(set26);
-        Assert.assertEquals(this.emptySet, actual6);
+        assertEquals(this.emptySet, actual6);
     }
 
     @Test
@@ -702,27 +707,27 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     {
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
-        Assert.assertFalse(set11.isSubsetOf(set21));
+        assertFalse(set11.isSubsetOf(set21));
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
-        Assert.assertTrue(set12.isSubsetOf(set22));
+        assertTrue(set12.isSubsetOf(set22));
 
         ImmutableBooleanSet set13 = this.trueFalseSet;
         ImmutableBooleanSet set23 = this.trueFalseSet;
-        Assert.assertTrue(set13.isSubsetOf(set23));
+        assertTrue(set13.isSubsetOf(set23));
 
         ImmutableBooleanSet set14 = this.trueFalseSet;
         ImmutableBooleanSet set24 = this.newWith();
-        Assert.assertFalse(set14.isSubsetOf(set24));
+        assertFalse(set14.isSubsetOf(set24));
 
         ImmutableBooleanSet set15 = this.newWith();
         ImmutableBooleanSet set25 = this.trueFalseSet;
-        Assert.assertTrue(set15.isSubsetOf(set25));
+        assertTrue(set15.isSubsetOf(set25));
 
         ImmutableBooleanSet set16 = this.newWith();
         ImmutableBooleanSet set26 = this.newWith();
-        Assert.assertTrue(set16.isSubsetOf(set26));
+        assertTrue(set16.isSubsetOf(set26));
     }
 
     @Test
@@ -730,31 +735,31 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
     {
         ImmutableBooleanSet set11 = this.newWith(true);
         ImmutableBooleanSet set21 = this.newWith(false);
-        Assert.assertFalse(set11.isProperSubsetOf(set21));
+        assertFalse(set11.isProperSubsetOf(set21));
 
         ImmutableBooleanSet set12 = this.newWith(false);
         ImmutableBooleanSet set22 = this.newWith(false);
-        Assert.assertFalse(set12.isProperSubsetOf(set22));
+        assertFalse(set12.isProperSubsetOf(set22));
 
         ImmutableBooleanSet set13 = this.trueSet;
         ImmutableBooleanSet set23 = this.trueFalseSet;
-        Assert.assertTrue(set13.isProperSubsetOf(set23));
+        assertTrue(set13.isProperSubsetOf(set23));
 
         ImmutableBooleanSet set14 = this.falseSet;
         ImmutableBooleanSet set24 = this.trueFalseSet;
-        Assert.assertTrue(set14.isProperSubsetOf(set24));
+        assertTrue(set14.isProperSubsetOf(set24));
 
         ImmutableBooleanSet set15 = this.trueFalseSet;
         ImmutableBooleanSet set25 = this.newWith();
-        Assert.assertFalse(set15.isProperSubsetOf(set25));
+        assertFalse(set15.isProperSubsetOf(set25));
 
         ImmutableBooleanSet set16 = this.newWith();
         ImmutableBooleanSet set26 = this.trueFalseSet;
-        Assert.assertTrue(set16.isProperSubsetOf(set26));
+        assertTrue(set16.isProperSubsetOf(set26));
 
         ImmutableBooleanSet set17 = this.newWith();
         ImmutableBooleanSet set27 = this.newWith();
-        Assert.assertFalse(set17.isProperSubsetOf(set27));
+        assertFalse(set17.isProperSubsetOf(set27));
     }
 
     @Test
@@ -764,38 +769,38 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         ImmutableBooleanSet set21 = this.falseSet;
         MutableSet<BooleanBooleanPair> expected1 = Sets.mutable.with(
                 PrimitiveTuples.pair(true, false));
-        Assert.assertEquals(expected1, set11.cartesianProduct(set21).toSet());
+        assertEquals(expected1, set11.cartesianProduct(set21).toSet());
 
         ImmutableBooleanSet set12 = this.falseSet;
         ImmutableBooleanSet set22 = this.falseSet;
         MutableSet<BooleanBooleanPair> expected2 = Sets.mutable.with(
                 PrimitiveTuples.pair(false, false));
-        Assert.assertEquals(expected2, set12.cartesianProduct(set22).toSet());
+        assertEquals(expected2, set12.cartesianProduct(set22).toSet());
 
         ImmutableBooleanSet set13 = this.trueSet;
         ImmutableBooleanSet set23 = this.trueFalseSet;
         MutableSet<BooleanBooleanPair> expected3 = Sets.mutable.with(
                 PrimitiveTuples.pair(true, true),
                 PrimitiveTuples.pair(true, false));
-        Assert.assertEquals(expected3, set13.cartesianProduct(set23).toSet());
+        assertEquals(expected3, set13.cartesianProduct(set23).toSet());
 
         ImmutableBooleanSet set14 = this.falseSet;
         ImmutableBooleanSet set24 = this.trueFalseSet;
         MutableSet<BooleanBooleanPair> expected4 = Sets.mutable.with(
                 PrimitiveTuples.pair(false, true),
                 PrimitiveTuples.pair(false, false));
-        Assert.assertEquals(expected4, set14.cartesianProduct(set24).toSet());
+        assertEquals(expected4, set14.cartesianProduct(set24).toSet());
 
         ImmutableBooleanSet set15 = this.trueFalseSet;
         ImmutableBooleanSet set25 = this.newWith();
-        Assert.assertEquals(Sets.mutable.empty(), set15.cartesianProduct(set25).toSet());
+        assertEquals(Sets.mutable.empty(), set15.cartesianProduct(set25).toSet());
 
         ImmutableBooleanSet set16 = this.newWith();
         ImmutableBooleanSet set26 = this.trueFalseSet;
-        Assert.assertEquals(Sets.mutable.empty(), set16.cartesianProduct(set26).toSet());
+        assertEquals(Sets.mutable.empty(), set16.cartesianProduct(set26).toSet());
 
         ImmutableBooleanSet set17 = this.newWith();
         ImmutableBooleanSet set27 = this.newWith();
-        Assert.assertEquals(Sets.mutable.empty(), set17.cartesianProduct(set27).toSet());
+        assertEquals(Sets.mutable.empty(), set17.cartesianProduct(set27).toSet());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
@@ -15,8 +15,9 @@ import java.util.Random;
 
 import org.eclipse.collections.api.block.predicate.primitive.LongPredicate;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 // extra tests not covered in the generated portion
 public class LongHashSetExtraTest
@@ -68,6 +69,6 @@ public class LongHashSetExtraTest
         }
         Field table = LongHashSet.class.getDeclaredField("table");
         table.setAccessible(true);
-        Assert.assertTrue(((long[]) table.get(set)).length < 10_000);
+        assertTrue(((long[]) table.get(set)).length < 10_000);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/SynchronizedBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/SynchronizedBooleanSetTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.collections.impl.set.mutable.primitive;
 
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanSet}.
@@ -38,9 +40,9 @@ public class SynchronizedBooleanSetTest extends AbstractBooleanSetTestCase
         super.asSynchronized();
         SynchronizedBooleanSet set = this.classUnderTest();
         MutableBooleanSet setWithLockObject = new SynchronizedBooleanSet(BooleanHashSet.newSetWith(true, false, true), new Object()).asSynchronized();
-        Assert.assertEquals(set, setWithLockObject);
-        Assert.assertSame(setWithLockObject, setWithLockObject.asSynchronized());
-        Assert.assertSame(set, set.asSynchronized());
-        Assert.assertEquals(set, set.asSynchronized());
+        assertEquals(set, setWithLockObject);
+        assertSame(setWithLockObject, setWithLockObject.asSynchronized());
+        assertSame(set, set.asSynchronized());
+        assertEquals(set, set.asSynchronized());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/UnmodifiableBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/UnmodifiableBooleanSetTest.java
@@ -13,8 +13,13 @@ package org.eclipse.collections.impl.set.mutable.primitive;
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanSet}.
@@ -129,21 +134,21 @@ public class UnmodifiableBooleanSetTest extends AbstractBooleanSetTestCase
     public void containsAllArray()
     {
         UnmodifiableBooleanSet collection = this.classUnderTest();
-        Assert.assertTrue(collection.containsAll(true));
-        Assert.assertTrue(collection.containsAll(true, false, true));
-        Assert.assertTrue(collection.containsAll(true, false));
-        Assert.assertTrue(collection.containsAll(true, true));
-        Assert.assertTrue(collection.containsAll(false, false));
+        assertTrue(collection.containsAll(true));
+        assertTrue(collection.containsAll(true, false, true));
+        assertTrue(collection.containsAll(true, false));
+        assertTrue(collection.containsAll(true, true));
+        assertTrue(collection.containsAll(false, false));
         UnmodifiableBooleanSet emptyCollection = this.newWith();
-        Assert.assertFalse(emptyCollection.containsAll(true));
-        Assert.assertFalse(emptyCollection.containsAll(false));
-        Assert.assertFalse(emptyCollection.containsAll(false, true, false));
-        Assert.assertFalse(this.newWith(true, true).containsAll(false, true, false));
+        assertFalse(emptyCollection.containsAll(true));
+        assertFalse(emptyCollection.containsAll(false));
+        assertFalse(emptyCollection.containsAll(false, true, false));
+        assertFalse(this.newWith(true, true).containsAll(false, true, false));
 
         UnmodifiableBooleanSet trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(true, false));
+        assertFalse(trueCollection.containsAll(true, false));
         UnmodifiableBooleanSet falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(true, false));
+        assertFalse(falseCollection.containsAll(true, false));
     }
 
     @Override
@@ -151,22 +156,22 @@ public class UnmodifiableBooleanSetTest extends AbstractBooleanSetTestCase
     public void containsAllIterable()
     {
         UnmodifiableBooleanSet emptyCollection = this.newWith();
-        Assert.assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(emptyCollection.containsAll(new BooleanArrayList()));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(true)));
+        assertFalse(emptyCollection.containsAll(BooleanArrayList.newListWith(false)));
         UnmodifiableBooleanSet collection = this.newWith(true, true, false, false, false);
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
-        Assert.assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
-        Assert.assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, true)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(false, false)));
+        assertTrue(collection.containsAll(BooleanArrayList.newListWith(true, false, true)));
+        assertFalse(this.newWith(true, true).containsAll(BooleanArrayList.newListWith(false, true, false)));
 
         UnmodifiableBooleanSet trueCollection = this.newWith(true, true, true, true);
-        Assert.assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(trueCollection.containsAll(BooleanArrayList.newListWith(true, false)));
         UnmodifiableBooleanSet falseCollection = this.newWith(false, false, false, false);
-        Assert.assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
+        assertFalse(falseCollection.containsAll(BooleanArrayList.newListWith(true, false)));
     }
 
     @Override
@@ -175,8 +180,8 @@ public class UnmodifiableBooleanSetTest extends AbstractBooleanSetTestCase
     {
         super.asUnmodifiable();
         MutableBooleanSet set = this.classUnderTest();
-        Assert.assertSame(set, set.asUnmodifiable());
-        Assert.assertEquals(set, set.asUnmodifiable());
+        assertSame(set, set.asUnmodifiable());
+        assertEquals(set, set.asUnmodifiable());
     }
 
     @Override
@@ -184,9 +189,9 @@ public class UnmodifiableBooleanSetTest extends AbstractBooleanSetTestCase
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override
@@ -194,8 +199,8 @@ public class UnmodifiableBooleanSetTest extends AbstractBooleanSetTestCase
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator booleanIterator = this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/primitive/ImmutableBooleanSetFactoryImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/primitive/ImmutableBooleanSetFactoryImplTest.java
@@ -15,8 +15,9 @@ import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ImmutableBooleanSetFactoryImplTest
 {
@@ -24,21 +25,21 @@ public class ImmutableBooleanSetFactoryImplTest
     public void of()
     {
         Verify.assertEmpty(BooleanSets.immutable.of());
-        Assert.assertEquals(BooleanHashSet.newSetWith(true).toImmutable(), BooleanSets.immutable.of(true));
+        assertEquals(BooleanHashSet.newSetWith(true).toImmutable(), BooleanSets.immutable.of(true));
     }
 
     @Test
     public void with()
     {
         Verify.assertEmpty(BooleanSets.immutable.with(null));
-        Assert.assertEquals(BooleanHashSet.newSetWith(false).toImmutable(), BooleanSets.immutable.with(new boolean[]{false}));
+        assertEquals(BooleanHashSet.newSetWith(false).toImmutable(), BooleanSets.immutable.with(new boolean[]{false}));
     }
 
     @Test
     public void ofAll()
     {
         ImmutableBooleanSet set = BooleanSets.immutable.of(true, false);
-        Assert.assertEquals(BooleanHashSet.newSet(set).toImmutable(), BooleanSets.immutable.ofAll(set));
-        Assert.assertEquals(BooleanHashSet.newSet(BooleanArrayList.newListWith(true, false, true)).toImmutable(), BooleanSets.immutable.ofAll(BooleanArrayList.newListWith(true, false)));
+        assertEquals(BooleanHashSet.newSet(set).toImmutable(), BooleanSets.immutable.ofAll(set));
+        assertEquals(BooleanHashSet.newSet(BooleanArrayList.newListWith(true, false, true)).toImmutable(), BooleanSets.immutable.ofAll(BooleanArrayList.newListWith(true, false)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSetTestCase.java
@@ -53,8 +53,17 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractImmutableSortedSetTestCase
 {
@@ -75,7 +84,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         MutableSortedSet<Integer> mutable = TreeSortedSet.newSet(immutable);
         Verify.assertEqualsAndHashCode(mutable, immutable);
         Verify.assertPostSerializedEqualsAndHashCode(immutable);
-        Assert.assertNotEquals(FastList.newList(mutable), immutable);
+        assertNotEquals(FastList.newList(mutable), immutable);
     }
 
     @Test
@@ -83,7 +92,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> immutable = this.classUnderTest();
         Verify.assertSortedSetsEqual(TreeSortedSet.newSet(Interval.fromTo(0, immutable.size())), immutable.newWith(0).castToSortedSet());
-        Assert.assertSame(immutable, immutable.newWith(immutable.size()));
+        assertSame(immutable, immutable.newWith(immutable.size()));
 
         ImmutableSortedSet<Integer> set = this.classUnderTest(Comparators.reverseNaturalOrder());
         Verify.assertSortedSetsEqual(
@@ -96,7 +105,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> immutable = this.classUnderTest();
         Verify.assertSortedSetsEqual(TreeSortedSet.newSet(Interval.oneTo(immutable.size() - 1)), immutable.newWithout(immutable.size()).castToSortedSet());
-        Assert.assertSame(immutable, immutable.newWithout(immutable.size() + 1));
+        assertSame(immutable, immutable.newWithout(immutable.size() + 1));
 
         ImmutableSortedSet<Integer> set = this.classUnderTest(Comparators.reverseNaturalOrder());
         Verify.assertSortedSetsEqual(
@@ -109,7 +118,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedSet<Integer> withAll = set.newWithAll(UnifiedSet.newSet(Interval.fromTo(1, set.size() + 1)));
-        Assert.assertNotEquals(set, withAll);
+        assertNotEquals(set, withAll);
         Verify.assertSortedSetsEqual(
                 TreeSortedSet.newSet(Comparators.reverseNaturalOrder(), Interval.fromTo(1, set.size() + 1)),
                 withAll.castToSortedSet());
@@ -121,14 +130,14 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         ImmutableSortedSet<Integer> withoutAll = set.newWithoutAll(set);
 
-        Assert.assertEquals(SortedSets.immutable.<Integer>of(), withoutAll);
-        Assert.assertEquals(Sets.immutable.<Integer>of(), withoutAll);
+        assertEquals(SortedSets.immutable.<Integer>of(), withoutAll);
+        assertEquals(Sets.immutable.<Integer>of(), withoutAll);
 
         ImmutableSortedSet<Integer> largeWithoutAll = set.newWithoutAll(Interval.fromTo(101, 150));
-        Assert.assertEquals(set, largeWithoutAll);
+        assertEquals(set, largeWithoutAll);
 
         ImmutableSortedSet<Integer> largeWithoutAll2 = set.newWithoutAll(UnifiedSet.newSet(Interval.fromTo(151, 199)));
-        Assert.assertEquals(set, largeWithoutAll2);
+        assertEquals(set, largeWithoutAll2);
     }
 
     @Test
@@ -143,14 +152,14 @@ public abstract class AbstractImmutableSortedSetTestCase
 
         SortedSet<Integer> set2 = new TreeSet<>(set1.castToSortedSet());
 
-        Assert.assertThrows(ClassCastException.class, () -> set1.contains(new Object()));
-        Assert.assertThrows(ClassCastException.class, () -> set2.contains(new Object()));
+        assertThrows(ClassCastException.class, () -> set1.contains(new Object()));
+        assertThrows(ClassCastException.class, () -> set2.contains(new Object()));
 
-        Assert.assertThrows(ClassCastException.class, () -> set1.contains("1"));
-        Assert.assertThrows(ClassCastException.class, () -> set2.contains("1"));
+        assertThrows(ClassCastException.class, () -> set1.contains("1"));
+        assertThrows(ClassCastException.class, () -> set2.contains("1"));
 
-        Assert.assertThrows(NullPointerException.class, () -> set1.contains(null));
-        Assert.assertThrows(NullPointerException.class, () -> set2.contains(null));
+        assertThrows(NullPointerException.class, () -> set1.contains(null));
+        assertThrows(NullPointerException.class, () -> set2.contains(null));
     }
 
     @Test
@@ -159,10 +168,10 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set1 = this.classUnderTest();
         SortedSet<Integer> set2 = new TreeSet<>(set1.castToSortedSet());
 
-        Assert.assertTrue(set1.containsAllArguments(set1.toArray()));
+        assertTrue(set1.containsAllArguments(set1.toArray()));
 
-        Assert.assertThrows(NullPointerException.class, () -> set1.containsAllArguments(null, null));
-        Assert.assertThrows(NullPointerException.class, () -> set2.containsAll(FastList.newListWith(null, null)));
+        assertThrows(NullPointerException.class, () -> set1.containsAllArguments(null, null));
+        assertThrows(NullPointerException.class, () -> set2.containsAll(FastList.newListWith(null, null)));
     }
 
     @Test
@@ -171,10 +180,10 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set1 = this.classUnderTest();
         SortedSet<Integer> set2 = new TreeSet<>(set1.castToSortedSet());
 
-        Assert.assertTrue(set1.containsAllIterable(Interval.oneTo(set1.size())));
+        assertTrue(set1.containsAllIterable(Interval.oneTo(set1.size())));
 
-        Assert.assertThrows(NullPointerException.class, () -> set1.containsAllIterable(FastList.newListWith(null, null)));
-        Assert.assertThrows(NullPointerException.class, () -> set2.containsAll(FastList.newListWith(null, null)));
+        assertThrows(NullPointerException.class, () -> set1.containsAllIterable(FastList.newListWith(null, null)));
+        assertThrows(NullPointerException.class, () -> set2.containsAll(FastList.newListWith(null, null)));
     }
 
     @Test
@@ -182,8 +191,8 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         MutableList<Integer> tapResult = Lists.mutable.of();
         ImmutableSortedSet<Integer> collection = this.classUnderTest();
-        Assert.assertSame(collection, collection.tap(tapResult::add));
-        Assert.assertEquals(collection.toList(), tapResult);
+        assertSame(collection, collection.tap(tapResult::add));
+        assertEquals(collection.toList(), tapResult);
     }
 
     @Test
@@ -192,7 +201,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         MutableSet<Integer> result = UnifiedSet.newSet();
         ImmutableSortedSet<Integer> collection = this.classUnderTest();
         collection.forEach(CollectionAddProcedure.on(result));
-        Assert.assertEquals(collection, result);
+        assertEquals(collection, result);
     }
 
     @Test
@@ -280,10 +289,10 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void selectInstancesOf()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(set, set.selectInstancesOf(Integer.class));
+        assertEquals(set, set.selectInstancesOf(Integer.class));
         Verify.assertIterableEmpty(set.selectInstancesOf(Double.class));
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), set.selectInstancesOf(Integer.class).comparator());
-        Assert.assertEquals(Collections.<Double>reverseOrder(), set.selectInstancesOf(Double.class).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), set.selectInstancesOf(Integer.class).comparator());
+        assertEquals(Collections.<Double>reverseOrder(), set.selectInstancesOf(Double.class).comparator());
     }
 
     @Test
@@ -292,9 +301,9 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionImmutableSortedSet<Integer> partition = integers.partition(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(partition.getSelected());
-        Assert.assertEquals(integers, partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(integers, partition.getRejected());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Test
@@ -303,9 +312,9 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionImmutableSortedSet<Integer> partition = integers.partitionWith(Predicates2.greaterThan(), integers.size());
         Verify.assertIterableEmpty(partition.getSelected());
-        Assert.assertEquals(integers, partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(integers, partition.getRejected());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Test
@@ -314,12 +323,12 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         PartitionImmutableSortedSet<Integer> partition1 = integers.partitionWhile(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(partition1.getSelected());
-        Assert.assertEquals(integers, partition1.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition1.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition1.getRejected().comparator());
+        assertEquals(integers, partition1.getRejected());
+        assertEquals(Collections.<Integer>reverseOrder(), partition1.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition1.getRejected().comparator());
 
         PartitionImmutableSortedSet<Integer> partition2 = integers.partitionWhile(Predicates.lessThanOrEqualTo(integers.size()));
-        Assert.assertEquals(integers, partition2.getSelected());
+        assertEquals(integers, partition2.getSelected());
         Verify.assertIterableEmpty(partition2.getRejected());
     }
 
@@ -329,11 +338,11 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedSet<Integer> take1 = integers.takeWhile(Predicates.greaterThan(integers.size()));
         Verify.assertIterableEmpty(take1);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), take1.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), take1.comparator());
 
         ImmutableSortedSet<Integer> take2 = integers.takeWhile(Predicates.lessThanOrEqualTo(integers.size()));
-        Assert.assertEquals(integers, take2);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), take2.comparator());
+        assertEquals(integers, take2);
+        assertEquals(Collections.<Integer>reverseOrder(), take2.comparator());
     }
 
     @Test
@@ -341,12 +350,12 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedSet<Integer> drop1 = integers.dropWhile(Predicates.greaterThan(integers.size()));
-        Assert.assertEquals(integers, drop1);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop1.comparator());
+        assertEquals(integers, drop1);
+        assertEquals(Collections.<Integer>reverseOrder(), drop1.comparator());
 
         ImmutableSortedSet<Integer> drop2 = integers.dropWhile(Predicates.lessThanOrEqualTo(integers.size()));
         Verify.assertIterableEmpty(drop2);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop2.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), drop2.comparator());
     }
 
     @Test
@@ -370,7 +379,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void collectWithIndex()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(4), 0),
                         PrimitiveTuples.pair(Integer.valueOf(3), 1),
@@ -386,7 +395,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void collectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(4), 0),
                         PrimitiveTuples.pair(Integer.valueOf(3), 1),
@@ -402,7 +411,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void selectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(4, 2),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -414,7 +423,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void rejectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(3, 1),
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -423,7 +432,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void collectToTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers, integers.collect(Functions.getIntegerPassThru(), UnifiedSet.newSet()));
+        assertEquals(integers, integers.collect(Functions.getIntegerPassThru(), UnifiedSet.newSet()));
         Verify.assertListsEqual(
                 integers.toList(),
                 integers.collect(Functions.getIntegerPassThru(), FastList.newList()));
@@ -434,7 +443,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableList<String> actual = this.classUnderTest(Collections.reverseOrder()).flatCollect(integer -> Lists.fixedSize.of(String.valueOf(integer)));
         ImmutableList<String> expected = this.classUnderTest(Collections.reverseOrder()).collect(String::valueOf);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         Verify.assertListsEqual(expected.toList(), actual.toList());
     }
 
@@ -456,30 +465,30 @@ public abstract class AbstractImmutableSortedSetTestCase
         List<Object> nullsMinusOne = Collections.nCopies(immutableSet.size() - 1, null);
 
         ImmutableList<Pair<Integer, Object>> pairs = immutableSet.zip(nulls);
-        Assert.assertEquals(immutableSet.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(immutableSet.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
         Verify.assertListsEqual(FastList.newList(Interval.fromTo(immutableSet.size(), 1)), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toList());
-        Assert.assertEquals(FastList.newList(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(FastList.newList(nulls), pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableList<Pair<Integer, Object>> pairsPlusOne = immutableSet.zip(nullsPlusOne);
-        Assert.assertEquals(immutableSet.toList(), pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(immutableSet.toList(), pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
         Verify.assertListsEqual(
                 FastList.newList(Interval.fromTo(immutableSet.size(), 1)),
                 pairsPlusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).castToList());
-        Assert.assertEquals(FastList.newList(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
+        assertEquals(FastList.newList(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo));
 
         ImmutableList<Pair<Integer, Object>> pairsMinusOne = immutableSet.zip(nullsMinusOne);
         Verify.assertListsEqual(
                 FastList.newList(Interval.fromTo(immutableSet.size(), 2)),
                 pairsMinusOne.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).castToList());
-        Assert.assertEquals(immutableSet.zip(nulls), immutableSet.zip(nulls, FastList.newList()));
+        assertEquals(immutableSet.zip(nulls), immutableSet.zip(nulls, FastList.newList()));
 
         FastList<Holder> holders = FastList.newListWith(new Holder(1), new Holder(2), new Holder(3));
         ImmutableList<Pair<Integer, Holder>> zipped = immutableSet.zip(holders);
         Verify.assertSize(3, zipped.castToList());
         AbstractImmutableSortedSetTestCase.Holder two = new Holder(-1);
         AbstractImmutableSortedSetTestCase.Holder two1 = new Holder(-1);
-        Assert.assertEquals(Tuples.pair(10, two1), zipped.newWith(Tuples.pair(10, two)).getLast());
-        Assert.assertEquals(Tuples.pair(1, new Holder(3)), this.classUnderTest().zip(holders.reverseThis()).getFirst());
+        assertEquals(Tuples.pair(10, two1), zipped.newWith(Tuples.pair(10, two)).getLast());
+        assertEquals(Tuples.pair(1, new Holder(3)), this.classUnderTest().zip(holders.reverseThis()).getFirst());
     }
 
     @Test
@@ -488,11 +497,11 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> immutableSet = this.classUnderTest(Collections.reverseOrder());
         ImmutableSortedSet<Pair<Integer, Integer>> pairs = immutableSet.zipWithIndex();
 
-        Assert.assertEquals(immutableSet.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(immutableSet.toList(), pairs.collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne));
+        assertEquals(
                 Interval.zeroTo(immutableSet.size() - 1).toList(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo));
-        Assert.assertEquals(
+        assertEquals(
                 immutableSet.zipWithIndex(),
                 immutableSet.zipWithIndex(UnifiedSet.newSet()));
         Verify.assertListsEqual(
@@ -509,7 +518,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     @Test
     public void chunk_large_size()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
+        assertEquals(this.classUnderTest(), this.classUnderTest().chunk(10).getFirst());
         Verify.assertInstanceOf(ImmutableSortedSet.class, this.classUnderTest().chunk(10).getFirst());
     }
 
@@ -517,16 +526,16 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void detect()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
-        Assert.assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detect(Predicates.equal(1)));
+        assertNull(integers.detect(Predicates.equal(integers.size() + 1)));
     }
 
     @Test
     public void detectWith()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
-        Assert.assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
+        assertEquals(Integer.valueOf(1), integers.detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(integers.detectWith(Object::equals, Integer.valueOf(integers.size() + 1)));
     }
 
     @Test
@@ -535,8 +544,8 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         Function0<Integer> function = new PassThruFunction0<>(integers.size() + 1);
         Integer sum = Integer.valueOf(integers.size() + 1);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
-        Assert.assertEquals(Integer.valueOf(integers.size() + 1), integers.detectWithIfNone(Object::equals, sum, function));
+        assertEquals(Integer.valueOf(1), integers.detectWithIfNone(Object::equals, Integer.valueOf(1), function));
+        assertEquals(Integer.valueOf(integers.size() + 1), integers.detectWithIfNone(Object::equals, sum, function));
     }
 
     @Test
@@ -544,60 +553,60 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         Function0<Integer> function = new PassThruFunction0<>(integers.size() + 1);
-        Assert.assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
-        Assert.assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
+        assertEquals(Integer.valueOf(1), integers.detectIfNone(Predicates.equal(1), function));
+        assertEquals(Integer.valueOf(integers.size() + 1), integers.detectIfNone(Predicates.equal(integers.size() + 1), function));
     }
 
     @Test
     public void detectIndex()
     {
         ImmutableSortedSet<Integer> integers1 = this.classUnderTest();
-        Assert.assertEquals(1, integers1.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(1, integers1.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
 
         ImmutableSortedSet<Integer> integers2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(1, integers2.detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(1, integers2.detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
     }
 
     @Test
     public void corresponds()
     {
         ImmutableSortedSet<Integer> integers1 = this.classUnderTest();
-        Assert.assertFalse(integers1.corresponds(this.classUnderTest().newWith(100), Predicates2.alwaysTrue()));
+        assertFalse(integers1.corresponds(this.classUnderTest().newWith(100), Predicates2.alwaysTrue()));
 
         ImmutableList<Integer> integers2 = integers1.collect(integers -> integers + 1);
-        Assert.assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
 
         ImmutableSortedSet<Integer> integers3 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
+        assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
     }
 
     @Test
     public void allSatisfy()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertTrue(integers.allSatisfy(Integer.class::isInstance));
-        Assert.assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
+        assertTrue(integers.allSatisfy(Integer.class::isInstance));
+        assertFalse(integers.allSatisfy(Integer.valueOf(0)::equals));
     }
 
     @Test
     public void anySatisfy()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertFalse(integers.anySatisfy(String.class::isInstance));
-        Assert.assertTrue(integers.anySatisfy(Integer.class::isInstance));
+        assertFalse(integers.anySatisfy(String.class::isInstance));
+        assertTrue(integers.anySatisfy(Integer.class::isInstance));
     }
 
     @Test
     public void count()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(integers.size(), integers.count(Integer.class::isInstance));
-        Assert.assertEquals(0, integers.count(String.class::isInstance));
+        assertEquals(integers.size(), integers.count(Integer.class::isInstance));
+        assertEquals(0, integers.count(String.class::isInstance));
     }
 
     @Test
@@ -618,26 +627,26 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void getFirst()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(1), integers.getFirst());
+        assertEquals(Integer.valueOf(1), integers.getFirst());
         ImmutableSortedSet<Integer> revInt = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(Integer.valueOf(revInt.size()), revInt.getFirst());
+        assertEquals(Integer.valueOf(revInt.size()), revInt.getFirst());
     }
 
     @Test
     public void getLast()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
-        Assert.assertEquals(Integer.valueOf(integers.size()), integers.getLast());
+        assertEquals(Integer.valueOf(integers.size()), integers.getLast());
         ImmutableSortedSet<Integer> revInt = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(Integer.valueOf(1), revInt.getLast());
+        assertEquals(Integer.valueOf(1), revInt.getLast());
     }
 
     @Test
     public void isEmpty()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
-        Assert.assertFalse(set.isEmpty());
-        Assert.assertTrue(set.notEmpty());
+        assertFalse(set.isEmpty());
+        assertTrue(set.notEmpty());
     }
 
     @Test
@@ -648,12 +657,12 @@ public abstract class AbstractImmutableSortedSetTestCase
         for (int i = 0; iterator.hasNext(); i++)
         {
             Integer integer = iterator.next();
-            Assert.assertEquals(i + 1, integer.intValue());
+            assertEquals(i + 1, integer.intValue());
         }
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertThrows(NoSuchElementException.class, iterator::next);
         Iterator<Integer> intItr = integers.iterator();
         intItr.next();
-        Assert.assertThrows(UnsupportedOperationException.class, intItr::remove);
+        assertThrows(UnsupportedOperationException.class, intItr::remove);
     }
 
     @Test
@@ -661,7 +670,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         Integer result = integers.injectInto(0, AddFunction.INTEGER);
-        Assert.assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
+        assertEquals(FastList.newList(integers).injectInto(0, AddFunction.INTEGER_TO_INT), result.intValue());
     }
 
     @Test
@@ -669,20 +678,20 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         MutableList<Integer> copy = FastList.newList(integers);
-        Assert.assertArrayEquals(integers.toArray(), copy.toArray());
-        Assert.assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
+        assertArrayEquals(integers.toArray(), copy.toArray());
+        assertArrayEquals(integers.toArray(new Integer[integers.size()]), copy.toArray(new Integer[integers.size()]));
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
+        assertEquals(FastList.newList(this.classUnderTest()).toString(), this.classUnderTest().toString());
     }
 
     @Test
     public void makeString()
     {
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).makeString(), this.classUnderTest().makeString());
+        assertEquals(FastList.newList(this.classUnderTest()).makeString(), this.classUnderTest().makeString());
     }
 
     @Test
@@ -690,7 +699,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         Appendable builder = new StringBuilder();
         this.classUnderTest().appendString(builder);
-        Assert.assertEquals(FastList.newList(this.classUnderTest()).makeString(), builder.toString());
+        assertEquals(FastList.newList(this.classUnderTest()).makeString(), builder.toString());
     }
 
     @Test
@@ -707,7 +716,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         MutableList<Integer> copy = FastList.newList(integers);
         MutableList<Integer> list = integers.toSortedList(Collections.reverseOrder());
-        Assert.assertEquals(copy.sortThis(Collections.reverseOrder()), list);
+        assertEquals(copy.sortThis(Collections.reverseOrder()), list);
         MutableList<Integer> list2 = integers.toSortedList();
         Verify.assertListsEqual(copy.sortThis(), list2);
     }
@@ -717,7 +726,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         MutableList<Integer> list = integers.toSortedListBy(String::valueOf);
-        Assert.assertEquals(integers.toList(), list);
+        assertEquals(integers.toList(), list);
     }
 
     @Test
@@ -733,8 +742,8 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         MutableSortedSet<Integer> set = integers.toSortedSet(Collections.reverseOrder());
-        Assert.assertEquals(integers.toSet(), set);
-        Assert.assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), set.toList());
+        assertEquals(integers.toSet(), set);
+        assertEquals(integers.toSortedList(Comparators.reverseNaturalOrder()), set.toList());
     }
 
     @Test
@@ -780,7 +789,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         for (Integer each : set)
         {
-            Assert.assertNotNull(each);
+            assertNotNull(each);
         }
     }
 
@@ -829,37 +838,37 @@ public abstract class AbstractImmutableSortedSetTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min(Integer::compareTo));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverse(Integer::compareTo)));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().max(Comparators.reverse(Integer::compareTo)));
     }
 
     @Test
     public void min_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().min());
+        assertEquals(Integer.valueOf(1), this.classUnderTest().min());
     }
 
     @Test
     public void max_without_comparator()
     {
-        Assert.assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
+        assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().max());
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
+        assertEquals(Integer.valueOf(1), this.classUnderTest().minBy(String::valueOf));
     }
 
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(String::valueOf));
+        assertEquals(Integer.valueOf(this.classUnderTest().size()), this.classUnderTest().maxBy(String::valueOf));
     }
 
     @Test
@@ -868,7 +877,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> undertest = this.classUnderTest();
         ImmutableSortedSetMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru());
         ImmutableSortedSetMultimap<Integer, Integer> expected = TreeSortedSet.newSet(undertest).groupBy(Functions.getPassThru()).toImmutable();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -878,7 +887,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         ImmutableSortedSetMultimap<Integer, Integer> actual = undertest.groupByEach(function);
         ImmutableSortedSetMultimap<Integer, Integer> expected = TreeSortedSet.newSet(undertest).groupByEach(function).toImmutable();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -887,7 +896,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> undertest = this.classUnderTest();
         TreeSortedSetMultimap<Integer, Integer> actual = undertest.groupBy(Functions.getPassThru(), TreeSortedSetMultimap.newMultimap());
         TreeSortedSetMultimap<Integer, Integer> expected = TreeSortedSet.newSet(undertest).groupBy(Functions.getPassThru());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -897,13 +906,13 @@ public abstract class AbstractImmutableSortedSetTestCase
         NegativeIntervalFunction function = new NegativeIntervalFunction();
         TreeSortedSetMultimap<Integer, Integer> actual = undertest.groupByEach(function, TreeSortedSetMultimap.newMultimap());
         TreeSortedSetMultimap<Integer, Integer> expected = TreeSortedSet.newSet(undertest).groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.classUnderTest().toBag().groupByUniqueKey(id -> id),
                 this.classUnderTest().groupByUniqueKey(id -> id));
     }
@@ -917,7 +926,7 @@ public abstract class AbstractImmutableSortedSetTestCase
     @Test
     public void groupByUniqueKey_target()
     {
-        Assert.assertEquals(this.classUnderTest().groupByUniqueKey(id -> id), this.classUnderTest().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
+        assertEquals(this.classUnderTest().groupByUniqueKey(id -> id), this.classUnderTest().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -933,7 +942,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> union = set.union(UnifiedSet.newSet(Interval.fromTo(set.size(), set.size() + 3)));
         Verify.assertSize(set.size() + 3, union.castToSortedSet());
         Verify.assertSortedSetsEqual(TreeSortedSet.newSet(Interval.oneTo(set.size() + 3)), union.castToSortedSet());
-        Assert.assertEquals(set, set.union(UnifiedSet.newSet()));
+        assertEquals(set, set.union(UnifiedSet.newSet()));
     }
 
     @Test
@@ -942,8 +951,8 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         MutableSet<Integer> union = set.unionInto(UnifiedSet.newSet(Interval.fromTo(set.size(), set.size() + 3)), UnifiedSet.newSet());
         Verify.assertSize(set.size() + 3, union);
-        Assert.assertTrue(union.containsAllIterable(Interval.oneTo(set.size() + 3)));
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith(), UnifiedSet.newSet()));
+        assertTrue(union.containsAllIterable(Interval.oneTo(set.size() + 3)));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith(), UnifiedSet.newSet()));
     }
 
     @Test
@@ -961,7 +970,7 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         MutableSet<Integer> intersect = set.intersectInto(UnifiedSet.newSet(Interval.oneTo(set.size() + 2)), UnifiedSet.newSet());
         Verify.assertSize(set.size(), intersect);
-        Assert.assertEquals(set, intersect);
+        assertEquals(set, intersect);
         Verify.assertEmpty(set.intersectInto(UnifiedSet.newSet(Interval.fromTo(set.size() + 1, set.size() + 4)), UnifiedSet.newSet()));
     }
 
@@ -1006,15 +1015,15 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void isSubsetOf()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
-        Assert.assertTrue(set.isSubsetOf(set));
+        assertTrue(set.isSubsetOf(set));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
-        Assert.assertTrue(set.isProperSubsetOf(Interval.oneTo(set.size() + 1).toSet()));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(Interval.oneTo(set.size() + 1).toSet()));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -1034,8 +1043,8 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         LazyIterable<Pair<Integer, Integer>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSet(Interval.oneTo(set.size())));
-        Assert.assertEquals(set.size() * set.size(), cartesianProduct.size());
-        Assert.assertEquals(set, cartesianProduct
+        assertEquals(set.size() * set.size(), cartesianProduct.size());
+        assertEquals(set, cartesianProduct
                 .select(Predicates.attributeEqual((Function<Pair<?, Integer>, Integer>) Pair::getTwo, 1))
                 .collect((Function<Pair<Integer, ?>, Integer>) Pair::getOne).toSet());
     }
@@ -1044,21 +1053,21 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void distinct()
     {
         ImmutableSortedSet<Integer> set1 = this.classUnderTest();
-        Assert.assertSame(set1, set1.distinct());
+        assertSame(set1, set1.distinct());
         ImmutableSortedSet<Integer> set2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertSame(set2, set2.distinct());
+        assertSame(set2, set2.distinct());
     }
 
     @Test
     public void indexOf()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(0, integers.indexOf(4));
-        Assert.assertEquals(1, integers.indexOf(3));
-        Assert.assertEquals(2, integers.indexOf(2));
-        Assert.assertEquals(3, integers.indexOf(1));
-        Assert.assertEquals(-1, integers.indexOf(0));
-        Assert.assertEquals(-1, integers.indexOf(5));
+        assertEquals(0, integers.indexOf(4));
+        assertEquals(1, integers.indexOf(3));
+        assertEquals(2, integers.indexOf(2));
+        assertEquals(3, integers.indexOf(1));
+        assertEquals(-1, integers.indexOf(0));
+        assertEquals(-1, integers.indexOf(5));
     }
 
     @Test
@@ -1067,16 +1076,16 @@ public abstract class AbstractImmutableSortedSetTestCase
         MutableList<Integer> result = FastList.newList();
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
         integers.forEach(1, 2, result::add);
-        Assert.assertEquals(Lists.immutable.with(3, 2), result);
+        assertEquals(Lists.immutable.with(3, 2), result);
 
         MutableList<Integer> result2 = FastList.newList();
         integers.forEach(0, 3, result2::add);
-        Assert.assertEquals(Lists.immutable.with(4, 3, 2, 1), result2);
+        assertEquals(Lists.immutable.with(4, 3, 2, 1), result2);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers.forEach(2, 1, result::add));
+        assertThrows(IllegalArgumentException.class, () -> integers.forEach(2, 1, result::add));
     }
 
     @Test
@@ -1085,23 +1094,23 @@ public abstract class AbstractImmutableSortedSetTestCase
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
         StringBuilder builder = new StringBuilder();
         integers.forEachWithIndex(1, 2, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("3122", builder.toString());
+        assertEquals("3122", builder.toString());
 
         MutableList<Integer> result2 = Lists.mutable.of();
         integers.forEachWithIndex(0, 3, new AddToList(result2));
-        Assert.assertEquals(Lists.immutable.with(4, 3, 2, 1), result2);
+        assertEquals(Lists.immutable.with(4, 3, 2, 1), result2);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result2)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result2)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result2)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result2)));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(2, 1, new AddToList(result2)));
+        assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(2, 1, new AddToList(result2)));
     }
 
     @Test
     public void toStack()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(ArrayStack.newStackWith(4, 3, 2, 1), set.toStack());
+        assertEquals(ArrayStack.newStackWith(4, 3, 2, 1), set.toStack());
     }
 
     @Test
@@ -1109,24 +1118,24 @@ public abstract class AbstractImmutableSortedSetTestCase
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         ImmutableSortedSet<Integer> actual = set.toImmutable();
-        Assert.assertEquals(set, actual);
-        Assert.assertSame(set, actual);
+        assertEquals(set, actual);
+        assertSame(set, actual);
     }
 
     @Test
     public void take()
     {
         ImmutableSortedSet<Integer> integers1 = this.classUnderTest();
-        Assert.assertEquals(SortedSets.immutable.of(integers1.comparator()), integers1.take(0));
-        Assert.assertSame(integers1.comparator(), integers1.take(0).comparator());
-        Assert.assertEquals(SortedSets.immutable.of(integers1.comparator(), 1, 2, 3), integers1.take(3));
-        Assert.assertSame(integers1.comparator(), integers1.take(3).comparator());
-        Assert.assertEquals(SortedSets.immutable.of(integers1.comparator(), 1, 2, 3), integers1.take(integers1.size() - 1));
+        assertEquals(SortedSets.immutable.of(integers1.comparator()), integers1.take(0));
+        assertSame(integers1.comparator(), integers1.take(0).comparator());
+        assertEquals(SortedSets.immutable.of(integers1.comparator(), 1, 2, 3), integers1.take(3));
+        assertSame(integers1.comparator(), integers1.take(3).comparator());
+        assertEquals(SortedSets.immutable.of(integers1.comparator(), 1, 2, 3), integers1.take(integers1.size() - 1));
 
         ImmutableSortedSet<Integer> integers2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertSame(integers2, integers2.take(integers2.size()));
-        Assert.assertSame(integers2, integers2.take(10));
-        Assert.assertSame(integers2, integers2.take(Integer.MAX_VALUE));
+        assertSame(integers2, integers2.take(integers2.size()));
+        assertSame(integers2, integers2.take(10));
+        assertSame(integers2, integers2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1139,17 +1148,17 @@ public abstract class AbstractImmutableSortedSetTestCase
     public void drop()
     {
         ImmutableSortedSet<Integer> integers1 = this.classUnderTest();
-        Assert.assertSame(integers1, integers1.drop(0));
-        Assert.assertSame(integers1.comparator(), integers1.drop(0).comparator());
-        Assert.assertEquals(SortedSets.immutable.of(integers1.comparator(), 4), integers1.drop(3));
-        Assert.assertSame(integers1.comparator(), integers1.drop(3).comparator());
-        Assert.assertEquals(SortedSets.immutable.of(integers1.comparator(), 4), integers1.drop(integers1.size() - 1));
+        assertSame(integers1, integers1.drop(0));
+        assertSame(integers1.comparator(), integers1.drop(0).comparator());
+        assertEquals(SortedSets.immutable.of(integers1.comparator(), 4), integers1.drop(3));
+        assertSame(integers1.comparator(), integers1.drop(3).comparator());
+        assertEquals(SortedSets.immutable.of(integers1.comparator(), 4), integers1.drop(integers1.size() - 1));
 
         ImmutableSortedSet<Integer> expectedSet = SortedSets.immutable.of(Comparators.reverseNaturalOrder());
         ImmutableSortedSet<Integer> integers2 = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(expectedSet, integers2.drop(integers2.size()));
-        Assert.assertEquals(expectedSet, integers2.drop(10));
-        Assert.assertEquals(expectedSet, integers2.drop(Integer.MAX_VALUE));
+        assertEquals(expectedSet, integers2.drop(integers2.size()));
+        assertEquals(expectedSet, integers2.drop(10));
+        assertEquals(expectedSet, integers2.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
@@ -49,8 +49,17 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestCase
 {
@@ -69,16 +78,16 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void testContainsAll()
     {
-        Assert.assertTrue(this.classUnderTest().containsAllIterable(UnifiedSet.<Integer>newSet()));
-        Assert.assertFalse(this.classUnderTest().containsAllIterable(UnifiedSet.newSetWith(1)));
+        assertTrue(this.classUnderTest().containsAllIterable(UnifiedSet.<Integer>newSet()));
+        assertFalse(this.classUnderTest().containsAllIterable(UnifiedSet.newSetWith(1)));
     }
 
     @Test
     public void testNewSortedSet()
     {
-        Assert.assertSame(SortedSets.immutable.of(), SortedSets.immutable.ofAll(FastList.newList()));
-        Assert.assertSame(SortedSets.immutable.of(), SortedSets.immutable.ofSortedSet(TreeSortedSet.newSet()));
-        Assert.assertNotSame(
+        assertSame(SortedSets.immutable.of(), SortedSets.immutable.ofAll(FastList.newList()));
+        assertSame(SortedSets.immutable.of(), SortedSets.immutable.ofSortedSet(TreeSortedSet.newSet()));
+        assertNotSame(
                 SortedSets.immutable.of(),
                 SortedSets.immutable.ofSortedSet(TreeSortedSet.newSet(Comparators.reverseNaturalOrder())));
     }
@@ -87,13 +96,13 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void newWith()
     {
-        Assert.assertEquals(UnifiedSet.newSetWith(1), this.classUnderTest().newWith(1));
-        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of(FastList.newList().toArray()));
-        Assert.assertEquals(
+        assertEquals(UnifiedSet.newSetWith(1), this.classUnderTest().newWith(1));
+        assertSame(SortedSets.immutable.empty(), SortedSets.immutable.of(FastList.newList().toArray()));
+        assertEquals(
                 SortedSets.immutable.empty(),
                 SortedSets.immutable.of(Comparators.naturalOrder(), FastList.newList().toArray()));
 
-        Assert.assertEquals(
+        assertEquals(
                 Comparators.<Integer>reverseNaturalOrder(),
                 this.classUnderTest(Comparators.reverseNaturalOrder()).newWith(1).comparator());
         Verify.assertSortedSetsEqual(
@@ -105,12 +114,12 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void newWithout()
     {
-        Assert.assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithout(1));
-        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithout(1));
-        Assert.assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithoutAll(Interval.oneTo(3)));
-        Assert.assertSame(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithoutAll(Interval.oneTo(3)));
+        assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithout(1));
+        assertSame(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithout(1));
+        assertEquals(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithoutAll(Interval.oneTo(3)));
+        assertSame(SortedSets.immutable.empty(), SortedSets.immutable.empty().newWithoutAll(Interval.oneTo(3)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Comparators.<Integer>reverseNaturalOrder(),
                 this.classUnderTest(Comparators.reverseNaturalOrder()).newWithout(1).comparator());
     }
@@ -119,14 +128,14 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void detect()
     {
-        Assert.assertNull(this.classUnderTest().detect(Integer.valueOf(1)::equals));
+        assertNull(this.classUnderTest().detect(Integer.valueOf(1)::equals));
     }
 
     @Override
     @Test
     public void detectWith()
     {
-        Assert.assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(1)));
+        assertNull(this.classUnderTest().detectWith(Object::equals, Integer.valueOf(1)));
     }
 
     @Override
@@ -134,7 +143,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void detectIndex()
     {
         //Any predicate will result in -1
-        Assert.assertEquals(Integer.valueOf(-1), Integer.valueOf(this.classUnderTest().detectIndex(Predicates.alwaysTrue())));
+        assertEquals(Integer.valueOf(-1), Integer.valueOf(this.classUnderTest().detectIndex(Predicates.alwaysTrue())));
     }
 
     @Override
@@ -144,24 +153,24 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         //Evaluates true for all empty sets and false for all non-empty sets
 
         ImmutableSortedSet<Integer> integers1 = this.classUnderTest();
-        Assert.assertTrue(integers1.corresponds(Lists.mutable.of(), Predicates2.alwaysFalse()));
+        assertTrue(integers1.corresponds(Lists.mutable.of(), Predicates2.alwaysFalse()));
 
         ImmutableSortedSet<Integer> integers2 = integers1.newWith(Integer.valueOf(1));
-        Assert.assertFalse(integers2.corresponds(integers1, Predicates2.alwaysTrue()));
+        assertFalse(integers2.corresponds(integers1, Predicates2.alwaysTrue()));
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(this.classUnderTest().allSatisfy(Integer.class::isInstance));
+        assertTrue(this.classUnderTest().allSatisfy(Integer.class::isInstance));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertFalse(this.classUnderTest().anySatisfy(Integer.class::isInstance));
+        assertFalse(this.classUnderTest().anySatisfy(Integer.class::isInstance));
     }
 
     @Override
@@ -189,7 +198,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void isEmpty()
     {
         Verify.assertIterableEmpty(this.classUnderTest());
-        Assert.assertFalse(this.classUnderTest().notEmpty());
+        assertFalse(this.classUnderTest().notEmpty());
     }
 
     @Override
@@ -240,14 +249,14 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     {
         ImmutableSortedSet<Integer> immutableSet = this.classUnderTest(Comparators.reverseNaturalOrder());
         ImmutableList<Pair<Integer, Integer>> pairs = immutableSet.zip(Interval.oneTo(10));
-        Assert.assertEquals(FastList.<Pair<Integer, Integer>>newList(), pairs);
+        assertEquals(FastList.<Pair<Integer, Integer>>newList(), pairs);
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<Pair<Integer, Integer>>newSet(),
                 immutableSet.zip(Interval.oneTo(10), UnifiedSet.newSet()));
 
         ImmutableList<Pair<Integer, Integer>> pairsWithExtras = pairs.newWith(Tuples.pair(1, 5)).newWith(Tuples.pair(5, 1));
-        Assert.assertEquals(FastList.newListWith(Tuples.pair(1, 5), Tuples.pair(5, 1)), pairsWithExtras.toList());
+        assertEquals(FastList.newListWith(Tuples.pair(1, 5), Tuples.pair(5, 1)), pairsWithExtras.toList());
     }
 
     @Override
@@ -257,15 +266,15 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         ImmutableSortedSet<Pair<Integer, Integer>> pairs = set.zipWithIndex();
 
-        Assert.assertEquals(UnifiedSet.<Pair<Integer, Integer>>newSet(), pairs);
+        assertEquals(UnifiedSet.<Pair<Integer, Integer>>newSet(), pairs);
 
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<Pair<Integer, Integer>>newSet(),
                 set.zipWithIndex(UnifiedSet.newSet()));
 
-        Assert.assertNotNull(pairs.comparator());
+        assertNotNull(pairs.comparator());
         ImmutableSortedSet<Pair<Integer, Integer>> pairsWithExtras = pairs.newWith(Tuples.pair(1, 5)).newWith(Tuples.pair(5, 1));
-        Assert.assertEquals(FastList.newListWith(Tuples.pair(1, 5), Tuples.pair(5, 1)), pairsWithExtras.toList());
+        assertEquals(FastList.newListWith(Tuples.pair(1, 5), Tuples.pair(5, 1)), pairsWithExtras.toList());
     }
 
     @Test
@@ -305,7 +314,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void unionInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("a", "b", "c"),
                 SortedSets.immutable.<String>empty().unionInto(UnifiedSet.newSetWith("a", "b", "c"), UnifiedSet.newSet()));
     }
@@ -314,11 +323,11 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void intersect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 SortedSets.immutable.<String>empty().intersect(UnifiedSet.newSetWith("1", "2", "3")));
 
-        Assert.assertEquals(
+        assertEquals(
                 Comparators.<Integer>reverseNaturalOrder(),
                 this.classUnderTest(Comparators.reverseNaturalOrder()).intersect(UnifiedSet.newSetWith(1, 2, 3)).comparator());
     }
@@ -327,7 +336,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void intersectInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 SortedSets.immutable.<String>empty().intersectInto(UnifiedSet.newSetWith("1", "2", "3"), UnifiedSet.newSet()));
     }
@@ -336,11 +345,11 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void difference()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 SortedSets.immutable.<String>empty().difference(UnifiedSet.newSetWith("not present")));
 
-        Assert.assertEquals(
+        assertEquals(
                 Comparators.<Integer>reverseNaturalOrder(),
                 this.classUnderTest(Comparators.reverseNaturalOrder()).difference(UnifiedSet.newSetWith(1, 2, 3)).comparator());
     }
@@ -350,7 +359,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void differenceInto()
     {
         ImmutableSortedSet<String> set = SortedSets.immutable.empty();
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.<String>newSet(),
                 set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
 
@@ -363,7 +372,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void symmetricDifference()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("not present"),
                 SortedSets.immutable.<String>empty().symmetricDifference(UnifiedSet.newSetWith("not present")));
 
@@ -376,7 +385,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void symmetricDifferenceInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith("not present"),
                 SortedSets.immutable.<String>empty().symmetricDifferenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
@@ -388,7 +397,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> immutable = this.classUnderTest();
         Verify.assertEqualsAndHashCode(UnifiedSet.newSet(), immutable);
         Verify.assertPostSerializedIdentity(immutable);
-        Assert.assertNotEquals(Lists.mutable.empty(), immutable);
+        assertNotEquals(Lists.mutable.empty(), immutable);
 
         ImmutableSortedSet<Integer> setWithComparator = this.classUnderTest(Comparators.reverseNaturalOrder());
         Verify.assertEqualsAndHashCode(UnifiedSet.newSet(), setWithComparator);
@@ -402,7 +411,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> set = this.classUnderTest();
         Verify.assertNotContains(Integer.valueOf(1), set.castToSortedSet());
         Verify.assertEmpty(set.castToSortedSet());
-        Assert.assertThrows(NullPointerException.class, () -> set.contains(null));
+        assertThrows(NullPointerException.class, () -> set.contains(null));
     }
 
     @Override
@@ -410,8 +419,8 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void containsAllIterable()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
-        Assert.assertFalse(set.containsAllIterable(FastList.newListWith(1, 2, 3)));
-        Assert.assertTrue(set.containsAllIterable(set));
+        assertFalse(set.containsAllIterable(FastList.newListWith(1, 2, 3)));
+        assertTrue(set.containsAllIterable(set));
     }
 
     @Override
@@ -419,8 +428,8 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void iterator()
     {
         Iterator<Integer> iterator = this.classUnderTest().iterator();
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertThrows(NoSuchElementException.class, iterator::next);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Override
@@ -430,7 +439,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
         Verify.assertEmpty(set.castToSortedSet());
         Verify.assertEmpty(set.select(Predicates.lessThan(4)).castToSortedSet());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), set.select(Predicates.lessThan(3)).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), set.select(Predicates.lessThan(3)).comparator());
     }
 
     @Override
@@ -439,7 +448,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         Verify.assertEmpty(integers.selectWith(Predicates2.lessThan(), 4).castToSortedSet());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), integers.selectWith(Predicates2.lessThan(), 3).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), integers.selectWith(Predicates2.lessThan(), 3).comparator());
     }
 
     @Override
@@ -449,7 +458,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
         Verify.assertEmpty(set.castToSortedSet());
         Verify.assertEmpty(set.reject(Predicates.lessThan(3)).castToSortedSet());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), set.reject(Predicates.lessThan(3)).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), set.reject(Predicates.lessThan(3)).comparator());
     }
 
     @Override
@@ -458,7 +467,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
         Verify.assertEmpty(integers.rejectWith(Predicates2.greaterThanOrEqualTo(), 4).castToSortedSet());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), integers.rejectWith(Predicates2.greaterThanOrEqualTo(), 4).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), integers.rejectWith(Predicates2.greaterThanOrEqualTo(), 4).comparator());
     }
 
     @Override
@@ -470,8 +479,8 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         PartitionImmutableSortedSet<Integer> partition = set.partition(Predicates.lessThan(4));
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -483,8 +492,8 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         PartitionImmutableSortedSet<Integer> partition = set.partitionWith(Predicates2.lessThan(), 4);
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -503,7 +512,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectWithIndex()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.collectWithIndex(PrimitiveTuples::pair));
     }
@@ -516,7 +525,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty()));
     }
@@ -529,7 +538,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void selectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -542,7 +551,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void rejectWithIndexWithTarget()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.empty(),
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -562,7 +571,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> integers = this.classUnderTest();
         ImmutableSortedSet<Integer> collect = integers.collect(Functions.getIntegerPassThru(), TreeSortedSet.newSet(Collections.reverseOrder())).toImmutable();
         Verify.assertIterableEmpty(collect);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), collect.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), collect.comparator());
     }
 
     @Override
@@ -574,8 +583,8 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         PartitionImmutableSortedSet<Integer> partition = set.partitionWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(partition.getSelected());
         Verify.assertIterableEmpty(partition.getRejected());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getSelected().comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -586,7 +595,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         Verify.assertEmpty(set.castToSortedSet());
         ImmutableSortedSet<Integer> take = set.takeWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(take);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), take.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), take.comparator());
     }
 
     @Override
@@ -597,7 +606,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         Verify.assertEmpty(set.castToSortedSet());
         ImmutableSortedSet<Integer> drop = set.dropWhile(Predicates.lessThan(4));
         Verify.assertIterableEmpty(drop);
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), drop.comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), drop.comparator());
     }
 
     @Override
@@ -607,7 +616,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
         Verify.assertEmpty(set.castToSortedSet());
         Verify.assertEmpty(set.selectInstancesOf(Integer.class).castToSortedSet());
-        Assert.assertEquals(Collections.<Double>reverseOrder(), set.selectInstancesOf(Double.class).comparator());
+        assertEquals(Collections.<Double>reverseOrder(), set.selectInstancesOf(Double.class).comparator());
     }
 
     @Override
@@ -615,7 +624,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void toSortedSet()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertNull(set.toSortedSet().comparator());
+        assertNull(set.toSortedSet().comparator());
         Verify.assertEmpty(set.toSortedSet());
     }
 
@@ -624,7 +633,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void toSortedSetWithComparator()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest();
-        Assert.assertEquals(Collections.<Integer>reverseOrder(), set.toSortedSet(Collections.reverseOrder()).comparator());
+        assertEquals(Collections.<Integer>reverseOrder(), set.toSortedSet(Collections.reverseOrder()).comparator());
         Verify.assertEmpty(set.toSortedSet());
     }
 
@@ -643,9 +652,9 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(0, (long) this.classUnderTest().compareTo(this.classUnderTest()));
-        Assert.assertEquals(-1, this.classUnderTest().compareTo(TreeSortedSet.newSetWith(1)));
-        Assert.assertEquals(-4, this.classUnderTest().compareTo(TreeSortedSet.newSetWith(1, 2, 3, 4)));
+        assertEquals(0, (long) this.classUnderTest().compareTo(this.classUnderTest()));
+        assertEquals(-1, this.classUnderTest().compareTo(TreeSortedSet.newSetWith(1)));
+        assertEquals(-4, this.classUnderTest().compareTo(TreeSortedSet.newSetWith(1, 2, 3, 4)));
     }
 
     @Override
@@ -664,12 +673,12 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void indexOf()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(-1, integers.indexOf(4));
-        Assert.assertEquals(-1, integers.indexOf(3));
-        Assert.assertEquals(-1, integers.indexOf(2));
-        Assert.assertEquals(-1, integers.indexOf(1));
-        Assert.assertEquals(-1, integers.indexOf(0));
-        Assert.assertEquals(-1, integers.indexOf(5));
+        assertEquals(-1, integers.indexOf(4));
+        assertEquals(-1, integers.indexOf(3));
+        assertEquals(-1, integers.indexOf(2));
+        assertEquals(-1, integers.indexOf(1));
+        assertEquals(-1, integers.indexOf(0));
+        assertEquals(-1, integers.indexOf(5));
     }
 
     @Override
@@ -678,9 +687,9 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     {
         MutableSortedSet<Integer> result = TreeSortedSet.newSet(Comparators.reverseNaturalOrder());
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, 0, result::add));
     }
 
     @Override
@@ -690,16 +699,16 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
         MutableList<Integer> result = Lists.mutable.empty();
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Comparators.reverseNaturalOrder());
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, 0, new AddToList(result)));
     }
 
     @Override
     public void toStack()
     {
         ImmutableSortedSet<Integer> set = this.classUnderTest(Comparators.reverseNaturalOrder());
-        Assert.assertEquals(Stacks.mutable.with(), set.toStack());
+        assertEquals(Stacks.mutable.with(), set.toStack());
     }
 
     @Override
@@ -707,7 +716,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void powerSet()
     {
         Verify.assertSize(1, this.classUnderTest().powerSet().castToSortedSet());
-        Assert.assertEquals(SortedSets.immutable.of(SortedSets.immutable.<Integer>empty()), this.classUnderTest().powerSet());
+        assertEquals(SortedSets.immutable.of(SortedSets.immutable.<Integer>empty()), this.classUnderTest().powerSet());
     }
 
     @Override
@@ -727,7 +736,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
                 Functions.getIntegerPassThru(), Functions.getIntegerPassThru());
         Verify.assertEmpty(map);
         Verify.assertInstanceOf(TreeSortedMap.class, map);
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), map.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), map.comparator());
     }
 
     @Override
@@ -766,7 +775,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectBoolean()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(BooleanArrayList.newListWith(), integers.collectBoolean(PrimitiveFunctions.integerIsPositive()));
+        assertEquals(BooleanArrayList.newListWith(), integers.collectBoolean(PrimitiveFunctions.integerIsPositive()));
     }
 
     @Override
@@ -774,7 +783,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectByte()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(ByteArrayList.newListWith(), integers.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
+        assertEquals(ByteArrayList.newListWith(), integers.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Override
@@ -782,7 +791,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectChar()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(CharArrayList.newListWith(), integers.collectChar(integer -> (char) (integer.intValue() + 64)));
+        assertEquals(CharArrayList.newListWith(), integers.collectChar(integer -> (char) (integer.intValue() + 64)));
     }
 
     @Override
@@ -790,7 +799,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectDouble()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(DoubleArrayList.newListWith(), integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
+        assertEquals(DoubleArrayList.newListWith(), integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Override
@@ -798,7 +807,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectFloat()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(FloatArrayList.newListWith(), integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
+        assertEquals(FloatArrayList.newListWith(), integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Override
@@ -806,7 +815,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectInt()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(IntArrayList.newListWith(), integers.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
+        assertEquals(IntArrayList.newListWith(), integers.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Override
@@ -814,7 +823,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectLong()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(LongArrayList.newListWith(), integers.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
+        assertEquals(LongArrayList.newListWith(), integers.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Override
@@ -822,7 +831,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void collectShort()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(ShortArrayList.newListWith(), integers.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
+        assertEquals(ShortArrayList.newListWith(), integers.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
 
     @Override
@@ -830,7 +839,7 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void groupByUniqueKey_throws()
     {
         super.groupByUniqueKey_throws();
-        Assert.assertEquals(UnifiedMap.newMap().toImmutable(), this.classUnderTest().groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newMap().toImmutable(), this.classUnderTest().groupByUniqueKey(id -> id));
     }
 
     @Override
@@ -838,20 +847,20 @@ public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestC
     public void groupByUniqueKey_target_throws()
     {
         super.groupByUniqueKey_target_throws();
-        Assert.assertEquals(UnifiedMap.newMap(), this.classUnderTest().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
+        assertEquals(UnifiedMap.newMap(), this.classUnderTest().groupByUniqueKey(id -> id, UnifiedMap.newMap()));
     }
 
     @Override
     @Test
     public void take()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().take(2));
     }
 
     @Override
     @Test
     public void drop()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
+        assertEquals(this.classUnderTest(), this.classUnderTest().drop(2));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSetTest.java
@@ -32,8 +32,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableTreeSetTest
         extends AbstractImmutableSortedSetTestCase
@@ -53,13 +56,13 @@ public class ImmutableTreeSetTest
     @Test
     public void constructWithNull()
     {
-        Assert.assertThrows(ClassCastException.class, () -> new TreeSet<>(Arrays.asList(new Object())));
-        Assert.assertThrows(NullPointerException.class, () -> new TreeSet<>(Arrays.asList(null, null)));
-        Assert.assertThrows(NullPointerException.class, () -> new TreeSet<>(Arrays.asList((Object) null)));
+        assertThrows(ClassCastException.class, () -> new TreeSet<>(Arrays.asList(new Object())));
+        assertThrows(NullPointerException.class, () -> new TreeSet<>(Arrays.asList(null, null)));
+        assertThrows(NullPointerException.class, () -> new TreeSet<>(Arrays.asList((Object) null)));
 
-        Assert.assertThrows(ClassCastException.class, () -> SortedSets.immutable.of(new Object()));
-        Assert.assertThrows(NullPointerException.class, () -> SortedSets.immutable.of((Object) null, null));
-        Assert.assertThrows(NullPointerException.class, () -> SortedSets.immutable.of((Object) null));
+        assertThrows(ClassCastException.class, () -> SortedSets.immutable.of(new Object()));
+        assertThrows(NullPointerException.class, () -> SortedSets.immutable.of((Object) null, null));
+        assertThrows(NullPointerException.class, () -> SortedSets.immutable.of((Object) null));
     }
 
     @Override
@@ -68,15 +71,15 @@ public class ImmutableTreeSetTest
     {
         super.equalsAndHashCode();
 
-        Assert.assertNotEquals(
+        assertNotEquals(
                 new TreeSet<>(Arrays.asList("1", "2", "3")),
                 new TreeSet<>(Arrays.asList(1, 2, 3)));
 
-        Assert.assertNotEquals(
+        assertNotEquals(
                 new TreeSet<>(Arrays.asList("1", "2", "3")),
                 Sets.immutable.of("1", "2", null));
 
-        Assert.assertNotEquals(
+        assertNotEquals(
                 SortedSets.immutable.of("1", "2", "3"),
                 SortedSets.immutable.of(1, 2, 3));
     }
@@ -131,12 +134,12 @@ public class ImmutableTreeSetTest
     public void compareTo()
     {
         ImmutableSortedSet<Integer> set = SortedSets.immutable.of(1, 2, 3);
-        Assert.assertEquals(0, set.compareTo(set));
-        Assert.assertEquals(-1, set.compareTo(SortedSets.immutable.of(1, 2, 3, 4)));
-        Assert.assertEquals(1, set.compareTo(SortedSets.immutable.of(1, 2)));
+        assertEquals(0, set.compareTo(set));
+        assertEquals(-1, set.compareTo(SortedSets.immutable.of(1, 2, 3, 4)));
+        assertEquals(1, set.compareTo(SortedSets.immutable.of(1, 2)));
 
-        Assert.assertEquals(-1, set.compareTo(SortedSets.immutable.of(1, 2, 4)));
-        Assert.assertEquals(1, set.compareTo(SortedSets.immutable.of(1, 2, 2)));
+        assertEquals(-1, set.compareTo(SortedSets.immutable.of(1, 2, 4)));
+        assertEquals(1, set.compareTo(SortedSets.immutable.of(1, 2, 2)));
     }
 
     @Override
@@ -144,7 +147,7 @@ public class ImmutableTreeSetTest
     public void collectBoolean()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(BooleanArrayList.newListWith(true, true, true, true), integers.collectBoolean(PrimitiveFunctions.integerIsPositive()));
+        assertEquals(BooleanArrayList.newListWith(true, true, true, true), integers.collectBoolean(PrimitiveFunctions.integerIsPositive()));
     }
 
     @Override
@@ -152,7 +155,7 @@ public class ImmutableTreeSetTest
     public void collectByte()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(ByteArrayList.newListWith((byte) 4, (byte) 3, (byte) 2, (byte) 1), integers.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
+        assertEquals(ByteArrayList.newListWith((byte) 4, (byte) 3, (byte) 2, (byte) 1), integers.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Override
@@ -160,7 +163,7 @@ public class ImmutableTreeSetTest
     public void collectChar()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(CharArrayList.newListWith('D', 'C', 'B', 'A'), integers.collectChar(integer -> (char) (integer.intValue() + 64)));
+        assertEquals(CharArrayList.newListWith('D', 'C', 'B', 'A'), integers.collectChar(integer -> (char) (integer.intValue() + 64)));
     }
 
     @Override
@@ -168,7 +171,7 @@ public class ImmutableTreeSetTest
     public void collectDouble()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(DoubleArrayList.newListWith(4.0d, 3.0d, 2.0d, 1.0d), integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
+        assertEquals(DoubleArrayList.newListWith(4.0d, 3.0d, 2.0d, 1.0d), integers.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Override
@@ -176,7 +179,7 @@ public class ImmutableTreeSetTest
     public void collectFloat()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(FloatArrayList.newListWith(4.0f, 3.0f, 2.0f, 1.0f), integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
+        assertEquals(FloatArrayList.newListWith(4.0f, 3.0f, 2.0f, 1.0f), integers.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Override
@@ -184,7 +187,7 @@ public class ImmutableTreeSetTest
     public void collectInt()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(IntArrayList.newListWith(4, 3, 2, 1), integers.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
+        assertEquals(IntArrayList.newListWith(4, 3, 2, 1), integers.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Override
@@ -192,7 +195,7 @@ public class ImmutableTreeSetTest
     public void collectLong()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(LongArrayList.newListWith(4, 3, 2, 1), integers.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
+        assertEquals(LongArrayList.newListWith(4, 3, 2, 1), integers.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Override
@@ -200,6 +203,6 @@ public class ImmutableTreeSetTest
     public void collectShort()
     {
         ImmutableSortedSet<Integer> integers = this.classUnderTest(Collections.reverseOrder());
-        Assert.assertEquals(ShortArrayList.newListWith((short) 4, (short) 3, (short) 2, (short) 1), integers.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
+        assertEquals(ShortArrayList.newListWith((short) 4, (short) 3, (short) 2, (short) 1), integers.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/AbstractSortedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/AbstractSortedSetTestCase.java
@@ -51,8 +51,14 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableSortedSet}s.
@@ -81,11 +87,11 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         TreeSortedSet<Integer> expected = TreeSortedSet.newSet(Lists.mutable.with(1, 2, 3));
         MutableSortedSet<Integer> collection = this.newWith();
 
-        Assert.assertTrue(collection.addAll(Lists.mutable.with(3, 2, 1)));
-        Assert.assertEquals(expected, collection);
+        assertTrue(collection.addAll(Lists.mutable.with(3, 2, 1)));
+        assertEquals(expected, collection);
 
-        Assert.assertFalse(collection.addAll(Lists.mutable.with(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertFalse(collection.addAll(Lists.mutable.with(1, 2, 3)));
+        assertEquals(expected, collection);
     }
 
     @Override
@@ -97,25 +103,25 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         TreeSortedSet<Integer> expected = TreeSortedSet.newSet(Lists.mutable.with(1, 2, 3));
         MutableSortedSet<Integer> collection = this.newWith();
 
-        Assert.assertTrue(collection.addAllIterable(Lists.mutable.with(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertTrue(collection.addAllIterable(Lists.mutable.with(1, 2, 3)));
+        assertEquals(expected, collection);
 
-        Assert.assertFalse(collection.addAllIterable(Lists.mutable.with(1, 2, 3)));
-        Assert.assertEquals(expected, collection);
+        assertFalse(collection.addAllIterable(Lists.mutable.with(1, 2, 3)));
+        assertEquals(expected, collection);
     }
 
     @Override
     @Test
     public void testToString()
     {
-        Assert.assertEquals("[1, 2]", this.newWith(1, 2).toString());
+        assertEquals("[1, 2]", this.newWith(1, 2).toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals(this.newWith(1, 2, 3).toString(), '[' + this.newWith(1, 2, 3).makeString() + ']');
+        assertEquals(this.newWith(1, 2, 3).toString(), '[' + this.newWith(1, 2, 3).makeString() + ']');
     }
 
     @Override
@@ -125,7 +131,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableCollection<Integer> mutableCollection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         mutableCollection.appendString(builder);
-        Assert.assertEquals(mutableCollection.toString(), '[' + builder.toString() + ']');
+        assertEquals(mutableCollection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -133,7 +139,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void removeIf()
     {
         MutableSortedSet<Integer> objects = this.newWith(4, 1, 3, 2);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(2)));
+        assertTrue(objects.removeIf(Predicates.equal(2)));
         Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(1, 3, 4), objects);
     }
 
@@ -155,22 +161,22 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
 
         MutableList<Integer> tapRevResult = Lists.mutable.of();
         MutableSortedSet<Integer> revInt = this.newWith(Collections.reverseOrder(), 1, 2, 4, 3, 5);
-        Assert.assertSame(revInt, revInt.tap(tapRevResult::add));
-        Assert.assertEquals(revInt.toList(), tapRevResult);
+        assertSame(revInt, revInt.tap(tapRevResult::add));
+        assertEquals(revInt.toList(), tapRevResult);
     }
 
     @Test
     public void corresponds()
     {
         MutableSortedSet<Integer> integers1 = this.newWith(1, 2, 3, 4);
-        Assert.assertFalse(integers1.corresponds(this.newWith(1, 2, 3, 4, 5), Predicates2.alwaysTrue()));
+        assertFalse(integers1.corresponds(this.newWith(1, 2, 3, 4, 5), Predicates2.alwaysTrue()));
 
         MutableList<Integer> integers2 = integers1.collect(integer -> integer + 1, FastList.newList());
-        Assert.assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
-        Assert.assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
+        assertTrue(integers1.corresponds(integers2, Predicates2.lessThan()));
+        assertFalse(integers1.corresponds(integers2, Predicates2.greaterThan()));
 
         MutableSortedSet<Integer> integers3 = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
-        Assert.assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
+        assertFalse(integers3.corresponds(integers1, Predicates2.equal()));
     }
 
     @Override
@@ -241,8 +247,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         PartitionMutableSortedSet<Integer> partition = integers.partition(IntegerPredicates.isEven());
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 6, 4, 2), partition.getSelected());
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 5, 3, 1), partition.getRejected());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
     }
 
     @Override
@@ -253,8 +259,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         PartitionMutableSortedSet<Integer> partition = integers.partitionWith(Predicates2.in(), integers.select(IntegerPredicates.isEven()));
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 6, 4, 2), partition.getSelected());
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 5, 3, 1), partition.getRejected());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
     }
 
     @Test
@@ -264,8 +270,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         PartitionMutableSortedSet<Integer> partition = integers.partitionWhile(Predicates.greaterThan(3));
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 6, 5, 4), partition.getSelected());
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 1), partition.getRejected());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getSelected().comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), partition.getRejected().comparator());
     }
 
     @Test
@@ -274,7 +280,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 2, 1, 3, 5, 6);
         MutableSortedSet<Integer> take = integers.takeWhile(Predicates.greaterThan(3));
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 6, 5, 4), take);
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), take.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), take.comparator());
     }
 
     @Test
@@ -283,7 +289,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 2, 1, 3, 5, 6);
         MutableSortedSet<Integer> drop = integers.dropWhile(Predicates.greaterThan(3));
         Verify.assertSortedSetsEqual(this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 1), drop);
-        Assert.assertEquals(Comparators.<Integer>reverseNaturalOrder(), drop.comparator());
+        assertEquals(Comparators.<Integer>reverseNaturalOrder(), drop.comparator());
     }
 
     @Test
@@ -291,8 +297,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 2, 1, 3, 5, 6);
         MutableSortedSet<Integer> distinct = integers.distinct();
-        Assert.assertEquals(integers, distinct);
-        Assert.assertNotSame(integers, distinct);
+        assertEquals(integers, distinct);
+        assertNotSame(integers, distinct);
     }
 
     @Override
@@ -329,7 +335,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     @Test
     public void selectWithIndex()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.of(5, 6),
                 this.newWith(6, 4, 5).selectWithIndex((object, value) -> value > 0, Lists.mutable.empty()));
     }
@@ -348,7 +354,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
                     @Override
                     public boolean accept(Integer object, int value)
                     {
-                        Assert.assertEquals(this.index++, value);
+                        assertEquals(this.index++, value);
                         return false;
                     }
                 }, Lists.mutable.empty()));
@@ -361,7 +367,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void rejectWithIndexNoneRejected()
     {
         MutableSortedSet<Integer> integers = this.newWith(6, 4, 5);
-        Verify.assertEquals(
+        assertEquals(
                 Lists.mutable.of(4, 5, 6),
                 integers.rejectWithIndex(new ObjectIntPredicate<Integer>()
                 {
@@ -369,7 +375,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
                     @Override
                     public boolean accept(Integer object, int value)
                     {
-                        Assert.assertEquals(this.index++, value);
+                        assertEquals(this.index++, value);
                         return false;
                     }
                 }, Lists.mutable.empty()));
@@ -382,7 +388,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void rejectWithIndex()
     {
         MutableSortedSet<Integer> integers = this.newWith(6, 4, 5);
-        Verify.assertEquals(Lists.mutable.of(5, 6),
+        assertEquals(Lists.mutable.of(5, 6),
                 integers.rejectWithIndex((object, value) -> value < 1, Lists.mutable.empty()));
     }
 
@@ -411,7 +417,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> integers = this.newWith(4, 5, 6);
         MutableList<Integer> expected = Lists.mutable.with(4, 6);
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 integers.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -424,7 +430,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> integers = this.newWith(4, 5, 6);
         MutableList<Integer> expected = Lists.mutable.with(5);
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 integers.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
@@ -491,10 +497,10 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         }
         MutableSortedSetMultimap<Integer, Integer> actual =
                 set.groupByEach(function);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
         MutableSortedSetMultimap<Integer, Integer> actualWithTarget =
                 set.groupByEach(function, this.<Integer>newWith().groupByEach(function));
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
         for (int i = 1; i < 8; ++i)
         {
             Verify.assertSortedSetsEqual(expected.get(-i), actual.get(-i));
@@ -559,8 +565,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
 
         for (int i = 1; i < 6; ++i)
         {
-            Assert.assertEquals(Tuples.pair(i, 6 - i), zipItr.next());
-            Assert.assertEquals(Tuples.pair(6 - i, i), revZipItr.next());
+            assertEquals(Tuples.pair(i, 6 - i), zipItr.next());
+            assertEquals(Tuples.pair(6 - i, i), revZipItr.next());
         }
 
         Person john = new Person("John", "Smith");
@@ -568,11 +574,11 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<Person> people = this.newWith(john, johnDoe);
         MutableList<Holder> list = Lists.mutable.with(new Holder(1), new Holder(2), new Holder(3));
         MutableList<Pair<Person, Holder>> pairs = people.zip(list);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(Tuples.pair(johnDoe, new Holder(1)), Tuples.pair(john, new Holder(2))),
                 pairs.toList());
-        Assert.assertTrue(pairs.add(Tuples.pair(new Person("Jack", "Baker"), new Holder(3))));
-        Assert.assertEquals(Tuples.pair(new Person("Jack", "Baker"), new Holder(3)), pairs.getLast());
+        assertTrue(pairs.add(Tuples.pair(new Person("Jack", "Baker"), new Holder(3))));
+        assertEquals(Tuples.pair(new Person("Jack", "Baker"), new Holder(3)), pairs.getLast());
     }
 
     @Override
@@ -584,7 +590,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         Iterator<Pair<Integer, Integer>> zip = integers.zipWithIndex().iterator();
         for (int i = 5; i > 0; --i)
         {
-            Assert.assertEquals(Tuples.pair(i, 5 - i), zip.next());
+            assertEquals(Tuples.pair(i, 5 - i), zip.next());
         }
         Person john = new Person("John", "Smith");
         Person jane = new Person("Jane", "Smith");
@@ -608,7 +614,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> union = set.unionInto(UnifiedSet.newSetWith("1", "2", "5", "3"), UnifiedSet.newSet());
         Verify.assertSetsEqual(UnifiedSet.newSetWith("1", "2", "3", "4", "5"), union);
-        Assert.assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
+        assertEquals(set, set.unionInto(UnifiedSet.newSetWith("1"), UnifiedSet.newSet()));
         MutableSortedSet<String> sortedUnion = set.unionInto(TreeSortedSet.newSetWith("5", "1", "6"), TreeSortedSet.newSet());
         Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith("1", "2", "3", "4", "5", "6"), sortedUnion);
     }
@@ -636,7 +642,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<String> set = this.newWith("5", "2", "3", "4", "1");
         MutableSortedSet<String> difference = set.difference(UnifiedSet.newSetWith("2", "3", "4", "not present"));
         Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith("1", "5"), difference);
-        Assert.assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
+        assertEquals(set, set.difference(UnifiedSet.newSetWith("not present")));
     }
 
     @Test
@@ -644,8 +650,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<String> set = this.newWith("1", "2", "3", "4");
         MutableSet<String> difference = set.differenceInto(UnifiedSet.newSetWith("2", "3", "4", "not present"), UnifiedSet.newSet());
-        Assert.assertEquals(UnifiedSet.newSetWith("1"), difference);
-        Assert.assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
+        assertEquals(UnifiedSet.newSetWith("1"), difference);
+        assertEquals(set, set.differenceInto(UnifiedSet.newSetWith("not present"), UnifiedSet.newSet()));
     }
 
     @Test
@@ -674,15 +680,15 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void isSubsetOf()
     {
         MutableSortedSet<String> set = this.newWith("3", "4", "1", "2");
-        Assert.assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertTrue(set.isSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
     }
 
     @Test
     public void isProperSubsetOf()
     {
         MutableSortedSet<String> set = this.newWith("3", "1", "4", "1", "2", "3");
-        Assert.assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
-        Assert.assertFalse(set.isProperSubsetOf(set));
+        assertTrue(set.isProperSubsetOf(UnifiedSet.newSetWith("1", "2", "3", "4", "5")));
+        assertFalse(set.isProperSubsetOf(set));
     }
 
     @Test
@@ -721,7 +727,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<String> set = this.newWith("1", "2", "3", "4", "1", "2", "3", "4");
         LazyIterable<Pair<String, String>> cartesianProduct = set.cartesianProduct(UnifiedSet.newSetWith("One", "Two"));
         Verify.assertIterableSize(set.size() * 2, cartesianProduct);
-        Assert.assertEquals(
+        assertEquals(
                 set,
                 cartesianProduct
                         .select(Predicates.attributeEqual((Function<Pair<?, String>, String>) Pair::getTwo, "One"))
@@ -732,11 +738,11 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void firstLast()
     {
         MutableSortedSet<Integer> set = this.newWith(1, 2, 3, 4, 5);
-        Assert.assertEquals(Integer.valueOf(1), set.first());
-        Assert.assertEquals(Integer.valueOf(5), set.last());
+        assertEquals(Integer.valueOf(1), set.first());
+        assertEquals(Integer.valueOf(5), set.last());
         MutableSortedSet<Integer> set2 = this.newWith(Collections.reverseOrder(), 1, 2, 3, 4, 5);
-        Assert.assertEquals(Integer.valueOf(5), set2.first());
-        Assert.assertEquals(Integer.valueOf(1), set2.last());
+        assertEquals(Integer.valueOf(5), set2.first());
+        assertEquals(Integer.valueOf(1), set2.last());
     }
 
     @Test
@@ -744,7 +750,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> set = this.newWith(1, 2, 3);
         MutableSortedSet<Integer> clone = set.clone();
-        Assert.assertNotSame(set, clone);
+        assertNotSame(set, clone);
         Verify.assertSortedSetsEqual(set, clone);
     }
 
@@ -777,8 +783,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         set.clear();
         Verify.assertEmpty(subSet);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subSet.add(5));
-        Assert.assertThrows(IllegalArgumentException.class, () -> subSet.add(0));
+        assertThrows(IllegalArgumentException.class, () -> subSet.add(5));
+        assertThrows(IllegalArgumentException.class, () -> subSet.add(0));
     }
 
     @Test
@@ -800,8 +806,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         set.clear();
         Verify.assertEmpty(subSet);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subSet.add(6));
-        Assert.assertTrue(subSet.add(0));
+        assertThrows(IllegalArgumentException.class, () -> subSet.add(6));
+        assertTrue(subSet.add(0));
     }
 
     @Test
@@ -823,8 +829,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         set.clear();
         Verify.assertEmpty(subSet);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> subSet.add(1));
-        Assert.assertTrue(subSet.add(10));
+        assertThrows(IllegalArgumentException.class, () -> subSet.add(1));
+        assertTrue(subSet.add(10));
     }
 
     @Override
@@ -832,8 +838,8 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Number> numbers = this.newWith((o1, o2) -> Double.compare(o1.doubleValue(), o2.doubleValue()), 1, 2.0, 3, 4.0, 5);
         MutableSortedSet<Integer> integers = numbers.selectInstancesOf(Integer.class);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
-        Assert.assertEquals(Lists.mutable.with(1, 3, 5), integers.toList());
+        assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
+        assertEquals(Lists.mutable.with(1, 3, 5), integers.toList());
     }
 
     @Test
@@ -841,7 +847,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 4, 2, 1, 3, 5, 6);
         MutableStack<Integer> stack = integers.toStack();
-        Assert.assertEquals(Stacks.immutable.with(6, 5, 4, 3, 2, 1), stack);
+        assertEquals(Stacks.immutable.with(6, 5, 4, 3, 2, 1), stack);
     }
 
     @Override
@@ -907,20 +913,20 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableSortedSet<Integer> integers = this.newWith(Comparators.reverseNaturalOrder(), 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         StringBuilder builder = new StringBuilder();
         integers.forEachWithIndex(5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("453627", builder.toString());
+        assertEquals("453627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         integers.forEachWithIndex(5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("45", builder2.toString());
+        assertEquals("45", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         integers.forEachWithIndex(0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("90817263544536271809", builder3.toString());
+        assertEquals("90817263544536271809", builder3.toString());
 
         MutableList<Integer> result = Lists.mutable.of();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(7, 5, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(-1, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> integers.forEachWithIndex(0, -1, new AddToList(result)));
+        assertThrows(IllegalArgumentException.class, () -> integers.forEachWithIndex(7, 5, new AddToList(result)));
     }
 
     @Test
@@ -932,11 +938,11 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         this.validateForEachWithIndexOnRange(set, 3, 5, SortedSets.mutable.with(Comparators.reverseNaturalOrder(), 6, 5, 4));
         this.validateForEachWithIndexOnRange(set, 9, 9, SortedSets.mutable.with(Comparators.reverseNaturalOrder(), 0));
         this.validateForEachWithIndexOnRange(set, 0, 9, SortedSets.mutable.with(Comparators.reverseNaturalOrder(), 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
-        Assert.assertThrows(
+        assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> this.validateForEachWithIndexOnRange(set, 10, 10, SortedSets.mutable.with(Comparators.reverseNaturalOrder())));
 
-        Assert.assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> this.validateForEachWithIndexOnRange(set, 9, 0, SortedSets.mutable.with(Comparators.reverseNaturalOrder(), 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)));
     }
@@ -956,38 +962,38 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void indexOf()
     {
         MutableSortedSet<Integer> objects = this.newWith(Comparators.reverseNaturalOrder(), 3, 2, 1);
-        Assert.assertEquals(0, objects.indexOf(3));
-        Assert.assertEquals(1, objects.indexOf(2));
-        Assert.assertEquals(2, objects.indexOf(1));
-        Assert.assertEquals(-1, objects.indexOf(0));
+        assertEquals(0, objects.indexOf(3));
+        assertEquals(1, objects.indexOf(2));
+        assertEquals(2, objects.indexOf(1));
+        assertEquals(-1, objects.indexOf(0));
     }
 
     @Test
     public void detectIndex()
     {
         MutableSortedSet<Integer> integers1 = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(1, integers1.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(1, integers1.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(0, integers1.detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers1.detectIndex(integer -> integer % 5 == 0));
 
         MutableSortedSet<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
-        Assert.assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(1, integers2.detectIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
+        assertEquals(0, integers2.detectIndex(integer -> integer % 2 == 0));
+        assertEquals(1, integers2.detectIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers2.detectIndex(integer -> integer % 5 == 0));
     }
 
     @Test
     public void detectLastIndex()
     {
         MutableSortedSet<Integer> integers1 = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(3, integers1.detectLastIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(2, integers1.detectLastIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers1.detectLastIndex(integer -> integer % 5 == 0));
+        assertEquals(3, integers1.detectLastIndex(integer -> integer % 2 == 0));
+        assertEquals(2, integers1.detectLastIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers1.detectLastIndex(integer -> integer % 5 == 0));
 
         MutableSortedSet<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
-        Assert.assertEquals(3, integers2.detectLastIndex(integer -> integer % 2 == 0));
-        Assert.assertEquals(2, integers2.detectLastIndex(integer -> integer % 2 != 0));
-        Assert.assertEquals(-1, integers2.detectLastIndex(integer -> integer % 5 == 0));
+        assertEquals(3, integers2.detectLastIndex(integer -> integer % 2 == 0));
+        assertEquals(2, integers2.detectLastIndex(integer -> integer % 2 != 0));
+        assertEquals(-1, integers2.detectLastIndex(integer -> integer % 5 == 0));
     }
 
     @Test
@@ -995,7 +1001,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     {
         MutableSortedSet<Integer> integers = this.newWith(1, 2, 3, 4);
         MutableSortedSet<Integer> reversed = integers.toReversed();
-        Assert.assertEquals(
+        assertEquals(
                 SortedSets.mutable.with(Comparators.reverseNaturalOrder(), 3, 2, 1),
                 reversed);
     }
@@ -1006,7 +1012,7 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableList<Integer> list = Lists.mutable.empty();
         MutableSortedSet<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.reverseForEach(list::add);
-        Assert.assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
+        assertEquals(Lists.mutable.with(4, 3, 2, 1), list);
     }
 
     @Test
@@ -1015,24 +1021,24 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
         MutableList<Integer> list = Lists.mutable.empty();
         MutableSortedSet<Integer> integers = this.newWith(1, 2, 3, 4);
         integers.reverseForEachWithIndex((each, index) -> list.add(each + index));
-        Assert.assertEquals(Lists.mutable.with(7, 6, 5, 4), list);
+        assertEquals(Lists.mutable.with(7, 6, 5, 4), list);
     }
 
     @Test
     public void take()
     {
         MutableSortedSet<Integer> integers1 = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(SortedSets.mutable.of(integers1.comparator()), integers1.take(0));
-        Assert.assertSame(integers1.comparator(), integers1.take(0).comparator());
-        Assert.assertEquals(SortedSets.mutable.of(integers1.comparator(), 1, 2, 3), integers1.take(3));
-        Assert.assertSame(integers1.comparator(), integers1.take(3).comparator());
-        Assert.assertEquals(SortedSets.mutable.of(integers1.comparator(), 1, 2, 3), integers1.take(integers1.size() - 1));
+        assertEquals(SortedSets.mutable.of(integers1.comparator()), integers1.take(0));
+        assertSame(integers1.comparator(), integers1.take(0).comparator());
+        assertEquals(SortedSets.mutable.of(integers1.comparator(), 1, 2, 3), integers1.take(3));
+        assertSame(integers1.comparator(), integers1.take(3).comparator());
+        assertEquals(SortedSets.mutable.of(integers1.comparator(), 1, 2, 3), integers1.take(integers1.size() - 1));
 
         MutableSortedSet<Integer> expectedSet = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
         MutableSortedSet<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
-        Assert.assertEquals(expectedSet, integers2.take(integers2.size()));
-        Assert.assertEquals(expectedSet, integers2.take(10));
-        Assert.assertEquals(expectedSet, integers2.take(Integer.MAX_VALUE));
+        assertEquals(expectedSet, integers2.take(integers2.size()));
+        assertEquals(expectedSet, integers2.take(10));
+        assertEquals(expectedSet, integers2.take(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1045,18 +1051,18 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     public void drop()
     {
         MutableSortedSet<Integer> integers1 = this.newWith(1, 2, 3, 4);
-        Assert.assertEquals(integers1, integers1.drop(0));
-        Assert.assertSame(integers1.comparator(), integers1.drop(0).comparator());
-        Assert.assertNotSame(integers1, integers1.drop(0));
-        Assert.assertEquals(SortedSets.mutable.of(integers1.comparator(), 4), integers1.drop(3));
-        Assert.assertSame(integers1.comparator(), integers1.drop(3).comparator());
-        Assert.assertEquals(SortedSets.mutable.of(integers1.comparator(), 4), integers1.drop(integers1.size() - 1));
+        assertEquals(integers1, integers1.drop(0));
+        assertSame(integers1.comparator(), integers1.drop(0).comparator());
+        assertNotSame(integers1, integers1.drop(0));
+        assertEquals(SortedSets.mutable.of(integers1.comparator(), 4), integers1.drop(3));
+        assertSame(integers1.comparator(), integers1.drop(3).comparator());
+        assertEquals(SortedSets.mutable.of(integers1.comparator(), 4), integers1.drop(integers1.size() - 1));
 
         MutableSortedSet<Integer> expectedSet = SortedSets.mutable.of(Comparators.reverseNaturalOrder());
         MutableSortedSet<Integer> integers2 = this.newWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1);
-        Assert.assertEquals(expectedSet, integers2.drop(integers2.size()));
-        Assert.assertEquals(expectedSet, integers2.drop(10));
-        Assert.assertEquals(expectedSet, integers2.drop(Integer.MAX_VALUE));
+        assertEquals(expectedSet, integers2.drop(integers2.size()));
+        assertEquals(expectedSet, integers2.drop(10));
+        assertEquals(expectedSet, integers2.drop(Integer.MAX_VALUE));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1068,16 +1074,16 @@ public abstract class AbstractSortedSetTestCase extends AbstractCollectionTestCa
     @Test
     public void getFirstOptional()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2).getFirstOptional().get());
-        Assert.assertTrue(this.newWith(1, 2).getFirstOptional().isPresent());
-        Assert.assertFalse(this.newWith().getFirstOptional().isPresent());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2).getFirstOptional().get());
+        assertTrue(this.newWith(1, 2).getFirstOptional().isPresent());
+        assertFalse(this.newWith().getFirstOptional().isPresent());
     }
 
     @Test
     public void getLastOptional()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.newWith(1, 2).getLastOptional().get());
-        Assert.assertTrue(this.newWith(1, 2).getLastOptional().isPresent());
-        Assert.assertFalse(this.newWith().getLastOptional().isPresent());
+        assertEquals(Integer.valueOf(2), this.newWith(1, 2).getLastOptional().get());
+        assertTrue(this.newWith(1, 2).getLastOptional().isPresent());
+        assertFalse(this.newWith().getLastOptional().isPresent());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
@@ -28,8 +28,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link SortedSetAdapter}.
@@ -85,14 +90,14 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEach()
     {
-        this.newWith(1, 2, 3).reverseForEach(each -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEach(each -> fail("Should not be evaluated"));
     }
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEachWithIndex()
     {
-        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> fail("Should not be evaluated"));
     }
 
     @Override
@@ -159,11 +164,11 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
         MutableSortedSet<Integer> set4 = TreeSortedSet.newSetWith(2, 3, 4);
 
         Verify.assertEqualsAndHashCode(set1, set1);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), set1);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3), set2);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), set1);
+        assertEquals(UnifiedSet.newSetWith(1, 2, 3), set2);
 
-        Assert.assertEquals(set1, set2);
-        Assert.assertNotEquals(set2, set3);
+        assertEquals(set1, set2);
+        assertNotEquals(set2, set3);
         Verify.assertEqualsAndHashCode(set3, set4);
         Verify.assertSortedSetsEqual(TreeSortedSet.newSetWith(Collections.reverseOrder(), 1, 2, 3), set2);
     }
@@ -194,9 +199,9 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
     public void getFirst()
     {
         super.getFirst();
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(Collections.reverseOrder(), 1, 2, 3).getFirst());
-        Assert.assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getFirst());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 3).getFirst());
+        assertEquals(Integer.valueOf(3), this.newWith(Collections.reverseOrder(), 1, 2, 3).getFirst());
+        assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getFirst());
     }
 
     @Override
@@ -204,10 +209,10 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
     public void getLast()
     {
         super.getLast();
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(Collections.reverseOrder(), 1, 2, 3).getLast());
-        Assert.assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 3).getLast());
+        assertEquals(Integer.valueOf(1), this.newWith(Collections.reverseOrder(), 1, 2, 3).getLast());
+        assertThrows(NoSuchElementException.class, () -> new SortedSetAdapter<>(new TreeSet<>()).getLast());
     }
 
     @Override
@@ -247,7 +252,7 @@ public class SortedSetAdapterTest extends AbstractSortedSetTestCase
     @Test
     public void adaptNull()
     {
-        Assert.assertThrows(NullPointerException.class, () -> new SortedSetAdapter<>(null));
-        Assert.assertThrows(NullPointerException.class, () -> SortedSetAdapter.adapt(null));
+        assertThrows(NullPointerException.class, () -> new SortedSetAdapter<>(null));
+        assertThrows(NullPointerException.class, () -> SortedSetAdapter.adapt(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet2Test.java
@@ -15,8 +15,10 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link SynchronizedSortedSet}.
@@ -39,7 +41,7 @@ public class SynchronizedSortedSet2Test extends AbstractSortedSetTestCase
     public void asSynchronized()
     {
         MutableSortedSet<Object> synchronizedSet = this.newWith();
-        Assert.assertSame(synchronizedSet, synchronizedSet.asSynchronized());
+        assertSame(synchronizedSet, synchronizedSet.asSynchronized());
     }
 
     @Override
@@ -71,14 +73,14 @@ public class SynchronizedSortedSet2Test extends AbstractSortedSetTestCase
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEach()
     {
-        this.newWith(1, 2, 3).reverseForEach(each -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEach(each -> fail("Should not be evaluated"));
     }
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEachWithIndex()
     {
-        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> fail("Should not be evaluated"));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSetTest.java
@@ -27,8 +27,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedSortedSet}.
@@ -55,7 +58,7 @@ public class SynchronizedSortedSetTest extends AbstractSynchronizedCollectionTes
     public void removeIf()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(objects.removeIf(Predicates.equal(2)));
+        assertTrue(objects.removeIf(Predicates.equal(2)));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 3, 4);
     }
@@ -64,7 +67,7 @@ public class SynchronizedSortedSetTest extends AbstractSynchronizedCollectionTes
     public void removeWithIf()
     {
         MutableCollection<Integer> objects = this.newWith(1, 2, 3, 4);
-        Assert.assertTrue(objects.removeIfWith(Predicates2.equal(), 2));
+        assertTrue(objects.removeIfWith(Predicates2.equal(), 2));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 3, 4);
     }
@@ -83,8 +86,8 @@ public class SynchronizedSortedSetTest extends AbstractSynchronizedCollectionTes
         MutableSortedSet<Number> mutableSortedSet = SortedSetAdapter.adapt(new TreeSet<>((o1, o2) -> Double.compare(o1.doubleValue(), o2.doubleValue())));
         MutableSortedSet<Number> synchronizedSortedSet = new SynchronizedSortedSet<>(mutableSortedSet).withAll(FastList.newListWith(1, 2.0, 3, 4.0, 5));
         MutableSortedSet<Integer> integers = synchronizedSortedSet.selectInstancesOf(Integer.class);
-        Assert.assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
-        Assert.assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
+        assertEquals(UnifiedSet.newSetWith(1, 3, 5), integers);
+        assertEquals(FastList.newListWith(1, 3, 5), integers.toList());
     }
 
     @Override
@@ -159,16 +162,16 @@ public class SynchronizedSortedSetTest extends AbstractSynchronizedCollectionTes
     @Test
     public void getFirstOptional()
     {
-        Assert.assertEquals(Integer.valueOf(1), this.newWith(1, 2).getFirstOptional().get());
-        Assert.assertTrue(this.newWith(1, 2).getFirstOptional().isPresent());
-        Assert.assertFalse(this.newWith().getFirstOptional().isPresent());
+        assertEquals(Integer.valueOf(1), this.newWith(1, 2).getFirstOptional().get());
+        assertTrue(this.newWith(1, 2).getFirstOptional().isPresent());
+        assertFalse(this.newWith().getFirstOptional().isPresent());
     }
 
     @Test
     public void getLastOptional()
     {
-        Assert.assertEquals(Integer.valueOf(2), this.newWith(1, 2).getLastOptional().get());
-        Assert.assertTrue(this.newWith(1, 2).getLastOptional().isPresent());
-        Assert.assertFalse(this.newWith().getLastOptional().isPresent());
+        assertEquals(Integer.valueOf(2), this.newWith(1, 2).getLastOptional().get());
+        assertTrue(this.newWith(1, 2).getLastOptional().isPresent());
+        assertFalse(this.newWith().getLastOptional().isPresent());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSetTest.java
@@ -19,8 +19,10 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TreeSortedSetTest extends AbstractSortedSetTestCase
 {
@@ -56,7 +58,7 @@ public class TreeSortedSetTest extends AbstractSortedSetTestCase
         TreeSortedSet<Integer> sortedSetA = TreeSortedSet.newSet(Collections.reverseOrder());
         TreeSortedSet<Integer> sortedSetB = TreeSortedSet.newSet(sortedSetA.with(1).with(2, 3).with(4, 5, 6));
         Verify.assertSortedSetsEqual(sortedSetA, sortedSetB);
-        Assert.assertTrue(sortedSetA.first().equals(sortedSetB.first()) && sortedSetB.first() == 6);
+        assertTrue(sortedSetA.first().equals(sortedSetB.first()) && sortedSetB.first() == 6);
         Verify.assertSortedSetsEqual(sortedSetB, new TreeSortedSet<>(sortedSetB));
     }
 
@@ -94,14 +96,14 @@ public class TreeSortedSetTest extends AbstractSortedSetTestCase
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEach()
     {
-        this.newWith(1, 2, 3).reverseForEach(each -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEach(each -> fail("Should not be evaluated"));
     }
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEachWithIndex()
     {
-        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> fail("Should not be evaluated"));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
@@ -19,9 +19,15 @@ import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link UnmodifiableSortedSet}.
@@ -72,7 +78,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     {
         Verify.assertInstanceOf(UnmodifiableSortedSet.class, this.newWith().asUnmodifiable());
         MutableSortedSet<Object> set = this.newWith();
-        Assert.assertSame(set, set.asUnmodifiable());
+        assertSame(set, set.asUnmodifiable());
     }
 
     @Test
@@ -97,7 +103,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     {
         MutableSortedSet<String> set = this.newWith();
         MutableSortedSet<String> clone = set.clone();
-        Assert.assertSame(clone, set);
+        assertSame(clone, set);
     }
 
     @Override
@@ -105,7 +111,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void min()
     {
         super.min();
-        Assert.assertEquals("1", this.newWith("1", "3", "2").min(String::compareTo));
+        assertEquals("1", this.newWith("1", "3", "2").min(String::compareTo));
     }
 
     @Override
@@ -113,7 +119,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void max()
     {
         super.max();
-        Assert.assertEquals("3", this.newWith("1", "3", "2").max(String::compareTo));
+        assertEquals("3", this.newWith("1", "3", "2").max(String::compareTo));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -149,7 +155,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void min_without_comparator()
     {
         super.min_without_comparator();
-        Assert.assertEquals("1", this.newWith("1", "3", "2").min());
+        assertEquals("1", this.newWith("1", "3", "2").min());
     }
 
     @Override
@@ -157,7 +163,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void max_without_comparator()
     {
         super.max_without_comparator();
-        Assert.assertEquals("3", this.newWith("1", "3", "2").max());
+        assertEquals("3", this.newWith("1", "3", "2").max());
     }
 
     @Override
@@ -165,7 +171,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void minBy()
     {
         super.minBy();
-        Assert.assertEquals("1", this.newWith("1", "3", "2").minBy(Functions.getStringToInteger()));
+        assertEquals("1", this.newWith("1", "3", "2").minBy(Functions.getStringToInteger()));
     }
 
     @Override
@@ -173,7 +179,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void maxBy()
     {
         super.maxBy();
-        Assert.assertEquals("3", this.newWith("1", "3", "2").maxBy(Functions.getStringToInteger()));
+        assertEquals("3", this.newWith("1", "3", "2").maxBy(Functions.getStringToInteger()));
     }
 
     @Override
@@ -253,7 +259,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
         super.testToString();
         MutableCollection<Object> collection = this.newWith(1, 2);
         String toString = collection.toString();
-        Assert.assertTrue("[1, 2]".equals(toString) || "[2, 1]".equals(toString));
+        assertTrue("[1, 2]".equals(toString) || "[2, 1]".equals(toString));
     }
 
     @Override
@@ -262,7 +268,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     {
         super.makeString();
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
-        Assert.assertEquals(collection.toString(), '[' + collection.makeString() + ']');
+        assertEquals(collection.toString(), '[' + collection.makeString() + ']');
     }
 
     @Override
@@ -273,7 +279,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
         MutableCollection<Object> collection = this.newWith(1, 2, 3);
         Appendable builder = new StringBuilder();
         collection.appendString(builder);
-        Assert.assertEquals(collection.toString(), '[' + builder.toString() + ']');
+        assertEquals(collection.toString(), '[' + builder.toString() + ']');
     }
 
     @Override
@@ -281,8 +287,8 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void getFirst()
     {
         super.getFirst();
-        Assert.assertNotNull(this.newWith(1, 2, 3).getFirst());
-        Assert.assertNull(this.newWith().getFirst());
+        assertNotNull(this.newWith(1, 2, 3).getFirst());
+        assertNull(this.newWith().getFirst());
     }
 
     @Override
@@ -290,8 +296,8 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     public void getLast()
     {
         super.getLast();
-        Assert.assertNotNull(this.newWith(1, 2, 3).getLast());
-        Assert.assertNull(this.newWith().getLast());
+        assertNotNull(this.newWith(1, 2, 3).getLast());
+        assertNull(this.newWith().getLast());
     }
 
     @Override
@@ -360,14 +366,14 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEach()
     {
-        this.newWith(1, 2, 3).reverseForEach(each -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEach(each -> fail("Should not be evaluated"));
     }
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
     public void reverseForEachWithIndex()
     {
-        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> Assert.fail("Should not be evaluated"));
+        this.newWith(1, 2, 3).reverseForEachWithIndex((each, index) -> fail("Should not be evaluated"));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableEmptySetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableEmptySetWithHashingStrategyTest.java
@@ -20,8 +20,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.immutable.AbstractImmutableEmptySetTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ImmutableEmptySetWithHashingStrategyTest extends AbstractImmutableEmptySetTestCase
 {
@@ -49,10 +51,10 @@ public class ImmutableEmptySetWithHashingStrategyTest extends AbstractImmutableE
     @Test
     public void newWithout()
     {
-        Assert.assertEquals(
+        assertEquals(
                 HashingStrategySets.immutable.of(HASHING_STRATEGY),
                 HashingStrategySets.immutable.of(HASHING_STRATEGY).newWithout(1));
-        Assert.assertEquals(
+        assertEquals(
                 HashingStrategySets.immutable.of(HASHING_STRATEGY),
                 HashingStrategySets.immutable.of(HASHING_STRATEGY).newWithoutAll(Interval.oneTo(3)));
     }
@@ -65,6 +67,6 @@ public class ImmutableEmptySetWithHashingStrategyTest extends AbstractImmutableE
         MutableSet<Integer> mutable = UnifiedSet.newSet(immutable);
         Verify.assertEqualsAndHashCode(mutable, immutable);
         Verify.assertPostSerializedEqualsAndHashCode(immutable);
-        Assert.assertNotEquals(FastList.newList(mutable), immutable);
+        assertNotEquals(FastList.newList(mutable), immutable);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyTest.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.impl.set.immutable.AbstractImmutableUnifiedSetTes
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableUnifiedSetWithHashingStrategy}.
@@ -78,7 +80,7 @@ public class ImmutableUnifiedSetWithHashingStrategyTest extends AbstractImmutabl
     {
         super.newCollection();
         ImmutableSet<Integer> set = ImmutableUnifiedSetWithHashingStrategy.newSet(HASHING_STRATEGY, UnifiedSet.newSet());
-        Assert.assertTrue(set.isEmpty());
+        assertTrue(set.isEmpty());
         Verify.assertSize(0, set);
     }
 
@@ -86,7 +88,7 @@ public class ImmutableUnifiedSetWithHashingStrategyTest extends AbstractImmutabl
     public void getBatchCount()
     {
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.newSet(1, 2, 3, 4, 5, 6);
-        Assert.assertEquals(2, integerBatchIterable.getBatchCount(3));
+        assertEquals(2, integerBatchIterable.getBatchCount(3));
     }
 
     @Test
@@ -95,7 +97,7 @@ public class ImmutableUnifiedSetWithHashingStrategyTest extends AbstractImmutabl
         Sum sum = new IntegerSum(0);
         BatchIterable<Integer> integerBatchIterable = (BatchIterable<Integer>) this.newSet(1, 2, 3, 4, 5);
         integerBatchIterable.batchForEach(new SumProcedure<>(sum), 0, 1);
-        Assert.assertEquals(15, sum.getValue());
+        assertEquals(15, sum.getValue());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/StackIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/StackIterableTestCase.java
@@ -78,8 +78,16 @@ import org.eclipse.collections.impl.stack.mutable.primitive.ShortArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public abstract class StackIterableTestCase
         extends AbstractRichIterableTestCase
@@ -101,7 +109,7 @@ public abstract class StackIterableTestCase
     @Test
     public void testNewStackFromTopToBottom()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackWith(3, 2, 1),
                 this.newStackFromTopToBottom(1, 2, 3));
     }
@@ -134,44 +142,44 @@ public abstract class StackIterableTestCase
     public void peek_illegal_arguments()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertThrows(IllegalArgumentException.class, () -> stack.peek(-1));
+        assertThrows(IllegalArgumentException.class, () -> stack.peek(-1));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> stack.peek(4));
+        assertThrows(IllegalArgumentException.class, () -> stack.peek(4));
 
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3), stack.peek(3));
+        assertEquals(Lists.mutable.with(1, 2, 3), stack.peek(3));
     }
 
     @Test
     public void peek()
     {
-        Assert.assertEquals("3", this.newStackWith("1", "2", "3").peek());
-        Assert.assertEquals(Lists.mutable.with(), this.newStackWith("1", "2", "3").peek(0));
-        Assert.assertEquals(Lists.mutable.with("3", "2"), this.newStackWith("1", "2", "3").peek(2));
+        assertEquals("3", this.newStackWith("1", "2", "3").peek());
+        assertEquals(Lists.mutable.with(), this.newStackWith("1", "2", "3").peek(0));
+        assertEquals(Lists.mutable.with("3", "2"), this.newStackWith("1", "2", "3").peek(2));
     }
 
     @Test
     public void peekAt()
     {
-        Assert.assertEquals("3", this.newStackWith("1", "2", "3").peekAt(0));
-        Assert.assertEquals("2", this.newStackWith("1", "2", "3").peekAt(1));
-        Assert.assertEquals("1", this.newStackWith("1", "2", "3").peekAt(2));
+        assertEquals("3", this.newStackWith("1", "2", "3").peekAt(0));
+        assertEquals("2", this.newStackWith("1", "2", "3").peekAt(1));
+        assertEquals("1", this.newStackWith("1", "2", "3").peekAt(2));
     }
 
     @Test
     public void peekAt_illegal_arguments()
     {
         StackIterable<String> stack = this.newStackWith("1", "2", "3");
-        Assert.assertThrows(IllegalArgumentException.class, () -> stack.peekAt(stack.size()));
+        assertThrows(IllegalArgumentException.class, () -> stack.peekAt(stack.size()));
     }
 
     @Test
     public void size()
     {
         StackIterable<Integer> stack1 = this.newStackWith();
-        Assert.assertEquals(0, stack1.size());
+        assertEquals(0, stack1.size());
 
         StackIterable<Integer> stack2 = this.newStackWith(1, 2);
-        Assert.assertEquals(2, stack2.size());
+        assertEquals(2, stack2.size());
     }
 
     @Override
@@ -179,11 +187,11 @@ public abstract class StackIterableTestCase
     public void getFirst()
     {
         StackIterable<Integer> stack = this.newStackWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(3), stack.getFirst());
-        Assert.assertEquals(stack.peek(), stack.getFirst());
-        Assert.assertThrows(EmptyStackException.class, () -> this.newStackWith().getFirst());
+        assertEquals(Integer.valueOf(3), stack.getFirst());
+        assertEquals(stack.peek(), stack.getFirst());
+        assertThrows(EmptyStackException.class, () -> this.newStackWith().getFirst());
         StackIterable<Integer> stack2 = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(1), stack2.getFirst());
+        assertEquals(Integer.valueOf(1), stack2.getFirst());
     }
 
     @Override
@@ -191,23 +199,23 @@ public abstract class StackIterableTestCase
     public void getLast()
     {
         StackIterable<Integer> stack = this.newStackWith(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(1), stack.getLast());
+        assertEquals(Integer.valueOf(1), stack.getLast());
     }
 
     @Test
     public void containsAll()
     {
         StackIterable<Integer> stack = this.newStackWith(1, 2, 3, 4);
-        Assert.assertTrue(stack.containsAll(Interval.oneTo(2)));
-        Assert.assertFalse(stack.containsAll(Lists.mutable.with(1, 2, 5)));
+        assertTrue(stack.containsAll(Interval.oneTo(2)));
+        assertFalse(stack.containsAll(Lists.mutable.with(1, 2, 5)));
     }
 
     @Test
     public void containsAllArguments()
     {
         StackIterable<Integer> stack = this.newStackWith(1, 2, 3, 4);
-        Assert.assertTrue(stack.containsAllArguments(2, 1, 3));
-        Assert.assertFalse(stack.containsAllArguments(2, 1, 3, 5));
+        assertTrue(stack.containsAllArguments(2, 1, 3));
+        assertFalse(stack.containsAllArguments(2, 1, 3, 5));
     }
 
     @Override
@@ -216,12 +224,12 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Boolean> stack = this.newStackFromTopToBottom(Boolean.TRUE, Boolean.FALSE, null);
         CountingFunction<Object, String> function = CountingFunction.of(String::valueOf);
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackFromTopToBottom("true", "false", "null"),
                 stack.collect(function));
-        Assert.assertEquals(3, function.count);
+        assertEquals(3, function.count);
 
-        Assert.assertEquals(Lists.mutable.with("true", "false", "null"), stack.collect(String::valueOf, FastList.newList()));
+        assertEquals(Lists.mutable.with("true", "false", "null"), stack.collect(String::valueOf, FastList.newList()));
     }
 
     /**
@@ -237,7 +245,7 @@ public abstract class StackIterableTestCase
                 PrimitiveTuples.pair("3", 1),
                 PrimitiveTuples.pair("2", 2),
                 PrimitiveTuples.pair("1", 3));
-        Assert.assertEquals(expected, stack.collectWithIndex(PrimitiveTuples::pair));
+        assertEquals(expected, stack.collectWithIndex(PrimitiveTuples::pair));
     }
 
     /**
@@ -253,7 +261,7 @@ public abstract class StackIterableTestCase
                 PrimitiveTuples.pair("3", 1),
                 PrimitiveTuples.pair("2", 2),
                 PrimitiveTuples.pair("1", 3));
-        Assert.assertEquals(expected, stack.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty()));
+        assertEquals(expected, stack.collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty()));
     }
 
     /**
@@ -265,7 +273,7 @@ public abstract class StackIterableTestCase
         StackIterable<String> stack = this.newStackFromTopToBottom("4", "3", "2", "1");
 
         List<String> expected = Lists.mutable.with("4", "2");
-        Assert.assertEquals(expected, stack.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
+        assertEquals(expected, stack.selectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
 
     /**
@@ -277,7 +285,7 @@ public abstract class StackIterableTestCase
         StackIterable<String> stack = this.newStackFromTopToBottom("4", "3", "2", "1");
 
         List<String> expected = Lists.mutable.with("3", "1");
-        Assert.assertEquals(expected, stack.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
+        assertEquals(expected, stack.rejectWithIndex((each, index) -> index % 2 == 0, Lists.mutable.empty()));
     }
 
     @Override
@@ -285,7 +293,7 @@ public abstract class StackIterableTestCase
     public void collectBoolean()
     {
         StackIterable<String> stack = this.newStackFromTopToBottom("true", "nah", "TrUe", "false");
-        Assert.assertEquals(
+        assertEquals(
                 BooleanArrayStack.newStackFromTopToBottom(true, false, true, false),
                 stack.collectBoolean(Boolean::parseBoolean));
     }
@@ -297,8 +305,8 @@ public abstract class StackIterableTestCase
         BooleanHashSet target = new BooleanHashSet();
         StackIterable<String> stack = this.newStackFromTopToBottom("true", "nah", "TrUe", "false");
         BooleanHashSet result = stack.collectBoolean(Boolean::parseBoolean, target);
-        Assert.assertEquals(BooleanHashSet.newSetWith(true, false, true, false), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(BooleanHashSet.newSetWith(true, false, true, false), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -306,7 +314,7 @@ public abstract class StackIterableTestCase
     public void collectByte()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(ByteArrayStack.newStackFromTopToBottom((byte) 1, (byte) 2, (byte) 3), stack.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
+        assertEquals(ByteArrayStack.newStackFromTopToBottom((byte) 1, (byte) 2, (byte) 3), stack.collectByte(PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Override
@@ -316,8 +324,8 @@ public abstract class StackIterableTestCase
         ByteHashSet target = new ByteHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         ByteHashSet result = stack.collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 2, (byte) 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 2, (byte) 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -325,7 +333,7 @@ public abstract class StackIterableTestCase
     public void collectChar()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(CharArrayStack.newStackFromTopToBottom((char) 1, (char) 2, (char) 3), stack.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
+        assertEquals(CharArrayStack.newStackFromTopToBottom((char) 1, (char) 2, (char) 3), stack.collectChar(PrimitiveFunctions.unboxIntegerToChar()));
     }
 
     @Override
@@ -335,8 +343,8 @@ public abstract class StackIterableTestCase
         CharHashSet target = new CharHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CharHashSet result = stack.collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertEquals(CharHashSet.newSetWith((char) 1, (char) 2, (char) 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(CharHashSet.newSetWith((char) 1, (char) 2, (char) 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -344,7 +352,7 @@ public abstract class StackIterableTestCase
     public void collectDouble()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(DoubleArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
+        assertEquals(DoubleArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectDouble(PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Override
@@ -354,8 +362,8 @@ public abstract class StackIterableTestCase
         DoubleHashSet target = new DoubleHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         DoubleHashSet result = stack.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertEquals(DoubleHashSet.newSetWith(1, 2, 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(DoubleHashSet.newSetWith(1, 2, 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -363,7 +371,7 @@ public abstract class StackIterableTestCase
     public void collectFloat()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(FloatArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
+        assertEquals(FloatArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectFloat(PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Override
@@ -373,8 +381,8 @@ public abstract class StackIterableTestCase
         FloatHashSet target = new FloatHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         FloatHashSet result = stack.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertEquals(FloatHashSet.newSetWith(1, 2, 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(FloatHashSet.newSetWith(1, 2, 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -382,7 +390,7 @@ public abstract class StackIterableTestCase
     public void collectInt()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(IntArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
+        assertEquals(IntArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectInt(PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Override
@@ -392,8 +400,8 @@ public abstract class StackIterableTestCase
         IntHashSet target = new IntHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         IntHashSet result = stack.collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertEquals(IntHashSet.newSetWith(1, 2, 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(IntHashSet.newSetWith(1, 2, 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -401,7 +409,7 @@ public abstract class StackIterableTestCase
     public void collectLong()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(LongArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
+        assertEquals(LongArrayStack.newStackFromTopToBottom(1, 2, 3), stack.collectLong(PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Override
@@ -411,8 +419,8 @@ public abstract class StackIterableTestCase
         LongHashSet target = new LongHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         LongHashSet result = stack.collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertEquals(LongHashSet.newSetWith(1, 2, 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(LongHashSet.newSetWith(1, 2, 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -420,7 +428,7 @@ public abstract class StackIterableTestCase
     public void collectShort()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
-        Assert.assertEquals(ShortArrayStack.newStackFromTopToBottom((short) 1, (short) 2, (short) 3), stack.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
+        assertEquals(ShortArrayStack.newStackFromTopToBottom((short) 1, (short) 2, (short) 3), stack.collectShort(PrimitiveFunctions.unboxIntegerToShort()));
     }
 
     @Override
@@ -430,8 +438,8 @@ public abstract class StackIterableTestCase
         ShortHashSet target = new ShortHashSet();
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         ShortHashSet result = stack.collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertEquals(ShortHashSet.newSetWith((short) 1, (short) 2, (short) 3), result);
-        Assert.assertSame("Target sent as parameter not returned", target, result);
+        assertEquals(ShortHashSet.newSetWith((short) 1, (short) 2, (short) 3), result);
+        assertSame("Target sent as parameter not returned", target, result);
     }
 
     @Override
@@ -442,19 +450,19 @@ public abstract class StackIterableTestCase
 
         CountingPredicate<Integer> predicate1 = CountingPredicate.of(Predicates.lessThan(3));
         CountingFunction<Object, String> function1 = CountingFunction.of(String::valueOf);
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackFromTopToBottom("1", "2"),
                 stack.collectIf(predicate1, function1));
-        Assert.assertEquals(5, predicate1.count);
-        Assert.assertEquals(2, function1.count);
+        assertEquals(5, predicate1.count);
+        assertEquals(2, function1.count);
 
         CountingPredicate<Integer> predicate2 = CountingPredicate.of(Predicates.lessThan(3));
         CountingFunction<Object, String> function2 = CountingFunction.of(String::valueOf);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("1", "2"),
                 stack.collectIf(predicate2, function2, FastList.newList()));
-        Assert.assertEquals(5, predicate2.count);
-        Assert.assertEquals(2, function2.count);
+        assertEquals(5, predicate2.count);
+        assertEquals(2, function2.count);
     }
 
     @Override
@@ -462,7 +470,7 @@ public abstract class StackIterableTestCase
     public void collectWith()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(3, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 ArrayStack.newStackFromTopToBottom(4, 3, 2),
                 stack.collectWith(AddFunction.INTEGER, 1));
     }
@@ -471,7 +479,7 @@ public abstract class StackIterableTestCase
     public void collectWithTarget()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(3, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(4, 3, 2),
                 stack.collectWith(AddFunction.INTEGER, 1, FastList.newList()));
     }
@@ -493,12 +501,12 @@ public abstract class StackIterableTestCase
             return result;
         });
 
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackFromTopToBottom('1', 'O', 'n', 'e', '2', 'T', 'w', 'o'),
                 stack.flatCollect(function));
-        Assert.assertEquals(4, function.count);
+        assertEquals(4, function.count);
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with('1', 'O', 'n', 'e', '2', 'T', 'w', 'o'),
                 stack.flatCollect(function, FastList.newList()));
     }
@@ -510,12 +518,12 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CountingPredicate<Object> predicate = new CountingPredicate<>(Integer.valueOf(1)::equals);
         StackIterable<Integer> actual = stack.select(predicate);
-        Assert.assertEquals(this.newStackFromTopToBottom(1), actual);
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertEquals(
+        assertEquals(this.newStackFromTopToBottom(1), actual);
+        assertEquals(3, predicate.count);
+        assertEquals(
                 this.newStackFromTopToBottom(2, 3),
                 stack.select(Predicates.greaterThan(1)));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(2, 3),
                 stack.select(Predicates.greaterThan(1), FastList.newList()));
     }
@@ -525,15 +533,15 @@ public abstract class StackIterableTestCase
     public void selectInstancesOf()
     {
         StackIterable<Number> numbers = this.newStackFromTopToBottom(1, 2.0, 3, 4.0, 5);
-        Assert.assertEquals(this.newStackFromTopToBottom(1, 3, 5), numbers.selectInstancesOf(Integer.class));
-        Assert.assertEquals(this.<Number>newStackFromTopToBottom(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
+        assertEquals(this.newStackFromTopToBottom(1, 3, 5), numbers.selectInstancesOf(Integer.class));
+        assertEquals(this.<Number>newStackFromTopToBottom(1, 2.0, 3, 4.0, 5), numbers.selectInstancesOf(Number.class));
     }
 
     @Override
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ArrayStack.newStackFromTopToBottom(2, 1),
                 this.newStackFromTopToBottom(5, 4, 3, 2, 1).selectWith(Predicates2.lessThan(), 3));
     }
@@ -541,7 +549,7 @@ public abstract class StackIterableTestCase
     @Test
     public void selectWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(2, 1),
                 this.newStackFromTopToBottom(5, 4, 3, 2, 1).selectWith(Predicates2.lessThan(), 3, UnifiedSet.newSet()));
     }
@@ -552,11 +560,11 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(3, 2, 1);
         CountingPredicate<Integer> predicate = new CountingPredicate<>(Predicates.greaterThan(2));
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackFromTopToBottom(2, 1),
                 stack.reject(predicate));
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertEquals(
+        assertEquals(3, predicate.count);
+        assertEquals(
                 Lists.mutable.with(2, 1),
                 stack.reject(Predicates.greaterThan(2), FastList.newList()));
     }
@@ -566,7 +574,7 @@ public abstract class StackIterableTestCase
     public void rejectWith()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(3, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 this.newStackFromTopToBottom(2, 1),
                 stack.rejectWith(Predicates2.greaterThan(), 2));
     }
@@ -574,7 +582,7 @@ public abstract class StackIterableTestCase
     @Test
     public void rejectWithTarget()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(5, 4, 3),
                 this.newStackFromTopToBottom(5, 4, 3, 2, 1).rejectWith(Predicates2.lessThan(), 3, UnifiedSet.newSet()));
     }
@@ -585,9 +593,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CountingPredicate<Integer> predicate = new CountingPredicate<>(Predicates.lessThan(3));
-        Assert.assertEquals(Integer.valueOf(1), stack.detect(predicate));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertNull(stack.detect(Integer.valueOf(4)::equals));
+        assertEquals(Integer.valueOf(1), stack.detect(predicate));
+        assertEquals(1, predicate.count);
+        assertNull(stack.detect(Integer.valueOf(4)::equals));
     }
 
     @Override
@@ -596,9 +604,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CountingPredicate2<Integer, Integer> predicate = new CountingPredicate2<>(Predicates2.<Integer>lessThan());
-        Assert.assertEquals(Integer.valueOf(1), stack.detectWith(predicate, 3));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertNull(stack.detectWith(Object::equals, Integer.valueOf(4)));
+        assertEquals(Integer.valueOf(1), stack.detectWith(predicate, 3));
+        assertEquals(1, predicate.count);
+        assertNull(stack.detectWith(Object::equals, Integer.valueOf(4)));
     }
 
     @Override
@@ -607,11 +615,11 @@ public abstract class StackIterableTestCase
     {
         Function0<Integer> defaultResultFunction = new PassThruFunction0<>(-1);
         CountingPredicate<Integer> predicate = new CountingPredicate<>(Predicates.lessThan(3));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newStackFromTopToBottom(1, 2, 3, 4, 5).detectIfNone(predicate, defaultResultFunction));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertEquals(
+        assertEquals(1, predicate.count);
+        assertEquals(
                 Integer.valueOf(-1),
                 this.newStackWith(1, 2, 3, 4, 5).detectIfNone(Predicates.lessThan(-1), defaultResultFunction));
     }
@@ -621,11 +629,11 @@ public abstract class StackIterableTestCase
     {
         Function0<Integer> defaultResultFunction = new PassThruFunction0<>(-1);
         CountingPredicate2<Integer, Integer> predicate = new CountingPredicate2<>(Predicates2.<Integer>lessThan());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newStackFromTopToBottom(1, 2, 3, 4, 5).detectWithIfNone(predicate, Integer.valueOf(3), defaultResultFunction));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertEquals(
+        assertEquals(1, predicate.count);
+        assertEquals(
                 Integer.valueOf(-1),
                 this.newStackWith(1, 2, 3, 4, 5).detectIfNone(Predicates.lessThan(-1), defaultResultFunction));
     }
@@ -636,9 +644,9 @@ public abstract class StackIterableTestCase
     {
         CountingPredicate<Integer> predicate = new CountingPredicate<>(Predicates.lessThan(3));
         PartitionStack<Integer> partition = this.newStackFromTopToBottom(1, 2, 3, 4, 5).partition(predicate);
-        Assert.assertEquals(5, predicate.count);
-        Assert.assertEquals(this.newStackFromTopToBottom(1, 2), partition.getSelected());
-        Assert.assertEquals(this.newStackFromTopToBottom(3, 4, 5), partition.getRejected());
+        assertEquals(5, predicate.count);
+        assertEquals(this.newStackFromTopToBottom(1, 2), partition.getSelected());
+        assertEquals(this.newStackFromTopToBottom(3, 4, 5), partition.getRejected());
     }
 
     @Override
@@ -646,8 +654,8 @@ public abstract class StackIterableTestCase
     public void partitionWith()
     {
         PartitionStack<Integer> partition = this.newStackFromTopToBottom(1, 2, 3, 4, 5).partitionWith(Predicates2.lessThan(), 3);
-        Assert.assertEquals(this.newStackFromTopToBottom(1, 2), partition.getSelected());
-        Assert.assertEquals(this.newStackFromTopToBottom(3, 4, 5), partition.getRejected());
+        assertEquals(this.newStackFromTopToBottom(1, 2), partition.getSelected());
+        assertEquals(this.newStackFromTopToBottom(3, 4, 5), partition.getRejected());
     }
 
     @Override
@@ -666,9 +674,9 @@ public abstract class StackIterableTestCase
                 Tuples.pair("2", 6),
                 Tuples.pair("1", 7));
 
-        Assert.assertEquals(expected, stack.zip(interval));
+        assertEquals(expected, stack.zip(interval));
 
-        Assert.assertEquals(
+        assertEquals(
                 expected.toSet(),
                 stack.zip(interval, UnifiedSet.newSet()));
     }
@@ -684,8 +692,8 @@ public abstract class StackIterableTestCase
                 Tuples.pair("3", 1),
                 Tuples.pair("2", 2),
                 Tuples.pair("1", 3));
-        Assert.assertEquals(expected, stack.zipWithIndex());
-        Assert.assertEquals(expected.toSet(), stack.zipWithIndex(UnifiedSet.newSet()));
+        assertEquals(expected, stack.zipWithIndex());
+        assertEquals(expected.toSet(), stack.zipWithIndex(UnifiedSet.newSet()));
     }
 
     @Override
@@ -694,9 +702,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3, 4, 5);
         CountingPredicate<Integer> predicate = new CountingPredicate<>(Predicates.greaterThan(2));
-        Assert.assertEquals(3, stack.count(predicate));
-        Assert.assertEquals(5, predicate.count);
-        Assert.assertEquals(0, stack.count(Predicates.greaterThan(6)));
+        assertEquals(3, stack.count(predicate));
+        assertEquals(5, predicate.count);
+        assertEquals(0, stack.count(Predicates.greaterThan(6)));
     }
 
     @Override
@@ -705,9 +713,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3, 4, 5);
         CountingPredicate2<Object, Object> predicate = new CountingPredicate2<>(Object::equals);
-        Assert.assertEquals(1, stack.countWith(predicate, 1));
-        Assert.assertEquals(5, predicate.count);
-        Assert.assertNotEquals(2, stack.countWith(predicate, 4));
+        assertEquals(1, stack.countWith(predicate, 1));
+        assertEquals(5, predicate.count);
+        assertNotEquals(2, stack.countWith(predicate, 4));
     }
 
     @Override
@@ -716,9 +724,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CountingPredicate<Object> predicate = new CountingPredicate<>(Integer.valueOf(1)::equals);
-        Assert.assertTrue(stack.anySatisfy(predicate));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertFalse(stack.anySatisfy(Integer.valueOf(4)::equals));
+        assertTrue(stack.anySatisfy(predicate));
+        assertEquals(1, predicate.count);
+        assertFalse(stack.anySatisfy(Integer.valueOf(4)::equals));
     }
 
     @Override
@@ -727,9 +735,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackWith(3, 3, 3);
         CountingPredicate<Object> predicate = new CountingPredicate<>(Integer.valueOf(3)::equals);
-        Assert.assertTrue(stack.allSatisfy(predicate));
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertFalse(stack.allSatisfy(Integer.valueOf(2)::equals));
+        assertTrue(stack.allSatisfy(predicate));
+        assertEquals(3, predicate.count);
+        assertFalse(stack.allSatisfy(Integer.valueOf(2)::equals));
     }
 
     @Override
@@ -738,9 +746,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackWith(3, 3, 3);
         CountingPredicate<Object> predicate = new CountingPredicate<>(Integer.valueOf(4)::equals);
-        Assert.assertTrue(stack.noneSatisfy(predicate));
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertTrue(stack.noneSatisfy(Integer.valueOf(2)::equals));
+        assertTrue(stack.noneSatisfy(predicate));
+        assertEquals(3, predicate.count);
+        assertTrue(stack.noneSatisfy(Integer.valueOf(2)::equals));
     }
 
     @Override
@@ -749,9 +757,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CountingPredicate2<Object, Object> predicate = new CountingPredicate2<>(Object::equals);
-        Assert.assertTrue(stack.anySatisfyWith(predicate, 1));
-        Assert.assertEquals(1, predicate.count);
-        Assert.assertFalse(stack.anySatisfyWith(Object::equals, 4));
+        assertTrue(stack.anySatisfyWith(predicate, 1));
+        assertEquals(1, predicate.count);
+        assertFalse(stack.anySatisfyWith(Object::equals, 4));
     }
 
     @Override
@@ -760,9 +768,9 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackWith(3, 3, 3);
         CountingPredicate2<Object, Object> predicate = new CountingPredicate2<>(Object::equals);
-        Assert.assertTrue(stack.allSatisfyWith(predicate, 3));
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertFalse(stack.allSatisfyWith(Object::equals, 2));
+        assertTrue(stack.allSatisfyWith(predicate, 3));
+        assertEquals(3, predicate.count);
+        assertFalse(stack.allSatisfyWith(Object::equals, 2));
     }
 
     @Override
@@ -771,28 +779,28 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack = this.newStackWith(3, 3, 3);
         CountingPredicate2<Object, Object> predicate = new CountingPredicate2<>(Object::equals);
-        Assert.assertTrue(stack.noneSatisfyWith(predicate, 4));
-        Assert.assertEquals(3, predicate.count);
-        Assert.assertTrue(stack.noneSatisfyWith(Object::equals, 2));
+        assertTrue(stack.noneSatisfyWith(predicate, 4));
+        assertEquals(3, predicate.count);
+        assertTrue(stack.noneSatisfyWith(Object::equals, 2));
     }
 
     @Override
     @Test
     public void injectInto()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(10),
                 this.newStackWith(1, 2, 3, 4).injectInto(Integer.valueOf(0), AddFunction.INTEGER));
-        Assert.assertEquals(
+        assertEquals(
                 10,
                 this.newStackWith(1, 2, 3, 4).injectInto(0, AddFunction.INTEGER_TO_INT));
-        Assert.assertEquals(
+        assertEquals(
                 7.0,
                 this.newStackWith(1.0, 2.0, 3.0).injectInto(1.0d, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
-        Assert.assertEquals(
+        assertEquals(
                 7,
                 this.newStackWith(1, 2, 3).injectInto(1L, AddFunction.INTEGER_TO_LONG));
-        Assert.assertEquals(
+        assertEquals(
                 7.0,
                 this.newStackWith(1, 2, 3).injectInto(1.0f, AddFunction.INTEGER_TO_FLOAT), 0.001);
     }
@@ -801,10 +809,10 @@ public abstract class StackIterableTestCase
     public void sumOf()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3, 4);
-        Assert.assertEquals(10, stack.sumOfInt(integer -> integer));
-        Assert.assertEquals(10, stack.sumOfLong(Integer::longValue));
-        Assert.assertEquals(10.0d, stack.sumOfDouble(Integer::doubleValue), 0.001);
-        Assert.assertEquals(10.0f, stack.sumOfFloat(Integer::floatValue), 0.001);
+        assertEquals(10, stack.sumOfInt(integer -> integer));
+        assertEquals(10, stack.sumOfLong(Integer::longValue));
+        assertEquals(10.0d, stack.sumOfDouble(Integer::doubleValue), 0.001);
+        assertEquals(10.0f, stack.sumOfFloat(Integer::floatValue), 0.001);
     }
 
     @Test
@@ -815,7 +823,7 @@ public abstract class StackIterableTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 stack.sumOfFloat(i -> 1.0f / (i.floatValue() * i.floatValue() * i.floatValue() * i.floatValue())),
                 1.0e-15);
@@ -827,7 +835,7 @@ public abstract class StackIterableTestCase
         MutableList<Integer> list = Interval.oneTo(100_000).toList().shuffleThis();
         StackIterable<Integer> stack = this.newStackWith(list.toArray(new Integer[]{}));
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 stack.sumOfDouble(i -> 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue())),
                 1.0e-15);
@@ -852,12 +860,12 @@ public abstract class StackIterableTestCase
 
         // The test only ensures the consistency/stability of rounding. This is not meant to test the "correctness" of the float calculation result.
         // Indeed, the lower bits of this calculation result are always incorrect due to the information loss of original float values.
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(1),
                 1.0e-15);
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233761663,
                 result.get(2),
                 1.0e-15);
@@ -880,12 +888,12 @@ public abstract class StackIterableTestCase
                     return 1.0d / (i.doubleValue() * i.doubleValue() * i.doubleValue() * i.doubleValue());
                 });
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(1),
                 1.0e-15);
 
-        Assert.assertEquals(
+        assertEquals(
                 1.082323233711138,
                 result.get(2),
                 1.0e-15);
@@ -895,10 +903,10 @@ public abstract class StackIterableTestCase
     @Test
     public void max()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(4),
                 this.newStackFromTopToBottom(4, 3, 2, 1).max());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newStackFromTopToBottom(4, 3, 2, 1).max(Comparators.reverseNaturalOrder()));
     }
@@ -907,7 +915,7 @@ public abstract class StackIterableTestCase
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(3),
                 this.newStackWith(1, 2, 3).maxBy(String::valueOf));
     }
@@ -916,10 +924,10 @@ public abstract class StackIterableTestCase
     @Test
     public void min()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newStackWith(1, 2, 3, 4).min());
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(4),
                 this.newStackWith(1, 2, 3, 4).min(Comparators.reverseNaturalOrder()));
     }
@@ -929,10 +937,10 @@ public abstract class StackIterableTestCase
     public void minBy()
     {
         CountingFunction<Object, String> function = CountingFunction.of(String::valueOf);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 this.newStackWith(1, 2, 3).minBy(function));
-        Assert.assertEquals(3, function.count);
+        assertEquals(3, function.count);
     }
 
     @Override
@@ -940,16 +948,16 @@ public abstract class StackIterableTestCase
     public void testToString()
     {
         StackIterable<Integer> stack = this.newStackFromTopToBottom(4, 3, 2, 1);
-        Assert.assertEquals("[4, 3, 2, 1]", stack.toString());
+        assertEquals("[4, 3, 2, 1]", stack.toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals("3, 2, 1", this.newStackFromTopToBottom(3, 2, 1).makeString());
-        Assert.assertEquals("3~2~1", this.newStackFromTopToBottom(3, 2, 1).makeString("~"));
-        Assert.assertEquals("[3/2/1]", this.newStackFromTopToBottom(3, 2, 1).makeString("[", "/", "]"));
+        assertEquals("3, 2, 1", this.newStackFromTopToBottom(3, 2, 1).makeString());
+        assertEquals("3~2~1", this.newStackFromTopToBottom(3, 2, 1).makeString("~"));
+        assertEquals("[3/2/1]", this.newStackFromTopToBottom(3, 2, 1).makeString("[", "/", "]"));
     }
 
     @Override
@@ -960,15 +968,15 @@ public abstract class StackIterableTestCase
         Appendable appendable = new StringBuilder();
 
         stack.appendString(appendable);
-        Assert.assertEquals("3, 2, 1", appendable.toString());
+        assertEquals("3, 2, 1", appendable.toString());
 
         Appendable appendable2 = new StringBuilder();
         stack.appendString(appendable2, "/");
-        Assert.assertEquals("3/2/1", appendable2.toString());
+        assertEquals("3/2/1", appendable2.toString());
 
         Appendable appendable3 = new StringBuilder();
         stack.appendString(appendable3, "[", "/", "]");
-        Assert.assertEquals("[3/2/1]", appendable3.toString());
+        assertEquals("[3/2/1]", appendable3.toString());
     }
 
     @Override
@@ -980,8 +988,8 @@ public abstract class StackIterableTestCase
                 Tuples.pair(Boolean.TRUE, "3"),
                 Tuples.pair(Boolean.FALSE, "2"),
                 Tuples.pair(Boolean.TRUE, "1"));
-        Assert.assertEquals(expected, stack.groupBy(object -> IntegerPredicates.isOdd().accept(Integer.parseInt(object))));
-        Assert.assertEquals(expected, stack.groupBy(object -> IntegerPredicates.isOdd().accept(Integer.parseInt(object)), FastListMultimap.newMultimap()));
+        assertEquals(expected, stack.groupBy(object -> IntegerPredicates.isOdd().accept(Integer.parseInt(object))));
+        assertEquals(expected, stack.groupBy(object -> IntegerPredicates.isOdd().accept(Integer.parseInt(object)), FastListMultimap.newMultimap()));
     }
 
     @Override
@@ -995,18 +1003,18 @@ public abstract class StackIterableTestCase
 
         Multimap<Integer, Integer> actual =
                 stack.groupByEach(new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Multimap<Integer, Integer> actualWithTarget =
                 stack.groupByEach(new NegativeIntervalFunction(), FastListMultimap.newMultimap());
-        Assert.assertEquals(expected, actualWithTarget);
+        assertEquals(expected, actualWithTarget);
     }
 
     @Override
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newStackWith(1, 2, 3).groupByUniqueKey(id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), this.newStackWith(1, 2, 3).groupByUniqueKey(id -> id));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1020,7 +1028,7 @@ public abstract class StackIterableTestCase
     public void groupByUniqueKey_target()
     {
         MutableMap<Integer, Integer> integers = this.newStackWith(1, 2, 3).groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0));
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), integers);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1065,8 +1073,8 @@ public abstract class StackIterableTestCase
     {
         MutableList<String> tapResult = Lists.mutable.of();
         StackIterable<String> stack = this.newStackWith("1", "2", "3", "4", "5");
-        Assert.assertSame(stack, stack.tap(tapResult::add));
-        Assert.assertEquals(stack.toList(), tapResult);
+        assertSame(stack, stack.tap(tapResult::add));
+        assertEquals(stack.toList(), tapResult);
     }
 
     @Override
@@ -1077,7 +1085,7 @@ public abstract class StackIterableTestCase
         Appendable builder = new StringBuilder();
         Procedure<String> appendProcedure = Procedures.append(builder);
         stack.forEach(appendProcedure);
-        Assert.assertEquals("54321", builder.toString());
+        assertEquals("54321", builder.toString());
     }
 
     @Override
@@ -1087,7 +1095,7 @@ public abstract class StackIterableTestCase
         StackIterable<String> stack = this.newStackWith("1", "2", "3", "4");
         StringBuilder builder = new StringBuilder();
         stack.forEachWith((argument1, argument2) -> builder.append(argument1).append(argument2), 0);
-        Assert.assertEquals("40302010", builder.toString());
+        assertEquals("40302010", builder.toString());
     }
 
     @Override
@@ -1097,14 +1105,14 @@ public abstract class StackIterableTestCase
         StackIterable<String> stack = this.newStackFromTopToBottom("5", "4", "3", "2", "1");
         StringBuilder builder = new StringBuilder();
         stack.forEachWithIndex((each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("5041322314", builder.toString());
+        assertEquals("5041322314", builder.toString());
     }
 
     @Override
     @Test
     public void toList()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(4, 3, 2, 1),
                 this.newStackFromTopToBottom(4, 3, 2, 1).toList());
     }
@@ -1112,16 +1120,16 @@ public abstract class StackIterableTestCase
     @Test
     public void toStack()
     {
-        Assert.assertEquals(this.newStackFromTopToBottom(3, 2, 1), this.newStackFromTopToBottom(3, 2, 1).toStack());
+        assertEquals(this.newStackFromTopToBottom(3, 2, 1), this.newStackFromTopToBottom(3, 2, 1).toStack());
     }
 
     @Test
     public void toSortedList()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Interval.oneTo(4),
                 this.newStackFromTopToBottom(4, 3, 1, 2).toSortedList());
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(4, 1),
                 this.newStackFromTopToBottom(4, 3, 1, 2).toSortedList(Collections.reverseOrder()));
     }
@@ -1131,7 +1139,7 @@ public abstract class StackIterableTestCase
     public void toSortedListBy()
     {
         MutableList<Integer> list = FastList.newList(Interval.oneTo(10)).shuffleThis();
-        Assert.assertEquals(
+        assertEquals(
                 Interval.oneTo(10),
                 this.newStack(list).toSortedListBy(Functions.getIntegerPassThru()));
     }
@@ -1140,7 +1148,7 @@ public abstract class StackIterableTestCase
     @Test
     public void toSet()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSetWith(4, 3, 2, 1),
                 this.newStackWith(1, 2, 3, 4).toSet());
     }
@@ -1151,12 +1159,12 @@ public abstract class StackIterableTestCase
         MutableSortedSet<Integer> expected = TreeSortedSet.newSetWith(1, 2, 4, 5);
         StackIterable<Integer> stack = this.newStackWith(2, 1, 5, 4);
 
-        Assert.assertEquals(expected, stack.toSortedSet());
-        Assert.assertEquals(Lists.mutable.with(1, 2, 4, 5), stack.toSortedSet().toList());
+        assertEquals(expected, stack.toSortedSet());
+        assertEquals(Lists.mutable.with(1, 2, 4, 5), stack.toSortedSet().toList());
 
         MutableSortedSet<Integer> reversed = stack.toSortedSet(Comparators.reverseNaturalOrder());
         Verify.assertSortedSetsEqual(reversed, stack.toSortedSet(Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(5, 4, 2, 1),
                 stack.toSortedSet(Comparators.reverseNaturalOrder()).toList());
     }
@@ -1168,10 +1176,10 @@ public abstract class StackIterableTestCase
         SetIterable<Integer> expected = UnifiedSet.newSetWith(10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
 
         StackIterable<Integer> stack = this.newStackWith(5, 2, 4, 3, 1, 6, 7, 8, 9, 10);
-        Assert.assertEquals(
+        assertEquals(
                 expected,
                 stack.toSortedSetBy(String::valueOf));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(1, 10, 2, 3, 4, 5, 6, 7, 8, 9),
                 stack.toSortedSetBy(String::valueOf).toList());
     }
@@ -1180,7 +1188,7 @@ public abstract class StackIterableTestCase
     @Test
     public void toBag()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.of("C", "B", "A"),
                 this.newStackFromTopToBottom("C", "B", "A").toBag());
     }
@@ -1192,11 +1200,11 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackWith(2, 2, 1, 5, 4);
 
         Verify.assertSortedBagsEqual(expected, stack.toSortedBag());
-        Assert.assertEquals(Lists.mutable.with(1, 2, 2, 4, 5), stack.toSortedBag().toList());
+        assertEquals(Lists.mutable.with(1, 2, 2, 4, 5), stack.toSortedBag().toList());
 
         SortedBag<Integer> expected2 = TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 1, 2, 2, 4, 5);
         Verify.assertSortedBagsEqual(expected2, stack.toSortedBag(Comparators.reverseNaturalOrder()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(5, 4, 2, 2, 1),
                 stack.toSortedBag(Comparators.reverseNaturalOrder()).toList());
     }
@@ -1217,7 +1225,7 @@ public abstract class StackIterableTestCase
     @Test
     public void toMap()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues("4", "4", "3", "3", "2", "2", "1", "1"),
                 this.newStackFromTopToBottom(4, 3, 2, 1).toMap(String::valueOf, String::valueOf));
     }
@@ -1226,15 +1234,15 @@ public abstract class StackIterableTestCase
     @Test
     public void toSortedMap()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(3, "3", 2, "2", 1, "1"),
                 this.newStackFromTopToBottom(3, 2, 1).toSortedMap(Functions.getIntegerPassThru(), String::valueOf));
 
-        Assert.assertEquals(
+        assertEquals(
                 TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), 3, "3", 2, "2", 1, "1"),
                 this.newStackFromTopToBottom(3, 2, 1).toSortedMap(Comparators.reverseNaturalOrder(), Functions.getIntegerPassThru(), String::valueOf));
 
-        Assert.assertEquals(
+        assertEquals(
                 TreeSortedMap.newMapWith(Comparators.reverseNaturalOrder(), 3, "3", 2, "2", 1, "1"),
                 this.newStackFromTopToBottom(3, 2, 1).toSortedMapBy(key -> -key, Functions.getIntegerPassThru(), String::valueOf));
     }
@@ -1242,7 +1250,7 @@ public abstract class StackIterableTestCase
     @Test
     public void asLazy()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with("3", "2", "1"),
                 this.newStackFromTopToBottom("3", "2", "1").asLazy().toList());
     }
@@ -1251,8 +1259,8 @@ public abstract class StackIterableTestCase
     @Test
     public void toArray()
     {
-        Assert.assertArrayEquals(new Object[]{4, 3, 2, 1}, this.newStackFromTopToBottom(4, 3, 2, 1).toArray());
-        Assert.assertArrayEquals(new Integer[]{4, 3, 2, 1}, this.newStackFromTopToBottom(4, 3, 2, 1).toArray(new Integer[0]));
+        assertArrayEquals(new Object[]{4, 3, 2, 1}, this.newStackFromTopToBottom(4, 3, 2, 1).toArray());
+        assertArrayEquals(new Integer[]{4, 3, 2, 1}, this.newStackFromTopToBottom(4, 3, 2, 1).toArray(new Integer[0]));
     }
 
     @Override
@@ -1265,7 +1273,7 @@ public abstract class StackIterableTestCase
         {
             builder.append(string);
         }
-        Assert.assertEquals("54321", builder.toString());
+        assertEquals("54321", builder.toString());
     }
 
     @Test
@@ -1280,14 +1288,14 @@ public abstract class StackIterableTestCase
 
         Verify.assertEqualsAndHashCode(stack1, stack2);
         Verify.assertPostSerializedEqualsAndHashCode(this.newStackWith(1, 2, 3, 4));
-        Assert.assertNotEquals(stack1, stack3);
-        Assert.assertNotEquals(stack1, stack4);
-        Assert.assertNotEquals(stack1, stack5);
-        Assert.assertNotEquals(stack1, stack6);
+        assertNotEquals(stack1, stack3);
+        assertNotEquals(stack1, stack4);
+        assertNotEquals(stack1, stack5);
+        assertNotEquals(stack1, stack6);
 
         Verify.assertPostSerializedEqualsAndHashCode(this.newStackWith(null, null, null));
 
-        Assert.assertEquals(Stacks.mutable.of(), this.newStackWith());
+        assertEquals(Stacks.mutable.of(), this.newStackWith());
     }
 
     @Test
@@ -1295,14 +1303,14 @@ public abstract class StackIterableTestCase
     {
         StackIterable<Integer> stack1 = this.newStackWith(1, 2, 3, 5);
         StackIterable<Integer> stack2 = this.newStackWith(1, 2, 3, 4);
-        Assert.assertNotEquals(stack1.hashCode(), stack2.hashCode());
+        assertNotEquals(stack1.hashCode(), stack2.hashCode());
 
-        Assert.assertEquals(
+        assertEquals(
                 31 * 31 * 31 * 31 + 1 * 31 * 31 * 31 + 2 * 31 * 31 + 3 * 31 + 4,
                 this.newStackFromTopToBottom(1, 2, 3, 4).hashCode());
-        Assert.assertEquals(31 * 31 * 31, this.newStackFromTopToBottom(null, null, null).hashCode());
+        assertEquals(31 * 31 * 31, this.newStackFromTopToBottom(null, null, null).hashCode());
 
-        Assert.assertNotEquals(this.newStackFromTopToBottom(1, 2, 3, 4).hashCode(), this.newStackFromTopToBottom(4, 3, 2, 1).hashCode());
+        assertNotEquals(this.newStackFromTopToBottom(1, 2, 3, 4).hashCode(), this.newStackFromTopToBottom(4, 3, 2, 1).hashCode());
     }
 
     @Override
@@ -1312,9 +1320,9 @@ public abstract class StackIterableTestCase
         Function0<AtomicInteger> valueCreator = AtomicInteger::new;
         StackIterable<Integer> collection = this.newStackWith(1, 1, 1, 2, 2, 3);
         MapIterable<String, AtomicInteger> aggregation = collection.aggregateInPlaceBy(String::valueOf, valueCreator, AtomicInteger::addAndGet);
-        Assert.assertEquals(3, aggregation.get("1").intValue());
-        Assert.assertEquals(4, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(3, aggregation.get("1").intValue());
+        assertEquals(4, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     @Override
@@ -1325,9 +1333,9 @@ public abstract class StackIterableTestCase
         Function2<Integer, Integer, Integer> sumAggregator = (integer1, integer2) -> integer1 + integer2;
         StackIterable<Integer> collection = this.newStackWith(1, 1, 1, 2, 2, 3);
         MapIterable<String, Integer> aggregation = collection.aggregateBy(String::valueOf, valueCreator, sumAggregator);
-        Assert.assertEquals(3, aggregation.get("1").intValue());
-        Assert.assertEquals(4, aggregation.get("2").intValue());
-        Assert.assertEquals(3, aggregation.get("3").intValue());
+        assertEquals(3, aggregation.get("1").intValue());
+        assertEquals(4, aggregation.get("2").intValue());
+        assertEquals(3, aggregation.get("3").intValue());
     }
 
     private static final class CountingPredicate<T>

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStackTest.java
@@ -18,8 +18,12 @@ import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 
 public class ImmutableArrayStackTest extends ImmutableStackTestCase
 {
@@ -52,8 +56,8 @@ public class ImmutableArrayStackTest extends ImmutableStackTestCase
     public void testEquals()
     {
         super.testEquals();
-        Assert.assertEquals(ImmutableArrayStack.newStack(), ArrayStack.newStackWith());
-        Assert.assertNotEquals(this.newStackWith(4, 5, 6), ArrayStack.newStackWith(1, 2, 3));
+        assertEquals(ImmutableArrayStack.newStack(), ArrayStack.newStackWith());
+        assertNotEquals(this.newStackWith(4, 5, 6), ArrayStack.newStackWith(1, 2, 3));
     }
 
     @Test
@@ -61,108 +65,108 @@ public class ImmutableArrayStackTest extends ImmutableStackTestCase
     {
         ImmutableStack<Integer> stack = this.newStackWith(1, 2, 3);
         ImmutableStack<Integer> modifiedStack = stack.push(4);
-        Assert.assertEquals(this.newStackWith(1, 2, 3, 4), modifiedStack);
-        Assert.assertNotSame(modifiedStack, stack);
-        Assert.assertEquals(this.newStackWith(1, 2, 3), stack);
+        assertEquals(this.newStackWith(1, 2, 3, 4), modifiedStack);
+        assertNotSame(modifiedStack, stack);
+        assertEquals(this.newStackWith(1, 2, 3), stack);
         modifiedStack.push(5);
-        Assert.assertEquals(this.newStackWith(1, 2, 3), stack);
+        assertEquals(this.newStackWith(1, 2, 3), stack);
 
         ImmutableStack<Integer> stack1 = this.newStackWith();
         ImmutableStack<Integer> modifiedStack1 = stack1.push(1);
-        Assert.assertEquals(this.newStackWith(1), modifiedStack1);
-        Assert.assertNotSame(modifiedStack1, stack1);
-        Assert.assertEquals(this.newStackWith(), stack1);
+        assertEquals(this.newStackWith(1), modifiedStack1);
+        assertNotSame(modifiedStack1, stack1);
+        assertEquals(this.newStackWith(), stack1);
         modifiedStack1.push(5);
-        Assert.assertEquals(this.newStackWith(), stack1);
+        assertEquals(this.newStackWith(), stack1);
     }
 
     @Test
     public void pop()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newStackWith().pop());
+        assertThrows(EmptyStackException.class, () -> this.newStackWith().pop());
 
         ImmutableStack<Integer> stack = this.newStackWith(1, 2, 3);
         ImmutableStack<Integer> modifiedStack = stack.pop();
-        Assert.assertEquals(this.newStackWith(1, 2), modifiedStack);
-        Assert.assertNotSame(modifiedStack, stack);
-        Assert.assertEquals(this.newStackWith(1, 2, 3), stack);
+        assertEquals(this.newStackWith(1, 2), modifiedStack);
+        assertNotSame(modifiedStack, stack);
+        assertEquals(this.newStackWith(1, 2, 3), stack);
 
         ImmutableStack<Integer> stack1 = this.newStackWith(1);
         ImmutableStack<Integer> modifiedStack1 = stack1.pop();
-        Assert.assertEquals(this.newStackWith(), modifiedStack1);
-        Assert.assertNotSame(modifiedStack1, stack1);
-        Assert.assertEquals(this.newStackWith(1), stack1);
+        assertEquals(this.newStackWith(), modifiedStack1);
+        assertNotSame(modifiedStack1, stack1);
+        assertEquals(this.newStackWith(1), stack1);
     }
 
     @Test
     public void popCount()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newStackWith().pop(1));
+        assertThrows(EmptyStackException.class, () -> this.newStackWith().pop(1));
 
-        Assert.assertEquals(this.newStackWith(), this.newStackWith().pop(0));
+        assertEquals(this.newStackWith(), this.newStackWith().pop(0));
 
         ImmutableStack<Integer> stack = this.newStackWith(1, 2, 3);
         ImmutableStack<Integer> modifiedStack = stack.pop(1);
-        Assert.assertEquals(this.newStackWith(1, 2), modifiedStack);
-        Assert.assertNotSame(modifiedStack, stack);
-        Assert.assertNotSame(this.newStackWith(1, 2, 3), stack);
+        assertEquals(this.newStackWith(1, 2), modifiedStack);
+        assertNotSame(modifiedStack, stack);
+        assertNotSame(this.newStackWith(1, 2, 3), stack);
 
         ImmutableStack<Integer> stack1 = this.newStackWith(1);
-        Assert.assertThrows(IllegalArgumentException.class, () -> stack1.pop(2));
+        assertThrows(IllegalArgumentException.class, () -> stack1.pop(2));
         ImmutableStack<Integer> modifiedStack1 = stack1.pop(1);
-        Assert.assertEquals(this.newStackWith(), modifiedStack1);
-        Assert.assertNotSame(modifiedStack1, stack1);
-        Assert.assertEquals(this.newStackWith(1), stack1);
+        assertEquals(this.newStackWith(), modifiedStack1);
+        assertNotSame(modifiedStack1, stack1);
+        assertEquals(this.newStackWith(1), stack1);
     }
 
     @Test
     public void peekAndPop()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newStackWith().pop());
+        assertThrows(EmptyStackException.class, () -> this.newStackWith().pop());
 
         ImmutableStack<Integer> stack = this.newStackWith(1, 2, 3);
         Pair<Integer, ImmutableStack<Integer>> elementAndStack = stack.peekAndPop();
         Integer poppedElement = elementAndStack.getOne();
         ImmutableStack<Integer> modifiedStack = elementAndStack.getTwo();
-        Assert.assertEquals(3, poppedElement.intValue());
-        Assert.assertEquals(this.newStackWith(1, 2), modifiedStack);
-        Assert.assertNotSame(modifiedStack, stack);
-        Assert.assertEquals(this.newStackWith(1, 2, 3), stack);
+        assertEquals(3, poppedElement.intValue());
+        assertEquals(this.newStackWith(1, 2), modifiedStack);
+        assertNotSame(modifiedStack, stack);
+        assertEquals(this.newStackWith(1, 2, 3), stack);
 
         ImmutableStack<Integer> stack1 = this.newStackWith(1);
         Pair<Integer, ImmutableStack<Integer>> elementAndStack1 = stack1.peekAndPop();
         Integer poppedElement1 = elementAndStack1.getOne();
         ImmutableStack<Integer> modifiedStack1 = elementAndStack1.getTwo();
-        Assert.assertEquals(1, poppedElement1.intValue());
-        Assert.assertEquals(this.newStackWith(), modifiedStack1);
-        Assert.assertNotSame(modifiedStack1, stack1);
-        Assert.assertEquals(this.newStackWith(1), stack1);
+        assertEquals(1, poppedElement1.intValue());
+        assertEquals(this.newStackWith(), modifiedStack1);
+        assertNotSame(modifiedStack1, stack1);
+        assertEquals(this.newStackWith(1), stack1);
     }
 
     @Test
     public void peekAndPopCount()
     {
-        Assert.assertThrows(EmptyStackException.class, () -> this.newStackWith().peekAndPop(1));
+        assertThrows(EmptyStackException.class, () -> this.newStackWith().peekAndPop(1));
 
-        Assert.assertEquals(this.newStackWith(), this.newStackWith().peekAndPop(0).getTwo());
+        assertEquals(this.newStackWith(), this.newStackWith().peekAndPop(0).getTwo());
 
         ImmutableStack<Integer> stack = this.newStackWith(1, 2, 3);
         Pair<ListIterable<Integer>, ImmutableStack<Integer>> elementsAndStack = stack.peekAndPop(1);
         ListIterable<Integer> poppedElements = elementsAndStack.getOne();
         ImmutableStack<Integer> modifiedStack = elementsAndStack.getTwo();
-        Assert.assertEquals(Lists.fixedSize.of(3), poppedElements);
-        Assert.assertEquals(this.newStackWith(1, 2), modifiedStack);
-        Assert.assertNotSame(modifiedStack, stack);
-        Assert.assertNotSame(this.newStackWith(1, 2, 3), stack);
+        assertEquals(Lists.fixedSize.of(3), poppedElements);
+        assertEquals(this.newStackWith(1, 2), modifiedStack);
+        assertNotSame(modifiedStack, stack);
+        assertNotSame(this.newStackWith(1, 2, 3), stack);
 
         ImmutableStack<Integer> stack1 = this.newStackWith(1);
-        Assert.assertThrows(IllegalArgumentException.class, () -> stack1.pop(2));
+        assertThrows(IllegalArgumentException.class, () -> stack1.pop(2));
         Pair<ListIterable<Integer>, ImmutableStack<Integer>> elementsAndStack1 = stack1.peekAndPop(1);
         ListIterable<Integer> poppedElements1 = elementsAndStack1.getOne();
         ImmutableStack<Integer> modifiedStack1 = elementsAndStack1.getTwo();
-        Assert.assertEquals(Lists.fixedSize.of(1), poppedElements1);
-        Assert.assertEquals(this.newStackWith(), modifiedStack1);
-        Assert.assertNotSame(modifiedStack1, stack1);
-        Assert.assertEquals(this.newStackWith(1), stack1);
+        assertEquals(Lists.fixedSize.of(1), poppedElements1);
+        assertEquals(this.newStackWith(), modifiedStack1);
+        assertNotSame(modifiedStack1, stack1);
+        assertEquals(this.newStackWith(1), stack1);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableStackTestCase.java
@@ -14,7 +14,8 @@ import org.eclipse.collections.api.map.primitive.ImmutableObjectDoubleMap;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class ImmutableStackTestCase extends StackIterableTestCase
 {
@@ -34,31 +35,31 @@ public abstract class ImmutableStackTestCase extends StackIterableTestCase
     {
         ImmutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ImmutableObjectLongMap<Integer> result = values.sumByInt(i -> i % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     public void sumByFloat()
     {
         ImmutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ImmutableObjectDoubleMap<Integer> result = values.sumByFloat(f -> f % 2, e -> e);
-        Assert.assertEquals(25.0f, result.get(1), 0.0);
-        Assert.assertEquals(30.0f, result.get(0), 0.0);
+        assertEquals(25.0f, result.get(1), 0.0);
+        assertEquals(30.0f, result.get(0), 0.0);
     }
 
     public void sumByDouble()
     {
         ImmutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ImmutableObjectDoubleMap<Integer> result = values.sumByDouble(d -> d % 2, e -> e);
-        Assert.assertEquals(25.0d, result.get(1), 0.0);
-        Assert.assertEquals(30.0d, result.get(0), 0.0);
+        assertEquals(25.0d, result.get(1), 0.0);
+        assertEquals(30.0d, result.get(0), 0.0);
     }
 
     public void sumByLong()
     {
         ImmutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         ImmutableObjectLongMap<Integer> result = values.sumByLong(l -> l % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/AbstractImmutableBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/AbstractImmutableBooleanStackTestCase.java
@@ -18,8 +18,12 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanStack}.
@@ -63,11 +67,11 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
         ImmutableBooleanStack stack = this.classUnderTest();
         int size = stack.size();
         ImmutableBooleanStack modified = stack.push(true);
-        Assert.assertTrue(modified.peek());
+        assertTrue(modified.peek());
         Verify.assertSize(size + 1, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test
@@ -76,11 +80,11 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
         ImmutableBooleanStack stack = this.classUnderTest();
         int size = stack.size();
         ImmutableBooleanStack modified = stack.pop();
-        Assert.assertEquals((this.classUnderTest().size() & 1) == 0, modified.peek());
+        assertEquals((this.classUnderTest().size() & 1) == 0, modified.peek());
         Verify.assertSize(size - 1, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test
@@ -88,15 +92,15 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
     {
         ImmutableBooleanStack stack = this.classUnderTest();
         ImmutableBooleanStack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
         int size = stack.size();
         ImmutableBooleanStack modified = stack.pop(2);
-        Assert.assertEquals((this.classUnderTest().size() & 1) != 0, modified.peek());
+        assertEquals((this.classUnderTest().size() & 1) != 0, modified.peek());
         Verify.assertSize(size - 2, modified);
         Verify.assertSize(size, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -115,16 +119,16 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
     @Test
     public void testToString()
     {
-        Assert.assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
+        assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
     }
 
     @Override
     @Test
     public void makeString()
     {
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
-        Assert.assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
+        assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
+        assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
+        assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
     }
 
     @Override
@@ -133,15 +137,15 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
     {
         StringBuilder appendable1 = new StringBuilder();
         this.classUnderTest().appendString(appendable1);
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
+        assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2, "|");
-        Assert.assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
+        assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "{", "|", "}");
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
+        assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
     }
 
     @Override
@@ -150,7 +154,7 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
     {
         BooleanArrayList expected = BooleanArrayList.newListWith();
         this.classUnderTest().forEach(expected::add);
-        Assert.assertEquals(expected, this.classUnderTest().toList());
+        assertEquals(expected, this.classUnderTest().toList());
     }
 
     @Override
@@ -159,6 +163,6 @@ public abstract class AbstractImmutableBooleanStackTestCase extends AbstractBool
     {
         super.toImmutable();
         ImmutableBooleanStack expected = this.classUnderTest();
-        Assert.assertSame(expected, expected.toImmutable());
+        assertSame(expected, expected.toImmutable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanArrayStackTest.java
@@ -13,8 +13,9 @@ package org.eclipse.collections.impl.stack.immutable.primitive;
 import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * JUnit test for {@link ImmutableBooleanArrayStack}.
@@ -30,12 +31,12 @@ public class ImmutableBooleanArrayStackTest extends AbstractImmutableBooleanStac
     @Test
     public void newWithIterable()
     {
-        Assert.assertEquals(BooleanArrayStack.newStackWith(true, true, false), this.newWithIterable(BooleanArrayList.newListWith(true, true, false)));
+        assertEquals(BooleanArrayStack.newStackWith(true, true, false), this.newWithIterable(BooleanArrayList.newListWith(true, true, false)));
     }
 
     @Test
     public void newWithTopToBottom()
     {
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, true, false), this.newWithTopToBottom(true, true, false));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, true, false), this.newWithTopToBottom(true, true, false));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanEmptyStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanEmptyStackTest.java
@@ -16,8 +16,12 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptyStack}.
@@ -50,8 +54,8 @@ public class ImmutableBooleanEmptyStackTest extends AbstractImmutableBooleanStac
     {
         ImmutableBooleanStack stack = this.classUnderTest();
         ImmutableBooleanStack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
@@ -59,7 +63,7 @@ public class ImmutableBooleanEmptyStackTest extends AbstractImmutableBooleanStac
     public void booleanIterator()
     {
         BooleanIterator iterator = this.classUnderTest().booleanIterator();
-        Assert.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Override
@@ -72,8 +76,8 @@ public class ImmutableBooleanEmptyStackTest extends AbstractImmutableBooleanStac
     @Test
     public void peekWithCount()
     {
-        Assert.assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertThrows(EmptyStackException.class, () -> this.classUnderTest().peek(1));
+        assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertThrows(EmptyStackException.class, () -> this.classUnderTest().peek(1));
     }
 
     @Override
@@ -94,7 +98,7 @@ public class ImmutableBooleanEmptyStackTest extends AbstractImmutableBooleanStac
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(this.newWith().notEmpty());
+        assertFalse(this.newWith().notEmpty());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanSingletonStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanSingletonStackTest.java
@@ -14,8 +14,14 @@ import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableBooleanSingletonStack}.
@@ -36,8 +42,8 @@ public class ImmutableBooleanSingletonStackTest extends AbstractImmutableBoolean
         ImmutableBooleanStack modified = stack.pop();
         Verify.assertEmpty(modified);
         Verify.assertSize(1, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
@@ -46,23 +52,23 @@ public class ImmutableBooleanSingletonStackTest extends AbstractImmutableBoolean
     {
         ImmutableBooleanStack stack = this.classUnderTest();
         ImmutableBooleanStack stack1 = stack.pop(0);
-        Assert.assertSame(stack1, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertSame(stack1, stack);
+        assertEquals(this.classUnderTest(), stack);
         ImmutableBooleanStack modified = stack.pop(1);
         Verify.assertEmpty(modified);
         Verify.assertSize(1, stack);
-        Assert.assertNotSame(modified, stack);
-        Assert.assertEquals(this.classUnderTest(), stack);
+        assertNotSame(modified, stack);
+        assertEquals(this.classUnderTest(), stack);
     }
 
     @Override
     @Test
     public void peek()
     {
-        Assert.assertTrue(this.classUnderTest().peek());
-        Assert.assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertEquals(BooleanArrayList.newListWith(true), this.classUnderTest().peek(1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().peek(2));
+        assertTrue(this.classUnderTest().peek());
+        assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertEquals(BooleanArrayList.newListWith(true), this.classUnderTest().peek(1));
+        assertThrows(IllegalArgumentException.class, () -> this.classUnderTest().peek(2));
     }
 
     @Override
@@ -70,12 +76,12 @@ public class ImmutableBooleanSingletonStackTest extends AbstractImmutableBoolean
     public void testEquals()
     {
         ImmutableBooleanStack stack = this.classUnderTest();
-        Assert.assertEquals(stack, stack);
+        assertEquals(stack, stack);
         Verify.assertPostSerializedEqualsAndHashCode(stack);
-        Assert.assertEquals(stack, BooleanArrayStack.newStackWith(true));
-        Assert.assertNotEquals(stack, this.newWith(true, false));
-        Assert.assertNotEquals(stack, BooleanArrayList.newListWith(true));
-        Assert.assertEquals(stack, this.newWith(true));
-        Assert.assertNotEquals(stack, this.newWith());
+        assertEquals(stack, BooleanArrayStack.newStackWith(true));
+        assertNotEquals(stack, this.newWith(true, false));
+        assertNotEquals(stack, BooleanArrayList.newListWith(true));
+        assertEquals(stack, this.newWith(true));
+        assertNotEquals(stack, this.newWith());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/ArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/ArrayStackTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.stack.mutable;
 
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.factory.Stacks;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link ArrayStack}.
@@ -48,69 +49,69 @@ public class ArrayStackTest extends MutableStackTestCase
     public void takeWhile()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.takeWhile(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.takeWhile(null));
     }
 
     @Test
     public void dropWhile()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.dropWhile(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.dropWhile(null));
     }
 
     @Test
     public void partitionWhile()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.partitionWhile(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.partitionWhile(null));
     }
 
     @Test
     public void distinct()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, arrayStack::distinct);
+        assertThrows(UnsupportedOperationException.class, arrayStack::distinct);
     }
 
     @Test
     public void indexOf()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.indexOf(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.indexOf(null));
     }
 
     @Test
     public void corresponds()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.corresponds(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.corresponds(null, null));
     }
 
     @Test
     public void hasSameElements()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.hasSameElements(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.hasSameElements(null));
     }
 
     @Test
     public void forEach_exception()
     {
         MutableStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.forEach(0, 1, null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.forEach(0, 1, null));
     }
 
     @Test
     public void forEachWithIndex_exception()
     {
         MutableStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.forEachWithIndex(0, 1, null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.forEachWithIndex(0, 1, null));
     }
 
     @Test
     public void detectIndex()
     {
         ArrayStack<Object> arrayStack = new ArrayStack<>();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> arrayStack.detectIndex(null));
+        assertThrows(UnsupportedOperationException.class, () -> arrayStack.detectIndex(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/MutableStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/MutableStackTestCase.java
@@ -19,8 +19,9 @@ import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public abstract class MutableStackTestCase extends StackIterableTestCase
 {
@@ -41,54 +42,54 @@ public abstract class MutableStackTestCase extends StackIterableTestCase
     {
         MutableStack<String> stack = this.newStackWith();
         stack.push("1");
-        Assert.assertEquals("1", stack.peek());
-        Assert.assertEquals(this.newStackWith("1"), stack);
+        assertEquals("1", stack.peek());
+        assertEquals(this.newStackWith("1"), stack);
 
         stack.push("2");
-        Assert.assertEquals("2", stack.peek());
-        Assert.assertEquals(this.newStackWith("1", "2"), stack);
+        assertEquals("2", stack.peek());
+        assertEquals(this.newStackWith("1", "2"), stack);
 
         stack.push("3");
-        Assert.assertEquals("3", stack.peek());
-        Assert.assertEquals(this.newStackWith("1", "2", "3"), stack);
+        assertEquals("3", stack.peek());
+        assertEquals(this.newStackWith("1", "2", "3"), stack);
 
-        Assert.assertEquals("2", stack.peekAt(1));
-        Assert.assertEquals("3", stack.pop());
-        Assert.assertEquals("2", stack.peek());
-        Assert.assertEquals("2", stack.pop());
-        Assert.assertEquals("1", stack.peek());
-        Assert.assertEquals("1", stack.pop());
+        assertEquals("2", stack.peekAt(1));
+        assertEquals("3", stack.pop());
+        assertEquals("2", stack.peek());
+        assertEquals("2", stack.pop());
+        assertEquals("1", stack.peek());
+        assertEquals("1", stack.pop());
 
         MutableStack<Integer> stack2 = this.newStackFromTopToBottom(5, 4, 3, 2, 1);
         stack2.pop(2);
-        Assert.assertEquals(this.newStackFromTopToBottom(3, 2, 1), stack2);
-        Assert.assertEquals(FastList.newListWith(3, 2), stack2.peek(2));
+        assertEquals(this.newStackFromTopToBottom(3, 2, 1), stack2);
+        assertEquals(FastList.newListWith(3, 2), stack2.peek(2));
 
         MutableStack<Integer> stack3 = Stacks.mutable.ofReversed(1, 2, 3);
-        Assert.assertEquals(this.newStackFromTopToBottom(1, 2, 3), stack3);
+        assertEquals(this.newStackFromTopToBottom(1, 2, 3), stack3);
 
         MutableStack<Integer> stack4 = Stacks.mutable.ofAll(FastList.newListWith(1, 2, 3));
         MutableStack<Integer> stack5 = Stacks.mutable.ofAllReversed(FastList.newListWith(1, 2, 3));
 
-        Assert.assertEquals(this.newStackFromTopToBottom(3, 2, 1), stack4);
-        Assert.assertEquals(this.newStackFromTopToBottom(1, 2, 3), stack5);
+        assertEquals(this.newStackFromTopToBottom(3, 2, 1), stack4);
+        assertEquals(this.newStackFromTopToBottom(1, 2, 3), stack5);
 
         MutableStack<Integer> stack6 = this.newStackFromTopToBottom(1, 2, 3, 4);
-        Assert.assertEquals(FastList.newListWith(1, 2), stack6.pop(2, FastList.newList()));
+        assertEquals(FastList.newListWith(1, 2), stack6.pop(2, FastList.newList()));
 
         MutableStack<Integer> stack7 = this.newStackFromTopToBottom(1, 2, 3, 4);
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(2, 1), stack7.pop(2, ArrayStack.newStack()));
+        assertEquals(ArrayStack.newStackFromTopToBottom(2, 1), stack7.pop(2, ArrayStack.newStack()));
 
         MutableStack<Integer> stack8 = this.newStackFromTopToBottom(1, 2, 3, 4);
         Verify.assertIterableEmpty(stack8.pop(0));
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3, 4), stack8);
-        Assert.assertEquals(FastList.newList(), stack8.peek(0));
+        assertEquals(ArrayStack.newStackFromTopToBottom(1, 2, 3, 4), stack8);
+        assertEquals(FastList.newList(), stack8.peek(0));
 
         MutableStack<Integer> stack9 = ArrayStack.newStack();
-        Assert.assertEquals(FastList.newList(), stack9.pop(0));
-        Assert.assertEquals(FastList.newList(), stack9.peek(0));
-        Assert.assertEquals(FastList.newList(), stack9.pop(0, FastList.newList()));
-        Assert.assertEquals(ArrayStack.newStack(), stack9.pop(0, ArrayStack.newStack()));
+        assertEquals(FastList.newList(), stack9.pop(0));
+        assertEquals(FastList.newList(), stack9.peek(0));
+        assertEquals(FastList.newList(), stack9.pop(0, FastList.newList()));
+        assertEquals(ArrayStack.newStack(), stack9.pop(0, ArrayStack.newStack()));
     }
 
     @Test
@@ -96,7 +97,7 @@ public abstract class MutableStackTestCase extends StackIterableTestCase
     {
         MutableStack<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         stack.clear();
-        Assert.assertEquals(ArrayStack.newStack(), stack);
+        assertEquals(ArrayStack.newStack(), stack);
         Verify.assertIterableEmpty(stack);
     }
 
@@ -104,36 +105,36 @@ public abstract class MutableStackTestCase extends StackIterableTestCase
     public void testNewStackWithOrder()
     {
         MutableStack<String> stack = this.newStackWith("1", "2", "3");
-        Assert.assertEquals("3", stack.pop());
-        Assert.assertEquals("2", stack.pop());
-        Assert.assertEquals("1", stack.pop());
+        assertEquals("3", stack.pop());
+        assertEquals("2", stack.pop());
+        assertEquals("1", stack.pop());
     }
 
     @Test
     public void testNewStackIterableOrder()
     {
         MutableStack<String> stack = this.newStack(FastList.newListWith("1", "2", "3"));
-        Assert.assertEquals("3", stack.pop());
-        Assert.assertEquals("2", stack.pop());
-        Assert.assertEquals("1", stack.pop());
+        assertEquals("3", stack.pop());
+        assertEquals("2", stack.pop());
+        assertEquals("1", stack.pop());
     }
 
     @Test
     public void testNewStackFromTopToBottomOrder()
     {
         MutableStack<String> stack = this.newStackFromTopToBottom("3", "2", "1");
-        Assert.assertEquals("3", stack.pop());
-        Assert.assertEquals("2", stack.pop());
-        Assert.assertEquals("1", stack.pop());
+        assertEquals("3", stack.pop());
+        assertEquals("2", stack.pop());
+        assertEquals("1", stack.pop());
     }
 
     @Test
     public void testNewStackFromTopToBottomIterableOrder()
     {
         MutableStack<String> stack = this.newStackFromTopToBottom(FastList.newListWith("3", "2", "1"));
-        Assert.assertEquals("3", stack.pop());
-        Assert.assertEquals("2", stack.pop());
-        Assert.assertEquals("1", stack.pop());
+        assertEquals("3", stack.pop());
+        assertEquals("2", stack.pop());
+        assertEquals("1", stack.pop());
     }
 
     @Test(expected = EmptyStackException.class)
@@ -212,31 +213,31 @@ public abstract class MutableStackTestCase extends StackIterableTestCase
     {
         MutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         MutableObjectLongMap<Integer> result = values.sumByInt(i -> i % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     public void sumByFloat()
     {
         MutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         MutableObjectDoubleMap<Integer> result = values.sumByFloat(f -> f % 2, e -> e);
-        Assert.assertEquals(25.0f, result.get(1), 0.0);
-        Assert.assertEquals(30.0f, result.get(0), 0.0);
+        assertEquals(25.0f, result.get(1), 0.0);
+        assertEquals(30.0f, result.get(0), 0.0);
     }
 
     public void sumByLong()
     {
         MutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         MutableObjectLongMap<Integer> result = values.sumByLong(l -> l % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     public void sumByDouble()
     {
         MutableStack<Integer> values = this.newStackFromTopToBottom(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         MutableObjectDoubleMap<Integer> result = values.sumByDouble(d -> d % 2, e -> e);
-        Assert.assertEquals(25.0d, result.get(1), 0.0);
-        Assert.assertEquals(30.0d, result.get(0), 0.0);
+        assertEquals(25.0d, result.get(1), 0.0);
+        assertEquals(30.0d, result.get(0), 0.0);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStackTest.java
@@ -11,8 +11,9 @@
 package org.eclipse.collections.impl.stack.mutable;
 
 import org.eclipse.collections.api.stack.MutableStack;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for {@link SynchronizedStack}.
@@ -46,6 +47,6 @@ public class SynchronizedStackTest extends MutableStackTestCase
     @Test
     public void testNullStack()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> SynchronizedStack.of(null));
+        assertThrows(IllegalArgumentException.class, () -> SynchronizedStack.of(null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStackTest.java
@@ -17,9 +17,11 @@ import org.eclipse.collections.impl.block.factory.StringPredicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class UnmodifiableStackTest extends StackIterableTestCase
 {
@@ -64,33 +66,33 @@ public class UnmodifiableStackTest extends StackIterableTestCase
     public void iterator()
     {
         super.iterator();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackWith(1, 2, 3).iterator().remove());
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackWith(1, 2, 3).iterator().remove());
     }
 
     @Test
     public void testNullStack()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> UnmodifiableStack.of(null));
+        assertThrows(IllegalArgumentException.class, () -> UnmodifiableStack.of(null));
     }
 
     @Test
     public void testPop()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop());
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop());
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2).pop(3));
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2).pop(3));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3));
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3, FastList.newList()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3, FastList.newList()));
 
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3, ArrayStack.newStack()));
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).pop(3, ArrayStack.newStack()));
     }
 
     @Test
     public void testPush()
     {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).push(4));
+        assertThrows(UnsupportedOperationException.class, () -> this.newStackFromTopToBottom(1, 2, 3).push(4));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -102,7 +104,7 @@ public class UnmodifiableStackTest extends StackIterableTestCase
     @Test
     public void testSelect()
     {
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom(2, 3), this.unmodifiableStack.select(Predicates.greaterThan(1)));
+        assertEquals(ArrayStack.newStackFromTopToBottom(2, 3), this.unmodifiableStack.select(Predicates.greaterThan(1)));
         Verify.assertSize(3, this.unmodifiableStackString.select(ignored -> true, FastList.newList()));
     }
 
@@ -120,8 +122,8 @@ public class UnmodifiableStackTest extends StackIterableTestCase
     @Test
     public void testReject()
     {
-        Assert.assertEquals(ArrayStack.newStackFromTopToBottom("2", "3"), this.unmodifiableStackString.reject(StringPredicates.contains("1")));
-        Assert.assertEquals(
+        assertEquals(ArrayStack.newStackFromTopToBottom("2", "3"), this.unmodifiableStackString.reject(StringPredicates.contains("1")));
+        assertEquals(
                 FastList.newListWith("2", "3"),
                 this.unmodifiableStackString.reject(StringPredicates.contains("1"), FastList.newList()));
     }
@@ -140,31 +142,31 @@ public class UnmodifiableStackTest extends StackIterableTestCase
     @Test
     public void testCollect()
     {
-        Assert.assertEquals(this.mutableStack, this.unmodifiableStackString.collect(Integer::valueOf));
+        assertEquals(this.mutableStack, this.unmodifiableStackString.collect(Integer::valueOf));
     }
 
     @Test
     public void testSize()
     {
-        Assert.assertEquals(this.mutableStack.size(), this.unmodifiableStack.size());
+        assertEquals(this.mutableStack.size(), this.unmodifiableStack.size());
     }
 
     @Test
     public void testIsEmpty()
     {
-        Assert.assertEquals(this.mutableStack.isEmpty(), this.unmodifiableStack.isEmpty());
+        assertEquals(this.mutableStack.isEmpty(), this.unmodifiableStack.isEmpty());
     }
 
     @Test
     public void testGetFirst()
     {
-        Assert.assertEquals(this.mutableStack.getFirst(), this.unmodifiableStack.getFirst());
+        assertEquals(this.mutableStack.getFirst(), this.unmodifiableStack.getFirst());
     }
 
     @Test
     public void testCount()
     {
-        Assert.assertEquals(
+        assertEquals(
                 this.mutableStack.count(ignored1 -> true),
                 this.unmodifiableStack.count(ignored -> true));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStackTest.java
@@ -16,8 +16,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable
 import org.eclipse.collections.impl.factory.primitive.BooleanStacks;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link BooleanArrayStack}.
@@ -65,36 +68,36 @@ public class BooleanArrayStackTest extends AbstractMutableBooleanStackTestCase
     {
         BooleanArrayStack stack = BooleanArrayStack.newStackFromTopToBottom();
         stack.push(true);
-        Assert.assertTrue(stack.peek());
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), stack);
+        assertTrue(stack.peek());
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true), stack);
 
         stack.push(false);
-        Assert.assertFalse(stack.peek());
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(false, true), stack);
+        assertFalse(stack.peek());
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(false, true), stack);
 
         stack.push(true);
-        Assert.assertTrue(stack.peek());
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, true), stack);
+        assertTrue(stack.peek());
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, true), stack);
 
-        Assert.assertFalse(stack.peekAt(1));
-        Assert.assertTrue(stack.pop());
-        Assert.assertFalse(stack.peek());
-        Assert.assertFalse(stack.pop());
-        Assert.assertTrue(stack.peek());
-        Assert.assertTrue(stack.pop());
+        assertFalse(stack.peekAt(1));
+        assertTrue(stack.pop());
+        assertFalse(stack.peek());
+        assertFalse(stack.pop());
+        assertTrue(stack.peek());
+        assertTrue(stack.pop());
 
         BooleanArrayStack stack2 = BooleanArrayStack.newStackFromTopToBottom(true, false, true, false, true);
         stack2.pop(2);
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, true), stack2);
-        Assert.assertEquals(BooleanArrayList.newListWith(true, false), stack2.peek(2));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(true, false, true), stack2);
+        assertEquals(BooleanArrayList.newListWith(true, false), stack2.peek(2));
 
         BooleanArrayStack stack8 = BooleanArrayStack.newStackFromTopToBottom(false, true, false, true);
         Verify.assertEmpty(stack8.pop(0));
-        Assert.assertEquals(BooleanArrayStack.newStackFromTopToBottom(false, true, false, true), stack8);
-        Assert.assertEquals(new BooleanArrayList(), stack8.peek(0));
+        assertEquals(BooleanArrayStack.newStackFromTopToBottom(false, true, false, true), stack8);
+        assertEquals(new BooleanArrayList(), stack8.peek(0));
 
         BooleanArrayStack stack9 = BooleanArrayStack.newStackFromTopToBottom();
-        Assert.assertEquals(new BooleanArrayList(), stack9.pop(0));
-        Assert.assertEquals(new BooleanArrayList(), stack9.peek(0));
+        assertEquals(new BooleanArrayList(), stack9.pop(0));
+        assertEquals(new BooleanArrayList(), stack9.peek(0));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/SynchronizedBooleanStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/SynchronizedBooleanStackTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.stack.mutable.primitive;
 import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableBooleanStackTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanStack}.
@@ -62,7 +64,7 @@ public class SynchronizedBooleanStackTest extends AbstractMutableBooleanStackTes
     public void asSynchronized()
     {
         MutableBooleanStack stack1 = new SynchronizedBooleanStack(BooleanArrayStack.newStackWith(true, false, true), new Object());
-        Assert.assertSame(stack1, stack1.asSynchronized());
-        Assert.assertEquals(stack1, stack1.asSynchronized());
+        assertSame(stack1, stack1.asSynchronized());
+        assertEquals(stack1, stack1.asSynchronized());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/UnmodifiableBooleanStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/UnmodifiableBooleanStackTest.java
@@ -14,8 +14,11 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanStack}.
@@ -77,7 +80,7 @@ public class UnmodifiableBooleanStackTest extends AbstractBooleanStackTestCase
     public void asUnmodifiable()
     {
         MutableBooleanStack stack1 = new UnmodifiableBooleanStack(BooleanArrayStack.newStackWith(true, false, true));
-        Assert.assertSame(stack1, stack1.asUnmodifiable());
+        assertSame(stack1, stack1.asUnmodifiable());
     }
 
     @Test
@@ -91,16 +94,16 @@ public class UnmodifiableBooleanStackTest extends AbstractBooleanStackTestCase
     public void booleanIterator_with_remove()
     {
         MutableBooleanIterator booleanIterator = (MutableBooleanIterator) this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
+        assertTrue(booleanIterator.hasNext());
         booleanIterator.next();
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 
     @Test
     public void iterator_throws_on_invocation_of_remove_before_next()
     {
         MutableBooleanIterator booleanIterator = (MutableBooleanIterator) this.classUnderTest().booleanIterator();
-        Assert.assertTrue(booleanIterator.hasNext());
-        Assert.assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
+        assertTrue(booleanIterator.hasNext());
+        assertThrows(UnsupportedOperationException.class, booleanIterator::remove);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/primitive/AbstractBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/primitive/AbstractBooleanStackTestCase.java
@@ -19,8 +19,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBoolean
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract JUnit test for {@link BooleanStack}.
@@ -52,21 +55,21 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
         int size = this.classUnderTest().size();
         for (int i = 0; i < size; i++)
         {
-            Assert.assertTrue(iterator.hasNext());
+            assertTrue(iterator.hasNext());
             boolean sizeEven = (size & 1) == 0;
             boolean iEven = (i & 1) == 0;
-            Assert.assertEquals(sizeEven != iEven, iterator.next());
+            assertEquals(sizeEven != iEven, iterator.next());
         }
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().booleanIterator().next());
+        assertFalse(iterator.hasNext());
+        assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().booleanIterator().next());
     }
 
     @Test
     public void peek()
     {
-        Assert.assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().peek());
-        Assert.assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
-        Assert.assertEquals(
+        assertEquals((this.classUnderTest().size() & 1) != 0, this.classUnderTest().peek());
+        assertEquals(BooleanArrayList.newListWith(), this.classUnderTest().peek(0));
+        assertEquals(
                 BooleanArrayList.newListWith((this.classUnderTest().size() & 1) != 0, (this.classUnderTest().size() & 1) == 0),
                 this.classUnderTest().peek(2));
     }
@@ -79,7 +82,7 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
         {
             boolean sizeEven = (this.classUnderTest().size() & 1) == 0;
             boolean iEven = (i & 1) == 0;
-            Assert.assertEquals(sizeEven != iEven, this.classUnderTest().peekAt(i));
+            assertEquals(sizeEven != iEven, this.classUnderTest().peekAt(i));
         }
     }
 
@@ -106,7 +109,7 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
     public void testToString()
     {
         super.testToString();
-        Assert.assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
+        assertEquals(this.createExpectedString("[", ", ", "]"), this.classUnderTest().toString());
     }
 
     @Override
@@ -120,7 +123,7 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
         {
             list.add((i & 1) != 0);
         }
-        Assert.assertEquals(list, this.classUnderTest().toList());
+        assertEquals(list, this.classUnderTest().toList());
     }
 
     @Override
@@ -128,9 +131,9 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
     public void makeString()
     {
         super.makeString();
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
-        Assert.assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
+        assertEquals(this.createExpectedString("", ", ", ""), this.classUnderTest().makeString());
+        assertEquals(this.createExpectedString("", "|", ""), this.classUnderTest().makeString("|"));
+        assertEquals(this.createExpectedString("{", "|", "}"), this.classUnderTest().makeString("{", "|", "}"));
     }
 
     protected String createExpectedString(String start, String sep, String end)
@@ -155,21 +158,21 @@ public abstract class AbstractBooleanStackTestCase extends AbstractBooleanIterab
         super.appendString();
         StringBuilder appendable1 = new StringBuilder();
         this.classUnderTest().appendString(appendable1);
-        Assert.assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
+        assertEquals(this.createExpectedString("", ", ", ""), appendable1.toString());
 
         StringBuilder appendable2 = new StringBuilder();
         this.classUnderTest().appendString(appendable2, "|");
-        Assert.assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
+        assertEquals(this.createExpectedString("", "|", ""), appendable2.toString());
 
         StringBuilder appendable3 = new StringBuilder();
         this.classUnderTest().appendString(appendable3, "{", "|", "}");
-        Assert.assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
+        assertEquals(this.createExpectedString("{", "|", "}"), appendable3.toString());
     }
 
     @Test
     public void toImmutable()
     {
-        Assert.assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
+        assertEquals(this.classUnderTest(), this.classUnderTest().toImmutable());
         Verify.assertInstanceOf(ImmutableBooleanStack.class, this.classUnderTest().toImmutable());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stream/PrimitiveStreamsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stream/PrimitiveStreamsTest.java
@@ -52,8 +52,9 @@ import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.collections.impl.factory.primitive.LongStacks;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.list.primitive.LongInterval;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @since 9.0
@@ -64,235 +65,235 @@ public class PrimitiveStreamsTest
     public void toIntList()
     {
         MutableIntList list = PrimitiveStreams.mIntList(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10), list);
-        Assert.assertEquals(IntLists.immutable.ofAll(IntStream.rangeClosed(1, 10)), list);
+        assertEquals(IntInterval.oneTo(10), list);
+        assertEquals(IntLists.immutable.ofAll(IntStream.rangeClosed(1, 10)), list);
     }
 
     @Test
     public void toImmutableIntList()
     {
         ImmutableIntList list = PrimitiveStreams.iIntList(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10), list);
-        Assert.assertEquals(IntLists.mutable.ofAll(IntStream.rangeClosed(1, 10)), list);
+        assertEquals(IntInterval.oneTo(10), list);
+        assertEquals(IntLists.mutable.ofAll(IntStream.rangeClosed(1, 10)), list);
     }
 
     @Test
     public void toIntSet()
     {
         MutableIntSet set = PrimitiveStreams.mIntSet(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).toSet(), set);
-        Assert.assertEquals(IntSets.immutable.ofAll(IntStream.rangeClosed(1, 10)), set);
+        assertEquals(IntInterval.oneTo(10).toSet(), set);
+        assertEquals(IntSets.immutable.ofAll(IntStream.rangeClosed(1, 10)), set);
     }
 
     @Test
     public void toImmutableIntSet()
     {
         ImmutableIntSet set = PrimitiveStreams.iIntSet(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).toSet(), set);
-        Assert.assertEquals(IntSets.mutable.ofAll(IntStream.rangeClosed(1, 10)), set);
+        assertEquals(IntInterval.oneTo(10).toSet(), set);
+        assertEquals(IntSets.mutable.ofAll(IntStream.rangeClosed(1, 10)), set);
     }
 
     @Test
     public void toIntBag()
     {
         MutableIntBag bag = PrimitiveStreams.mIntBag(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).toBag(), bag);
-        Assert.assertEquals(IntBags.immutable.ofAll(IntStream.rangeClosed(1, 10)), bag);
+        assertEquals(IntInterval.oneTo(10).toBag(), bag);
+        assertEquals(IntBags.immutable.ofAll(IntStream.rangeClosed(1, 10)), bag);
     }
 
     @Test
     public void toImmutableIntBag()
     {
         ImmutableIntBag bag = PrimitiveStreams.iIntBag(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).toBag(), bag);
-        Assert.assertEquals(IntBags.mutable.ofAll(IntStream.rangeClosed(1, 10)), bag);
+        assertEquals(IntInterval.oneTo(10).toBag(), bag);
+        assertEquals(IntBags.mutable.ofAll(IntStream.rangeClosed(1, 10)), bag);
     }
 
     @Test
     public void toEmptyImmutableIntBag()
     {
         ImmutableIntBag bag = PrimitiveStreams.iIntBag(IntStream.empty());
-        Assert.assertEquals(IntBags.immutable.empty(), bag);
+        assertEquals(IntBags.immutable.empty(), bag);
     }
 
     @Test
     public void toImmutableIntBagWithOneElement()
     {
         ImmutableIntBag bag = PrimitiveStreams.iIntBag(IntStream.rangeClosed(1, 1));
-        Assert.assertEquals(IntInterval.oneTo(1).toBag(), bag);
-        Assert.assertEquals(IntBags.mutable.ofAll(IntStream.rangeClosed(1, 1)), bag);
+        assertEquals(IntInterval.oneTo(1).toBag(), bag);
+        assertEquals(IntBags.mutable.ofAll(IntStream.rangeClosed(1, 1)), bag);
     }
 
     @Test
     public void toIntStack()
     {
         MutableIntStack stack = PrimitiveStreams.mIntStack(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntStacks.mutable.withAll(IntInterval.oneTo(10)), stack);
-        Assert.assertEquals(IntStacks.immutable.ofAll(IntStream.rangeClosed(1, 10)), stack);
+        assertEquals(IntStacks.mutable.withAll(IntInterval.oneTo(10)), stack);
+        assertEquals(IntStacks.immutable.ofAll(IntStream.rangeClosed(1, 10)), stack);
     }
 
     @Test
     public void toImmutableIntStack()
     {
         ImmutableIntStack stack = PrimitiveStreams.iIntStack(IntStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntStacks.immutable.withAll(IntInterval.oneTo(10)), stack);
-        Assert.assertEquals(IntStacks.mutable.ofAll(IntStream.rangeClosed(1, 10)), stack);
+        assertEquals(IntStacks.immutable.withAll(IntInterval.oneTo(10)), stack);
+        assertEquals(IntStacks.mutable.ofAll(IntStream.rangeClosed(1, 10)), stack);
     }
 
     @Test
     public void toLongList()
     {
         MutableLongList list = PrimitiveStreams.mLongList(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongLists.mutable.empty()), list);
-        Assert.assertEquals(LongLists.immutable.ofAll(LongStream.rangeClosed(1, 10)), list);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongLists.mutable.empty()), list);
+        assertEquals(LongLists.immutable.ofAll(LongStream.rangeClosed(1, 10)), list);
     }
 
     @Test
     public void toImmutableLongList()
     {
         ImmutableLongList list = PrimitiveStreams.iLongList(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongLists.mutable.empty()), list);
-        Assert.assertEquals(LongLists.mutable.ofAll(LongStream.rangeClosed(1, 10)), list);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongLists.mutable.empty()), list);
+        assertEquals(LongLists.mutable.ofAll(LongStream.rangeClosed(1, 10)), list);
     }
 
     @Test
     public void toLongSet()
     {
         MutableLongSet set = PrimitiveStreams.mLongSet(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongSets.mutable.empty()), set);
-        Assert.assertEquals(LongSets.immutable.ofAll(LongStream.rangeClosed(1, 10)), set);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongSets.mutable.empty()), set);
+        assertEquals(LongSets.immutable.ofAll(LongStream.rangeClosed(1, 10)), set);
     }
 
     @Test
     public void toImmutableLongSet()
     {
         ImmutableLongSet set = PrimitiveStreams.iLongSet(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongSets.mutable.empty()), set);
-        Assert.assertEquals(LongSets.mutable.ofAll(LongStream.rangeClosed(1, 10)), set);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongSets.mutable.empty()), set);
+        assertEquals(LongSets.mutable.ofAll(LongStream.rangeClosed(1, 10)), set);
     }
 
     @Test
     public void toLongBag()
     {
         MutableLongBag bag = PrimitiveStreams.mLongBag(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongBags.mutable.empty()), bag);
-        Assert.assertEquals(LongBags.immutable.ofAll(LongStream.rangeClosed(1, 10)), bag);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongBags.mutable.empty()), bag);
+        assertEquals(LongBags.immutable.ofAll(LongStream.rangeClosed(1, 10)), bag);
     }
 
     @Test
     public void toImmutableLongBag()
     {
         ImmutableLongBag bag = PrimitiveStreams.iLongBag(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongBags.mutable.empty()), bag);
-        Assert.assertEquals(LongBags.mutable.ofAll(LongStream.rangeClosed(1, 10)), bag);
+        assertEquals(IntInterval.oneTo(10).collectLong(i -> (long) i, LongBags.mutable.empty()), bag);
+        assertEquals(LongBags.mutable.ofAll(LongStream.rangeClosed(1, 10)), bag);
     }
 
     @Test
     public void toEmptyImmutableLongBag()
     {
         ImmutableLongBag bag = PrimitiveStreams.iLongBag(LongStream.empty());
-        Assert.assertEquals(LongBags.immutable.empty(), bag);
+        assertEquals(LongBags.immutable.empty(), bag);
     }
 
     @Test
     public void toImmutableLongBagWithOneElement()
     {
         ImmutableLongBag bag = PrimitiveStreams.iLongBag(LongStream.rangeClosed(1, 1));
-        Assert.assertEquals(LongInterval.oneTo(1).toBag(), bag);
-        Assert.assertEquals(LongBags.mutable.ofAll(LongStream.rangeClosed(1, 1)), bag);
+        assertEquals(LongInterval.oneTo(1).toBag(), bag);
+        assertEquals(LongBags.mutable.ofAll(LongStream.rangeClosed(1, 1)), bag);
     }
 
     @Test
     public void toLongStack()
     {
         MutableLongStack stack = PrimitiveStreams.mLongStack(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(LongStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectLong(i -> (long) i)), stack);
-        Assert.assertEquals(LongStacks.immutable.ofAll(LongStream.rangeClosed(1, 10)), stack);
+        assertEquals(LongStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectLong(i -> (long) i)), stack);
+        assertEquals(LongStacks.immutable.ofAll(LongStream.rangeClosed(1, 10)), stack);
     }
 
     @Test
     public void toImmutableLongStack()
     {
         ImmutableLongStack stack = PrimitiveStreams.iLongStack(LongStream.rangeClosed(1, 10));
-        Assert.assertEquals(LongStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectLong(i -> (long) i)), stack);
-        Assert.assertEquals(LongStacks.mutable.ofAll(LongStream.rangeClosed(1, 10)), stack);
+        assertEquals(LongStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectLong(i -> (long) i)), stack);
+        assertEquals(LongStacks.mutable.ofAll(LongStream.rangeClosed(1, 10)), stack);
     }
 
     @Test
     public void toDoubleList()
     {
         MutableDoubleList list = PrimitiveStreams.mDoubleList(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleLists.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), list);
-        Assert.assertEquals(DoubleLists.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), list);
+        assertEquals(DoubleLists.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), list);
+        assertEquals(DoubleLists.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), list);
     }
 
     @Test
     public void toImmutableDoubleList()
     {
         ImmutableDoubleList list = PrimitiveStreams.iDoubleList(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleLists.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), list);
-        Assert.assertEquals(DoubleLists.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), list);
+        assertEquals(DoubleLists.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), list);
+        assertEquals(DoubleLists.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), list);
     }
 
     @Test
     public void toDoubleSet()
     {
         MutableDoubleSet set = PrimitiveStreams.mDoubleSet(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleSets.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), set);
-        Assert.assertEquals(DoubleSets.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), set);
+        assertEquals(DoubleSets.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), set);
+        assertEquals(DoubleSets.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), set);
     }
 
     @Test
     public void toImmutableDoubleSet()
     {
         ImmutableDoubleSet set = PrimitiveStreams.iDoubleSet(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleSets.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), set);
-        Assert.assertEquals(DoubleSets.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), set);
+        assertEquals(DoubleSets.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), set);
+        assertEquals(DoubleSets.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), set);
     }
 
     @Test
     public void toDoubleBag()
     {
         MutableDoubleBag bag = PrimitiveStreams.mDoubleBag(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleBags.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), bag);
-        Assert.assertEquals(DoubleBags.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), bag);
+        assertEquals(DoubleBags.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), bag);
+        assertEquals(DoubleBags.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), bag);
     }
 
     @Test
     public void toImmutableDoubleBag()
     {
         ImmutableDoubleBag bag = PrimitiveStreams.iDoubleBag(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleBags.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), bag);
-        Assert.assertEquals(DoubleBags.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), bag);
+        assertEquals(DoubleBags.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), bag);
+        assertEquals(DoubleBags.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), bag);
     }
 
     @Test
     public void toEmptyImmutableDoubleBag()
     {
         ImmutableDoubleBag bag = PrimitiveStreams.iDoubleBag(DoubleStream.empty());
-        Assert.assertEquals(DoubleBags.immutable.empty(), bag);
+        assertEquals(DoubleBags.immutable.empty(), bag);
     }
 
     @Test
     public void toImmutableDoubleBagWithOneElement()
     {
         ImmutableDoubleBag bag = PrimitiveStreams.iDoubleBag(DoubleStream.of(1.0));
-        Assert.assertEquals(DoubleBags.mutable.ofAll(DoubleStream.of(1.0)), bag);
+        assertEquals(DoubleBags.mutable.ofAll(DoubleStream.of(1.0)), bag);
     }
 
     @Test
     public void toDoubleStack()
     {
         MutableDoubleStack stack = PrimitiveStreams.mDoubleStack(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), stack);
-        Assert.assertEquals(DoubleStacks.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), stack);
+        assertEquals(DoubleStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), stack);
+        assertEquals(DoubleStacks.immutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), stack);
     }
 
     @Test
     public void toImmutableDoubleStack()
     {
         ImmutableDoubleStack stack = PrimitiveStreams.iDoubleStack(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
-        Assert.assertEquals(DoubleStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), stack);
-        Assert.assertEquals(DoubleStacks.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), stack);
+        assertEquals(DoubleStacks.mutable.ofAll(IntInterval.oneTo(10).asLazy().collectDouble(i -> (double) i)), stack);
+        assertEquals(DoubleStacks.mutable.ofAll(DoubleStream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)), stack);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CharAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CharAdapterTest.java
@@ -16,8 +16,11 @@ import org.eclipse.collections.api.list.primitive.ImmutableCharList;
 import org.eclipse.collections.impl.factory.Strings;
 import org.eclipse.collections.impl.factory.primitive.CharBags;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableCharListTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class CharAdapterTest extends AbstractImmutableCharListTestCase
 {
@@ -40,7 +43,7 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
     public void stringBuilder()
     {
         CharAdapter adapt = CharAdapter.adapt(UNICODE_STRING);
-        Assert.assertEquals(UNICODE_STRING, new StringBuilder(adapt).toString());
+        assertEquals(UNICODE_STRING, new StringBuilder(adapt).toString());
     }
 
     @Test
@@ -48,7 +51,7 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
     {
         CharAdapter adapt = CharAdapter.adapt(UNICODE_STRING);
         CharSequence sequence = adapt.subSequence(1, 3);
-        Assert.assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
+        assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
     }
 
     @Override
@@ -59,7 +62,7 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
         expected.addOccurrences('a', 3);
         expected.addOccurrences('b', 3);
         expected.addOccurrences('c', 3);
-        Assert.assertEquals(expected, CharAdapter.adapt("aaabbbccc").toBag());
+        assertEquals(expected, CharAdapter.adapt("aaabbbccc").toBag());
     }
 
     @Override
@@ -77,8 +80,8 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
             expectedString.append(each == size - 1 ? "" : ", ");
             expectedString1.append(each == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), list.makeString());
-        Assert.assertEquals(expectedString1.toString(), list.makeString("/"));
+        assertEquals(expectedString.toString(), list.makeString());
+        assertEquals(expectedString1.toString(), list.makeString("/"));
     }
 
     @Override
@@ -98,10 +101,10 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
         ImmutableCharList list = this.classUnderTest();
         StringBuilder appendable2 = new StringBuilder();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
     }
 
     @Override
@@ -114,16 +117,16 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
         {
             expectedString.append((char) (each + (char) 1));
         }
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Test
     public void getCharacter()
     {
         CharAdapter adapter = Strings.asChars("123");
-        Assert.assertEquals(Character.valueOf('1'), adapter.getCharacter(0));
-        Assert.assertEquals(Character.valueOf('2'), adapter.getCharacter(1));
-        Assert.assertEquals(Character.valueOf('3'), adapter.getCharacter(2));
+        assertEquals(Character.valueOf('1'), adapter.getCharacter(0));
+        assertEquals(Character.valueOf('2'), adapter.getCharacter(1));
+        assertEquals(Character.valueOf('3'), adapter.getCharacter(2));
     }
 
     @Test
@@ -131,7 +134,7 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
     {
         CharAdapter adapter = Strings.asChars("123");
         ImmutableCharList immutable = adapter.toImmutable();
-        Assert.assertSame(adapter, immutable);
+        assertSame(adapter, immutable);
     }
 
     @Test
@@ -140,14 +143,14 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
         CharAdapter adapter = Strings.asChars("123");
         LazyCharIterable iterable = adapter.asReversed();
         String string = iterable.makeString("");
-        Assert.assertEquals("321", string);
+        assertEquals("321", string);
     }
 
     @Test
     public void dotProduct()
     {
         CharAdapter adapter = Strings.asChars("123");
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () ->
                 {
@@ -159,7 +162,7 @@ public class CharAdapterTest extends AbstractImmutableCharListTestCase
     public void binarySearch()
     {
         CharAdapter adapter = Strings.asChars("123");
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () ->
                 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointAdapterTest.java
@@ -20,8 +20,15 @@ import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.Strings;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableIntListTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
 {
@@ -44,7 +51,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     public void stringBuilder()
     {
         CodePointAdapter adapt = CodePointAdapter.adapt(UNICODE_STRING);
-        Assert.assertEquals(UNICODE_STRING, new StringBuilder(adapt).toString());
+        assertEquals(UNICODE_STRING, new StringBuilder(adapt).toString());
     }
 
     @Test
@@ -52,7 +59,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         CodePointAdapter adapt = CodePointAdapter.adapt(UNICODE_STRING);
         CharSequence sequence = adapt.subSequence(1, 3);
-        Assert.assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
+        assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
     }
 
     @Override
@@ -62,82 +69,82 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         super.testEquals();
         ImmutableIntList list1 = this.newWith(1, 2, 3, 4);
         ImmutableIntList list2 = this.newWith(4, 3, 2, 1);
-        Assert.assertNotEquals(list1, list2);
-        Assert.assertEquals(CodePointAdapter.adapt(UNICODE_STRING), CodePointAdapter.adapt(UNICODE_STRING));
-        Assert.assertNotEquals(CodePointAdapter.adapt("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046"), CodePointAdapter.adapt(UNICODE_STRING));
-        Assert.assertEquals(CodePointAdapter.adapt("ABC"), CodePointAdapter.adapt("ABC"));
-        Assert.assertNotEquals(CodePointAdapter.adapt("123"), CodePointAdapter.adapt("ABC"));
+        assertNotEquals(list1, list2);
+        assertEquals(CodePointAdapter.adapt(UNICODE_STRING), CodePointAdapter.adapt(UNICODE_STRING));
+        assertNotEquals(CodePointAdapter.adapt("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046"), CodePointAdapter.adapt(UNICODE_STRING));
+        assertEquals(CodePointAdapter.adapt("ABC"), CodePointAdapter.adapt("ABC"));
+        assertNotEquals(CodePointAdapter.adapt("123"), CodePointAdapter.adapt("ABC"));
         Verify.assertEqualsAndHashCode(CodePointAdapter.adapt("ABC"), CodePointList.from("ABC"));
         Verify.assertEqualsAndHashCode(CodePointAdapter.adapt(UNICODE_STRING), CodePointList.from(UNICODE_STRING));
-        Assert.assertNotEquals(CodePointList.from("123"), CodePointAdapter.adapt("ABC"));
-        Assert.assertNotEquals(CodePointAdapter.adapt("ABC"), CodePointList.from("123"));
-        Assert.assertNotEquals(CodePointList.from("ABCD"), CodePointAdapter.adapt("ABC"));
-        Assert.assertNotEquals(CodePointAdapter.adapt("ABC"), CodePointList.from("ABCD"));
-        Assert.assertNotEquals(CodePointList.from("ABC"), CodePointAdapter.adapt("ABCD"));
-        Assert.assertNotEquals(CodePointAdapter.adapt("ABCD"), CodePointList.from("ABC"));
+        assertNotEquals(CodePointList.from("123"), CodePointAdapter.adapt("ABC"));
+        assertNotEquals(CodePointAdapter.adapt("ABC"), CodePointList.from("123"));
+        assertNotEquals(CodePointList.from("ABCD"), CodePointAdapter.adapt("ABC"));
+        assertNotEquals(CodePointAdapter.adapt("ABC"), CodePointList.from("ABCD"));
+        assertNotEquals(CodePointList.from("ABC"), CodePointAdapter.adapt("ABCD"));
+        assertNotEquals(CodePointAdapter.adapt("ABCD"), CodePointList.from("ABC"));
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertEquals(9L, this.newWith(1, 2, 9).max());
-        Assert.assertEquals(32L, this.newWith(1, 0, 9, 30, 31, 32).max());
-        Assert.assertEquals(32L, this.newWith(0, 9, 30, 31, 32).max());
-        Assert.assertEquals(31L, this.newWith(31, 0, 30).max());
-        Assert.assertEquals(39L, this.newWith(32, 39, 35).max());
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max());
+        assertEquals(9L, this.newWith(1, 2, 9).max());
+        assertEquals(32L, this.newWith(1, 0, 9, 30, 31, 32).max());
+        assertEquals(32L, this.newWith(0, 9, 30, 31, 32).max());
+        assertEquals(31L, this.newWith(31, 0, 30).max());
+        assertEquals(39L, this.newWith(32, 39, 35).max());
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertEquals(1L, this.newWith(1, 2, 9).min());
-        Assert.assertEquals(0L, this.newWith(1, 0, 9, 30, 31, 32).min());
-        Assert.assertEquals(31L, this.newWith(31, 32, 33).min());
-        Assert.assertEquals(32L, this.newWith(32, 39, 35).min());
-        Assert.assertEquals(1L, this.classUnderTest().min());
+        assertEquals(1L, this.newWith(1, 2, 9).min());
+        assertEquals(0L, this.newWith(1, 0, 9, 30, 31, 32).min());
+        assertEquals(31L, this.newWith(31, 32, 33).min());
+        assertEquals(32L, this.newWith(32, 39, 35).min());
+        assertEquals(1L, this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.newWith(1, 0, 2).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(1, 2, 3).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(1, 2, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(32).allSatisfy(IntPredicates.equal(33)));
+        assertFalse(this.newWith(1, 0, 2).allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2, 3).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(32).allSatisfy(IntPredicates.equal(33)));
         IntIterable iterable = this.newWith(0, 1, 2);
-        Assert.assertFalse(iterable.allSatisfy(value -> 3 < value));
-        Assert.assertTrue(iterable.allSatisfy(IntPredicates.lessThan(3)));
+        assertFalse(iterable.allSatisfy(value -> 3 < value));
+        assertTrue(iterable.allSatisfy(IntPredicates.lessThan(3)));
 
         IntIterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size == 0, iterable1.allSatisfy(IntPredicates.greaterThan(3)));
-        Assert.assertEquals(size < 3, iterable1.allSatisfy(IntPredicates.lessThan(3)));
+        assertEquals(size == 0, iterable1.allSatisfy(IntPredicates.greaterThan(3)));
+        assertEquals(size < 3, iterable1.allSatisfy(IntPredicates.lessThan(3)));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(1, 2).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 2).anySatisfy(IntPredicates.equal(0)));
-        Assert.assertTrue(this.newWith(31, 32).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(2, 31, 32).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 31, 32).anySatisfy(IntPredicates.equal(0)));
-        Assert.assertTrue(this.newWith(32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2).anySatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 2).anySatisfy(IntPredicates.equal(0)));
+        assertTrue(this.newWith(31, 32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(2, 31, 32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 31, 32).anySatisfy(IntPredicates.equal(0)));
+        assertTrue(this.newWith(32).anySatisfy(IntPredicates.greaterThan(0)));
         IntIterable iterable = this.newWith(0, 1, 2);
-        Assert.assertTrue(iterable.anySatisfy(value -> value < 3));
-        Assert.assertFalse(iterable.anySatisfy(IntPredicates.greaterThan(3)));
+        assertTrue(iterable.anySatisfy(value -> value < 3));
+        assertFalse(iterable.anySatisfy(IntPredicates.greaterThan(3)));
 
         IntIterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size > 3, iterable1.anySatisfy(IntPredicates.greaterThan(3)));
-        Assert.assertEquals(size != 0, iterable1.anySatisfy(IntPredicates.lessThan(3)));
+        assertEquals(size > 3, iterable1.anySatisfy(IntPredicates.greaterThan(3)));
+        assertEquals(size != 0, iterable1.anySatisfy(IntPredicates.lessThan(3)));
     }
 
     @Override
@@ -150,7 +157,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         {
             expectedString.appendCodePoint(each + 1);
         }
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Override
@@ -168,8 +175,8 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
             expectedString.append(each == size - 1 ? "" : ", ");
             expectedString1.append(each == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), list.makeString());
-        Assert.assertEquals(expectedString1.toString(), list.makeString("/"));
+        assertEquals(expectedString.toString(), list.makeString());
+        assertEquals(expectedString1.toString(), list.makeString("/"));
     }
 
     @Override
@@ -189,10 +196,10 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         StringBuilder appendable2 = new StringBuilder();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
     }
 
     @SuppressWarnings("StringBufferMayBeStringBuilder")
@@ -212,13 +219,13 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         StringBuffer appendable2 = new StringBuffer();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuffer appendable3 = new StringBuffer();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuffer appendable4 = new StringBuffer();
         this.classUnderTest().appendString(appendable4, "", "", "");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Test
@@ -237,19 +244,19 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         SBAppendable appendable2 = new SBAppendable();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         SBAppendable appendable3 = new SBAppendable();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
     }
 
     @Test
     public void collectCodePointUnicode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UNICODE_STRING.codePoints().boxed().collect(Collectors.toList()),
                 CodePointAdapter.adapt(UNICODE_STRING).collect(i -> i));
-        Assert.assertEquals(
+        assertEquals(
                 UNICODE_STRING.codePoints().boxed().collect(Collectors.toList()),
                 CodePointAdapter.adapt(UNICODE_STRING).collect(i -> i));
     }
@@ -258,28 +265,28 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     public void selectCodePointUnicode()
     {
         String string = CodePointAdapter.adapt(UNICODE_STRING).select(Character::isBmpCodePoint).toString();
-        Assert.assertEquals("\u3042\u3044\u3046", string);
+        assertEquals("\u3042\u3044\u3046", string);
     }
 
     @Test
     public void allSatisfyUnicode()
     {
-        Assert.assertTrue(CodePointAdapter.adapt("\u3042\u3044\u3046").allSatisfy(Character::isBmpCodePoint));
-        Assert.assertFalse(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").allSatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointAdapter.adapt("\u3042\u3044\u3046").allSatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").allSatisfy(Character::isBmpCodePoint));
     }
 
     @Test
     public void anySatisfyUnicode()
     {
-        Assert.assertTrue(CodePointAdapter.adapt("\u3042\u3044\u3046").anySatisfy(Character::isBmpCodePoint));
-        Assert.assertFalse(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").anySatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointAdapter.adapt("\u3042\u3044\u3046").anySatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").anySatisfy(Character::isBmpCodePoint));
     }
 
     @Test
     public void noneSatisfyUnicode()
     {
-        Assert.assertFalse(CodePointAdapter.adapt("\u3042\u3044\u3046").noneSatisfy(Character::isBmpCodePoint));
-        Assert.assertTrue(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").noneSatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointAdapter.adapt("\u3042\u3044\u3046").noneSatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").noneSatisfy(Character::isBmpCodePoint));
     }
 
     @Test
@@ -287,7 +294,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointAdapter.adapt(UNICODE_STRING).forEach(builder::appendCodePoint);
-        Assert.assertEquals(UNICODE_STRING, builder.toString());
+        assertEquals(UNICODE_STRING, builder.toString());
     }
 
     @Test
@@ -295,13 +302,13 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointAdapter.adapt(UNICODE_STRING).asReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointAdapter.adapt("\uD840\uDC00\u3042\uD840\uDC03\u3044\uD83D\uDE09\u3046").asReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
+        assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
 
-        CodePointAdapter.adapt("").asReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointAdapter.adapt("").asReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -309,17 +316,17 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uDC00\uD840\u3044\uDC03\uD840\u3046\uDE09\uD83D").asReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uD840\u3044\uD840\u3046\uD840").asReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
+        assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uDC00\u3044\uDC03\u3046\uDC06").asReversed().forEach(builder3::appendCodePoint);
-        Assert.assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
+        assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
 
-        CodePointAdapter.adapt("").asReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointAdapter.adapt("").asReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -327,13 +334,13 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointAdapter.adapt(UNICODE_STRING).toReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointAdapter.adapt("\uD840\uDC00\u3042\uD840\uDC03\u3044\uD83D\uDE09\u3046").toReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
+        assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
 
-        CodePointAdapter.adapt("").toReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointAdapter.adapt("").toReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -341,23 +348,23 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uDC00\uD840\u3044\uDC03\uD840\u3046\uDE09\uD83D").toReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uD840\u3044\uD840\u3046\uD840").toReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
+        assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         CodePointAdapter.adapt("\u3042\uDC00\u3044\uDC03\u3046\uDC06").toReversed().forEach(builder3::appendCodePoint);
-        Assert.assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
+        assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
 
-        CodePointAdapter.adapt("").toReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointAdapter.adapt("").toReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
     public void distinctUnicode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 "\uD840\uDC00\uD840\uDC03\uD83D\uDE09",
                 CodePointAdapter.adapt("\uD840\uDC00\uD840\uDC03\uD83D\uDE09\uD840\uDC00\uD840\uDC03\uD83D\uDE09").distinct().toString());
     }
@@ -402,19 +409,19 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     public void toReversed()
     {
         super.toReversed();
-        Assert.assertEquals("cba", CodePointAdapter.adapt("abc").toReversed().toString());
+        assertEquals("cba", CodePointAdapter.adapt("abc").toReversed().toString());
     }
 
     @Test
     public void primitiveStream()
     {
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4, 5).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4, 5).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void primitiveParallelStream()
     {
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
@@ -422,7 +429,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     {
         CodePointAdapter adapter = Strings.asCodePoints("123");
         ImmutableIntList immutable = adapter.toImmutable();
-        Assert.assertSame(adapter, immutable);
+        assertSame(adapter, immutable);
     }
 
     @Test
@@ -431,14 +438,14 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
         CodePointAdapter adapter = Strings.asCodePoints("123");
         LazyIntIterable iterable = adapter.asReversed();
         String string = iterable.collectChar(each -> (char) each).makeString("");
-        Assert.assertEquals("321", string);
+        assertEquals("321", string);
     }
 
     @Test
     public void dotProduct()
     {
         CodePointAdapter adapter = Strings.asCodePoints("123");
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () ->
                 {
@@ -450,7 +457,7 @@ public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
     public void binarySearch()
     {
         CodePointAdapter adapter = Strings.asCodePoints("123");
-        Assert.assertThrows(
+        assertThrows(
                 UnsupportedOperationException.class,
                 () ->
                 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointListTest.java
@@ -20,8 +20,13 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableIntListTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CodePointListTest extends AbstractImmutableIntListTestCase
 {
@@ -46,13 +51,13 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     public void stringBuilder()
     {
         CodePointList list = CodePointList.from(UNICODE_STRING);
-        Assert.assertEquals(UNICODE_STRING, new StringBuilder(list).toString());
+        assertEquals(UNICODE_STRING, new StringBuilder(list).toString());
         CodePointList list2 = CodePointList.from(UNICODE_EMOJI_STRING);
-        Assert.assertEquals(UNICODE_EMOJI_STRING, new StringBuilder(list2).toString());
+        assertEquals(UNICODE_EMOJI_STRING, new StringBuilder(list2).toString());
         CodePointList list3 = CodePointList.from(UNICODE_EMOJI_STRING2);
-        Assert.assertEquals(UNICODE_EMOJI_STRING2, new StringBuilder(list3).toString());
+        assertEquals(UNICODE_EMOJI_STRING2, new StringBuilder(list3).toString());
         CodePointList list4 = CodePointList.from("Hello World!");
-        Assert.assertEquals("Hello World!", new StringBuilder(list4).toString());
+        assertEquals("Hello World!", new StringBuilder(list4).toString());
     }
 
     @Test
@@ -60,70 +65,70 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         CodePointList adapt = CodePointList.from(UNICODE_STRING);
         CharSequence sequence = adapt.subSequence(1, 3);
-        Assert.assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
+        assertEquals(UNICODE_STRING.subSequence(1, 3), sequence);
     }
 
     @Override
     @Test
     public void max()
     {
-        Assert.assertEquals(9L, this.newWith(1, 2, 9).max());
-        Assert.assertEquals(32L, this.newWith(1, 0, 9, 30, 31, 32).max());
-        Assert.assertEquals(32L, this.newWith(0, 9, 30, 31, 32).max());
-        Assert.assertEquals(31L, this.newWith(31, 0, 30).max());
-        Assert.assertEquals(39L, this.newWith(32, 39, 35).max());
-        Assert.assertEquals(this.classUnderTest().size(), this.classUnderTest().max());
+        assertEquals(9L, this.newWith(1, 2, 9).max());
+        assertEquals(32L, this.newWith(1, 0, 9, 30, 31, 32).max());
+        assertEquals(32L, this.newWith(0, 9, 30, 31, 32).max());
+        assertEquals(31L, this.newWith(31, 0, 30).max());
+        assertEquals(39L, this.newWith(32, 39, 35).max());
+        assertEquals(this.classUnderTest().size(), this.classUnderTest().max());
     }
 
     @Override
     @Test
     public void min()
     {
-        Assert.assertEquals(1L, this.newWith(1, 2, 9).min());
-        Assert.assertEquals(0L, this.newWith(1, 0, 9, 30, 31, 32).min());
-        Assert.assertEquals(31L, this.newWith(31, 32, 33).min());
-        Assert.assertEquals(32L, this.newWith(32, 39, 35).min());
-        Assert.assertEquals(1L, this.classUnderTest().min());
+        assertEquals(1L, this.newWith(1, 2, 9).min());
+        assertEquals(0L, this.newWith(1, 0, 9, 30, 31, 32).min());
+        assertEquals(31L, this.newWith(31, 32, 33).min());
+        assertEquals(32L, this.newWith(32, 39, 35).min());
+        assertEquals(1L, this.classUnderTest().min());
     }
 
     @Override
     @Test
     public void allSatisfy()
     {
-        Assert.assertFalse(this.newWith(1, 0, 2).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(1, 2, 3).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(1, 2, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(32).allSatisfy(IntPredicates.equal(33)));
+        assertFalse(this.newWith(1, 0, 2).allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2, 3).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 0, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2, 31, 32).allSatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(32).allSatisfy(IntPredicates.equal(33)));
         IntIterable iterable = this.newWith(0, 1, 2);
-        Assert.assertFalse(iterable.allSatisfy(value -> 3 < value));
-        Assert.assertTrue(iterable.allSatisfy(IntPredicates.lessThan(3)));
+        assertFalse(iterable.allSatisfy(value -> 3 < value));
+        assertTrue(iterable.allSatisfy(IntPredicates.lessThan(3)));
 
         IntIterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size == 0, iterable1.allSatisfy(IntPredicates.greaterThan(3)));
-        Assert.assertEquals(size < 3, iterable1.allSatisfy(IntPredicates.lessThan(3)));
+        assertEquals(size == 0, iterable1.allSatisfy(IntPredicates.greaterThan(3)));
+        assertEquals(size < 3, iterable1.allSatisfy(IntPredicates.lessThan(3)));
     }
 
     @Override
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(this.newWith(1, 2).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 2).anySatisfy(IntPredicates.equal(0)));
-        Assert.assertTrue(this.newWith(31, 32).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertTrue(this.newWith(2, 31, 32).anySatisfy(IntPredicates.greaterThan(0)));
-        Assert.assertFalse(this.newWith(1, 31, 32).anySatisfy(IntPredicates.equal(0)));
-        Assert.assertTrue(this.newWith(32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(1, 2).anySatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 2).anySatisfy(IntPredicates.equal(0)));
+        assertTrue(this.newWith(31, 32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertTrue(this.newWith(2, 31, 32).anySatisfy(IntPredicates.greaterThan(0)));
+        assertFalse(this.newWith(1, 31, 32).anySatisfy(IntPredicates.equal(0)));
+        assertTrue(this.newWith(32).anySatisfy(IntPredicates.greaterThan(0)));
         IntIterable iterable = this.newWith(0, 1, 2);
-        Assert.assertTrue(iterable.anySatisfy(value -> value < 3));
-        Assert.assertFalse(iterable.anySatisfy(IntPredicates.greaterThan(3)));
+        assertTrue(iterable.anySatisfy(value -> value < 3));
+        assertFalse(iterable.anySatisfy(IntPredicates.greaterThan(3)));
 
         IntIterable iterable1 = this.classUnderTest();
         int size = iterable1.size();
-        Assert.assertEquals(size > 3, iterable1.anySatisfy(IntPredicates.greaterThan(3)));
-        Assert.assertEquals(size != 0, iterable1.anySatisfy(IntPredicates.lessThan(3)));
+        assertEquals(size > 3, iterable1.anySatisfy(IntPredicates.greaterThan(3)));
+        assertEquals(size != 0, iterable1.anySatisfy(IntPredicates.lessThan(3)));
     }
 
     @Override
@@ -136,7 +141,7 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         {
             expectedString.appendCodePoint(each + 1);
         }
-        Assert.assertEquals(expectedString.toString(), this.classUnderTest().toString());
+        assertEquals(expectedString.toString(), this.classUnderTest().toString());
     }
 
     @Override
@@ -154,9 +159,9 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
             expectedString.append(each == size - 1 ? "" : ", ");
             expectedString1.append(each == size - 1 ? "" : "/");
         }
-        Assert.assertEquals(expectedString.toString(), list.makeString());
-        Assert.assertEquals(expectedString1.toString(), list.makeString("/"));
-        Assert.assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("", "", ""));
+        assertEquals(expectedString.toString(), list.makeString());
+        assertEquals(expectedString1.toString(), list.makeString("/"));
+        assertEquals(this.classUnderTest().toString(), this.classUnderTest().makeString("", "", ""));
     }
 
     @Override
@@ -176,13 +181,13 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         StringBuilder appendable2 = new StringBuilder();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuilder appendable3 = new StringBuilder();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuilder appendable4 = new StringBuilder();
         this.classUnderTest().appendString(appendable4, "", "", "");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @SuppressWarnings("StringBufferMayBeStringBuilder")
@@ -202,13 +207,13 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         StringBuffer appendable2 = new StringBuffer();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         StringBuffer appendable3 = new StringBuffer();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         StringBuffer appendable4 = new StringBuffer();
         this.classUnderTest().appendString(appendable4, "", "", "");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Test
@@ -227,22 +232,22 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         ImmutableIntList list = this.classUnderTest();
         SBAppendable appendable2 = new SBAppendable();
         list.appendString(appendable2);
-        Assert.assertEquals(expectedString.toString(), appendable2.toString());
+        assertEquals(expectedString.toString(), appendable2.toString());
         SBAppendable appendable3 = new SBAppendable();
         list.appendString(appendable3, "/");
-        Assert.assertEquals(expectedString1.toString(), appendable3.toString());
+        assertEquals(expectedString1.toString(), appendable3.toString());
         SBAppendable appendable4 = new SBAppendable();
         this.classUnderTest().appendString(appendable4, "", "", "");
-        Assert.assertEquals(this.classUnderTest().toString(), appendable4.toString());
+        assertEquals(this.classUnderTest().toString(), appendable4.toString());
     }
 
     @Test
     public void collectCodePointUnicode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UNICODE_STRING.codePoints().boxed().collect(Collectors.toList()),
                 CodePointList.from(UNICODE_STRING).collect(i -> i));
-        Assert.assertEquals(
+        assertEquals(
                 UNICODE_STRING.codePoints().boxed().collect(Collectors.toList()),
                 CodePointList.from(UNICODE_STRING).collect(i -> i));
     }
@@ -251,28 +256,28 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     public void selectCodePointUnicode()
     {
         String string = CodePointList.from(UNICODE_STRING).select(Character::isBmpCodePoint).toString();
-        Assert.assertEquals("\u3042\u3044\u3046", string);
+        assertEquals("\u3042\u3044\u3046", string);
     }
 
     @Test
     public void allSatisfyUnicode()
     {
-        Assert.assertTrue(CodePointList.from("\u3042\u3044\u3046").allSatisfy(Character::isBmpCodePoint));
-        Assert.assertFalse(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").allSatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointList.from("\u3042\u3044\u3046").allSatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").allSatisfy(Character::isBmpCodePoint));
     }
 
     @Test
     public void anySatisfyUnicode()
     {
-        Assert.assertTrue(CodePointList.from("\u3042\u3044\u3046").anySatisfy(Character::isBmpCodePoint));
-        Assert.assertFalse(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").anySatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointList.from("\u3042\u3044\u3046").anySatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").anySatisfy(Character::isBmpCodePoint));
     }
 
     @Test
     public void noneSatisfyUnicode()
     {
-        Assert.assertFalse(CodePointList.from("\u3042\u3044\u3046").noneSatisfy(Character::isBmpCodePoint));
-        Assert.assertTrue(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").noneSatisfy(Character::isBmpCodePoint));
+        assertFalse(CodePointList.from("\u3042\u3044\u3046").noneSatisfy(Character::isBmpCodePoint));
+        assertTrue(CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09").noneSatisfy(Character::isBmpCodePoint));
     }
 
     @Test
@@ -280,7 +285,7 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointList.from(UNICODE_STRING).forEach(builder::appendCodePoint);
-        Assert.assertEquals(UNICODE_STRING, builder.toString());
+        assertEquals(UNICODE_STRING, builder.toString());
     }
 
     @Test
@@ -288,13 +293,13 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointList.from(UNICODE_STRING).asReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointList.from("\uD840\uDC00\u3042\uD840\uDC03\u3044\uD83D\uDE09\u3046").asReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
+        assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
 
-        CodePointList.from("").asReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointList.from("").asReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -302,17 +307,17 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointList.from("\u3042\uDC00\uD840\u3044\uDC03\uD840\u3046\uDE09\uD83D").asReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointList.from("\u3042\uD840\u3044\uD840\u3046\uD840").asReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
+        assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         CodePointList.from("\u3042\uDC00\u3044\uDC03\u3046\uDC06").asReversed().forEach(builder3::appendCodePoint);
-        Assert.assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
+        assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
 
-        CodePointList.from("").asReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointList.from("").asReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -320,13 +325,13 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointList.from(UNICODE_STRING).toReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointList.from("\uD840\uDC00\u3042\uD840\uDC03\u3044\uD83D\uDE09\u3046").toReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
+        assertEquals("\u3046\uD83D\uDE09\u3044\uD840\uDC03\u3042\uD840\uDC00", builder2.toString());
 
-        CodePointList.from("").toReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointList.from("").toReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -334,17 +339,17 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         StringBuilder builder = new StringBuilder();
         CodePointList.from("\u3042\uDC00\uD840\u3044\uDC03\uD840\u3046\uDE09\uD83D").toReversed().forEach(builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         CodePointList.from("\u3042\uD840\u3044\uD840\u3046\uD840").toReversed().forEach(builder2::appendCodePoint);
-        Assert.assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
+        assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         CodePointList.from("\u3042\uDC00\u3044\uDC03\u3046\uDC06").toReversed().forEach(builder3::appendCodePoint);
-        Assert.assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
+        assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
 
-        CodePointList.from("").toReversed().forEach((int codePoint) -> Assert.fail());
+        CodePointList.from("").toReversed().forEach((int codePoint) -> fail());
     }
 
     @Test
@@ -386,7 +391,7 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     @Test
     public void distinctUnicode()
     {
-        Assert.assertEquals(
+        assertEquals(
                 "\uD840\uDC00\uD840\uDC03\uD83D\uDE09",
                 CodePointList.from("\uD840\uDC00\uD840\uDC03\uD83D\uDE09\uD840\uDC00\uD840\uDC03\uD83D\uDE09").distinct().toString());
     }
@@ -395,19 +400,19 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     public void toReversed()
     {
         super.toReversed();
-        Assert.assertEquals("cba", CodePointList.from("abc").toReversed().toString());
+        assertEquals("cba", CodePointList.from("abc").toReversed().toString());
     }
 
     @Test
     public void primitiveStream()
     {
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), CodePointList.from(1, 2, 3, 4, 5).primitiveStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), CodePointList.from(1, 2, 3, 4, 5).primitiveStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
     public void primitiveParallelStream()
     {
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), CodePointList.from(1, 2, 3, 4, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), CodePointList.from(1, 2, 3, 4, 5).primitiveParallelStream().boxed().collect(Collectors.toList()));
     }
 
     @Test
@@ -415,7 +420,7 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
     {
         CodePointList list = CodePointList.from("123");
         ImmutableIntList immutable = list.toImmutable();
-        Assert.assertSame(list, immutable);
+        assertSame(list, immutable);
     }
 
     @Test
@@ -424,7 +429,7 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         CodePointList list = CodePointList.from("123");
         LazyIntIterable iterable = list.asReversed();
         String string = iterable.collectChar(each -> (char) each).makeString("");
-        Assert.assertEquals("321", string);
+        assertEquals("321", string);
     }
 
     @Test
@@ -434,14 +439,14 @@ public class CodePointListTest extends AbstractImmutableIntListTestCase
         long actual = list.dotProduct(list);
         MutableIntList mutable = IntLists.mutable.with((int) '1', (int) '2', (int) '3');
         long expected = mutable.dotProduct(mutable);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void binarySearch()
     {
         CodePointList list = CodePointList.from("123");
-        Assert.assertEquals(1, list.binarySearch((int) '2'));
+        assertEquals(1, list.binarySearch((int) '2'));
     }
 
     private static class SBAppendable implements Appendable

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/AbstractImmutableEntryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/AbstractImmutableEntryTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.tuple;
 
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class AbstractImmutableEntryTest
 {
@@ -21,13 +22,13 @@ public class AbstractImmutableEntryTest
     public void getKeyFunction()
     {
         Map.Entry<String, Integer> entry = new ImmutableEntry<>("foo", 2);
-        Assert.assertEquals("foo", AbstractImmutableEntry.<String>getKeyFunction().valueOf(entry));
+        assertEquals("foo", AbstractImmutableEntry.<String>getKeyFunction().valueOf(entry));
     }
 
     @Test
     public void getValueFunction()
     {
         Map.Entry<String, Integer> entry = new ImmutableEntry<>("foo", 2);
-        Assert.assertEquals(Integer.valueOf(2), AbstractImmutableEntry.<Integer>getValueFunction().valueOf(entry));
+        assertEquals(Integer.valueOf(2), AbstractImmutableEntry.<Integer>getValueFunction().valueOf(entry));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
@@ -24,8 +24,13 @@ import org.eclipse.collections.api.tuple.Triplet;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class TuplesTest
 {
@@ -35,74 +40,74 @@ public class TuplesTest
         Pair<String, String> pair = Tuples.pair("1", "2");
         Map.Entry<String, String> entry = pair.toEntry();
         Pair<String, String> pair2 = Tuples.pairFrom(entry);
-        Assert.assertEquals(pair, pair2);
+        assertEquals(pair, pair2);
     }
 
     @Test
     public void pair()
     {
         Pair<String, String> pair = Tuples.pair("1", "2");
-        Assert.assertEquals("1", pair.getOne());
-        Assert.assertEquals("2", pair.getTwo());
-        Assert.assertFalse(pair.isEqual());
-        Assert.assertFalse(pair.isSame());
+        assertEquals("1", pair.getOne());
+        assertEquals("2", pair.getTwo());
+        assertFalse(pair.isEqual());
+        assertFalse(pair.isSame());
     }
 
     @Test
     public void twin()
     {
         Twin<String> twin = Tuples.twin("1", "2");
-        Assert.assertEquals("1", twin.getOne());
-        Assert.assertEquals("2", twin.getTwo());
-        Assert.assertFalse(twin.isEqual());
-        Assert.assertFalse(twin.isSame());
+        assertEquals("1", twin.getOne());
+        assertEquals("2", twin.getTwo());
+        assertFalse(twin.isEqual());
+        assertFalse(twin.isSame());
     }
 
     @Test
     public void identicalTwin()
     {
         Twin<String> twin = Tuples.identicalTwin("1");
-        Assert.assertEquals("1", twin.getOne());
-        Assert.assertEquals("1", twin.getTwo());
-        Assert.assertTrue(twin.isEqual());
-        Assert.assertTrue(twin.isSame());
-        Assert.assertEquals(twin.getOne(), twin.getTwo());
+        assertEquals("1", twin.getOne());
+        assertEquals("1", twin.getTwo());
+        assertTrue(twin.isEqual());
+        assertTrue(twin.isSame());
+        assertEquals(twin.getOne(), twin.getTwo());
     }
 
     @Test
     public void triple()
     {
         Triple<String, String, String> triple = Tuples.triple("1", "2", "3");
-        Assert.assertEquals("1", triple.getOne());
-        Assert.assertEquals("2", triple.getTwo());
-        Assert.assertEquals("3", triple.getThree());
-        Assert.assertFalse(triple.isEqual());
-        Assert.assertFalse(triple.isSame());
+        assertEquals("1", triple.getOne());
+        assertEquals("2", triple.getTwo());
+        assertEquals("3", triple.getThree());
+        assertFalse(triple.isEqual());
+        assertFalse(triple.isSame());
     }
 
     @Test
     public void triplet()
     {
         Triplet<String> triplet = Tuples.triplet("1", "2", "3");
-        Assert.assertEquals("1", triplet.getOne());
-        Assert.assertEquals("2", triplet.getTwo());
-        Assert.assertEquals("3", triplet.getThree());
-        Assert.assertFalse(triplet.isEqual());
-        Assert.assertFalse(triplet.isSame());
+        assertEquals("1", triplet.getOne());
+        assertEquals("2", triplet.getTwo());
+        assertEquals("3", triplet.getThree());
+        assertFalse(triplet.isEqual());
+        assertFalse(triplet.isSame());
     }
 
     @Test
     public void identicalTriplet()
     {
         Triplet<String> triplet = Tuples.identicalTriplet("1");
-        Assert.assertEquals("1", triplet.getOne());
-        Assert.assertEquals("1", triplet.getTwo());
-        Assert.assertEquals("1", triplet.getThree());
-        Assert.assertEquals(triplet.getOne(), triplet.getTwo());
-        Assert.assertEquals(triplet.getTwo(), triplet.getThree());
-        Assert.assertEquals(triplet.getThree(), triplet.getOne());
-        Assert.assertTrue(triplet.isEqual());
-        Assert.assertTrue(triplet.isSame());
+        assertEquals("1", triplet.getOne());
+        assertEquals("1", triplet.getTwo());
+        assertEquals("1", triplet.getThree());
+        assertEquals(triplet.getOne(), triplet.getTwo());
+        assertEquals(triplet.getTwo(), triplet.getThree());
+        assertEquals(triplet.getThree(), triplet.getOne());
+        assertTrue(triplet.isEqual());
+        assertTrue(triplet.isSame());
     }
 
     @Test
@@ -117,8 +122,8 @@ public class TuplesTest
         Verify.assertEqualsAndHashCode(pair1, pair1a);
         Verify.assertEqualsAndHashCode(pair3, pair3);
         Verify.assertEqualsAndHashCode(pair1, pair3);
-        Assert.assertNotEquals(pair1, pair2);
-        Assert.assertNotEquals(pair1, new Object());
+        assertNotEquals(pair1, pair2);
+        assertNotEquals(pair1, new Object());
     }
 
     @Test
@@ -133,8 +138,8 @@ public class TuplesTest
         Verify.assertEqualsAndHashCode(triple1, triple1a);
         Verify.assertEqualsAndHashCode(triple3, triple3);
         Verify.assertEqualsAndHashCode(triple1, triple3);
-        Assert.assertNotEquals(triple1, triple2);
-        Assert.assertNotEquals(triple1, new Object());
+        assertNotEquals(triple1, triple2);
+        assertNotEquals(triple1, new Object());
     }
 
     @Test
@@ -151,16 +156,16 @@ public class TuplesTest
     public void testToString()
     {
         Pair<String, String> pair1 = Tuples.pair("1", "1");
-        Assert.assertEquals("1:1", pair1.toString());
+        assertEquals("1:1", pair1.toString());
 
         Triple<String, String, String> triple = Tuples.triple("1", "2", "3");
-        Assert.assertEquals("1:2:3", triple.toString());
+        assertEquals("1:2:3", triple.toString());
 
         Twin<String> identicalTwin = Tuples.identicalTwin("1");
-        Assert.assertEquals("1:1", identicalTwin.toString());
+        assertEquals("1:1", identicalTwin.toString());
 
         Triplet<String> identicalTriplet = Tuples.identicalTriplet("1");
-        Assert.assertEquals("1:1:1", identicalTriplet.toString());
+        assertEquals("1:1:1", identicalTriplet.toString());
     }
 
     @Test
@@ -168,8 +173,8 @@ public class TuplesTest
     {
         Integer two = 2;
         Pair<String, Integer> pair = Tuples.pair("One", two);
-        Assert.assertEquals("One", ((Function<Pair<String, ?>, String>) Pair::getOne).valueOf(pair));
-        Assert.assertSame(two, ((Function<Pair<?, Integer>, Integer>) Pair::getTwo).valueOf(pair));
+        assertEquals("One", ((Function<Pair<String, ?>, String>) Pair::getOne).valueOf(pair));
+        assertSame(two, ((Function<Pair<?, Integer>, Integer>) Pair::getTwo).valueOf(pair));
     }
 
     @Test
@@ -178,23 +183,23 @@ public class TuplesTest
         Pair<String, Integer> pair = Tuples.pair("One", 1);
         Pair<Integer, String> swappedPair = pair.swap();
         Pair<Integer, String> expectedPair = Tuples.pair(1, "One");
-        Assert.assertEquals(Integer.valueOf(1), swappedPair.getOne());
-        Assert.assertEquals("One", swappedPair.getTwo());
-        Assert.assertEquals(expectedPair, swappedPair);
+        assertEquals(Integer.valueOf(1), swappedPair.getOne());
+        assertEquals("One", swappedPair.getTwo());
+        assertEquals(expectedPair, swappedPair);
 
         Twin<String> twin = Tuples.twin("One", "1");
         Twin<String> swappedTwin = twin.swap();
         Twin<String> expectedTwin = Tuples.twin("1", "One");
-        Assert.assertEquals("1", swappedTwin.getOne());
-        Assert.assertEquals("One", swappedTwin.getTwo());
-        Assert.assertEquals(expectedTwin, swappedTwin);
+        assertEquals("1", swappedTwin.getOne());
+        assertEquals("One", swappedTwin.getTwo());
+        assertEquals(expectedTwin, swappedTwin);
 
         Twin<String> identicalTwin = Tuples.identicalTwin("1");
         Twin<String> swappedIdenticalTwin = identicalTwin.swap();
         Twin<String> expectedIdenticalTwin = Tuples.identicalTwin("1");
-        Assert.assertEquals("1", swappedIdenticalTwin.getOne());
-        Assert.assertEquals("1", swappedIdenticalTwin.getTwo());
-        Assert.assertEquals(expectedIdenticalTwin, swappedIdenticalTwin);
+        assertEquals("1", swappedIdenticalTwin.getOne());
+        assertEquals("1", swappedIdenticalTwin.getTwo());
+        assertEquals(expectedIdenticalTwin, swappedIdenticalTwin);
     }
 
     @Test
@@ -203,67 +208,67 @@ public class TuplesTest
         Triple<String, Integer, Boolean> triple = Tuples.triple("One", 2, true);
         Triple<Boolean, Integer, String> reversedTriple = triple.reverse();
         Triple<Boolean, Integer, String> expectedTriple = Tuples.triple(true, 2, "One");
-        Assert.assertEquals(true, reversedTriple.getOne());
-        Assert.assertEquals(Integer.valueOf(2), reversedTriple.getTwo());
-        Assert.assertEquals("One", reversedTriple.getThree());
-        Assert.assertEquals(expectedTriple, reversedTriple);
+        assertEquals(true, reversedTriple.getOne());
+        assertEquals(Integer.valueOf(2), reversedTriple.getTwo());
+        assertEquals("One", reversedTriple.getThree());
+        assertEquals(expectedTriple, reversedTriple);
 
         Triplet<String> triplet = Tuples.triplet("One", "2", "true");
         Triplet<String> reversedTriplet = triplet.reverse();
         Triplet<String> expectedTriplet = Tuples.triplet("true", "2", "One");
-        Assert.assertEquals("true", reversedTriplet.getOne());
-        Assert.assertEquals("2", reversedTriplet.getTwo());
-        Assert.assertEquals("One", reversedTriplet.getThree());
-        Assert.assertEquals(expectedTriplet, reversedTriplet);
+        assertEquals("true", reversedTriplet.getOne());
+        assertEquals("2", reversedTriplet.getTwo());
+        assertEquals("One", reversedTriplet.getThree());
+        assertEquals(expectedTriplet, reversedTriplet);
 
         Triplet<String> identicalTriplet = Tuples.identicalTriplet("One");
         Triplet<String> reversedIdenticalTriplet = identicalTriplet.reverse();
         Triplet<String> expectedIdenticalTriplet = Tuples.identicalTriplet("One");
-        Assert.assertEquals("One", reversedIdenticalTriplet.getOne());
-        Assert.assertEquals("One", reversedIdenticalTriplet.getTwo());
-        Assert.assertEquals("One", reversedIdenticalTriplet.getThree());
-        Assert.assertEquals(expectedIdenticalTriplet, reversedIdenticalTriplet);
+        assertEquals("One", reversedIdenticalTriplet.getOne());
+        assertEquals("One", reversedIdenticalTriplet.getTwo());
+        assertEquals("One", reversedIdenticalTriplet.getThree());
+        assertEquals(expectedIdenticalTriplet, reversedIdenticalTriplet);
     }
 
     @Test
     public void pairToList()
     {
         MutableList<Integer> integers = Tuples.pairToList(Tuples.pair(1, 2));
-        Assert.assertEquals(Lists.mutable.with(1, 2), integers);
+        assertEquals(Lists.mutable.with(1, 2), integers);
     }
 
     @Test
     public void pairToFixedSizeList()
     {
         FixedSizeList<Integer> integers = Tuples.pairToFixedSizeList(Tuples.pair(1, 2));
-        Assert.assertEquals(Lists.mutable.with(1, 2), integers);
+        assertEquals(Lists.mutable.with(1, 2), integers);
     }
 
     @Test
     public void pairToImmutableList()
     {
         ImmutableList<Integer> integers = Tuples.pairToImmutableList(Tuples.pair(1, 2));
-        Assert.assertEquals(Lists.mutable.with(1, 2), integers);
+        assertEquals(Lists.mutable.with(1, 2), integers);
     }
 
     @Test
     public void tripleToList()
     {
         MutableList<Integer> integers = Tuples.tripleToList(Tuples.triple(1, 2, 3));
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3), integers);
+        assertEquals(Lists.mutable.with(1, 2, 3), integers);
     }
 
     @Test
     public void tripleToFixedSizeList()
     {
         FixedSizeList<Integer> integers = Tuples.tripleToFixedSizeList(Tuples.triple(1, 2, 3));
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3), integers);
+        assertEquals(Lists.mutable.with(1, 2, 3), integers);
     }
 
     @Test
     public void tripleToImmutableList()
     {
         ImmutableList<Integer> integers = Tuples.tripleToImmutableList(Tuples.triple(1, 2, 3));
-        Assert.assertEquals(Lists.mutable.with(1, 2, 3), integers);
+        assertEquals(Lists.mutable.with(1, 2, 3), integers);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanBooleanPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanBooleanPairImplTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link BooleanBooleanPairImpl}.
@@ -24,36 +28,36 @@ public class BooleanBooleanPairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair(true, false), PrimitiveTuples.pair(true, false));
-        Assert.assertNotEquals(PrimitiveTuples.pair(false, true), PrimitiveTuples.pair(true, false));
-        Assert.assertEquals(Tuples.pair(true, false).hashCode(), PrimitiveTuples.pair(true, false).hashCode());
+        assertNotEquals(PrimitiveTuples.pair(false, true), PrimitiveTuples.pair(true, false));
+        assertEquals(Tuples.pair(true, false).hashCode(), PrimitiveTuples.pair(true, false).hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertTrue(PrimitiveTuples.pair(true, false).getOne());
-        Assert.assertFalse(PrimitiveTuples.pair(false, true).getOne());
+        assertTrue(PrimitiveTuples.pair(true, false).getOne());
+        assertFalse(PrimitiveTuples.pair(false, true).getOne());
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertTrue(PrimitiveTuples.pair(false, true).getTwo());
-        Assert.assertFalse(PrimitiveTuples.pair(true, false).getTwo());
+        assertTrue(PrimitiveTuples.pair(false, true).getTwo());
+        assertFalse(PrimitiveTuples.pair(true, false).getTwo());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("true:false", PrimitiveTuples.pair(true, false).toString());
-        Assert.assertEquals("true:true", PrimitiveTuples.pair(true, true).toString());
+        assertEquals("true:false", PrimitiveTuples.pair(true, false).toString());
+        assertEquals("true:true", PrimitiveTuples.pair(true, true).toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(1, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(false, false)));
-        Assert.assertEquals(0, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(true, false)));
-        Assert.assertEquals(-1, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(true, true)));
+        assertEquals(1, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(false, false)));
+        assertEquals(0, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(true, false)));
+        assertEquals(-1, PrimitiveTuples.pair(true, false).compareTo(PrimitiveTuples.pair(true, true)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanObjectPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanObjectPairImplTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link BooleanBooleanPairImpl}.
@@ -24,36 +28,36 @@ public class BooleanObjectPairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair(true, "false"), PrimitiveTuples.pair(true, "false"));
-        Assert.assertNotEquals(PrimitiveTuples.pair(false, "true"), PrimitiveTuples.pair(true, "false"));
-        Assert.assertEquals(Tuples.pair(true, "false").hashCode(), PrimitiveTuples.pair(true, "false").hashCode());
+        assertNotEquals(PrimitiveTuples.pair(false, "true"), PrimitiveTuples.pair(true, "false"));
+        assertEquals(Tuples.pair(true, "false").hashCode(), PrimitiveTuples.pair(true, "false").hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertTrue(PrimitiveTuples.pair(true, "false").getOne());
-        Assert.assertFalse(PrimitiveTuples.pair(false, "true").getOne());
+        assertTrue(PrimitiveTuples.pair(true, "false").getOne());
+        assertFalse(PrimitiveTuples.pair(false, "true").getOne());
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertEquals("true", PrimitiveTuples.pair(false, "true").getTwo());
-        Assert.assertEquals("false", PrimitiveTuples.pair(true, "false").getTwo());
+        assertEquals("true", PrimitiveTuples.pair(false, "true").getTwo());
+        assertEquals("false", PrimitiveTuples.pair(true, "false").getTwo());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("true:false", PrimitiveTuples.pair(true, "false").toString());
-        Assert.assertEquals("true:true", PrimitiveTuples.pair(true, "true").toString());
+        assertEquals("true:false", PrimitiveTuples.pair(true, "false").toString());
+        assertEquals("true:true", PrimitiveTuples.pair(true, "true").toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(1, PrimitiveTuples.pair(true, "false").compareTo(PrimitiveTuples.pair(false, "false")));
-        Assert.assertEquals(0, PrimitiveTuples.pair(true, "false").compareTo(PrimitiveTuples.pair(true, "false")));
-        Assert.assertEquals(-1, PrimitiveTuples.pair(false, "false").compareTo(PrimitiveTuples.pair(true, "true")));
+        assertEquals(1, PrimitiveTuples.pair(true, "false").compareTo(PrimitiveTuples.pair(false, "false")));
+        assertEquals(0, PrimitiveTuples.pair(true, "false").compareTo(PrimitiveTuples.pair(true, "false")));
+        assertEquals(-1, PrimitiveTuples.pair(false, "false").compareTo(PrimitiveTuples.pair(true, "true")));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/ObjectBooleanPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/ObjectBooleanPairImplTest.java
@@ -12,8 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanPairImpl}.
@@ -24,36 +28,36 @@ public class ObjectBooleanPairImplTest
     public void testEqualsAndHashCode()
     {
         Verify.assertEqualsAndHashCode(PrimitiveTuples.pair("true", false), PrimitiveTuples.pair("true", false));
-        Assert.assertNotEquals(PrimitiveTuples.pair("false", true), PrimitiveTuples.pair("true", false));
-        Assert.assertEquals(Tuples.pair("true", false).hashCode(), PrimitiveTuples.pair("true", false).hashCode());
+        assertNotEquals(PrimitiveTuples.pair("false", true), PrimitiveTuples.pair("true", false));
+        assertEquals(Tuples.pair("true", false).hashCode(), PrimitiveTuples.pair("true", false).hashCode());
     }
 
     @Test
     public void getOne()
     {
-        Assert.assertEquals("true", PrimitiveTuples.pair("true", false).getOne());
-        Assert.assertEquals("false", PrimitiveTuples.pair("false", true).getOne());
+        assertEquals("true", PrimitiveTuples.pair("true", false).getOne());
+        assertEquals("false", PrimitiveTuples.pair("false", true).getOne());
     }
 
     @Test
     public void getTwo()
     {
-        Assert.assertTrue(PrimitiveTuples.pair("false", true).getTwo());
-        Assert.assertFalse(PrimitiveTuples.pair("true", false).getTwo());
+        assertTrue(PrimitiveTuples.pair("false", true).getTwo());
+        assertFalse(PrimitiveTuples.pair("true", false).getTwo());
     }
 
     @Test
     public void testToString()
     {
-        Assert.assertEquals("true:false", PrimitiveTuples.pair("true", false).toString());
-        Assert.assertEquals("true:true", PrimitiveTuples.pair("true", true).toString());
+        assertEquals("true:false", PrimitiveTuples.pair("true", false).toString());
+        assertEquals("true:true", PrimitiveTuples.pair("true", true).toString());
     }
 
     @Test
     public void compareTo()
     {
-        Assert.assertEquals(1, PrimitiveTuples.pair("true", true).compareTo(PrimitiveTuples.pair("true", false)));
-        Assert.assertEquals(0, PrimitiveTuples.pair("true", false).compareTo(PrimitiveTuples.pair("true", false)));
-        Assert.assertEquals(-1, PrimitiveTuples.pair("true", false).compareTo(PrimitiveTuples.pair("true", true)));
+        assertEquals(1, PrimitiveTuples.pair("true", true).compareTo(PrimitiveTuples.pair("true", false)));
+        assertEquals(0, PrimitiveTuples.pair("true", false).compareTo(PrimitiveTuples.pair("true", false)));
+        assertEquals(-1, PrimitiveTuples.pair("true", false).compareTo(PrimitiveTuples.pair("true", true)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/PrimitiveTuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/PrimitiveTuplesTest.java
@@ -74,8 +74,11 @@ import org.eclipse.collections.api.tuple.primitive.ShortFloatPair;
 import org.eclipse.collections.api.tuple.primitive.ShortIntPair;
 import org.eclipse.collections.api.tuple.primitive.ShortLongPair;
 import org.eclipse.collections.api.tuple.primitive.ShortObjectPair;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PrimitiveTuplesTest
 {
@@ -87,8 +90,8 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         byte valueTwo = (byte) 1;
         ObjectBytePair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -97,8 +100,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         String valueTwo = "a";
         ByteObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -107,8 +110,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         int valueTwo = 555;
         ByteIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -117,8 +120,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         float valueTwo = 555.0f;
         ByteFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -127,8 +130,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         double valueTwo = 555.0d;
         ByteDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -137,8 +140,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         long valueTwo = 454L;
         ByteLongPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -147,8 +150,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         short valueTwo = (short) 454;
         ByteShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -157,8 +160,8 @@ public class PrimitiveTuplesTest
         byte valueOne = (byte) 1;
         char valueTwo = 'c';
         ByteCharPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -166,8 +169,8 @@ public class PrimitiveTuplesTest
     {
         byte valueOne = (byte) 1;
         ByteBooleanPair pair = PrimitiveTuples.pair(valueOne, false);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertFalse(pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertFalse(pair.getTwo());
     }
 
     @Test
@@ -176,8 +179,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         String valueTwo = "a";
         CharObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -186,8 +189,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         int valueTwo = 343;
         CharIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -196,8 +199,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         float valueTwo = 343.00f;
         CharFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -206,8 +209,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         double valueTwo = 343.00d;
         CharDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -215,8 +218,8 @@ public class PrimitiveTuplesTest
     {
         float valueTwo = 454.01f;
         BooleanFloatPair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertTrue(pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -224,8 +227,8 @@ public class PrimitiveTuplesTest
     {
         double valueTwo = 454.01d;
         BooleanDoublePair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertTrue(pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -233,8 +236,8 @@ public class PrimitiveTuplesTest
     {
         long valueTwo = 444434L;
         BooleanLongPair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertTrue(pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -242,8 +245,8 @@ public class PrimitiveTuplesTest
     {
         short valueTwo = (short) 34;
         BooleanShortPair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertTrue(pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -251,8 +254,8 @@ public class PrimitiveTuplesTest
     {
         byte valueTwo = (byte) 34;
         BooleanBytePair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertTrue(pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -260,8 +263,8 @@ public class PrimitiveTuplesTest
     {
         char valueTwo = 'd';
         BooleanCharPair pair = PrimitiveTuples.pair(true, valueTwo);
-        Assert.assertTrue(pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertTrue(pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -270,8 +273,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         long valueTwo = 454L;
         CharLongPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -280,8 +283,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         short valueTwo = (short) 454;
         CharShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -290,8 +293,8 @@ public class PrimitiveTuplesTest
         char valueOne = 'c';
         byte valueTwo = (byte) 454;
         CharBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -299,8 +302,8 @@ public class PrimitiveTuplesTest
     {
         char valueOne = 'c';
         CharBooleanPair pair = PrimitiveTuples.pair(valueOne, true);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertTrue(pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertTrue(pair.getTwo());
     }
 
     @Test
@@ -309,8 +312,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 10;
         String valueTwo = "a";
         ShortObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -319,8 +322,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 10;
         int valueTwo = 589;
         ShortIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -329,8 +332,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 10;
         byte valueTwo = (byte) 589;
         ShortBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -339,8 +342,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 10;
         char valueTwo = 'd';
         ShortCharPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -349,8 +352,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 10;
         long valueTwo = 589L;
         ShortLongPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -358,8 +361,8 @@ public class PrimitiveTuplesTest
     {
         short valueOne = (short) 10;
         ShortBooleanPair pair = PrimitiveTuples.pair(valueOne, false);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertFalse(pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertFalse(pair.getTwo());
     }
 
     @Test
@@ -368,8 +371,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 12;
         float valueTwo = 589.09f;
         ShortFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -378,8 +381,8 @@ public class PrimitiveTuplesTest
         short valueOne = (short) 12;
         double valueTwo = 589.09d;
         ShortDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -388,8 +391,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         String valueTwo = "a";
         FloatObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -398,8 +401,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         double valueTwo = 567.00d;
         FloatDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -408,8 +411,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         long valueTwo = 55L;
         FloatLongPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -418,8 +421,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         short valueTwo = (short) 55;
         FloatShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -428,8 +431,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         byte valueTwo = (byte) 55;
         FloatBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -438,8 +441,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         char valueTwo = 'd';
         FloatCharPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -447,8 +450,8 @@ public class PrimitiveTuplesTest
     {
         float valueOne = 10.00f;
         FloatBooleanPair pair = PrimitiveTuples.pair(valueOne, false);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertFalse(pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertFalse(pair.getTwo());
     }
 
     @Test
@@ -457,8 +460,8 @@ public class PrimitiveTuplesTest
         float valueOne = 10.00f;
         int valueTwo = 55;
         FloatIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((double) valueOne, (double) pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -467,8 +470,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         int valueTwo = 55;
         DoubleIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -477,8 +480,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         short valueTwo = (short) 55;
         DoubleShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -487,8 +490,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         char valueTwo = 'r';
         DoubleCharPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -496,8 +499,8 @@ public class PrimitiveTuplesTest
     {
         double valueOne = 10.00d;
         DoubleBooleanPair pair = PrimitiveTuples.pair(valueOne, true);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertTrue(pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertTrue(pair.getTwo());
     }
 
     @Test
@@ -506,8 +509,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         byte valueTwo = (byte) 55;
         DoubleBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -516,8 +519,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         long valueTwo = 55L;
         DoubleLongPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -526,8 +529,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         float valueTwo = 55.0f;
         DoubleFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -536,8 +539,8 @@ public class PrimitiveTuplesTest
         double valueOne = 10.00d;
         String valueTwo = "a";
         DoubleObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne(), DELTA);
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals(valueOne, pair.getOne(), DELTA);
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -546,8 +549,8 @@ public class PrimitiveTuplesTest
         int valueOne = 123;
         float valueTwo = 789.00f;
         IntFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -556,8 +559,8 @@ public class PrimitiveTuplesTest
         int valueOne = 123;
         double valueTwo = 789.00d;
         IntDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -566,8 +569,8 @@ public class PrimitiveTuplesTest
         int valueOne = 123;
         short valueTwo = (short) 696;
         IntShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -576,8 +579,8 @@ public class PrimitiveTuplesTest
         int valueOne = 123;
         byte valueTwo = (byte) 696;
         IntBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -586,8 +589,8 @@ public class PrimitiveTuplesTest
         int valueOne = 123;
         byte valueTwo = (byte) 696;
         IntBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals((long) valueOne, (long) pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals((long) valueOne, (long) pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -596,8 +599,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         String valueTwo = "a";
         LongObjectPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -606,8 +609,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         int valueTwo = 33;
         LongIntPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -616,8 +619,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         float valueTwo = 33.01f;
         LongFloatPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -626,8 +629,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         double valueTwo = 33.01d;
         LongDoublePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals(valueOne, pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 
     @Test
@@ -636,8 +639,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         short valueTwo = (short) 444;
         LongShortPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -646,8 +649,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         byte valueTwo = (byte) 444;
         LongBytePair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -656,8 +659,8 @@ public class PrimitiveTuplesTest
         long valueOne = 123L;
         char valueTwo = 'd';
         LongCharPair pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -665,8 +668,8 @@ public class PrimitiveTuplesTest
     {
         long valueOne = 123L;
         LongBooleanPair pair = PrimitiveTuples.pair(valueOne, false);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertFalse(pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertFalse(pair.getTwo());
     }
 
     @Test
@@ -675,8 +678,8 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         char valueTwo = 'c';
         ObjectCharPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -685,8 +688,8 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         short valueTwo = (short) 1;
         ObjectShortPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((long) valueTwo, (long) pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((long) valueTwo, (long) pair.getTwo());
     }
 
     @Test
@@ -695,8 +698,8 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         float valueTwo = 1.00f;
         ObjectFloatPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
+        assertEquals(valueOne, pair.getOne());
+        assertEquals((double) valueTwo, (double) pair.getTwo(), DELTA);
     }
 
     @Test
@@ -705,8 +708,8 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         long valueTwo = 500L;
         ObjectLongPair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo());
+        assertEquals(valueOne, pair.getOne());
+        assertEquals(valueTwo, pair.getTwo());
     }
 
     @Test
@@ -715,7 +718,7 @@ public class PrimitiveTuplesTest
         String valueOne = "a";
         double valueTwo = 1.00d;
         ObjectDoublePair<String> pair = PrimitiveTuples.pair(valueOne, valueTwo);
-        Assert.assertEquals(valueOne, pair.getOne());
-        Assert.assertEquals(valueTwo, pair.getTwo(), DELTA);
+        assertEquals(valueOne, pair.getOne());
+        assertEquals(valueTwo, pair.getTwo(), DELTA);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
@@ -62,10 +62,17 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ArrayIterateTest
 {
@@ -75,7 +82,7 @@ public class ArrayIterateTest
     public void injectInto()
     {
         Integer[] objectArray = this.threeIntegerArray2();
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(7),
                 ArrayIterate.injectInto(1, objectArray, AddFunction.INTEGER));
     }
@@ -89,7 +96,7 @@ public class ArrayIterateTest
     public void injectIntoDouble()
     {
         Double[] objectArray = {(double) 1, (double) 2, (double) 3};
-        Assert.assertEquals(
+        assertEquals(
                 new Double(1 + 1 + 2 + 3),
                 ArrayIterate.injectInto((double) 1, objectArray, AddFunction.DOUBLE));
     }
@@ -98,17 +105,17 @@ public class ArrayIterateTest
     public void injectIntoPrimitives()
     {
         double doubleActual = ArrayIterate.injectInto(1.0d, new Double[]{1.0d, 2.0d, 3.0d}, (doubleParameter, objectParameter) -> doubleParameter + objectParameter);
-        Assert.assertEquals(7.0, doubleActual, 0.000001);
-        Assert.assertEquals(1.0, ArrayIterate.injectInto(1.0d, new Double[]{}, (doubleParameter, objectParameter) -> doubleParameter + objectParameter), 0.000001);
+        assertEquals(7.0, doubleActual, 0.000001);
+        assertEquals(1.0, ArrayIterate.injectInto(1.0d, new Double[]{}, (doubleParameter, objectParameter) -> doubleParameter + objectParameter), 0.000001);
         long longActual = ArrayIterate.injectInto(1L, new Long[]{1L, 2L, 3L}, (long longParameter, Long objectParameter) -> longParameter + objectParameter);
-        Assert.assertEquals(7L, longActual);
-        Assert.assertEquals(1L, ArrayIterate.injectInto(1L, new Long[]{}, (long longParameter, Long objectParameter) -> longParameter + objectParameter));
+        assertEquals(7L, longActual);
+        assertEquals(1L, ArrayIterate.injectInto(1L, new Long[]{}, (long longParameter, Long objectParameter) -> longParameter + objectParameter));
         int intActual = ArrayIterate.injectInto(1, new Integer[]{1, 2, 3}, (int intParameter, Integer objectParameter) -> intParameter + objectParameter);
-        Assert.assertEquals(7, intActual);
-        Assert.assertEquals(1, ArrayIterate.injectInto(1, new Integer[]{}, (int intParameter, Integer objectParameter) -> intParameter + objectParameter));
+        assertEquals(7, intActual);
+        assertEquals(1, ArrayIterate.injectInto(1, new Integer[]{}, (int intParameter, Integer objectParameter) -> intParameter + objectParameter));
         float floatActual = ArrayIterate.injectInto(1.0f, new Float[]{1.0f, 2.0f, 3.0f}, (float floatParameter, Float objectParameter) -> floatParameter + objectParameter);
-        Assert.assertEquals(7.0f, floatActual, 0.000001);
-        Assert.assertEquals(1.0f, ArrayIterate.injectInto(1.0f, new Float[]{}, (float floatParameter, Float objectParameter) -> floatParameter + objectParameter), 0.000001);
+        assertEquals(7.0f, floatActual, 0.000001);
+        assertEquals(1.0f, ArrayIterate.injectInto(1.0f, new Float[]{}, (float floatParameter, Float objectParameter) -> floatParameter + objectParameter), 0.000001);
     }
 
     @Test
@@ -116,11 +123,11 @@ public class ArrayIterateTest
     {
         Integer[] objectArray = this.threeIntegerArray2();
         Function3<Integer, Integer, Integer, Integer> function = (argument1, argument2, argument3) -> argument1 + argument2 + argument3;
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(10),
                 ArrayIterate.injectIntoWith(1, objectArray, function, 1));
         Integer[] emptyArray = {};
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 ArrayIterate.injectIntoWith(1, emptyArray, function, 1));
     }
@@ -128,11 +135,11 @@ public class ArrayIterateTest
     @Test
     public void injectIntoThrowsOnNullArgument()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(0, null, (int intParameter, Object objectParameter) -> 0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(0L, null, (long longParameter, Object objectParameter) -> 0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto((double) 0, null, (doubleParameter, objectParameter) -> 0.0));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(null, null, null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(5.0f, null, (float floatParameter, Object objectParameter) -> 5.0f));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(0, null, (int intParameter, Object objectParameter) -> 0));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(0L, null, (long longParameter, Object objectParameter) -> 0));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto((double) 0, null, (doubleParameter, objectParameter) -> 0.0));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(5.0f, null, (float floatParameter, Object objectParameter) -> 5.0f));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -296,8 +303,8 @@ public class ArrayIterateTest
     {
         PartitionIterable<Integer> result =
                 ArrayIterate.partition(new Integer[]{1, 2, 3, 3, 4, 4, 5, 5, 5, 2}, Predicates.greaterThan(3));
-        Assert.assertEquals(Lists.immutable.of(4, 4, 5, 5, 5), result.getSelected());
-        Assert.assertEquals(Lists.immutable.of(1, 2, 3, 3, 2), result.getRejected());
+        assertEquals(Lists.immutable.of(4, 4, 5, 5, 5), result.getSelected());
+        assertEquals(Lists.immutable.of(1, 2, 3, 3, 2), result.getRejected());
     }
 
     @Test
@@ -305,22 +312,22 @@ public class ArrayIterateTest
     {
         PartitionIterable<Integer> result =
                 ArrayIterate.partitionWith(new Integer[]{1, 2, 3, 3, 4, 4, 5, 5, 5, 2}, Predicates2.greaterThan(), 3);
-        Assert.assertEquals(Lists.immutable.of(4, 4, 5, 5, 5), result.getSelected());
-        Assert.assertEquals(Lists.immutable.of(1, 2, 3, 3, 2), result.getRejected());
+        assertEquals(Lists.immutable.of(4, 4, 5, 5, 5), result.getSelected());
+        assertEquals(Lists.immutable.of(1, 2, 3, 3, 2), result.getRejected());
     }
 
     @Test
     public void injectIntoString()
     {
         String[] objectArray1 = {"1", "2", "3"};
-        Assert.assertEquals("0123", ArrayIterate.injectInto("0", objectArray1, AddFunction.STRING));
+        assertEquals("0123", ArrayIterate.injectInto("0", objectArray1, AddFunction.STRING));
 
         String[] objectArray2 = {"A", "AB", "ABC", "ABCD"};
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(4),
                 ArrayIterate.injectInto(2, objectArray2, MaxSizeFunction.STRING));
 
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 ArrayIterate.injectInto(2, objectArray2, MinSizeFunction.STRING));
     }
@@ -329,7 +336,7 @@ public class ArrayIterateTest
     public void collect()
     {
         Boolean[] objectArray = {true, false, null};
-        Assert.assertEquals(
+        assertEquals(
                 iList("true", "false", "null"),
                 ArrayIterate.collect(objectArray, String::valueOf));
     }
@@ -338,7 +345,7 @@ public class ArrayIterateTest
     public void collectBoolean()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedBooleanResults(),
                 ArrayIterate.collectBoolean(objectArray, PrimitiveFunctions.integerIsPositive()));
     }
@@ -349,8 +356,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         BooleanArrayList target = new BooleanArrayList();
         MutableBooleanList result = ArrayIterate.collectBoolean(objectArray, PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertEquals(this.getExpectedBooleanResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedBooleanResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private BooleanArrayList getExpectedBooleanResults()
@@ -362,7 +369,7 @@ public class ArrayIterateTest
     public void collectByte()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedByteResults(),
                 ArrayIterate.collectByte(objectArray, PrimitiveFunctions.unboxIntegerToByte()));
     }
@@ -373,8 +380,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         ByteArrayList target = new ByteArrayList();
         ByteArrayList result = ArrayIterate.collectByte(objectArray, PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertEquals(this.getExpectedByteResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedByteResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private ByteArrayList getExpectedByteResults()
@@ -386,7 +393,7 @@ public class ArrayIterateTest
     public void collectChar()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedCharResults(),
                 ArrayIterate.collectChar(objectArray, PrimitiveFunctions.unboxIntegerToChar()));
     }
@@ -397,8 +404,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         CharArrayList target = new CharArrayList();
         CharArrayList result = ArrayIterate.collectChar(objectArray, PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertEquals(this.getExpectedCharResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedCharResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private CharArrayList getExpectedCharResults()
@@ -410,7 +417,7 @@ public class ArrayIterateTest
     public void collectDouble()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedDoubleResults(),
                 ArrayIterate.collectDouble(objectArray, PrimitiveFunctions.unboxIntegerToDouble()));
     }
@@ -421,8 +428,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         DoubleArrayList target = new DoubleArrayList();
         DoubleArrayList result = ArrayIterate.collectDouble(objectArray, PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertEquals(this.getExpectedDoubleResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedDoubleResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private DoubleArrayList getExpectedDoubleResults()
@@ -434,7 +441,7 @@ public class ArrayIterateTest
     public void collectFloat()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedFloatResults(),
                 ArrayIterate.collectFloat(objectArray, PrimitiveFunctions.unboxIntegerToFloat()));
     }
@@ -445,8 +452,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         FloatArrayList target = new FloatArrayList();
         FloatArrayList result = ArrayIterate.collectFloat(objectArray, PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertEquals(this.getExpectedFloatResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedFloatResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private FloatArrayList getExpectedFloatResults()
@@ -458,7 +465,7 @@ public class ArrayIterateTest
     public void collectInt()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedIntResults(),
                 ArrayIterate.collectInt(objectArray, PrimitiveFunctions.unboxIntegerToInt()));
     }
@@ -469,8 +476,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         IntArrayList target = new IntArrayList();
         IntArrayList result = ArrayIterate.collectInt(objectArray, PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertEquals(this.getExpectedIntResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedIntResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private IntArrayList getExpectedIntResults()
@@ -482,7 +489,7 @@ public class ArrayIterateTest
     public void collectLong()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedLongResults(),
                 ArrayIterate.collectLong(objectArray, PrimitiveFunctions.unboxIntegerToLong()));
     }
@@ -493,8 +500,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         LongArrayList target = new LongArrayList();
         LongArrayList result = ArrayIterate.collectLong(objectArray, PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertEquals(this.getExpectedLongResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedLongResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private LongArrayList getExpectedLongResults()
@@ -506,7 +513,7 @@ public class ArrayIterateTest
     public void collectShort()
     {
         Integer[] objectArray = {-1, 0, 42};
-        Assert.assertEquals(
+        assertEquals(
                 this.getExpectedShortResults(),
                 ArrayIterate.collectShort(objectArray, PrimitiveFunctions.unboxIntegerToShort()));
     }
@@ -517,8 +524,8 @@ public class ArrayIterateTest
         Integer[] objectArray = {-1, 0, 42};
         ShortArrayList target = new ShortArrayList();
         ShortArrayList result = ArrayIterate.collectShort(objectArray, PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertEquals(this.getExpectedShortResults(), result);
-        Assert.assertSame("Target List not returned as result", target, result);
+        assertEquals(this.getExpectedShortResults(), result);
+        assertSame("Target List not returned as result", target, result);
     }
 
     private ShortArrayList getExpectedShortResults()
@@ -530,7 +537,7 @@ public class ArrayIterateTest
     public void collectWith()
     {
         Boolean[] objectArray = {true, false, null};
-        Assert.assertEquals(
+        assertEquals(
                 iList("true", "false", "null"),
                 ArrayIterate.collectWith(objectArray, Functions2.fromFunction(String::valueOf), null));
     }
@@ -541,11 +548,11 @@ public class ArrayIterateTest
         Integer[] objectArray = {1, 2, 3, 4};
         Function<Integer, Interval> function = Interval::zeroTo;
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(0, 1, 0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 4),
                 ArrayIterate.flatCollect(objectArray, function));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(5, 0, 1, 0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 4),
                 ArrayIterate.flatCollect(objectArray, function, FastList.newListWith(5)));
     }
@@ -555,10 +562,10 @@ public class ArrayIterateTest
     {
         MutableList<Integer> result = Lists.mutable.of();
         ArrayIterate.addAllTo(new Integer[]{1, 2, 3}, result);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), result);
+        assertEquals(FastList.newListWith(1, 2, 3), result);
 
         MutableList<Integer> returnedResult = ArrayIterate.addAllTo(new Integer[]{4, 5, 6}, result);
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), returnedResult);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5, 6), returnedResult);
     }
 
     @Test
@@ -569,22 +576,22 @@ public class ArrayIterateTest
         list.add(null);
         list.add(Boolean.FALSE);
         Object[] objectArray = list.toArray();
-        Assert.assertEquals(Boolean.TRUE, ArrayIterate.getFirst(objectArray));
-        Assert.assertEquals(Boolean.FALSE, ArrayIterate.getLast(objectArray));
+        assertEquals(Boolean.TRUE, ArrayIterate.getFirst(objectArray));
+        assertEquals(Boolean.FALSE, ArrayIterate.getLast(objectArray));
     }
 
     @Test
     public void getFirstAndLastOnEmpty()
     {
         Object[] objectArray = {};
-        Assert.assertNull(ArrayIterate.getFirst(objectArray));
-        Assert.assertNull(ArrayIterate.getLast(objectArray));
+        assertNull(ArrayIterate.getFirst(objectArray));
+        assertNull(ArrayIterate.getLast(objectArray));
     }
 
     @Test
     public void select()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(5, 4, 3, 2, 1),
                 ArrayIterate.select(INTEGER_ARRAY, Integer.class::isInstance));
     }
@@ -592,7 +599,7 @@ public class ArrayIterateTest
     @Test
     public void reject()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(5, 4, 3, 2, 1),
                 ArrayIterate.reject(INTEGER_ARRAY, String.class::isInstance));
     }
@@ -602,13 +609,13 @@ public class ArrayIterateTest
     {
         List<Integer> result = FastList.newList();
         ArrayIterate.distinct(new Integer[]{5, 3, 1, 5, 7, 1}, result);
-        Assert.assertEquals(FastList.newListWith(5, 3, 1, 7), result);
+        assertEquals(FastList.newListWith(5, 3, 1, 7), result);
         result.clear();
         ArrayIterate.distinct(INTEGER_ARRAY, result);
-        Assert.assertEquals(FastList.newListWith(INTEGER_ARRAY), result);
+        assertEquals(FastList.newListWith(INTEGER_ARRAY), result);
 
         MutableList<Integer> list = ArrayIterate.distinct(new Integer[]{5, 3, 1, 5, 7, 1});
-        Assert.assertEquals(FastList.newListWith(5, 3, 1, 7), list);
+        assertEquals(FastList.newListWith(5, 3, 1, 7), list);
     }
 
     @Test
@@ -616,21 +623,21 @@ public class ArrayIterateTest
     {
         String[] objectArray = {"A", "a", "b", "c", "B", "D", "e", "e", "E", "D"};
         MutableList<String> objectArrayExpected = FastList.newListWith("A", "b", "c", "D", "e");
-        Assert.assertEquals(ArrayIterate.distinct(objectArray, HashingStrategies.fromFunction(String::toLowerCase)), objectArrayExpected);
+        assertEquals(ArrayIterate.distinct(objectArray, HashingStrategies.fromFunction(String::toLowerCase)), objectArrayExpected);
     }
 
     @Test
     public void distinct_throws()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null, HashingStrategies.defaultStrategy()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null, FastList.newList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null, HashingStrategies.defaultStrategy()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.distinct(null, FastList.newList()));
     }
 
     @Test
     public void selectWith()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(5, 4, 3, 2, 1),
                 ArrayIterate.selectWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
     }
@@ -638,7 +645,7 @@ public class ArrayIterateTest
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 3, 5),
                 ArrayIterate.selectInstancesOf(new Number[]{1, 2.0, 3, 4.0, 5}, Integer.class));
     }
@@ -646,23 +653,23 @@ public class ArrayIterateTest
     @Test
     public void countOnNullOrEmptyArray()
     {
-        Assert.assertEquals(0, ArrayIterate.count(null, ignored1 -> true));
-        Assert.assertEquals(0, ArrayIterate.count(new Object[]{}, ignored -> true));
+        assertEquals(0, ArrayIterate.count(null, ignored1 -> true));
+        assertEquals(0, ArrayIterate.count(new Object[]{}, ignored -> true));
     }
 
     @Test
     public void count()
     {
-        Assert.assertEquals(3, ArrayIterate.count(INTEGER_ARRAY, Predicates.lessThan(4)));
+        assertEquals(3, ArrayIterate.count(INTEGER_ARRAY, Predicates.lessThan(4)));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(5, ArrayIterate.countWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, ArrayIterate.countWith(new Integer[]{}, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(1, ArrayIterate.countWith(new Object[]{"test", null, Integer.valueOf(2)}, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, ArrayIterate.countWith(null, Predicates2.instanceOf(), Integer.class));
+        assertEquals(5, ArrayIterate.countWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, ArrayIterate.countWith(new Integer[]{}, Predicates2.instanceOf(), Integer.class));
+        assertEquals(1, ArrayIterate.countWith(new Object[]{"test", null, Integer.valueOf(2)}, Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, ArrayIterate.countWith(null, Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
@@ -683,7 +690,7 @@ public class ArrayIterateTest
     @Test
     public void selectWithDifferentTargetCollection()
     {
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(5, 4, 3, 2, 1),
                 ArrayIterate.select(INTEGER_ARRAY, Integer.class::isInstance, new ArrayList<>()));
     }
@@ -736,96 +743,96 @@ public class ArrayIterateTest
     @Test
     public void contains()
     {
-        Assert.assertTrue(ArrayIterate.contains(INTEGER_ARRAY, 5));
-        Assert.assertFalse(ArrayIterate.contains(INTEGER_ARRAY, 6));
-        Assert.assertFalse(ArrayIterate.contains(INTEGER_ARRAY, null));
-        Assert.assertTrue(ArrayIterate.contains(new Object[]{null}, null));
+        assertTrue(ArrayIterate.contains(INTEGER_ARRAY, 5));
+        assertFalse(ArrayIterate.contains(INTEGER_ARRAY, 6));
+        assertFalse(ArrayIterate.contains(INTEGER_ARRAY, null));
+        assertTrue(ArrayIterate.contains(new Object[]{null}, null));
     }
 
     @Test
     public void containsInt()
     {
         int[] array = {1, 2, 3, 4, 5};
-        Assert.assertTrue(ArrayIterate.contains(array, 5));
-        Assert.assertFalse(ArrayIterate.contains(array, 6));
+        assertTrue(ArrayIterate.contains(array, 5));
+        assertFalse(ArrayIterate.contains(array, 6));
     }
 
     @Test
     public void containsLong()
     {
         long[] array = {1, 2, 3, 4, 5};
-        Assert.assertTrue(ArrayIterate.contains(array, 5));
-        Assert.assertFalse(ArrayIterate.contains(array, 6));
+        assertTrue(ArrayIterate.contains(array, 5));
+        assertFalse(ArrayIterate.contains(array, 6));
     }
 
     @Test
     public void containsDouble()
     {
         double[] array = {1, 2, 3, 4, 5};
-        Assert.assertTrue(ArrayIterate.contains(array, 5));
-        Assert.assertFalse(ArrayIterate.contains(array, 6));
+        assertTrue(ArrayIterate.contains(array, 5));
+        assertFalse(ArrayIterate.contains(array, 6));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(ArrayIterate.anySatisfy(INTEGER_ARRAY, Integer.class::isInstance));
-        Assert.assertFalse(ArrayIterate.anySatisfy(INTEGER_ARRAY, Predicates.isNull()));
+        assertTrue(ArrayIterate.anySatisfy(INTEGER_ARRAY, Integer.class::isInstance));
+        assertFalse(ArrayIterate.anySatisfy(INTEGER_ARRAY, Predicates.isNull()));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertTrue(ArrayIterate.anySatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
+        assertTrue(ArrayIterate.anySatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(ArrayIterate.allSatisfy(INTEGER_ARRAY, Integer.class::isInstance));
-        Assert.assertFalse(ArrayIterate.allSatisfy(INTEGER_ARRAY, Predicates.isNull()));
+        assertTrue(ArrayIterate.allSatisfy(INTEGER_ARRAY, Integer.class::isInstance));
+        assertFalse(ArrayIterate.allSatisfy(INTEGER_ARRAY, Predicates.isNull()));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertTrue(ArrayIterate.allSatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
+        assertTrue(ArrayIterate.allSatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertTrue(ArrayIterate.noneSatisfy(INTEGER_ARRAY, String.class::isInstance));
-        Assert.assertFalse(ArrayIterate.noneSatisfy(INTEGER_ARRAY, Predicates.notNull()));
+        assertTrue(ArrayIterate.noneSatisfy(INTEGER_ARRAY, String.class::isInstance));
+        assertFalse(ArrayIterate.noneSatisfy(INTEGER_ARRAY, Predicates.notNull()));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertTrue(ArrayIterate.noneSatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), String.class));
+        assertTrue(ArrayIterate.noneSatisfyWith(INTEGER_ARRAY, Predicates2.instanceOf(), String.class));
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertFalse(ArrayIterate.isEmpty(INTEGER_ARRAY));
-        Assert.assertTrue(ArrayIterate.isEmpty(new Object[]{}));
-        Assert.assertTrue(ArrayIterate.isEmpty(null));
+        assertFalse(ArrayIterate.isEmpty(INTEGER_ARRAY));
+        assertTrue(ArrayIterate.isEmpty(new Object[]{}));
+        assertTrue(ArrayIterate.isEmpty(null));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(ArrayIterate.notEmpty(new Integer[]{5, 4, 3, 2, 1}));
-        Assert.assertFalse(ArrayIterate.notEmpty(new Object[]{}));
-        Assert.assertFalse(ArrayIterate.notEmpty(null));
+        assertTrue(ArrayIterate.notEmpty(new Integer[]{5, 4, 3, 2, 1}));
+        assertFalse(ArrayIterate.notEmpty(new Object[]{}));
+        assertFalse(ArrayIterate.notEmpty(null));
     }
 
     @Test
     public void size()
     {
-        Assert.assertEquals(5, ArrayIterate.size(new Integer[]{5, 4, 3, 2, 1}));
-        Assert.assertEquals(0, ArrayIterate.size(null));
+        assertEquals(5, ArrayIterate.size(new Integer[]{5, 4, 3, 2, 1}));
+        assertEquals(0, ArrayIterate.size(null));
     }
 
     @Test
@@ -836,17 +843,17 @@ public class ArrayIterateTest
             MutableList<Integer> integers = Interval.oneTo(i).toList().shuffleThis();
             Integer[] array = integers.toArray(new Integer[i]);
             ArrayIterate.sort(array, array.length, null);
-            Assert.assertArrayEquals(array, Interval.oneTo(i).toArray());
+            assertArrayEquals(array, Interval.oneTo(i).toArray());
             ArrayIterate.sort(array, array.length, Comparator.reverseOrder());
             Integer[] expected = Interval.oneTo(i).reverseThis().toArray();
-            Assert.assertArrayEquals(array, expected);
+            assertArrayEquals(array, expected);
         }
     }
 
     @Test
     public void get()
     {
-        Assert.assertEquals(Integer.valueOf(1), new Integer[]{5, 4, 3, 2, 1}[4]);
+        assertEquals(Integer.valueOf(1), new Integer[]{5, 4, 3, 2, 1}[4]);
     }
 
     @Test
@@ -855,9 +862,9 @@ public class ArrayIterateTest
         FastList<String> target = FastList.newList();
         ArrayIterate.forEach(new String[]{"0", "1", "2", "3"}, 1, 2,
                 new FastListCollectProcedure<String, String>(Functions.getPassThru(), target));
-        Assert.assertEquals(Lists.mutable.of("1", "2"), target);
+        assertEquals(Lists.mutable.of("1", "2"), target);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class,
+        assertThrows(IndexOutOfBoundsException.class,
                 () -> ArrayIterate.forEach(new String[]{"0", "1", "2", "3"}, 1, 5,
                         new FastListCollectProcedure<String, String>(Functions.getPassThru(), target)));
     }
@@ -870,30 +877,30 @@ public class ArrayIterateTest
                 new String[]{"1", "2", "3"},
                 new String[]{"a", "b", "c"},
                 new MapPutProcedure<>(map));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(
                         "1", "a",
                         "2", "b",
                         "3", "c"),
                 map);
-        ArrayIterate.forEachInBoth(null, null, (argument1, argument2) -> Assert.fail());
+        ArrayIterate.forEachInBoth(null, null, (argument1, argument2) -> fail());
     }
 
     @Test(expected = RuntimeException.class)
     public void forEachInBothThrowsOnDifferentLengthArrays()
     {
-        ArrayIterate.forEachInBoth(new Integer[]{1, 2, 3}, new Integer[]{1, 2}, (argument1, argument2) -> Assert.fail());
+        ArrayIterate.forEachInBoth(new Integer[]{1, 2, 3}, new Integer[]{1, 2}, (argument1, argument2) -> fail());
     }
 
     @Test
     public void forEachWithIndex()
     {
         Integer[] objectArray = {1, 2, 3, 4};
-        ArrayIterate.forEachWithIndex(objectArray, (i, index) -> Assert.assertEquals(index, i - 1));
+        ArrayIterate.forEachWithIndex(objectArray, (i, index) -> assertEquals(index, i - 1));
 
         MutableList<Twin<Integer>> list = Lists.mutable.empty();
         ArrayIterate.forEachWithIndex(objectArray, (each, parameter) -> list.add(Tuples.twin(each, parameter)));
-        Assert.assertEquals(Lists.mutable.of(
+        assertEquals(Lists.mutable.of(
                 Tuples.twin(1, 0),
                 Tuples.twin(2, 1),
                 Tuples.twin(3, 2),
@@ -907,27 +914,27 @@ public class ArrayIterateTest
         Integer[] integers = {4, 4, 4, 4, 3, 3, 3, 2, 2, 1};
         StringBuilder builder = new StringBuilder();
         ArrayIterate.forEachWithIndex(integers, 5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("353627", builder.toString());
+        assertEquals("353627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         ArrayIterate.forEachWithIndex(integers, 5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("35", builder2.toString());
+        assertEquals("35", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         ArrayIterate.forEachWithIndex(integers, 0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("40414243343536272819", builder3.toString());
+        assertEquals("40414243343536272819", builder3.toString());
 
         StringBuilder builder4 = new StringBuilder();
         ArrayIterate.forEachWithIndex(integers, 7, 5, (each, index) -> builder4.append(each).append(index));
-        Assert.assertEquals("273635", builder4.toString());
+        assertEquals("273635", builder4.toString());
 
         StringBuilder builder5 = new StringBuilder();
         ArrayIterate.forEachWithIndex(integers, 9, 0, (each, index) -> builder5.append(each).append(index));
-        Assert.assertEquals("19282736353443424140", builder5.toString());
+        assertEquals("19282736353443424140", builder5.toString());
 
         MutableList<Integer> result = Lists.mutable.of();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayIterate.forEachWithIndex(integers, -1, 0, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayIterate.forEachWithIndex(integers, 0, -1, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayIterate.forEachWithIndex(integers, -1, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayIterate.forEachWithIndex(integers, 0, -1, new AddToList(result)));
     }
 
     private Integer[] createIntegerArray(int size)
@@ -943,47 +950,47 @@ public class ArrayIterateTest
     @Test
     public void detectOptional()
     {
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> ArrayIterate.detectOptional(null, Predicates.alwaysTrue()));
 
         Integer[] array = {1, 2, 3, 4, 5};
-        Assert.assertFalse(ArrayIterate.detectOptional(array, Predicates.alwaysFalse()).isPresent());
+        assertFalse(ArrayIterate.detectOptional(array, Predicates.alwaysFalse()).isPresent());
 
         Optional<Integer> resultOptional = ArrayIterate.detectOptional(array, IntegerPredicates.isEven());
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 2, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 2, resultOptional.get());
     }
 
     @Test
     public void detectWithOptional()
     {
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> ArrayIterate.detectWithOptional(null, Predicates2.alwaysTrue(), "param"));
 
         Integer[] array = {1, 2, 3, 4, 5};
-        Assert.assertFalse(ArrayIterate.detectWithOptional(array, Predicates2.alwaysFalse(), "param")
+        assertFalse(ArrayIterate.detectWithOptional(array, Predicates2.alwaysFalse(), "param")
                 .isPresent());
 
         Optional<Integer> resultOptional = ArrayIterate.detectWithOptional(array, Predicates2.greaterThan(), 2);
-        Assert.assertTrue(resultOptional.isPresent());
-        Assert.assertEquals((Integer) 3, resultOptional.get());
+        assertTrue(resultOptional.isPresent());
+        assertEquals((Integer) 3, resultOptional.get());
     }
 
     @Test
     public void detect()
     {
         Integer[] array = this.createIntegerArray(1);
-        Assert.assertEquals(Integer.valueOf(1), ArrayIterate.detect(array, integer -> integer == 1));
+        assertEquals(Integer.valueOf(1), ArrayIterate.detect(array, integer -> integer == 1));
     }
 
     @Test
     public void detectWith()
     {
         Integer[] array = this.createIntegerArray(1);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 ArrayIterate.detectWith(array, Predicates2.lessThan(), 2));
-        Assert.assertNull(
+        assertNull(
                 ArrayIterate.detectWith(new Integer[0], Predicates2.lessThan(), 2));
     }
 
@@ -991,18 +998,18 @@ public class ArrayIterateTest
     public void detectIfNone()
     {
         Integer[] array = this.createIntegerArray(1);
-        Assert.assertEquals(Integer.valueOf(7), ArrayIterate.detectIfNone(array, Integer.valueOf(2)::equals, 7));
-        Assert.assertEquals(Integer.valueOf(1), ArrayIterate.detectIfNone(array, Integer.valueOf(1)::equals, 7));
+        assertEquals(Integer.valueOf(7), ArrayIterate.detectIfNone(array, Integer.valueOf(2)::equals, 7));
+        assertEquals(Integer.valueOf(1), ArrayIterate.detectIfNone(array, Integer.valueOf(1)::equals, 7));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Integer[] array = this.createIntegerArray(1);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(7),
                 ArrayIterate.detectWithIfNone(array, Object::equals, 2, 7));
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1),
                 ArrayIterate.detectWithIfNone(array, Object::equals, 1, 7));
     }
@@ -1011,29 +1018,29 @@ public class ArrayIterateTest
     public void indexOf()
     {
         String[] array = {"1", "2", "3", null};
-        Assert.assertEquals(0, ArrayIterate.indexOf(array, "1"));
-        Assert.assertEquals(1, ArrayIterate.indexOf(array, "2"));
-        Assert.assertEquals(2, ArrayIterate.indexOf(array, "3"));
-        Assert.assertEquals(3, ArrayIterate.indexOf(array, null));
-        Assert.assertEquals(-1, ArrayIterate.indexOf(array, "4"));
+        assertEquals(0, ArrayIterate.indexOf(array, "1"));
+        assertEquals(1, ArrayIterate.indexOf(array, "2"));
+        assertEquals(2, ArrayIterate.indexOf(array, "3"));
+        assertEquals(3, ArrayIterate.indexOf(array, null));
+        assertEquals(-1, ArrayIterate.indexOf(array, "4"));
     }
 
     @Test
     public void indexOfPredicates()
     {
         String[] array = {"1", "2", "3", null};
-        Assert.assertEquals(0, ArrayIterate.detectIndex(array, String.class::isInstance));
-        Assert.assertEquals(3, ArrayIterate.detectIndex(array, Predicates.isNull()));
-        Assert.assertEquals(0, ArrayIterate.detectIndexWith(array, Predicates2.instanceOf(), String.class));
+        assertEquals(0, ArrayIterate.detectIndex(array, String.class::isInstance));
+        assertEquals(3, ArrayIterate.detectIndex(array, Predicates.isNull()));
+        assertEquals(0, ArrayIterate.detectIndexWith(array, Predicates2.instanceOf(), String.class));
     }
 
     @Test
     public void detectLastIndex()
     {
         Integer[] array = {1, 2, 2, 3, 3, 3, 4, 2};
-        Assert.assertEquals(7, ArrayIterate.detectLastIndex(array, integer -> integer == 2));
-        Assert.assertEquals(6, ArrayIterate.detectLastIndex(array, integer -> integer != 2));
-        Assert.assertEquals(-1, ArrayIterate.detectLastIndex(array, integer -> integer == 5));
+        assertEquals(7, ArrayIterate.detectLastIndex(array, integer -> integer == 2));
+        assertEquals(6, ArrayIterate.detectLastIndex(array, integer -> integer != 2));
+        assertEquals(-1, ArrayIterate.detectLastIndex(array, integer -> integer == 5));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1045,28 +1052,28 @@ public class ArrayIterateTest
     @Test
     public void take()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(0), 0),
                 ArrayIterate.take(Interval.zeroTo(0).toArray(), 0));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(5), 1),
                 ArrayIterate.take(Interval.zeroTo(5).toArray(), 1));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(5), 2),
                 ArrayIterate.take(Interval.zeroTo(5).toArray(), 2));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(0), 5),
                 ArrayIterate.take(Interval.zeroTo(0).toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(5), 5),
                 ArrayIterate.take(Interval.zeroTo(5).toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), 5),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), 15),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), 15));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), Integer.MAX_VALUE),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), Integer.MAX_VALUE));
     }
@@ -1080,22 +1087,22 @@ public class ArrayIterateTest
     @Test
     public void take_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(0), 0, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(0).toArray(), 0, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(0), 5, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(0).toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(5), 5, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(5).toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), 5, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), 15, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), 15, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.take(Interval.zeroTo(10), Integer.MAX_VALUE, FastList.newListWith(-1)),
                 ArrayIterate.take(Interval.zeroTo(10).toArray(), Integer.MAX_VALUE, FastList.newListWith(-1)));
     }
@@ -1109,25 +1116,25 @@ public class ArrayIterateTest
     @Test
     public void drop()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(5).toList(), 0),
                 ArrayIterate.drop(Interval.zeroTo(5).toList().toArray(), 0));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(5).toList(), 1),
                 ArrayIterate.drop(Interval.zeroTo(5).toList().toArray(), 1));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(0).toList(), 5),
                 ArrayIterate.drop(Interval.zeroTo(0).toList().toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(5), 5),
                 ArrayIterate.drop(Interval.zeroTo(5).toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), 5),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), 5));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), 15),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), 15));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), Integer.MAX_VALUE),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), Integer.MAX_VALUE));
     }
@@ -1141,19 +1148,19 @@ public class ArrayIterateTest
     @Test
     public void drop_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(0).toList(), 5, FastList.newListWith(-1)),
                 ArrayIterate.drop(Interval.zeroTo(0).toList().toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(5), 5, FastList.newListWith(-1)),
                 ArrayIterate.drop(Interval.zeroTo(5).toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), 5, FastList.newListWith(-1)),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), 5, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), 15, FastList.newListWith(-1)),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), 15, FastList.newListWith(-1)));
-        Assert.assertEquals(
+        assertEquals(
                 ListIterate.drop(Interval.zeroTo(10), Integer.MAX_VALUE, FastList.newListWith(-1)),
                 ArrayIterate.drop(Interval.zeroTo(10).toArray(), Integer.MAX_VALUE, FastList.newListWith(-1)));
     }
@@ -1176,7 +1183,7 @@ public class ArrayIterateTest
                         Boolean.FALSE, FastList.newListWith(2, 4, 6));
 
         Multimap<Boolean, Integer> multimap = ArrayIterate.groupBy(array, isOddFunction);
-        Assert.assertEquals(expected, multimap.toMap());
+        assertEquals(expected, multimap.toMap());
     }
 
     @Test
@@ -1189,13 +1196,13 @@ public class ArrayIterateTest
         }
 
         Multimap<Integer, Integer> actual = ArrayIterate.groupByEach(new Integer[]{1, 2, 3, 4, 5, 6, 7}, new NegativeIntervalFunction());
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3),
                 ArrayIterate.groupByUniqueKey(new Integer[]{1, 2, 3}, id -> id));
     }
@@ -1215,7 +1222,7 @@ public class ArrayIterateTest
     @Test
     public void groupByUniqueKey_target()
     {
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3),
                 ArrayIterate.groupByUniqueKey(new Integer[]{1, 2, 3}, id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
@@ -1241,24 +1248,24 @@ public class ArrayIterateTest
         Object[] nullsMinusOne = Collections.nCopies(array.length - 1, null).toArray();
 
         MutableList<Pair<String, Object>> pairs = ArrayIterate.zip(array, nulls);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(array),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(nulls),
                 pairs.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableList<Pair<String, Object>> pairsPlusOne = ArrayIterate.zip(array, nullsPlusOne);
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(array),
                 pairsPlusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(FastList.newListWith(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
+        assertEquals(FastList.newListWith(nulls), pairsPlusOne.collect((Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
 
         MutableList<Pair<String, Object>> pairsMinusOne = ArrayIterate.zip(array, nullsMinusOne);
-        Assert.assertEquals(array.length - 1, pairsMinusOne.size());
-        Assert.assertTrue(FastList.newListWith(array).containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
+        assertEquals(array.length - 1, pairsMinusOne.size());
+        assertTrue(FastList.newListWith(array).containsAll(pairsMinusOne.collect((Function<Pair<String, ?>, String>) Pair::getOne)));
 
-        Assert.assertEquals(
+        assertEquals(
                 ArrayIterate.zip(array, nulls),
                 ArrayIterate.zip(array, nulls, FastList.newList()));
     }
@@ -1269,14 +1276,14 @@ public class ArrayIterateTest
         String[] array = {"1", "2", "3", "4", "5", "6", "7"};
         MutableList<Pair<String, Integer>> pairs = ArrayIterate.zipWithIndex(array);
 
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith(array),
                 pairs.collect((Function<Pair<String, ?>, String>) Pair::getOne));
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(array.length - 1).toList(),
                 pairs.collect((Function<Pair<?, Integer>, Integer>) Pair::getTwo, FastList.newList()));
 
-        Assert.assertEquals(
+        assertEquals(
                 ArrayIterate.zipWithIndex(array),
                 ArrayIterate.zipWithIndex(array, FastList.newList()));
     }
@@ -1286,7 +1293,7 @@ public class ArrayIterateTest
     {
         String[] array = {"1", "2", "3", "4", "5", "6", "7"};
         RichIterable<RichIterable<String>> groups = ArrayIterate.chunk(array, 2);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Lists.immutable.with("1", "2"),
                         Lists.immutable.with("3", "4"),
@@ -1306,14 +1313,14 @@ public class ArrayIterateTest
     public void chunk_large_size()
     {
         String[] array = {"1", "2", "3", "4", "5", "6", "7"};
-        Assert.assertEquals(FastList.newListWith(array), ArrayIterate.chunk(array, 10).getFirst());
+        assertEquals(FastList.newListWith(array), ArrayIterate.chunk(array, 10).getFirst());
     }
 
     @Test
     public void makeString()
     {
         String[] array = {"1", "2", "3", "4", "5"};
-        Assert.assertEquals("1, 2, 3, 4, 5", ArrayIterate.makeString(array));
+        assertEquals("1, 2, 3, 4, 5", ArrayIterate.makeString(array));
     }
 
     @Test
@@ -1322,11 +1329,11 @@ public class ArrayIterateTest
         String[] array = {"1", "2", "3", "4", "5"};
         StringBuilder stringBuilder = new StringBuilder();
         ArrayIterate.appendString(array, stringBuilder);
-        Assert.assertEquals("1, 2, 3, 4, 5", stringBuilder.toString());
+        assertEquals("1, 2, 3, 4, 5", stringBuilder.toString());
 
         String[] emptyArray = {};
         ArrayIterate.appendString(emptyArray, stringBuilder);
-        Assert.assertEquals("1, 2, 3, 4, 5", stringBuilder.toString());
+        assertEquals("1, 2, 3, 4, 5", stringBuilder.toString());
     }
 
     @Test(expected = RuntimeException.class)
@@ -1357,7 +1364,7 @@ public class ArrayIterateTest
         Integer[] objects = {1, 2, 3};
         float expected = ArrayIterate.injectInto(0.0f, objects, AddFunction.INTEGER_TO_FLOAT);
         double actual = ArrayIterate.sumOfFloat(objects, Integer::floatValue);
-        Assert.assertEquals(expected, actual, 0.001);
+        assertEquals(expected, actual, 0.001);
     }
 
     @Test
@@ -1366,7 +1373,7 @@ public class ArrayIterateTest
         Integer[] objects = {1, 2, 3};
         double expected = ArrayIterate.injectInto(0.0d, objects, AddFunction.INTEGER_TO_DOUBLE);
         double actual = ArrayIterate.sumOfDouble(objects, Integer::doubleValue);
-        Assert.assertEquals(expected, actual, 0.001);
+        assertEquals(expected, actual, 0.001);
     }
 
     @Test
@@ -1375,7 +1382,7 @@ public class ArrayIterateTest
         Integer[] objects = {1, 2, 3};
         long expected = ArrayIterate.injectInto(0, objects, AddFunction.INTEGER_TO_LONG);
         long actual = ArrayIterate.sumOfInt(objects, integer -> integer);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -1384,21 +1391,21 @@ public class ArrayIterateTest
         Integer[] objects = {1, 2, 3};
         long expected = ArrayIterate.injectInto(0L, objects, AddFunction.INTEGER_TO_LONG);
         long actual = ArrayIterate.sumOfLong(objects, Integer::longValue);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void sumOfBigDecimal()
     {
         Integer[] objects = {1, 2, 3, 4, 5};
-        Assert.assertEquals(new BigDecimal(15), ArrayIterate.sumOfBigDecimal(objects, BigDecimal::new));
+        assertEquals(new BigDecimal(15), ArrayIterate.sumOfBigDecimal(objects, BigDecimal::new));
     }
 
     @Test
     public void sumOfBigInteger()
     {
         Integer[] objects = {1, 2, 3, 4, 5};
-        Assert.assertEquals(new BigInteger("15"), ArrayIterate.sumOfBigInteger(objects, integer -> new BigInteger(integer.toString())));
+        assertEquals(new BigInteger("15"), ArrayIterate.sumOfBigInteger(objects, integer -> new BigInteger(integer.toString())));
     }
 
     @Test
@@ -1406,8 +1413,8 @@ public class ArrayIterateTest
     {
         Integer[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         ObjectLongMap<Integer> result = ArrayIterate.sumByInt(values, i -> i % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -1415,8 +1422,8 @@ public class ArrayIterateTest
     {
         Integer[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         ObjectDoubleMap<Integer> result = ArrayIterate.sumByFloat(values, f -> f % 2, e -> e);
-        Assert.assertEquals(25.0f, result.get(1), 0.0);
-        Assert.assertEquals(30.0f, result.get(0), 0.0);
+        assertEquals(25.0f, result.get(1), 0.0);
+        assertEquals(30.0f, result.get(0), 0.0);
     }
 
     @Test
@@ -1424,8 +1431,8 @@ public class ArrayIterateTest
     {
         Integer[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         ObjectLongMap<Integer> result = ArrayIterate.sumByLong(values, l -> l % 2, e -> e);
-        Assert.assertEquals(25, result.get(1));
-        Assert.assertEquals(30, result.get(0));
+        assertEquals(25, result.get(1));
+        assertEquals(30, result.get(0));
     }
 
     @Test
@@ -1433,8 +1440,8 @@ public class ArrayIterateTest
     {
         Integer[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         ObjectDoubleMap<Integer> result = ArrayIterate.sumByDouble(values, d -> d % 2, e -> e);
-        Assert.assertEquals(25.0d, result.get(1), 0.0);
-        Assert.assertEquals(30.0d, result.get(0), 0.0);
+        assertEquals(25.0d, result.get(1), 0.0);
+        assertEquals(30.0d, result.get(0), 0.0);
     }
 
     @Test
@@ -1442,8 +1449,8 @@ public class ArrayIterateTest
     {
         Integer[] integers = {1, 2, 3, 4, 5};
         MutableMap<Integer, BigDecimal> result = ArrayIterate.sumByBigDecimal(integers, e -> e % 2, BigDecimal::new);
-        Assert.assertEquals(new BigDecimal(9), result.get(1));
-        Assert.assertEquals(new BigDecimal(6), result.get(0));
+        assertEquals(new BigDecimal(9), result.get(1));
+        assertEquals(new BigDecimal(6), result.get(0));
     }
 
     @Test
@@ -1451,8 +1458,8 @@ public class ArrayIterateTest
     {
         Integer[] integers = {1, 2, 3, 4, 5};
         MutableMap<Integer, BigInteger> result = ArrayIterate.sumByBigInteger(integers, e -> e % 2, i -> new BigInteger(i.toString()));
-        Assert.assertEquals(new BigInteger("9"), result.get(1));
-        Assert.assertEquals(new BigInteger("6"), result.get(0));
+        assertEquals(new BigInteger("9"), result.get(1));
+        assertEquals(new BigInteger("6"), result.get(0));
     }
 
     @Test
@@ -1467,8 +1474,8 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(7, 3), ArrayIterate.minBy(integerTwins, Functions.firstOfPair()));
-        Assert.assertEquals(Tuples.twin(9, 1), ArrayIterate.minBy(integerTwins, Functions.secondOfPair()));
+        assertEquals(Tuples.twin(7, 3), ArrayIterate.minBy(integerTwins, Functions.firstOfPair()));
+        assertEquals(Tuples.twin(9, 1), ArrayIterate.minBy(integerTwins, Functions.secondOfPair()));
     }
 
     @Test
@@ -1477,23 +1484,23 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(7, 3),
+        assertEquals(Tuples.twin(7, 3),
                 ArrayIterate.min(integerTwins, Comparators.byFunction(Functions.firstOfPair())));
 
-        Assert.assertEquals(Tuples.twin(9, 1),
+        assertEquals(Tuples.twin(9, 1),
                 ArrayIterate.min(integerTwins, Comparators.byFunction(Functions.secondOfPair())));
     }
 
     @Test
     public void min()
     {
-        Assert.assertEquals(Integer.valueOf(1), ArrayIterate.min(3, 1, 20));
+        assertEquals(Integer.valueOf(1), ArrayIterate.min(3, 1, 20));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals(Integer.valueOf(20), ArrayIterate.max(3, 1, 20));
+        assertEquals(Integer.valueOf(20), ArrayIterate.max(3, 1, 20));
     }
 
     @Test
@@ -1502,8 +1509,8 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(9, 1), ArrayIterate.maxBy(integerTwins, Functions.firstOfPair()));
-        Assert.assertEquals(Tuples.twin(7, 3), ArrayIterate.maxBy(integerTwins, Functions.secondOfPair()));
+        assertEquals(Tuples.twin(9, 1), ArrayIterate.maxBy(integerTwins, Functions.firstOfPair()));
+        assertEquals(Tuples.twin(7, 3), ArrayIterate.maxBy(integerTwins, Functions.secondOfPair()));
     }
 
     @Test
@@ -1512,10 +1519,10 @@ public class ArrayIterateTest
         Twin<Integer>[] integerTwins =
                 new Twin[] {Tuples.twin(9, 1), Tuples.twin(7, 3), Tuples.twin(8, 2)};
 
-        Assert.assertEquals(Tuples.twin(9, 1),
+        assertEquals(Tuples.twin(9, 1),
                 ArrayIterate.max(integerTwins, Comparators.byFunction(Functions.firstOfPair())));
 
-        Assert.assertEquals(Tuples.twin(7, 3),
+        assertEquals(Tuples.twin(7, 3),
                 ArrayIterate.max(integerTwins, Comparators.byFunction(Functions.secondOfPair())));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
@@ -58,11 +58,19 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link ArrayListIterate}.
@@ -86,7 +94,7 @@ public class ArrayListIterateTest
     public void testThisIsNotAnArrayList()
     {
         ThisIsNotAnArrayList<Integer> undertest = new ThisIsNotAnArrayList<>(FastList.newListWith(1, 2, 3));
-        Assert.assertNotSame(undertest.getClass(), ArrayList.class);
+        assertNotSame(undertest.getClass(), ArrayList.class);
     }
 
     @Test
@@ -123,12 +131,12 @@ public class ArrayListIterateTest
         ThisIsNotAnArrayList<Integer> notAnArrayList = this.newNotAnArrayList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         Integer[] target1 = {1, 2, null, null};
         ArrayListIterate.toArray(notAnArrayList, target1, 2, 2);
-        Assert.assertArrayEquals(target1, new Integer[]{1, 2, 1, 2});
+        assertArrayEquals(target1, new Integer[]{1, 2, 1, 2});
 
         ArrayList<Integer> arrayList = this.newArrayList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         Integer[] target2 = {1, 2, null, null};
         ArrayListIterate.toArray(arrayList, target2, 2, 2);
-        Assert.assertArrayEquals(target2, new Integer[]{1, 2, 1, 2});
+        assertArrayEquals(target2, new Integer[]{1, 2, 1, 2});
     }
 
     @Test
@@ -150,12 +158,12 @@ public class ArrayListIterateTest
         ArrayList<Integer> integers = Interval.oneTo(5).addAllTo(new ArrayList<>());
         ArrayList<Integer> results = new ArrayList<>();
         ArrayListIterate.forEach(integers, 0, 4, results::add);
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ArrayListIterate.forEach(integers, 4, 0, reverseResults::add);
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(integers, 4, -1, reverseResults::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(integers, -1, 4, reverseResults::add));
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(integers, 4, -1, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(integers, -1, 4, reverseResults::add));
     }
 
     @Test
@@ -165,12 +173,12 @@ public class ArrayListIterateTest
         ArrayList<Integer> optimisableList = Interval.oneTo(105).addAllTo(new ArrayList<>());
         ArrayList<Integer> results = new ArrayList<>();
         ArrayListIterate.forEach(optimisableList, 0, 4, results::add);
-        Assert.assertEquals(expected, results);
+        assertEquals(expected, results);
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ArrayListIterate.forEach(optimisableList, 4, 0, reverseResults::add);
-        Assert.assertEquals(ListIterate.reverseThis(expected), reverseResults);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(optimisableList, 104, -1, reverseResults::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(optimisableList, -1, 4, reverseResults::add));
+        assertEquals(ListIterate.reverseThis(expected), reverseResults);
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(optimisableList, 104, -1, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEach(optimisableList, -1, 4, reverseResults::add));
     }
 
     @Test
@@ -179,13 +187,13 @@ public class ArrayListIterateTest
         ArrayList<Integer> integers = Interval.oneTo(5).addAllTo(new ArrayList<>());
         ArrayList<Integer> results = new ArrayList<>();
         ArrayListIterate.forEachWithIndex(integers, 0, 4, ObjectIntProcedures.fromProcedure(results::add));
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ObjectIntProcedure<Integer> objectIntProcedure = ObjectIntProcedures.fromProcedure(reverseResults::add);
         ArrayListIterate.forEachWithIndex(integers, 4, 0, objectIntProcedure);
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
     }
 
     @Test
@@ -195,13 +203,13 @@ public class ArrayListIterateTest
         ArrayList<Integer> expected = Interval.oneTo(105).addAllTo(new ArrayList<>());
         ArrayList<Integer> results = new ArrayList<>();
         ArrayListIterate.forEachWithIndex(optimisableList, 0, 104, ObjectIntProcedures.fromProcedure(results::add));
-        Assert.assertEquals(expected, results);
+        assertEquals(expected, results);
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ObjectIntProcedure<Integer> objectIntProcedure = ObjectIntProcedures.fromProcedure(reverseResults::add);
         ArrayListIterate.forEachWithIndex(expected, 104, 0, objectIntProcedure);
-        Assert.assertEquals(ListIterate.reverseThis(expected), reverseResults);
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(expected, 104, -1, objectIntProcedure));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(expected, -1, 104, objectIntProcedure));
+        assertEquals(ListIterate.reverseThis(expected), reverseResults);
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(expected, 104, -1, objectIntProcedure));
+        assertThrows(IndexOutOfBoundsException.class, () -> ArrayListIterate.forEachWithIndex(expected, -1, 104, objectIntProcedure));
     }
 
     @Test
@@ -210,7 +218,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> integers = Interval.oneTo(5).addAllTo(new ArrayList<>());
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ArrayListIterate.reverseForEach(integers, reverseResults::add);
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
     }
 
     @Test
@@ -219,7 +227,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> integers = new ArrayList<>();
         MutableList<Integer> results = Lists.mutable.empty();
         ArrayListIterate.reverseForEach(integers, results::add);
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
     }
 
     @Test
@@ -228,21 +236,21 @@ public class ArrayListIterateTest
         ArrayList<Integer> integers = Interval.oneTo(5).addAllTo(new ArrayList<>());
         MutableList<Integer> reverseResults = Lists.mutable.empty();
         ArrayListIterate.reverseForEachWithIndex(integers, (each, index) -> reverseResults.add(each + index));
-        Assert.assertEquals(Lists.mutable.with(9, 7, 5, 3, 1), reverseResults);
+        assertEquals(Lists.mutable.with(9, 7, 5, 3, 1), reverseResults);
     }
 
     @Test
     public void reverseForEachWithIndex_emptyList()
     {
         ArrayList<Integer> integers = new ArrayList<>();
-        ArrayListIterate.reverseForEachWithIndex(integers, (each, index) -> Assert.fail("Should not be evaluated"));
+        ArrayListIterate.reverseForEachWithIndex(integers, (each, index) -> fail("Should not be evaluated"));
     }
 
     @Test
     public void injectInto()
     {
         ArrayList<Integer> list = this.newArrayList(1, 2, 3);
-        Assert.assertEquals(
+        assertEquals(
                 Integer.valueOf(1 + 1 + 2 + 3),
                 ArrayListIterate.injectInto(1, list, AddFunction.INTEGER));
     }
@@ -251,14 +259,14 @@ public class ArrayListIterateTest
     public void injectIntoOver100()
     {
         ArrayList<Integer> list = this.oneHundredAndOneOnes();
-        Assert.assertEquals(Integer.valueOf(102), ArrayListIterate.injectInto(1, list, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(102), ArrayListIterate.injectInto(1, list, AddFunction.INTEGER));
     }
 
     @Test
     public void injectIntoDoubleOver100()
     {
         ArrayList<Integer> list = this.oneHundredAndOneOnes();
-        Assert.assertEquals(102.0, ArrayListIterate.injectInto(1.0d, list, AddFunction.INTEGER_TO_DOUBLE), 0.0001);
+        assertEquals(102.0, ArrayListIterate.injectInto(1.0d, list, AddFunction.INTEGER_TO_DOUBLE), 0.0001);
     }
 
     private ArrayList<Integer> oneHundredAndOneOnes()
@@ -270,14 +278,14 @@ public class ArrayListIterateTest
     public void injectIntoIntegerOver100()
     {
         ArrayList<Integer> list = this.oneHundredAndOneOnes();
-        Assert.assertEquals(102, ArrayListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
+        assertEquals(102, ArrayListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
     }
 
     @Test
     public void injectIntoLongOver100()
     {
         ArrayList<Integer> list = this.oneHundredAndOneOnes();
-        Assert.assertEquals(102, ArrayListIterate.injectInto(1L, list, AddFunction.INTEGER_TO_LONG));
+        assertEquals(102, ArrayListIterate.injectInto(1L, list, AddFunction.INTEGER_TO_LONG));
     }
 
     @Test
@@ -287,7 +295,7 @@ public class ArrayListIterateTest
         list.add(1.0);
         list.add(2.0);
         list.add(3.0);
-        Assert.assertEquals(
+        assertEquals(
                 new Double(7.0),
                 ArrayListIterate.injectInto(1.0, list, AddFunction.DOUBLE));
     }
@@ -299,7 +307,7 @@ public class ArrayListIterateTest
         list.add(1.0f);
         list.add(2.0f);
         list.add(3.0f);
-        Assert.assertEquals(
+        assertEquals(
                 new Float(7.0f),
                 ArrayListIterate.injectInto(1.0f, list, AddFunction.FLOAT));
     }
@@ -311,7 +319,7 @@ public class ArrayListIterateTest
         list.add("1");
         list.add("2");
         list.add("3");
-        Assert.assertEquals("0123", ArrayListIterate.injectInto("0", list, AddFunction.STRING));
+        assertEquals("0123", ArrayListIterate.injectInto("0", list, AddFunction.STRING));
     }
 
     @Test
@@ -321,7 +329,7 @@ public class ArrayListIterateTest
         list.add("1");
         list.add("12");
         list.add("123");
-        Assert.assertEquals(Integer.valueOf(3), ArrayListIterate.injectInto(Integer.MIN_VALUE, list, MaxSizeFunction.STRING));
+        assertEquals(Integer.valueOf(3), ArrayListIterate.injectInto(Integer.MIN_VALUE, list, MaxSizeFunction.STRING));
     }
 
     @Test
@@ -331,7 +339,7 @@ public class ArrayListIterateTest
         list.add("1");
         list.add("12");
         list.add("123");
-        Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.injectInto(Integer.MAX_VALUE, list, MinSizeFunction.STRING));
+        assertEquals(Integer.valueOf(1), ArrayListIterate.injectInto(Integer.MAX_VALUE, list, MinSizeFunction.STRING));
     }
 
     @Test
@@ -359,7 +367,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableBooleanList actual = ArrayListIterate.collectBoolean(list, PrimitiveFunctions.integerIsPositive());
-        Assert.assertEquals(BooleanArrayList.newListWith(false, false, true), actual);
+        assertEquals(BooleanArrayList.newListWith(false, false, true), actual);
     }
 
     @Test
@@ -368,8 +376,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableBooleanList target = new BooleanArrayList();
         MutableBooleanList actual = ArrayListIterate.collectBoolean(list, PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(BooleanArrayList.newListWith(false, false, true), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(BooleanArrayList.newListWith(false, false, true), actual);
     }
 
     @Test
@@ -383,7 +391,7 @@ public class ArrayListIterateTest
         {
             expected.add(true);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -398,8 +406,8 @@ public class ArrayListIterateTest
         {
             expected.add(true);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -407,7 +415,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableByteList actual = ArrayListIterate.collectByte(list, PrimitiveFunctions.unboxIntegerToByte());
-        Assert.assertEquals(ByteArrayList.newListWith((byte) -1, (byte) 0, (byte) 4), actual);
+        assertEquals(ByteArrayList.newListWith((byte) -1, (byte) 0, (byte) 4), actual);
     }
 
     @Test
@@ -416,8 +424,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableByteList target = new ByteArrayList();
         MutableByteList actual = ArrayListIterate.collectByte(list, PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(ByteArrayList.newListWith((byte) -1, (byte) 0, (byte) 4), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(ByteArrayList.newListWith((byte) -1, (byte) 0, (byte) 4), actual);
     }
 
     @Test
@@ -430,7 +438,7 @@ public class ArrayListIterateTest
         {
             expected.add((byte) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -444,8 +452,8 @@ public class ArrayListIterateTest
         {
             expected.add((byte) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -453,7 +461,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableCharList actual = ArrayListIterate.collectChar(list, PrimitiveFunctions.unboxIntegerToChar());
-        Assert.assertEquals(CharArrayList.newListWith((char) -1, (char) 0, (char) 4), actual);
+        assertEquals(CharArrayList.newListWith((char) -1, (char) 0, (char) 4), actual);
     }
 
     @Test
@@ -462,8 +470,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableCharList target = new CharArrayList();
         MutableCharList actual = ArrayListIterate.collectChar(list, PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(CharArrayList.newListWith((char) -1, (char) 0, (char) 4), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(CharArrayList.newListWith((char) -1, (char) 0, (char) 4), actual);
     }
 
     @Test
@@ -476,7 +484,7 @@ public class ArrayListIterateTest
         {
             expected.add((char) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -490,8 +498,8 @@ public class ArrayListIterateTest
         {
             expected.add((char) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -499,7 +507,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableDoubleList actual = ArrayListIterate.collectDouble(list, PrimitiveFunctions.unboxIntegerToDouble());
-        Assert.assertEquals(DoubleArrayList.newListWith(-1.0d, 0.0d, 4.0d), actual);
+        assertEquals(DoubleArrayList.newListWith(-1.0d, 0.0d, 4.0d), actual);
     }
 
     @Test
@@ -508,8 +516,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableDoubleList target = new DoubleArrayList();
         MutableDoubleList actual = ArrayListIterate.collectDouble(list, PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(DoubleArrayList.newListWith(-1.0d, 0.0d, 4.0d), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(DoubleArrayList.newListWith(-1.0d, 0.0d, 4.0d), actual);
     }
 
     @Test
@@ -522,7 +530,7 @@ public class ArrayListIterateTest
         {
             expected.add((double) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -536,8 +544,8 @@ public class ArrayListIterateTest
         {
             expected.add((double) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -545,7 +553,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableFloatList actual = ArrayListIterate.collectFloat(list, PrimitiveFunctions.unboxIntegerToFloat());
-        Assert.assertEquals(FloatArrayList.newListWith(-1.0f, 0.0f, 4.0f), actual);
+        assertEquals(FloatArrayList.newListWith(-1.0f, 0.0f, 4.0f), actual);
     }
 
     @Test
@@ -554,8 +562,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableFloatList target = new FloatArrayList();
         MutableFloatList actual = ArrayListIterate.collectFloat(list, PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(FloatArrayList.newListWith(-1.0f, 0.0f, 4.0f), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(FloatArrayList.newListWith(-1.0f, 0.0f, 4.0f), actual);
     }
 
     @Test
@@ -568,7 +576,7 @@ public class ArrayListIterateTest
         {
             expected.add((float) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -582,8 +590,8 @@ public class ArrayListIterateTest
         {
             expected.add((float) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -591,7 +599,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableIntList actual = ArrayListIterate.collectInt(list, PrimitiveFunctions.unboxIntegerToInt());
-        Assert.assertEquals(IntArrayList.newListWith(-1, 0, 4), actual);
+        assertEquals(IntArrayList.newListWith(-1, 0, 4), actual);
     }
 
     @Test
@@ -600,8 +608,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableIntList target = new IntArrayList();
         MutableIntList actual = ArrayListIterate.collectInt(list, PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(IntArrayList.newListWith(-1, 0, 4), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(IntArrayList.newListWith(-1, 0, 4), actual);
     }
 
     @Test
@@ -614,7 +622,7 @@ public class ArrayListIterateTest
         {
             expected.add(i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -628,8 +636,8 @@ public class ArrayListIterateTest
         {
             expected.add(i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -637,7 +645,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableLongList actual = ArrayListIterate.collectLong(list, PrimitiveFunctions.unboxIntegerToLong());
-        Assert.assertEquals(LongArrayList.newListWith(-1L, 0L, 4L), actual);
+        assertEquals(LongArrayList.newListWith(-1L, 0L, 4L), actual);
     }
 
     @Test
@@ -646,8 +654,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableLongList target = new LongArrayList();
         MutableLongList actual = ArrayListIterate.collectLong(list, PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(LongArrayList.newListWith(-1L, 0L, 4L), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(LongArrayList.newListWith(-1L, 0L, 4L), actual);
     }
 
     @Test
@@ -660,7 +668,7 @@ public class ArrayListIterateTest
         {
             expected.add((long) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -674,8 +682,8 @@ public class ArrayListIterateTest
         {
             expected.add((long) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     @Test
@@ -683,7 +691,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.createIntegerList();
         MutableShortList actual = ArrayListIterate.collectShort(list, PrimitiveFunctions.unboxIntegerToShort());
-        Assert.assertEquals(ShortArrayList.newListWith((short) -1, (short) 0, (short) 4), actual);
+        assertEquals(ShortArrayList.newListWith((short) -1, (short) 0, (short) 4), actual);
     }
 
     @Test
@@ -692,8 +700,8 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableShortList target = new ShortArrayList();
         MutableShortList actual = ArrayListIterate.collectShort(list, PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertSame("Target list sent as parameter not returned", target, actual);
-        Assert.assertEquals(ShortArrayList.newListWith((short) -1, (short) 0, (short) 4), actual);
+        assertSame("Target list sent as parameter not returned", target, actual);
+        assertEquals(ShortArrayList.newListWith((short) -1, (short) 0, (short) 4), actual);
     }
 
     @Test
@@ -706,7 +714,7 @@ public class ArrayListIterateTest
         {
             expected.add((short) i);
         }
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -720,8 +728,8 @@ public class ArrayListIterateTest
         {
             expected.add((short) i);
         }
-        Assert.assertEquals(expected, actual);
-        Assert.assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertEquals(expected, actual);
+        assertSame("Target sent as parameter was not returned as result", target, actual);
     }
 
     private ArrayList<Integer> createIntegerList()
@@ -757,7 +765,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = this.getIntegerList();
         Iterate.sortThis(list);
-        ArrayListIterate.forEachWithIndex(list, (object, index) -> Assert.assertEquals(index, object - 1));
+        ArrayListIterate.forEachWithIndex(list, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -765,7 +773,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
         Iterate.sortThis(list);
-        ArrayListIterate.forEachWithIndex(list, (object, index) -> Assert.assertEquals(index, object - 1));
+        ArrayListIterate.forEachWithIndex(list, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -822,73 +830,73 @@ public class ArrayListIterateTest
         ArrayList<String> list2 = new ArrayList<>(mList("a", "b"));
         ArrayListIterate.forEachInBoth(list1, list2, (argument1, argument2) -> list.add(Tuples.twin(argument1, argument2)));
 
-        Assert.assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
+        assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
     }
 
     @Test
     public void detect()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detect(list, Integer.valueOf(1)::equals));
+        assertEquals(Integer.valueOf(1), ArrayListIterate.detect(list, Integer.valueOf(1)::equals));
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         ArrayList<Integer> list2 =
                 this.newArrayList(1, new Integer(2), 2);  // test relies on having a unique instance of "2"
-        Assert.assertSame(list2.get(1), ArrayListIterate.detect(list2, Integer.valueOf(2)::equals));
+        assertSame(list2.get(1), ArrayListIterate.detect(list2, Integer.valueOf(2)::equals));
     }
 
     @Test
     public void detectOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detect(list, Integer.valueOf(1)::equals));
+        assertEquals(Integer.valueOf(1), ArrayListIterate.detect(list, Integer.valueOf(1)::equals));
     }
 
     @Test
     public void detectWith()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detectWith(list, Object::equals, 1));
+        assertEquals(Integer.valueOf(1), ArrayListIterate.detectWith(list, Object::equals, 1));
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         ArrayList<Integer> list2 =
                 this.newArrayList(1, new Integer(2), 2);  // test relies on having a unique instance of "2"
-        Assert.assertSame(list2.get(1), ArrayListIterate.detectWith(list2, Object::equals, 2));
+        assertSame(list2.get(1), ArrayListIterate.detectWith(list2, Object::equals, 2));
     }
 
     @Test
     public void detectWithOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertEquals(Integer.valueOf(1), ArrayListIterate.detectWith(list, Object::equals, 1));
+        assertEquals(Integer.valueOf(1), ArrayListIterate.detectWith(list, Object::equals, 1));
     }
 
     @Test
     public void detectIfNone()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(7), ArrayListIterate.detectIfNone(list, Integer.valueOf(6)::equals, 7));
-        Assert.assertEquals(Integer.valueOf(2), ArrayListIterate.detectIfNone(list, Integer.valueOf(2)::equals, 7));
+        assertEquals(Integer.valueOf(7), ArrayListIterate.detectIfNone(list, Integer.valueOf(6)::equals, 7));
+        assertEquals(Integer.valueOf(2), ArrayListIterate.detectIfNone(list, Integer.valueOf(2)::equals, 7));
     }
 
     @Test
     public void detectIfNoneOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertNull(ArrayListIterate.detectIfNone(list, Integer.valueOf(102)::equals, null));
+        assertNull(ArrayListIterate.detectIfNone(list, Integer.valueOf(102)::equals, null));
     }
 
     @Test
     public void detectWithIfNone()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(7), ArrayListIterate.detectWithIfNone(list, Object::equals, 6, 7));
-        Assert.assertEquals(Integer.valueOf(2), ArrayListIterate.detectWithIfNone(list, Object::equals, 2, 7));
+        assertEquals(Integer.valueOf(7), ArrayListIterate.detectWithIfNone(list, Object::equals, 6, 7));
+        assertEquals(Integer.valueOf(2), ArrayListIterate.detectWithIfNone(list, Object::equals, 2, 7));
     }
 
     @Test
     public void detectWithIfNoneOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertNull(ArrayListIterate.detectWithIfNone(list, Object::equals, 102, null));
+        assertNull(ArrayListIterate.detectWithIfNone(list, Object::equals, 102, null));
     }
 
     @Test
@@ -949,13 +957,13 @@ public class ArrayListIterateTest
         ArrayList<Integer> target = new ArrayList<>();
         ArrayListIterate.distinct(list, target);
         Verify.assertListsEqual(FastList.newListWith(9, 4, 7, 5, 6, 2), target);
-        Assert.assertEquals(FastList.newListWith(9, 4, 7, 7, 5, 6, 2, 4), list);
+        assertEquals(FastList.newListWith(9, 4, 7, 7, 5, 6, 2, 4), list);
 
         ArrayList<Integer> list2 = new ArrayList<>(Interval.oneTo(103));
         list2.add(103);
         ArrayList<Integer> target2 = new ArrayList<>();
         List<Integer> result2 = ArrayListIterate.distinct(list2, target2);
-        Assert.assertEquals(Interval.fromTo(1, 103), result2);
+        assertEquals(Interval.fromTo(1, 103), result2);
     }
 
     @Test
@@ -964,12 +972,12 @@ public class ArrayListIterateTest
         ArrayList<String> list = new ArrayList<>();
         list.addAll(FastList.newListWith("A", "a", "b", "c", "B", "D", "e", "e", "E", "D"));
         list = ArrayListIterate.distinct(list, HashingStrategies.fromFunction(String::toLowerCase));
-        Assert.assertEquals(FastList.newListWith("A", "b", "c", "D", "e"), list);
+        assertEquals(FastList.newListWith("A", "b", "c", "D", "e"), list);
 
         ArrayList<Integer> list2 = new ArrayList<>(Interval.oneTo(103));
         list2.add(103);
         List<Integer> result2 = ArrayListIterate.distinct(list2, HashingStrategies.fromFunction(String::valueOf));
-        Assert.assertEquals(Interval.fromTo(1, 103), result2);
+        assertEquals(Interval.fromTo(1, 103), result2);
     }
 
     @Test
@@ -978,7 +986,7 @@ public class ArrayListIterateTest
         ArrayList<Number> list = new ArrayList<>(Interval.oneTo(101));
         list.add(102.0);
         MutableList<Double> results = ArrayListIterate.selectInstancesOf(list, Double.class);
-        Assert.assertEquals(iList(102.0), results);
+        assertEquals(iList(102.0), results);
     }
 
     public static final class CollectionCreator
@@ -1008,7 +1016,7 @@ public class ArrayListIterateTest
 
         MutableList<Integer> target1 = Lists.mutable.empty();
         MutableList<Integer> results2 = ArrayListIterate.flatCollect(list, CollectionCreator::getCollection, target1);
-        Assert.assertSame(results2, target1);
+        assertSame(results2, target1);
 
         Verify.assertListsEqual(FastList.newListWith(1, 1, 2, 2), results2);
     }
@@ -1054,13 +1062,13 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> smallList = new ArrayList<>(Interval.oneTo(99));
         PartitionMutableList<Integer> smallPartition = ArrayListIterate.partition(smallList, Predicates.in(Interval.oneToBy(99, 2)));
-        Assert.assertEquals(Interval.oneToBy(99, 2), smallPartition.getSelected());
-        Assert.assertEquals(Interval.fromToBy(2, 98, 2), smallPartition.getRejected());
+        assertEquals(Interval.oneToBy(99, 2), smallPartition.getSelected());
+        assertEquals(Interval.fromToBy(2, 98, 2), smallPartition.getRejected());
 
         ArrayList<Integer> bigList = new ArrayList<>(Interval.oneTo(101));
         PartitionMutableList<Integer> bigPartition = ArrayListIterate.partition(bigList, Predicates.in(Interval.oneToBy(101, 2)));
-        Assert.assertEquals(Interval.oneToBy(101, 2), bigPartition.getSelected());
-        Assert.assertEquals(Interval.fromToBy(2, 100, 2), bigPartition.getRejected());
+        assertEquals(Interval.oneToBy(101, 2), bigPartition.getSelected());
+        assertEquals(Interval.fromToBy(2, 100, 2), bigPartition.getRejected());
     }
 
     @Test
@@ -1068,109 +1076,109 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> smallList = new ArrayList<>(Interval.oneTo(99));
         PartitionMutableList<Integer> smallPartition = ArrayListIterate.partitionWith(smallList, Predicates2.in(), Interval.oneToBy(99, 2));
-        Assert.assertEquals(Interval.oneToBy(99, 2), smallPartition.getSelected());
-        Assert.assertEquals(Interval.fromToBy(2, 98, 2), smallPartition.getRejected());
+        assertEquals(Interval.oneToBy(99, 2), smallPartition.getSelected());
+        assertEquals(Interval.fromToBy(2, 98, 2), smallPartition.getRejected());
 
         ArrayList<Integer> bigList = new ArrayList<>(Interval.oneTo(101));
         PartitionMutableList<Integer> bigPartition = ArrayListIterate.partitionWith(bigList, Predicates2.in(), Interval.oneToBy(101, 2));
-        Assert.assertEquals(Interval.oneToBy(101, 2), bigPartition.getSelected());
-        Assert.assertEquals(Interval.fromToBy(2, 100, 2), bigPartition.getRejected());
+        assertEquals(Interval.oneToBy(101, 2), bigPartition.getSelected());
+        assertEquals(Interval.fromToBy(2, 100, 2), bigPartition.getRejected());
     }
 
     @Test
     public void anySatisfyWith()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
+        assertTrue(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertFalse(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
     public void anySatisfy()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(ArrayListIterate.anySatisfy(list, Integer.class::isInstance));
-        Assert.assertFalse(ArrayListIterate.anySatisfy(list, Double.class::isInstance));
+        assertTrue(ArrayListIterate.anySatisfy(list, Integer.class::isInstance));
+        assertFalse(ArrayListIterate.anySatisfy(list, Double.class::isInstance));
     }
 
     @Test
     public void anySatisfyWithOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertTrue(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
+        assertTrue(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertFalse(ArrayListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
     public void anySatisfyOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertTrue(ArrayListIterate.anySatisfy(list, Integer.class::isInstance));
-        Assert.assertFalse(ArrayListIterate.anySatisfy(list, Double.class::isInstance));
+        assertTrue(ArrayListIterate.anySatisfy(list, Integer.class::isInstance));
+        assertFalse(ArrayListIterate.anySatisfy(list, Double.class::isInstance));
     }
 
     @Test
     public void allSatisfyWith()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(ArrayListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(ArrayListIterate.allSatisfyWith(list, Predicates2.greaterThan(), 2));
+        assertTrue(ArrayListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertFalse(ArrayListIterate.allSatisfyWith(list, Predicates2.greaterThan(), 2));
     }
 
     @Test
     public void allSatisfy()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(ArrayListIterate.allSatisfy(list, Integer.class::isInstance));
-        Assert.assertFalse(ArrayListIterate.allSatisfy(list, Predicates.greaterThan(2)));
+        assertTrue(ArrayListIterate.allSatisfy(list, Integer.class::isInstance));
+        assertFalse(ArrayListIterate.allSatisfy(list, Predicates.greaterThan(2)));
     }
 
     @Test
     public void allSatisfyWithOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertTrue(ArrayListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(ArrayListIterate.allSatisfyWith(list, Predicates2.greaterThan(), 2));
+        assertTrue(ArrayListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertFalse(ArrayListIterate.allSatisfyWith(list, Predicates2.greaterThan(), 2));
     }
 
     @Test
     public void allSatisfyOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertTrue(ArrayListIterate.allSatisfy(list, Integer.class::isInstance));
-        Assert.assertFalse(ArrayListIterate.allSatisfy(list, Predicates.greaterThan(2)));
+        assertTrue(ArrayListIterate.allSatisfy(list, Integer.class::isInstance));
+        assertFalse(ArrayListIterate.allSatisfy(list, Predicates.greaterThan(2)));
     }
 
     @Test
     public void noneSatisfyOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertFalse(ArrayListIterate.noneSatisfy(list, Integer.class::isInstance));
-        Assert.assertTrue(ArrayListIterate.noneSatisfy(list, Predicates.greaterThan(150)));
+        assertFalse(ArrayListIterate.noneSatisfy(list, Integer.class::isInstance));
+        assertTrue(ArrayListIterate.noneSatisfy(list, Predicates.greaterThan(150)));
     }
 
     @Test
     public void noneSatisfyWithOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertFalse(ArrayListIterate.noneSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertTrue(ArrayListIterate.noneSatisfyWith(list, Predicates2.greaterThan(), 150));
+        assertFalse(ArrayListIterate.noneSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertTrue(ArrayListIterate.noneSatisfyWith(list, Predicates2.greaterThan(), 150));
     }
 
     @Test
     public void countWith()
     {
         ArrayList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(5, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Double.class));
+        assertEquals(5, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
     public void countWithOver100()
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
-        Assert.assertEquals(101, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Double.class));
+        assertEquals(101, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, ArrayListIterate.countWith(list, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
@@ -1178,7 +1186,7 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> list = new ArrayList<>(Interval.oneTo(101));
         ArrayList<Class<?>> result = ArrayListIterate.collectIf(list, Integer.valueOf(101)::equals, Object::getClass);
-        Assert.assertEquals(FastList.newListWith(Integer.class), result);
+        assertEquals(FastList.newListWith(Integer.class), result);
     }
 
     @Test
@@ -1188,7 +1196,7 @@ public class ArrayListIterateTest
         ArrayList<String> result = ArrayListIterate.collectWith(list, (argument1, argument2) -> argument1.equals(argument2) ? "101" : null, 101);
         Verify.assertSize(101, result);
         Verify.assertContainsAll(result, null, "101");
-        Assert.assertEquals(100, Iterate.count(result, Predicates.isNull()));
+        assertEquals(100, Iterate.count(result, Predicates.isNull()));
     }
 
     @Test
@@ -1197,11 +1205,11 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = new ArrayList<>(Interval.toReverseList(1, 101));
         list.add(3);
         list.add(2);
-        Assert.assertEquals(100, ArrayListIterate.detectIndex(list, Integer.valueOf(1)::equals));
-        Assert.assertEquals(99, ArrayListIterate.detectIndex(list, Integer.valueOf(2)::equals));
-        Assert.assertEquals(98, ArrayListIterate.detectIndex(list, Integer.valueOf(3)::equals));
-        Assert.assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(101)::equals));
-        Assert.assertEquals(-1, Iterate.detectIndex(list, Integer.valueOf(200)::equals));
+        assertEquals(100, ArrayListIterate.detectIndex(list, Integer.valueOf(1)::equals));
+        assertEquals(99, ArrayListIterate.detectIndex(list, Integer.valueOf(2)::equals));
+        assertEquals(98, ArrayListIterate.detectIndex(list, Integer.valueOf(3)::equals));
+        assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(101)::equals));
+        assertEquals(-1, Iterate.detectIndex(list, Integer.valueOf(200)::equals));
     }
 
     @Test
@@ -1210,11 +1218,11 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = new ArrayList<>(Interval.toReverseList(1, 5));
         list.add(3);
         list.add(2);
-        Assert.assertEquals(4, ArrayListIterate.detectIndex(list, Integer.valueOf(1)::equals));
-        Assert.assertEquals(3, ArrayListIterate.detectIndex(list, Integer.valueOf(2)::equals));
-        Assert.assertEquals(2, ArrayListIterate.detectIndex(list, Integer.valueOf(3)::equals));
-        Assert.assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(5)::equals));
-        Assert.assertEquals(-1, Iterate.detectIndex(list, Integer.valueOf(10)::equals));
+        assertEquals(4, ArrayListIterate.detectIndex(list, Integer.valueOf(1)::equals));
+        assertEquals(3, ArrayListIterate.detectIndex(list, Integer.valueOf(2)::equals));
+        assertEquals(2, ArrayListIterate.detectIndex(list, Integer.valueOf(3)::equals));
+        assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(5)::equals));
+        assertEquals(-1, Iterate.detectIndex(list, Integer.valueOf(10)::equals));
     }
 
     @Test
@@ -1223,11 +1231,11 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = new ArrayList<>(Interval.toReverseList(1, 101));
         list.add(3);
         list.add(2);
-        Assert.assertEquals(100, ArrayListIterate.detectLastIndex(list, Integer.valueOf(1)::equals));
-        Assert.assertEquals(102, ArrayListIterate.detectLastIndex(list, Integer.valueOf(2)::equals));
-        Assert.assertEquals(101, ArrayListIterate.detectLastIndex(list, Integer.valueOf(3)::equals));
-        Assert.assertEquals(0, ArrayListIterate.detectLastIndex(list, Integer.valueOf(101)::equals));
-        Assert.assertEquals(-1, ArrayListIterate.detectLastIndex(list, Integer.valueOf(200)::equals));
+        assertEquals(100, ArrayListIterate.detectLastIndex(list, Integer.valueOf(1)::equals));
+        assertEquals(102, ArrayListIterate.detectLastIndex(list, Integer.valueOf(2)::equals));
+        assertEquals(101, ArrayListIterate.detectLastIndex(list, Integer.valueOf(3)::equals));
+        assertEquals(0, ArrayListIterate.detectLastIndex(list, Integer.valueOf(101)::equals));
+        assertEquals(-1, ArrayListIterate.detectLastIndex(list, Integer.valueOf(200)::equals));
     }
 
     @Test
@@ -1236,29 +1244,29 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = new ArrayList<>(Interval.toReverseList(1, 5));
         list.add(3);
         list.add(2);
-        Assert.assertEquals(4, ArrayListIterate.detectLastIndex(list, Integer.valueOf(1)::equals));
-        Assert.assertEquals(6, ArrayListIterate.detectLastIndex(list, Integer.valueOf(2)::equals));
-        Assert.assertEquals(5, ArrayListIterate.detectLastIndex(list, Integer.valueOf(3)::equals));
-        Assert.assertEquals(0, ArrayListIterate.detectLastIndex(list, Integer.valueOf(5)::equals));
-        Assert.assertEquals(-1, ArrayListIterate.detectLastIndex(list, Integer.valueOf(10)::equals));
+        assertEquals(4, ArrayListIterate.detectLastIndex(list, Integer.valueOf(1)::equals));
+        assertEquals(6, ArrayListIterate.detectLastIndex(list, Integer.valueOf(2)::equals));
+        assertEquals(5, ArrayListIterate.detectLastIndex(list, Integer.valueOf(3)::equals));
+        assertEquals(0, ArrayListIterate.detectLastIndex(list, Integer.valueOf(5)::equals));
+        assertEquals(-1, ArrayListIterate.detectLastIndex(list, Integer.valueOf(10)::equals));
     }
 
     @Test
     public void detectIndexWithOver100()
     {
         List<Integer> list = new ArrayList<>(Interval.toReverseList(1, 101));
-        Assert.assertEquals(100, Iterate.detectIndexWith(list, Object::equals, 1));
-        Assert.assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 101));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(list, Object::equals, 200));
+        assertEquals(100, Iterate.detectIndexWith(list, Object::equals, 1));
+        assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 101));
+        assertEquals(-1, Iterate.detectIndexWith(list, Object::equals, 200));
     }
 
     @Test
     public void detectIndexWithSmallList()
     {
         List<Integer> list = new ArrayList<>(Interval.toReverseList(1, 5));
-        Assert.assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
-        Assert.assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(list, Object::equals, 10));
+        assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
+        assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
+        assertEquals(-1, Iterate.detectIndexWith(list, Object::equals, 10));
     }
 
     @Test
@@ -1268,7 +1276,7 @@ public class ArrayListIterateTest
         Integer parameter = 2;
         Function3<Sum, Integer, Integer, Sum> function = (sum, element, withValue) -> sum.add((element.intValue() - element.intValue()) * withValue.intValue());
         Sum sumOfDoubledValues = ArrayListIterate.injectIntoWith(result, this.getOver100IntegerList(), function, parameter);
-        Assert.assertEquals(0, sumOfDoubledValues.getValue().intValue());
+        assertEquals(0, sumOfDoubledValues.getValue().intValue());
     }
 
     @Test
@@ -1413,15 +1421,15 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(100));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(1, 100),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(1000)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(0)));
     }
@@ -1507,15 +1515,15 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(100));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(4, 100),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(1000)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(1, 100),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(0)));
     }
@@ -1526,16 +1534,16 @@ public class ArrayListIterateTest
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(100));
 
         PartitionMutableList<Integer> partition1 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(4));
-        Assert.assertEquals(iList(1, 2, 3), partition1.getSelected());
-        Assert.assertEquals(Interval.fromTo(4, 100), partition1.getRejected());
+        assertEquals(iList(1, 2, 3), partition1.getSelected());
+        assertEquals(Interval.fromTo(4, 100), partition1.getRejected());
 
         PartitionMutableList<Integer> partition2 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(0));
-        Assert.assertEquals(iList(), partition2.getSelected());
-        Assert.assertEquals(Interval.fromTo(1, 100), partition2.getRejected());
+        assertEquals(iList(), partition2.getSelected());
+        assertEquals(Interval.fromTo(1, 100), partition2.getRejected());
 
         PartitionMutableList<Integer> partition3 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(1000));
-        Assert.assertEquals(Interval.fromTo(1, 100), partition3.getSelected());
-        Assert.assertEquals(iList(), partition3.getRejected());
+        assertEquals(Interval.fromTo(1, 100), partition3.getSelected());
+        assertEquals(iList(), partition3.getRejected());
     }
 
     @Test
@@ -1543,15 +1551,15 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(101));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(1, 2, 3),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(1, 101),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(1000)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 ArrayListIterate.takeWhile(arrayList, Predicates.lessThan(0)));
     }
@@ -1561,15 +1569,15 @@ public class ArrayListIterateTest
     {
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(101));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(4, 101),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(4)));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList(),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(1000)));
 
-        Assert.assertEquals(
+        assertEquals(
                 Interval.fromTo(1, 101),
                 ArrayListIterate.dropWhile(arrayList, Predicates.lessThan(0)));
     }
@@ -1580,16 +1588,16 @@ public class ArrayListIterateTest
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(101));
 
         PartitionMutableList<Integer> partition1 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(4));
-        Assert.assertEquals(iList(1, 2, 3), partition1.getSelected());
-        Assert.assertEquals(Interval.fromTo(4, 101), partition1.getRejected());
+        assertEquals(iList(1, 2, 3), partition1.getSelected());
+        assertEquals(Interval.fromTo(4, 101), partition1.getRejected());
 
         PartitionMutableList<Integer> partition2 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(0));
-        Assert.assertEquals(iList(), partition2.getSelected());
-        Assert.assertEquals(Interval.fromTo(1, 101), partition2.getRejected());
+        assertEquals(iList(), partition2.getSelected());
+        assertEquals(Interval.fromTo(1, 101), partition2.getRejected());
 
         PartitionMutableList<Integer> partition3 = ArrayListIterate.partitionWhile(arrayList, Predicates.lessThan(1000));
-        Assert.assertEquals(Interval.fromTo(1, 101), partition3.getSelected());
-        Assert.assertEquals(iList(), partition3.getRejected());
+        assertEquals(Interval.fromTo(1, 101), partition3.getSelected());
+        assertEquals(iList(), partition3.getRejected());
     }
 
     private ArrayList<Integer> newArrayList(Integer... items)
@@ -1608,7 +1616,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = new ArrayList<>(Interval.toReverseList(1, 105));
         MutableMultimap<String, Integer> target = new FastListMultimap<>();
         MutableMultimap<String, Integer> result = ArrayListIterate.groupBy(list, String::valueOf, target);
-        Assert.assertEquals(result.get("105"), FastList.newListWith(105));
+        assertEquals(result.get("105"), FastList.newListWith(105));
     }
 
     @Test
@@ -1618,19 +1626,19 @@ public class ArrayListIterateTest
         Function<Integer, Iterable<String>> function = object -> FastList.newListWith(object.toString(), object.toString() + '*');
         MutableMultimap<String, Integer> target = new FastListMultimap<>();
         MutableMultimap<String, Integer> result = ArrayListIterate.groupByEach(list, function, target);
-        Assert.assertEquals(result.get("105"), FastList.newListWith(105));
-        Assert.assertEquals(result.get("105*"), FastList.newListWith(105));
+        assertEquals(result.get("105"), FastList.newListWith(105));
+        assertEquals(result.get("105*"), FastList.newListWith(105));
     }
 
     @Test
     public void groupByUniqueKeyWithOptimisedList()
     {
         ArrayList<Integer> list1 = new ArrayList<>(Interval.toReverseList(1, 3));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3),
                 ArrayListIterate.groupByUniqueKey(list1, id -> id));
         ArrayList<Integer> list2 = new ArrayList<>(Interval.toReverseList(1, 105));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.ofAll(list2).groupByUniqueKey(id -> id),
                 ArrayListIterate.groupByUniqueKey(list2, id -> id));
     }
@@ -1653,12 +1661,12 @@ public class ArrayListIterateTest
     public void groupByUniqueKeyWithOptimisedList_target()
     {
         ArrayList<Integer> list1 = new ArrayList<>(Interval.toReverseList(1, 3));
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3),
                 ArrayListIterate.groupByUniqueKey(list1, id -> id, UnifiedMap.newWithKeysValues(0, 0)));
 
         ArrayList<Integer> list2 = new ArrayList<>(Interval.toReverseList(1, 105));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.ofAll(list2).groupByUniqueKey(id -> id, UnifiedMap.newWithKeysValues(0, 0)),
                 ArrayListIterate.groupByUniqueKey(list2, id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
@@ -1683,7 +1691,7 @@ public class ArrayListIterateTest
 
         ArrayList<Integer> result = ArrayListIterate.flatCollect(list, new CollectionWrappingFunction<>(),
                 new ArrayList<>());
-        Assert.assertEquals(105, result.get(0).intValue());
+        assertEquals(105, result.get(0).intValue());
     }
 
     private static class CollectionWrappingFunction<T> implements Function<T, Collection<T>>
@@ -1711,7 +1719,7 @@ public class ArrayListIterateTest
                 Tuples.twin(1, 1),
                 Tuples.twin(2, 2),
                 Tuples.twin(3, 3));
-        Assert.assertEquals(expected, ArrayListIterate.zip(integers, integers));
-        Assert.assertEquals(expected, ArrayListIterate.zip(integers, integers::iterator));
+        assertEquals(expected, ArrayListIterate.zip(integers, integers));
+        assertEquals(expected, ArrayListIterate.zip(integers, integers::iterator));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateNullTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateNullTest.java
@@ -21,8 +21,10 @@ import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 /**
  * JUnit test for the null handling behavior of {@link Iterate}, {@link ArrayIterate}, {@link ArrayListIterate},
@@ -35,353 +37,353 @@ public class IterateNullTest
     @Test
     public void collect()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, Functions.getPassThru()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, Functions.getPassThru()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collect(null, Functions.getPassThru()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collect(null, Functions.getPassThru()));
     }
 
     @Test
     public void collectBoolean()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
     }
 
     @Test
     public void collectBooleanWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
     }
 
     @Test
     public void collectByte()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Test
     public void collectByteWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
     }
 
     @Test
     public void collectChar()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
     }
 
     @Test
     public void collectCharWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
     }
 
     @Test
     public void collectDouble()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Test
     public void collectDoubleWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
     }
 
     @Test
     public void collectFloat()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Test
     public void collectFloatWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
     }
 
     @Test
     public void collectInt()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Test
     public void collectIntWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
     }
 
     @Test
     public void collectLong()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Test
     public void collectLongWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
     }
 
     @Test
     public void collectShort()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
     }
 
     @Test
     public void collectShortWithTarget()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, Functions.getPassThru()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, Functions.getPassThru()));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectIf(null, null, Functions.getPassThru()));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectIf(null, null, Functions.getPassThru()));
     }
 
     @Test
     public void collectWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.collectWith(null, null, null));
     }
 
     @Test
     public void select()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.select(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.select(null, null));
     }
 
     @Test
     public void selectAndRejectWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.selectAndRejectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.selectAndRejectWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectAndRejectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectAndRejectWith(null, null, null));
     }
 
     @Test
     public void partition()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.partition(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.partition(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.partition(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.partition(null, null));
     }
 
     @Test
     public void partitionWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.partitionWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.partitionWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.partitionWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.partitionWith(null, null, null));
     }
 
     @Test
     public void selectWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectWith(null, null, null));
     }
 
     @Test
     public void selectInstancesOf()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.selectInstancesOf(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.selectInstancesOf(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectInstancesOf(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.selectInstancesOf(null, null));
     }
 
     @Test
     public void detect()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detect(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detect(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detect(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detect(null, null));
     }
 
     @Test
     public void detectIfNone()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detectIfNone(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detectIfNone(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIfNone(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIfNone(null, null, null));
     }
 
     @Test
     public void detectWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detectWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectWith(null, null, null));
     }
 
     @Test
     public void detectWithIfNone()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detectWithIfNone(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detectWithIfNone(null, null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectWithIfNone(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectWithIfNone(null, null, null, null));
     }
 
     @Test
     public void detectIndex()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detectIndex(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detectIndex(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIndex(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIndex(null, null));
     }
 
     @Test
     public void detectIndexWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.detectIndexWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.detectIndexWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIndexWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.detectIndexWith(null, null, null));
     }
 
     @Test
     public void reject()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.reject(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.reject(null, null));
     }
 
     @Test
     public void rejectWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.rejectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.rejectWith(null, null, null));
     }
 
     @Test
     public void injectInto()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectInto(null, null, null));
     }
 
     @Test
     public void injectIntoWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectIntoWith(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectIntoWith(null, null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectIntoWith(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.injectIntoWith(null, null, null, null));
     }
 
     @Test
     public void forEach()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.forEach(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.forEach(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEach(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEach(null, null));
     }
 
     @Test
     public void forEachWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.forEachWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.forEachWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEachWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEachWith(null, null, null));
     }
 
     @Test
     public void forEachWithIndex()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.forEachWithIndex(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.forEachWithIndex(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEachWithIndex(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.forEachWithIndex(null, null));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.anySatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.anySatisfy(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.anySatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.anySatisfy(null, null));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.anySatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.anySatisfyWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.anySatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.anySatisfyWith(null, null, null));
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.allSatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.allSatisfy(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.allSatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.allSatisfy(null, null));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.allSatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.allSatisfyWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.allSatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.allSatisfyWith(null, null, null));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.noneSatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.noneSatisfy(null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.noneSatisfy(null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.noneSatisfy(null, null));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.noneSatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.noneSatisfyWith(null, null, null));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ArrayIterate.noneSatisfyWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> ArrayIterate.noneSatisfyWith(null, null, null));
     }
 
     // Others
@@ -389,192 +391,192 @@ public class IterateNullTest
     @Test
     public void collectArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.collect(null, Functions.getPassThru()));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.collect(null, Functions.getPassThru()));
     }
 
     @Test
     public void collectList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.collect(null, Functions.getPassThru()));
+        assertThrows(NullPointerException.class, () -> ListIterate.collect(null, Functions.getPassThru()));
     }
 
     @Test
     public void collectIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.collect(null, Functions.getPassThru()));
+        assertThrows(NullPointerException.class, () -> IterableIterate.collect(null, Functions.getPassThru()));
     }
 
     @Test
     public void selectArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.select(null, null));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.select(null, null));
     }
 
     @Test
     public void selectList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.select(null, null));
+        assertThrows(NullPointerException.class, () -> ListIterate.select(null, null));
     }
 
     @Test
     public void selectIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.select(null, null));
+        assertThrows(NullPointerException.class, () -> IterableIterate.select(null, null));
     }
 
     @Test
     public void detectArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(ArrayListIterate.detect(null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(ArrayListIterate.detect(null, null)));
     }
 
     @Test
     public void detectList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(ListIterate.detect(null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(ListIterate.detect(null, null)));
     }
 
     @Test
     public void detectIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(IterableIterate.detect(null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(IterableIterate.detect(null, null)));
     }
 
     @Test
     public void rejectArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.reject(null, null));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.reject(null, null));
     }
 
     @Test
     public void rejectList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.reject(null, null));
+        assertThrows(NullPointerException.class, () -> ListIterate.reject(null, null));
     }
 
     @Test
     public void rejectIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.reject(null, null));
+        assertThrows(NullPointerException.class, () -> IterableIterate.reject(null, null));
     }
 
     @Test
     public void injectArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(ArrayListIterate.injectInto(null, null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(ArrayListIterate.injectInto(null, null, null)));
     }
 
     @Test
     public void injectList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(ListIterate.injectInto(null, null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(ListIterate.injectInto(null, null, null)));
     }
 
     @Test
     public void injectIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Assert.assertNull(IterableIterate.injectInto(null, null, null)));
+        assertThrows(NullPointerException.class, () -> assertNull(IterableIterate.injectInto(null, null, null)));
     }
 
     @Test
     public void forEachArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.forEach(null, null));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.forEach(null, null));
     }
 
     @Test
     public void forEachList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.forEach(null, null));
+        assertThrows(NullPointerException.class, () -> ListIterate.forEach(null, null));
     }
 
     @Test
     public void forEachIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.forEach(null, null));
+        assertThrows(NullPointerException.class, () -> IterableIterate.forEach(null, null));
     }
 
     @Test
     public void takeArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.take(null, 0));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.take(null, 0));
     }
 
     @Test
     public void takeList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.take(null, 0));
+        assertThrows(NullPointerException.class, () -> ListIterate.take(null, 0));
     }
 
     @Test
     public void takeIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.take(null, 0));
+        assertThrows(NullPointerException.class, () -> IterableIterate.take(null, 0));
     }
 
     @Test
     public void dropArrayList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ArrayListIterate.drop(null, 0));
+        assertThrows(NullPointerException.class, () -> ArrayListIterate.drop(null, 0));
     }
 
     @Test
     public void dropList()
     {
-        Assert.assertThrows(NullPointerException.class, () -> ListIterate.drop(null, 0));
+        assertThrows(NullPointerException.class, () -> ListIterate.drop(null, 0));
     }
 
     @Test
     public void dropIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> IterableIterate.drop(null, 0));
+        assertThrows(NullPointerException.class, () -> IterableIterate.drop(null, 0));
     }
 
     @Test
     public void removeAllIterable()
     {
-        Assert.assertThrows(NullPointerException.class, () -> Iterate.removeAllIterable(null, null));
+        assertThrows(NullPointerException.class, () -> Iterate.removeAllIterable(null, null));
     }
 
     @Test
     public void sumOfBigInteger()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigInteger(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigInteger(null, null));
     }
 
     @Test
     public void sumByBigDecimal()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByBigDecimal(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByBigDecimal(null, null, null));
     }
 
     @Test
     public void sumByBigInteger()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByBigInteger(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByBigInteger(null, null, null));
     }
 
     @Test
     public void sumByInt()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByInt(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByInt(null, null, null));
     }
 
     @Test
     public void sumByLong()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByLong(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByLong(null, null, null));
     }
 
     @Test
     public void sumByFloat()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByFloat(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByFloat(null, null, null));
     }
 
     @Test
     public void sumByDouble()
     {
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumByDouble(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumByDouble(null, null, null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -102,7 +102,6 @@ import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -110,6 +109,13 @@ import static org.eclipse.collections.impl.factory.Iterables.iBag;
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IterateTest
 {
@@ -146,7 +152,7 @@ public class IterateTest
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newListWith(1, 3, 5);
         Iterate.removeAllFrom(removeFastList, sourceFastList);
-        Assert.assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList);
+        assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList);
     }
 
     @Test
@@ -173,7 +179,7 @@ public class IterateTest
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newListWith(7, 8, 9);
         Iterate.removeAllFrom(removeFastList, sourceFastList);
-        Assert.assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
+        assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
     }
 
     @Test
@@ -182,7 +188,7 @@ public class IterateTest
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newList();
         Iterate.removeAllFrom(removeFastList, sourceFastList);
-        Assert.assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
+        assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
     }
 
     @Test
@@ -190,17 +196,17 @@ public class IterateTest
     {
         MutableList<Integer> sourceFastList1 = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList1 = FastList.newListWith(1, 3, 5);
-        Assert.assertTrue(Iterate.removeAllIterable(removeFastList1, sourceFastList1));
-        Assert.assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList1);
-        Assert.assertFalse(Iterate.removeAllIterable(FastList.newListWith(0), sourceFastList1));
-        Assert.assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList1);
+        assertTrue(Iterate.removeAllIterable(removeFastList1, sourceFastList1));
+        assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList1);
+        assertFalse(Iterate.removeAllIterable(FastList.newListWith(0), sourceFastList1));
+        assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList1);
 
         MutableList<Integer> sourceFastList2 = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableSetMultimap<Integer, Integer> multimap = UnifiedSetMultimap.newMultimap(Tuples.pair(1, 1), Tuples.pair(1, 3), Tuples.pair(1, 5));
-        Assert.assertTrue(Iterate.removeAllIterable(multimap.valuesView(), sourceFastList2));
-        Assert.assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList2);
-        Assert.assertFalse(Iterate.removeAllIterable(UnifiedSetMultimap.newMultimap(Tuples.pair(0, 0)).valuesView(), sourceFastList2));
-        Assert.assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList2);
+        assertTrue(Iterate.removeAllIterable(multimap.valuesView(), sourceFastList2));
+        assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList2);
+        assertFalse(Iterate.removeAllIterable(UnifiedSetMultimap.newMultimap(Tuples.pair(0, 0)).valuesView(), sourceFastList2));
+        assertEquals(Lists.immutable.with(2, 4, 6), sourceFastList2);
     }
 
     @Test
@@ -208,7 +214,7 @@ public class IterateTest
     {
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
-        Assert.assertTrue(Iterate.removeAllIterable(removeFastList, sourceFastList));
+        assertTrue(Iterate.removeAllIterable(removeFastList, sourceFastList));
         Verify.assertEmpty(sourceFastList);
     }
 
@@ -217,7 +223,7 @@ public class IterateTest
     {
         MutableList<Integer> sourceFastList = FastList.newList();
         MutableList<Integer> removeFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
-        Assert.assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
+        assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
         Verify.assertEmpty(sourceFastList);
     }
 
@@ -226,8 +232,8 @@ public class IterateTest
     {
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newListWith(7, 8, 9);
-        Assert.assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
-        Assert.assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
+        assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
+        assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
     }
 
     @Test
@@ -235,29 +241,29 @@ public class IterateTest
     {
         MutableList<Integer> sourceFastList = FastList.newListWith(1, 2, 3, 4, 5, 6);
         MutableList<Integer> removeFastList = FastList.newList();
-        Assert.assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
-        Assert.assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
+        assertFalse(Iterate.removeAllIterable(removeFastList, sourceFastList));
+        assertEquals(Lists.immutable.with(1, 2, 3, 4, 5, 6), sourceFastList);
     }
 
     @Test
     public void sizeOf()
     {
-        Assert.assertEquals(5, Iterate.sizeOf(Interval.oneTo(5)));
-        Assert.assertEquals(5, Iterate.sizeOf(Interval.oneTo(5).toList()));
-        Assert.assertEquals(5, Iterate.sizeOf(Interval.oneTo(5).asLazy()));
-        Assert.assertEquals(3, Iterate.sizeOf(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3)));
-        Assert.assertEquals(5, Iterate.sizeOf(new IterableAdapter<>(Interval.oneTo(5))));
+        assertEquals(5, Iterate.sizeOf(Interval.oneTo(5)));
+        assertEquals(5, Iterate.sizeOf(Interval.oneTo(5).toList()));
+        assertEquals(5, Iterate.sizeOf(Interval.oneTo(5).asLazy()));
+        assertEquals(3, Iterate.sizeOf(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3)));
+        assertEquals(5, Iterate.sizeOf(new IterableAdapter<>(Interval.oneTo(5))));
     }
 
     @Test
     public void toArray()
     {
         Object[] expected = {1, 2, 3, 4, 5};
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5)));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toList()));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).asLazy()));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toSortedMap(a -> a, a -> a)));
-        Assert.assertArrayEquals(expected, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(5))));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5)));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toList()));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).asLazy()));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toSortedMap(a -> a, a -> a)));
+        assertArrayEquals(expected, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(5))));
     }
 
     @Test(expected = NullPointerException.class)
@@ -270,12 +276,12 @@ public class IterateTest
     public void toArray_with_array()
     {
         Object[] expected = {1, 2, 3, 4, 5};
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5), new Object[5]));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toList(), new Object[5]));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).asLazy(), new Object[5]));
-        Assert.assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toSortedMap(a -> a, a -> a), new Object[5]));
-        Assert.assertArrayEquals(expected, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(5)), new Object[5]));
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4, 5, 6, 7}, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(7)), new Object[5]));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5), new Object[5]));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toList(), new Object[5]));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).asLazy(), new Object[5]));
+        assertArrayEquals(expected, Iterate.toArray(Interval.oneTo(5).toSortedMap(a -> a, a -> a), new Object[5]));
+        assertArrayEquals(expected, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(5)), new Object[5]));
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 5, 6, 7}, Iterate.toArray(new IterableAdapter<>(Interval.oneTo(7)), new Object[5]));
     }
 
     @Test
@@ -289,13 +295,13 @@ public class IterateTest
     @Test
     public void reduceInPlaceCollector()
     {
-        this.iterables.each(each -> Assert.assertEquals(
+        this.iterables.each(each -> assertEquals(
                 Iterate.toSortedList(each),
                 Iterate.reduceInPlace(each, Collectors2.toSortedList())));
-        this.iterables.each(each -> Assert.assertEquals(
+        this.iterables.each(each -> assertEquals(
                 Iterate.sumByInt(each, value -> value % 2, value -> value),
                 Iterate.reduceInPlace(each, Collectors2.sumByInt(value -> value % 2, value -> value))));
-        this.iterables.each(each -> Assert.assertEquals(
+        this.iterables.each(each -> assertEquals(
                 Iterate.groupBy(each, value -> value % 2, Multimaps.mutable.bag.empty()),
                 Iterate.reduceInPlace(each, Collectors2.toBagMultimap(value -> value % 2))));
     }
@@ -303,7 +309,7 @@ public class IterateTest
     @Test
     public void reduceInPlace()
     {
-        this.iterables.each(each -> Assert.assertEquals(
+        this.iterables.each(each -> assertEquals(
                 Iterate.toSortedList(each),
                 Iterate.reduceInPlace(each, FastList::new, FastList::add).sortThis()));
     }
@@ -311,59 +317,59 @@ public class IterateTest
     @Test
     public void injectInto()
     {
-        this.iterables.each(each -> Assert.assertEquals(Integer.valueOf(15), Iterate.injectInto(0, each, AddFunction.INTEGER)));
+        this.iterables.each(each -> assertEquals(Integer.valueOf(15), Iterate.injectInto(0, each, AddFunction.INTEGER)));
     }
 
     @Test
     public void injectIntoInt()
     {
-        this.iterables.each(each -> Assert.assertEquals(15, Iterate.injectInto(0, each, AddFunction.INTEGER_TO_INT)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0, null, AddFunction.INTEGER_TO_INT));
+        this.iterables.each(each -> assertEquals(15, Iterate.injectInto(0, each, AddFunction.INTEGER_TO_INT)));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0, null, AddFunction.INTEGER_TO_INT));
     }
 
     @Test
     public void injectIntoLong()
     {
-        this.iterables.each(each -> Assert.assertEquals(15L, Iterate.injectInto(0L, each, AddFunction.INTEGER_TO_LONG)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0L, null, AddFunction.INTEGER_TO_LONG));
+        this.iterables.each(each -> assertEquals(15L, Iterate.injectInto(0L, each, AddFunction.INTEGER_TO_LONG)));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0L, null, AddFunction.INTEGER_TO_LONG));
     }
 
     @Test
     public void injectIntoDouble()
     {
-        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0d, each, AddFunction.INTEGER_TO_DOUBLE), 0.001));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0d, null, AddFunction.INTEGER_TO_DOUBLE));
+        this.iterables.each(each -> assertEquals(15.0d, Iterate.injectInto(0.0d, each, AddFunction.INTEGER_TO_DOUBLE), 0.001));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0d, null, AddFunction.INTEGER_TO_DOUBLE));
     }
 
     @Test
     public void injectIntoFloat()
     {
-        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.injectInto(0.0f, each, AddFunction.INTEGER_TO_FLOAT), 0.001));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0f, null, AddFunction.INTEGER_TO_FLOAT));
+        this.iterables.each(each -> assertEquals(15.0d, Iterate.injectInto(0.0f, each, AddFunction.INTEGER_TO_FLOAT), 0.001));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.injectInto(0.0f, null, AddFunction.INTEGER_TO_FLOAT));
     }
 
     @Test
     public void injectInto2()
     {
-        Assert.assertEquals(new Double(7), Iterate.injectInto(1.0, iList(1.0, 2.0, 3.0), AddFunction.DOUBLE));
+        assertEquals(new Double(7), Iterate.injectInto(1.0, iList(1.0, 2.0, 3.0), AddFunction.DOUBLE));
     }
 
     @Test
     public void injectIntoString()
     {
-        Assert.assertEquals("0123", Iterate.injectInto("0", iList("1", "2", "3"), AddFunction.STRING));
+        assertEquals("0123", Iterate.injectInto("0", iList("1", "2", "3"), AddFunction.STRING));
     }
 
     @Test
     public void injectIntoMaxString()
     {
-        Assert.assertEquals(Integer.valueOf(3), Iterate.injectInto(Integer.MIN_VALUE, iList("1", "12", "123"), MaxSizeFunction.STRING));
+        assertEquals(Integer.valueOf(3), Iterate.injectInto(Integer.MIN_VALUE, iList("1", "12", "123"), MaxSizeFunction.STRING));
     }
 
     @Test
     public void injectIntoMinString()
     {
-        Assert.assertEquals(Integer.valueOf(1), Iterate.injectInto(Integer.MAX_VALUE, iList("1", "12", "123"), MinSizeFunction.STRING));
+        assertEquals(Integer.valueOf(1), Iterate.injectInto(Integer.MAX_VALUE, iList("1", "12", "123"), MinSizeFunction.STRING));
     }
 
     @Test
@@ -374,22 +380,22 @@ public class IterateTest
                 new ListContainer<>(Lists.mutable.of("Two-and-a-half", "Three", "Four")),
                 new ListContainer<>(Lists.mutable.of()),
                 new ListContainer<>(Lists.mutable.of("Five")));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(list, ListContainer.getListFunction()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(Collections.synchronizedList(list), ListContainer.getListFunction()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(Collections.synchronizedCollection(list), ListContainer.getListFunction()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(LazyIterate.adapt(list), ListContainer.getListFunction()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(new ArrayList<>(list), ListContainer.getListFunction()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.flatCollect(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.flatCollect(null, null));
     }
 
     @Test
@@ -400,22 +406,22 @@ public class IterateTest
                 new ListContainer<>(Lists.mutable.of("Two-and-a-half", "Three", "Four")),
                 new ListContainer<>(Lists.mutable.of()),
                 new ListContainer<>(Lists.mutable.of("Five")));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(list, ListContainer.getListFunction(), FastList.newList()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(Collections.synchronizedList(list), ListContainer.getListFunction(), FastList.newList()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(Collections.synchronizedCollection(list), ListContainer.getListFunction(), FastList.newList()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(LazyIterate.adapt(list), ListContainer.getListFunction(), FastList.newList()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(new ArrayList<>(list), ListContainer.getListFunction(), FastList.newList()));
-        Assert.assertEquals(
+        assertEquals(
                 iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"),
                 Iterate.flatCollect(new IterableAdapter<>(new ArrayList<>(list)), ListContainer.getListFunction(), FastList.newList()));
     }
@@ -437,8 +443,8 @@ public class IterateTest
         Function<ListContainer<String>, List<String>> function = ListContainer::getList;
         Collection<String> result = Iterate.flatCollect(list, function);
         FastList<String> result2 = Iterate.flatCollect(list, function, FastList.newList());
-        Assert.assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
-        Assert.assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result2);
+        assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
+        assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result2);
     }
 
     @Test
@@ -450,7 +456,7 @@ public class IterateTest
                 Lists.mutable.of(),
                 Lists.mutable.of("Five"));
         Collection<String> result = Iterate.flatten(list);
-        Assert.assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
+        assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
     }
 
     @Test
@@ -463,8 +469,8 @@ public class IterateTest
                 Lists.mutable.of("Five"));
         MutableList<String> target = Lists.mutable.of();
         Collection<String> result = Iterate.flatten(list, target);
-        Assert.assertSame(result, target);
-        Assert.assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
+        assertSame(result, target);
+        assertEquals(iList("One", "Two", "Two-and-a-half", "Three", "Four", "Five"), result);
     }
 
     @Test
@@ -482,12 +488,12 @@ public class IterateTest
         expected.put('M', "Mary");
         expected.put('B', "Bob");
         expected.put('S', "Sara");
-        Assert.assertEquals(expected, result1);
-        Assert.assertEquals(expected, result2);
-        Assert.assertEquals(expected, result3);
-        Assert.assertEquals(expected, result4);
-        Assert.assertEquals(expected, result5);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.groupBy(null, null));
+        assertEquals(expected, result1);
+        assertEquals(expected, result2);
+        assertEquals(expected, result3);
+        assertEquals(expected, result4);
+        assertEquals(expected, result5);
+        assertThrows(IllegalArgumentException.class, () -> Iterate.groupBy(null, null));
     }
 
     @Test
@@ -512,12 +518,12 @@ public class IterateTest
         expected.putAll('R', FastList.newListWith("Mary", "Sara"));
         expected.put('B', "Bob");
         expected.put('O', "Bob");
-        Assert.assertEquals(expected, result1);
-        Assert.assertEquals(expected, result2);
-        Assert.assertEquals(expected, result3);
-        Assert.assertEquals(expected, result4);
-        Assert.assertEquals(expected, result5);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.groupByEach(null, null));
+        assertEquals(expected, result1);
+        assertEquals(expected, result2);
+        assertEquals(expected, result3);
+        assertEquals(expected, result4);
+        assertEquals(expected, result5);
+        assertThrows(IllegalArgumentException.class, () -> Iterate.groupByEach(null, null));
     }
 
     @Test
@@ -535,12 +541,12 @@ public class IterateTest
         expected.put('M', "Mary");
         expected.put('B', "Bob");
         expected.put('S', "Sara");
-        Assert.assertEquals(expected, result1);
-        Assert.assertEquals(expected, result2);
-        Assert.assertEquals(expected, result3);
-        Assert.assertEquals(expected, result4);
-        Assert.assertEquals(expected, result5);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.groupBy(null, null, null));
+        assertEquals(expected, result1);
+        assertEquals(expected, result2);
+        assertEquals(expected, result3);
+        assertEquals(expected, result4);
+        assertEquals(expected, result5);
+        assertThrows(IllegalArgumentException.class, () -> Iterate.groupBy(null, null, null));
     }
 
     @Test
@@ -566,12 +572,12 @@ public class IterateTest
         expected.put('Y', "Mary");
         expected.put('B', "Bob");
         expected.put('O', "Bob");
-        Assert.assertEquals(expected, result1);
-        Assert.assertEquals(expected, result2);
-        Assert.assertEquals(expected, result3);
-        Assert.assertEquals(expected, result4);
-        Assert.assertEquals(expected, result5);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.groupByEach(null, null, null));
+        assertEquals(expected, result1);
+        assertEquals(expected, result2);
+        assertEquals(expected, result3);
+        assertEquals(expected, result4);
+        assertEquals(expected, result5);
+        assertThrows(IllegalArgumentException.class, () -> Iterate.groupByEach(null, null, null));
     }
 
     @Test
@@ -602,43 +608,43 @@ public class IterateTest
         expectedMultimap4.putAllPairs(expectedPairs);
         MutableSortedSetMultimap<String, String> actualMultimap4 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.sortedSet.with(Comparators.naturalOrder()));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap4, actualMultimap4);
-        Assert.assertSame(expectedMultimap4.comparator(), actualMultimap4.comparator());
+        assertSame(expectedMultimap4.comparator(), actualMultimap4.comparator());
 
         MutableSortedSetMultimap<String, String> expectedMultimap5 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap5.putAllPairs(expectedPairs);
         MutableSortedSetMultimap<String, String> actualMultimap5 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, Multimaps.mutable.sortedSet.with(Comparators.reverseNaturalOrder()));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap5, actualMultimap5);
-        Assert.assertSame(expectedMultimap5.comparator(), actualMultimap5.comparator());
+        assertSame(expectedMultimap5.comparator(), actualMultimap5.comparator());
 
         MutableSortedBagMultimap<String, String> expectedMultimap6 = TreeBagMultimap.newMultimap(Comparators.naturalOrder());
         expectedMultimap6.putAllPairs(expectedPairs);
         MutableSortedBagMultimap<String, String> actualMultimap6 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, TreeBagMultimap.newMultimap(Comparators.naturalOrder()));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap6, actualMultimap6);
-        Assert.assertSame(expectedMultimap6.comparator(), actualMultimap6.comparator());
+        assertSame(expectedMultimap6.comparator(), actualMultimap6.comparator());
 
         MutableSortedBagMultimap<String, String> expectedMultimap7 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap7.putAllPairs(expectedPairs);
         MutableSortedBagMultimap<String, String> actualMultimap7 = Iterate.groupByAndCollect(list, keyFunction, valueFunction, TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder()));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap7, actualMultimap7);
-        Assert.assertSame(expectedMultimap7.comparator(), actualMultimap7.comparator());
+        assertSame(expectedMultimap7.comparator(), actualMultimap7.comparator());
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(FastList.newListWith(1, 2, 3), FastList.newList(Interval.oneTo(3)));
+        assertEquals(FastList.newListWith(1, 2, 3), FastList.newList(Interval.oneTo(3)));
     }
 
     @Test
     public void contains()
     {
-        Assert.assertTrue(Iterate.contains(FastList.newListWith(1, 2, 3), 1));
-        Assert.assertFalse(Iterate.contains(FastList.newListWith(1, 2, 3), 4));
-        Assert.assertTrue(Iterate.contains(FastList.newListWith(1, 2, 3).asLazy(), 1));
-        Assert.assertTrue(Iterate.contains(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), 1));
-        Assert.assertFalse(Iterate.contains(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), 4));
-        Assert.assertTrue(Iterate.contains(Interval.oneTo(3), 1));
-        Assert.assertFalse(Iterate.contains(Interval.oneTo(3), 4));
+        assertTrue(Iterate.contains(FastList.newListWith(1, 2, 3), 1));
+        assertFalse(Iterate.contains(FastList.newListWith(1, 2, 3), 4));
+        assertTrue(Iterate.contains(FastList.newListWith(1, 2, 3).asLazy(), 1));
+        assertTrue(Iterate.contains(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), 1));
+        assertFalse(Iterate.contains(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), 4));
+        assertTrue(Iterate.contains(Interval.oneTo(3), 1));
+        assertFalse(Iterate.contains(Interval.oneTo(3), 4));
     }
 
     public static final class ListContainer<T>
@@ -665,12 +671,12 @@ public class IterateTest
     public void getFirstAndLast()
     {
         MutableList<Boolean> list = mList(Boolean.TRUE, null, Boolean.FALSE);
-        Assert.assertEquals(Boolean.TRUE, Iterate.getFirst(list));
-        Assert.assertEquals(Boolean.FALSE, Iterate.getLast(list));
-        Assert.assertEquals(Boolean.TRUE, Iterate.getFirst(Collections.unmodifiableList(list)));
-        Assert.assertEquals(Boolean.FALSE, Iterate.getLast(Collections.unmodifiableList(list)));
-        Assert.assertEquals(Boolean.TRUE, Iterate.getFirst(new IterableAdapter<>(list)));
-        Assert.assertEquals(Boolean.FALSE, Iterate.getLast(new IterableAdapter<>(list)));
+        assertEquals(Boolean.TRUE, Iterate.getFirst(list));
+        assertEquals(Boolean.FALSE, Iterate.getLast(list));
+        assertEquals(Boolean.TRUE, Iterate.getFirst(Collections.unmodifiableList(list)));
+        assertEquals(Boolean.FALSE, Iterate.getLast(Collections.unmodifiableList(list)));
+        assertEquals(Boolean.TRUE, Iterate.getFirst(new IterableAdapter<>(list)));
+        assertEquals(Boolean.FALSE, Iterate.getLast(new IterableAdapter<>(list)));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -688,39 +694,39 @@ public class IterateTest
     @Test
     public void getFirstAndLastInterval()
     {
-        Assert.assertEquals(Integer.valueOf(1), Iterate.getFirst(Interval.oneTo(5)));
-        Assert.assertEquals(Integer.valueOf(5), Iterate.getLast(Interval.oneTo(5)));
+        assertEquals(Integer.valueOf(1), Iterate.getFirst(Interval.oneTo(5)));
+        assertEquals(Integer.valueOf(5), Iterate.getLast(Interval.oneTo(5)));
     }
 
     @Test
     public void getFirstAndLastLinkedList()
     {
         List<Boolean> list = new LinkedList<>(mList(Boolean.TRUE, null, Boolean.FALSE));
-        Assert.assertEquals(Boolean.TRUE, Iterate.getFirst(list));
-        Assert.assertEquals(Boolean.FALSE, Iterate.getLast(list));
+        assertEquals(Boolean.TRUE, Iterate.getFirst(list));
+        assertEquals(Boolean.FALSE, Iterate.getLast(list));
     }
 
     @Test
     public void getFirstAndLastTreeSet()
     {
         Set<String> set = new TreeSet<>(mList("1", "2"));
-        Assert.assertEquals("1", Iterate.getFirst(set));
-        Assert.assertEquals("2", Iterate.getLast(set));
+        assertEquals("1", Iterate.getFirst(set));
+        assertEquals("2", Iterate.getLast(set));
     }
 
     @Test
     public void getFirstAndLastCollection()
     {
         Collection<Boolean> list = mList(Boolean.TRUE, null, Boolean.FALSE).asSynchronized();
-        Assert.assertEquals(Boolean.TRUE, Iterate.getFirst(list));
-        Assert.assertEquals(Boolean.FALSE, Iterate.getLast(list));
+        assertEquals(Boolean.TRUE, Iterate.getFirst(list));
+        assertEquals(Boolean.FALSE, Iterate.getLast(list));
     }
 
     @Test
     public void getFirstAndLastOnEmpty()
     {
-        Assert.assertNull(Iterate.getFirst(mList()));
-        Assert.assertNull(Iterate.getLast(mList()));
+        assertNull(Iterate.getFirst(mList()));
+        assertNull(Iterate.getLast(mList()));
     }
 
     @Test
@@ -730,16 +736,16 @@ public class IterateTest
         orderedSet.add(1);
         orderedSet.add(2);
         orderedSet.add(3);
-        Assert.assertEquals(Integer.valueOf(1), Iterate.getFirst(orderedSet));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.getLast(orderedSet));
+        assertEquals(Integer.valueOf(1), Iterate.getFirst(orderedSet));
+        assertEquals(Integer.valueOf(3), Iterate.getLast(orderedSet));
     }
 
     @Test
     public void getFirstAndLastOnEmptyForSet()
     {
         MutableSet<Object> set = UnifiedSet.newSet();
-        Assert.assertNull(Iterate.getFirst(set));
-        Assert.assertNull(Iterate.getLast(set));
+        assertNull(Iterate.getFirst(set));
+        assertNull(Iterate.getLast(set));
     }
 
     private MutableSet<Integer> getIntegerSet()
@@ -752,7 +758,7 @@ public class IterateTest
     {
         MutableSet<Integer> set = this.getIntegerSet();
         List<Integer> list = Iterate.select(set, Integer.class::isInstance, new ArrayList<>());
-        Assert.assertEquals(FastList.newListWith(1, 2, 3, 4, 5), list);
+        assertEquals(FastList.newListWith(1, 2, 3, 4, 5), list);
     }
 
     @Test
@@ -766,7 +772,7 @@ public class IterateTest
     @Test
     public void count_empty()
     {
-        Assert.assertEquals(0, Iterate.count(iList(), ignored -> true));
+        assertEquals(0, Iterate.count(iList(), ignored -> true));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -873,25 +879,25 @@ public class IterateTest
         expectedMultimap4.putAllPairs(expectedPairs);
         MutableSortedSetMultimap<String, String> actualMultimap4 = Iterate.toMultimap(list, keyFunction, valuesFunction, Multimaps.mutable.sortedSet.with(Comparators.naturalOrder()));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap4, actualMultimap4);
-        Assert.assertSame(expectedMultimap4.comparator(), actualMultimap4.comparator());
+        assertSame(expectedMultimap4.comparator(), actualMultimap4.comparator());
 
         MutableSortedSetMultimap<String, String> expectedMultimap5 = TreeSortedSetMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap5.putAllPairs(expectedPairs);
         MutableSortedSetMultimap<String, String> actualMultimap5 = Iterate.toMultimap(list, keyFunction, valuesFunction, Multimaps.mutable.sortedSet.with(Comparators.reverseNaturalOrder()));
         Verify.assertSortedSetMultimapsEqual(expectedMultimap5, actualMultimap5);
-        Assert.assertSame(expectedMultimap5.comparator(), actualMultimap5.comparator());
+        assertSame(expectedMultimap5.comparator(), actualMultimap5.comparator());
 
         MutableSortedBagMultimap<String, String> expectedMultimap6 = TreeBagMultimap.newMultimap(Comparators.naturalOrder());
         expectedMultimap6.putAllPairs(expectedPairs);
         MutableSortedBagMultimap<String, String> actualMultimap6 = Iterate.toMultimap(list, keyFunction, valuesFunction, TreeBagMultimap.newMultimap(Comparators.naturalOrder()));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap6, actualMultimap6);
-        Assert.assertSame(expectedMultimap6.comparator(), actualMultimap6.comparator());
+        assertSame(expectedMultimap6.comparator(), actualMultimap6.comparator());
 
         MutableSortedBagMultimap<String, String> expectedMultimap7 = TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder());
         expectedMultimap7.putAllPairs(expectedPairs);
         MutableSortedBagMultimap<String, String> actualMultimap7 = Iterate.toMultimap(list, keyFunction, valuesFunction, TreeBagMultimap.newMultimap(Comparators.reverseNaturalOrder()));
         Verify.assertSortedBagMultimapsEqual(expectedMultimap7, actualMultimap7);
-        Assert.assertSame(expectedMultimap7.comparator(), actualMultimap7.comparator());
+        assertSame(expectedMultimap7.comparator(), actualMultimap7.comparator());
 
         // Below tests are for examples only. They do not add any coverage.
         BagMultimap<String, String> expectedMultimap8 = HashBagMultimap.newMultimap(
@@ -939,7 +945,7 @@ public class IterateTest
         this.iterables.each(each -> {
             UnifiedSet<Integer> set = UnifiedSet.newSet();
             Iterate.forEachWithIndex(each, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(set)));
-            Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
+            assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
         });
     }
 
@@ -965,7 +971,7 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Integer result = Iterate.detect(each, Predicates.instanceOf(Integer.class));
-            Assert.assertTrue(UnifiedSet.newSet(each).contains(result));
+            assertTrue(UnifiedSet.newSet(each).contains(result));
         });
     }
 
@@ -974,11 +980,11 @@ public class IterateTest
     {
         this.iterables.forEach(Procedures.cast(each -> {
             Optional<Integer> result = Iterate.detectOptional(each, Predicates.instanceOf(Integer.class));
-            Assert.assertTrue(result.isPresent());
+            assertTrue(result.isPresent());
             Verify.assertContains(result.get(), UnifiedSet.newSet(each));
 
             Optional<Integer> emptyResult = Iterate.detectOptional(each, Predicates.instanceOf(String.class));
-            Assert.assertFalse(emptyResult.isPresent());
+            assertFalse(emptyResult.isPresent());
         }));
     }
 
@@ -986,36 +992,36 @@ public class IterateTest
     public void detectIndex()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(4, Iterate.detectIndex(list, Integer.valueOf(1)::equals));
-        Assert.assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(5)::equals));
-        Assert.assertEquals(-1, Iterate.detectIndex(Lists.immutable.of(), Integer.valueOf(1)::equals));
-        Assert.assertEquals(-1, Iterate.detectIndex(Sets.immutable.of(), Integer.valueOf(1)::equals));
+        assertEquals(4, Iterate.detectIndex(list, Integer.valueOf(1)::equals));
+        assertEquals(0, Iterate.detectIndex(list, Integer.valueOf(5)::equals));
+        assertEquals(-1, Iterate.detectIndex(Lists.immutable.of(), Integer.valueOf(1)::equals));
+        assertEquals(-1, Iterate.detectIndex(Sets.immutable.of(), Integer.valueOf(1)::equals));
     }
 
     @Test
     public void detectIndexWithTreeSet()
     {
         Set<Integer> treeSet = new TreeSet<>(Interval.toReverseList(1, 5));
-        Assert.assertEquals(0, Iterate.detectIndex(treeSet, Integer.valueOf(1)::equals));
-        Assert.assertEquals(4, Iterate.detectIndex(treeSet, Integer.valueOf(5)::equals));
+        assertEquals(0, Iterate.detectIndex(treeSet, Integer.valueOf(1)::equals));
+        assertEquals(4, Iterate.detectIndex(treeSet, Integer.valueOf(5)::equals));
     }
 
     @Test
     public void detectIndexWith()
     {
         MutableList<Integer> list = Interval.toReverseList(1, 5);
-        Assert.assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
-        Assert.assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(iList(), Object::equals, 5));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(iSet(), Object::equals, 5));
+        assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
+        assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
+        assertEquals(-1, Iterate.detectIndexWith(iList(), Object::equals, 5));
+        assertEquals(-1, Iterate.detectIndexWith(iSet(), Object::equals, 5));
     }
 
     @Test
     public void detectIndexWithWithTreeSet()
     {
         Set<Integer> treeSet = new TreeSet<>(Interval.toReverseList(1, 5));
-        Assert.assertEquals(0, Iterate.detectIndexWith(treeSet, Object::equals, 1));
-        Assert.assertEquals(4, Iterate.detectIndexWith(treeSet, Object::equals, 5));
+        assertEquals(0, Iterate.detectIndexWith(treeSet, Object::equals, 1));
+        assertEquals(4, Iterate.detectIndexWith(treeSet, Object::equals, 5));
     }
 
     @Test
@@ -1032,9 +1038,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.selectWith(each, Predicates2.greaterThan(), 3);
-            Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
+            assertTrue(result.containsAll(FastList.newListWith(4, 5)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null));
     }
 
     @Test
@@ -1042,9 +1048,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.selectWith(each, Predicates2.greaterThan(), 3, FastList.newList());
-            Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
+            assertTrue(result.containsAll(FastList.newListWith(4, 5)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.selectWith(null, null, null, null));
     }
 
     @Test
@@ -1052,9 +1058,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.rejectWith(each, Predicates2.greaterThan(), 3);
-            Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
+            assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null));
     }
 
     @Test
@@ -1062,9 +1068,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.rejectWith(each, Predicates2.greaterThan(), 3, FastList.newList());
-            Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
+            assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.rejectWith(null, null, null, null));
     }
 
     @Test
@@ -1072,8 +1078,8 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Twin<MutableList<Integer>> result = Iterate.selectAndRejectWith(each, Predicates2.greaterThan(), 3);
-            Assert.assertEquals(iBag(4, 5), result.getOne().toBag());
-            Assert.assertEquals(iBag(1, 2, 3), result.getTwo().toBag());
+            assertEquals(iBag(4, 5), result.getOne().toBag());
+            assertEquals(iBag(1, 2, 3), result.getTwo().toBag());
         });
     }
 
@@ -1082,8 +1088,8 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             PartitionIterable<Integer> result = Iterate.partition(each, Predicates.greaterThan(3));
-            Assert.assertEquals(iBag(4, 5), result.getSelected().toBag());
-            Assert.assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
+            assertEquals(iBag(4, 5), result.getSelected().toBag());
+            assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
         });
     }
 
@@ -1092,8 +1098,8 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             PartitionIterable<Integer> result = Iterate.partitionWith(each, Predicates2.greaterThan(), 3);
-            Assert.assertEquals(iBag(4, 5), result.getSelected().toBag());
-            Assert.assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
+            assertEquals(iBag(4, 5), result.getSelected().toBag());
+            assertEquals(iBag(1, 2, 3), result.getRejected().toBag());
         });
     }
 
@@ -1132,37 +1138,37 @@ public class IterateTest
     @Test
     public void anySatisfy()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.anySatisfy(each, Integer.class::isInstance)));
+        this.iterables.each(each -> assertTrue(Iterate.anySatisfy(each, Integer.class::isInstance)));
     }
 
     @Test
     public void anySatisfyWith()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.anySatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
+        this.iterables.each(each -> assertTrue(Iterate.anySatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
     }
 
     @Test
     public void allSatisfy()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.allSatisfy(each, Integer.class::isInstance)));
+        this.iterables.each(each -> assertTrue(Iterate.allSatisfy(each, Integer.class::isInstance)));
     }
 
     @Test
     public void allSatisfyWith()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.allSatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
+        this.iterables.each(each -> assertTrue(Iterate.allSatisfyWith(each, Predicates2.instanceOf(), Integer.class)));
     }
 
     @Test
     public void noneSatisfy()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.noneSatisfy(each, String.class::isInstance)));
+        this.iterables.each(each -> assertTrue(Iterate.noneSatisfy(each, String.class::isInstance)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
-        this.iterables.each(each -> Assert.assertTrue(Iterate.noneSatisfyWith(each, Predicates2.instanceOf(), String.class)));
+        this.iterables.each(each -> assertTrue(Iterate.noneSatisfyWith(each, Predicates2.instanceOf(), String.class)));
     }
 
     @Test
@@ -1182,49 +1188,49 @@ public class IterateTest
     @Test
     public void detectWithSet()
     {
-        Assert.assertEquals(Integer.valueOf(1), Iterate.detectWith(this.getIntegerSet(), Object::equals, 1));
+        assertEquals(Integer.valueOf(1), Iterate.detectWith(this.getIntegerSet(), Object::equals, 1));
     }
 
     @Test
     public void detectWithRandomAccess()
     {
         List<Integer> list = Collections.synchronizedList(Interval.oneTo(5));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.detectWith(list, Object::equals, 1));
+        assertEquals(Integer.valueOf(1), Iterate.detectWith(list, Object::equals, 1));
     }
 
     @Test
     public void detectWithOptionalSet()
     {
-        Assert.assertEquals(Optional.of(Integer.valueOf(1)), Iterate.detectWithOptional(this.getIntegerSet(), Object::equals, 1));
-        Assert.assertEquals(Optional.empty(), Iterate.detectWithOptional(this.getIntegerSet(), Object::equals, 10));
+        assertEquals(Optional.of(Integer.valueOf(1)), Iterate.detectWithOptional(this.getIntegerSet(), Object::equals, 1));
+        assertEquals(Optional.empty(), Iterate.detectWithOptional(this.getIntegerSet(), Object::equals, 10));
     }
 
     @Test
     public void detectWithOptionalRandomAccess()
     {
         List<Integer> list = Collections.synchronizedList(Interval.oneTo(5));
-        Assert.assertEquals(Optional.of(Integer.valueOf(1)), Iterate.detectWithOptional(list, Object::equals, 1));
-        Assert.assertEquals(Optional.empty(), Iterate.detectWithOptional(list, Object::equals, 10));
+        assertEquals(Optional.of(Integer.valueOf(1)), Iterate.detectWithOptional(list, Object::equals, 1));
+        assertEquals(Optional.empty(), Iterate.detectWithOptional(list, Object::equals, 10));
     }
 
     @Test
     public void anySatisfyWithSet()
     {
-        Assert.assertTrue(Iterate.anySatisfyWith(this.getIntegerSet(), Object::equals, 1));
+        assertTrue(Iterate.anySatisfyWith(this.getIntegerSet(), Object::equals, 1));
     }
 
     @Test
     public void allSatisfyWithSet()
     {
-        Assert.assertFalse(Iterate.allSatisfyWith(this.getIntegerSet(), Object::equals, 1));
-        Assert.assertTrue(Iterate.allSatisfyWith(this.getIntegerSet(), Predicates2.instanceOf(), Integer.class));
+        assertFalse(Iterate.allSatisfyWith(this.getIntegerSet(), Object::equals, 1));
+        assertTrue(Iterate.allSatisfyWith(this.getIntegerSet(), Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
     public void noneSatisfyWithSet()
     {
-        Assert.assertTrue(Iterate.noneSatisfyWith(this.getIntegerSet(), Object::equals, 100));
-        Assert.assertFalse(Iterate.noneSatisfyWith(this.getIntegerSet(), Predicates2.instanceOf(), Integer.class));
+        assertTrue(Iterate.noneSatisfyWith(this.getIntegerSet(), Object::equals, 100));
+        assertFalse(Iterate.noneSatisfyWith(this.getIntegerSet(), Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
@@ -1241,7 +1247,7 @@ public class IterateTest
         this.iterables.each(each -> {
             UnifiedSet<Integer> set = UnifiedSet.newSet();
             Iterate.forEach(each, Procedures.cast(set::add));
-            Assert.assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
+            assertEquals(UnifiedSet.newSetWith(1, 2, 3, 4, 5), set);
         });
     }
 
@@ -1250,9 +1256,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collectIf(each, Predicates.greaterThan(3), String::valueOf);
-            Assert.assertTrue(result.containsAll(FastList.newListWith("4", "5")));
+            assertTrue(result.containsAll(FastList.newListWith("4", "5")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null));
     }
 
     @Test
@@ -1260,9 +1266,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collectIf(each, Predicates.greaterThan(3), String::valueOf, FastList.newList());
-            Assert.assertTrue(result.containsAll(FastList.newListWith("4", "5")));
+            assertTrue(result.containsAll(FastList.newListWith("4", "5")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectIf(null, null, null, null));
     }
 
     @Test
@@ -1270,9 +1276,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collect(each, String::valueOf);
-            Assert.assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
+            assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a));
     }
 
     @Test
@@ -1280,9 +1286,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableBooleanCollection result = Iterate.collectBoolean(each, PrimitiveFunctions.integerIsPositive());
-            Assert.assertTrue(result.containsAll(true, true, true, true, true));
+            assertTrue(result.containsAll(true, true, true, true, true));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive()));
     }
 
     @Test
@@ -1291,10 +1297,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableBooleanCollection expected = new BooleanArrayList();
             MutableBooleanCollection actual = Iterate.collectBoolean(each, PrimitiveFunctions.integerIsPositive(), expected);
-            Assert.assertTrue(expected.containsAll(true, true, true, true, true));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(expected.containsAll(true, true, true, true, true));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
     }
 
     @Test
@@ -1302,9 +1308,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableByteCollection result = Iterate.collectByte(each, PrimitiveFunctions.unboxIntegerToByte());
-            Assert.assertTrue(result.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
+            assertTrue(result.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte()));
     }
 
     @Test
@@ -1313,10 +1319,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableByteCollection expected = new ByteArrayList();
             MutableByteCollection actual = Iterate.collectByte(each, PrimitiveFunctions.unboxIntegerToByte(), expected);
-            Assert.assertTrue(actual.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
     }
 
     @Test
@@ -1324,9 +1330,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableCharCollection result = Iterate.collectChar(each, PrimitiveFunctions.unboxIntegerToChar());
-            Assert.assertTrue(result.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
+            assertTrue(result.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar()));
     }
 
     @Test
@@ -1335,10 +1341,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableCharCollection expected = new CharArrayList();
             MutableCharCollection actual = Iterate.collectChar(each, PrimitiveFunctions.unboxIntegerToChar(), expected);
-            Assert.assertTrue(actual.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
     }
 
     @Test
@@ -1346,9 +1352,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableDoubleCollection result = Iterate.collectDouble(each, PrimitiveFunctions.unboxIntegerToDouble());
-            Assert.assertTrue(result.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
+            assertTrue(result.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble()));
     }
 
     @Test
@@ -1357,10 +1363,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableDoubleCollection expected = new DoubleArrayList();
             MutableDoubleCollection actual = Iterate.collectDouble(each, PrimitiveFunctions.unboxIntegerToDouble(), expected);
-            Assert.assertTrue(actual.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
     }
 
     @Test
@@ -1368,9 +1374,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableFloatCollection result = Iterate.collectFloat(each, PrimitiveFunctions.unboxIntegerToFloat());
-            Assert.assertTrue(result.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
+            assertTrue(result.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat()));
     }
 
     @Test
@@ -1379,10 +1385,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableFloatCollection expected = new FloatArrayList();
             MutableFloatCollection actual = Iterate.collectFloat(each, PrimitiveFunctions.unboxIntegerToFloat(), expected);
-            Assert.assertTrue(actual.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
     }
 
     @Test
@@ -1390,9 +1396,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableIntCollection result = Iterate.collectInt(each, PrimitiveFunctions.unboxIntegerToInt());
-            Assert.assertTrue(result.containsAll(1, 2, 3, 4, 5));
+            assertTrue(result.containsAll(1, 2, 3, 4, 5));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt()));
     }
 
     @Test
@@ -1401,10 +1407,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableIntCollection expected = new IntArrayList();
             MutableIntCollection actual = Iterate.collectInt(each, PrimitiveFunctions.unboxIntegerToInt(), expected);
-            Assert.assertTrue(actual.containsAll(1, 2, 3, 4, 5));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll(1, 2, 3, 4, 5));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
     }
 
     @Test
@@ -1412,9 +1418,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableLongCollection result = Iterate.collectLong(each, PrimitiveFunctions.unboxIntegerToLong());
-            Assert.assertTrue(result.containsAll(1L, 2L, 3L, 4L, 5L));
+            assertTrue(result.containsAll(1L, 2L, 3L, 4L, 5L));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong()));
     }
 
     @Test
@@ -1423,10 +1429,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableLongCollection expected = new LongArrayList();
             MutableLongCollection actual = Iterate.collectLong(each, PrimitiveFunctions.unboxIntegerToLong(), expected);
-            Assert.assertTrue(actual.containsAll(1L, 2L, 3L, 4L, 5L));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll(1L, 2L, 3L, 4L, 5L));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
     }
 
     @Test
@@ -1434,9 +1440,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             MutableShortCollection result = Iterate.collectShort(each, PrimitiveFunctions.unboxIntegerToShort());
-            Assert.assertTrue(result.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
+            assertTrue(result.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort()));
     }
 
     @Test
@@ -1445,10 +1451,10 @@ public class IterateTest
         this.iterables.each(each -> {
             MutableShortCollection expected = new ShortArrayList();
             MutableShortCollection actual = Iterate.collectShort(each, PrimitiveFunctions.unboxIntegerToShort(), expected);
-            Assert.assertTrue(actual.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
-            Assert.assertSame("Target list sent as parameter not returned", expected, actual);
+            assertTrue(actual.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
+            assertSame("Target list sent as parameter not returned", expected, actual);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
     }
 
     @Test
@@ -1541,7 +1547,7 @@ public class IterateTest
         foos.add(new Foo(2));
         Collection<Bar> bars = Iterate.collect(foos, foo -> new Bar(foo.getValue()));
 
-        Assert.assertEquals(FastList.newListWith(new Bar(1), new Bar(2)), bars);
+        assertEquals(FastList.newListWith(new Bar(1), new Bar(2)), bars);
     }
 
     @Test
@@ -1549,9 +1555,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collect(each, String::valueOf, UnifiedSet.newSet());
-            Assert.assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
+            assertTrue(result.containsAll(FastList.newListWith("1", "2", "3", "4", "5")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collect(null, a -> a, null));
     }
 
     @Test
@@ -1559,9 +1565,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collectWith(each, (each1, parm) -> each1 + parm, " ");
-            Assert.assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
+            assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null));
     }
 
     @Test
@@ -1569,9 +1575,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<String> result = Iterate.collectWith(each, (each1, parm) -> each1 + parm, " ", UnifiedSet.newSet());
-            Assert.assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
+            assertTrue(result.containsAll(FastList.newListWith("1 ", "2 ", "3 ", "4 ", "5 ")));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.collectWith(null, null, null, null));
     }
 
     @Test
@@ -1585,30 +1591,30 @@ public class IterateTest
 
         MutableList<Integer> integers3 = Interval.oneTo(5).toList();
         this.assertRemoveIfFromList(FastList.newList(integers3));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.removeIf(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.removeIf(null, null));
     }
 
     @Test
     public void removeIfWith()
     {
         MutableList<Integer> objects = FastList.newList(Lists.fixedSize.of(1, 2, 3, null));
-        Assert.assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
+        assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
 
         MutableList<Integer> objects2 = FastList.newList(Lists.fixedSize.of(null, 1, 2, 3));
-        Assert.assertTrue(Iterate.removeIfWith(objects2, (each, ignored) -> each == null, null));
+        assertTrue(Iterate.removeIfWith(objects2, (each, ignored) -> each == null, null));
         Verify.assertSize(3, objects2);
         Verify.assertContainsAll(objects2, 1, 2, 3);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.removeIfWith(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.removeIfWith(null, null, null));
     }
 
     private void assertRemoveIfFromList(List<Integer> newIntegers)
     {
-        Assert.assertTrue(Iterate.removeIf(newIntegers, IntegerPredicates.isEven()));
-        Assert.assertFalse(Iterate.removeIf(FastList.newListWith(1, 3, 5), IntegerPredicates.isEven()));
-        Assert.assertFalse(Iterate.removeIf(FastList.newList(), IntegerPredicates.isEven()));
+        assertTrue(Iterate.removeIf(newIntegers, IntegerPredicates.isEven()));
+        assertFalse(Iterate.removeIf(FastList.newListWith(1, 3, 5), IntegerPredicates.isEven()));
+        assertFalse(Iterate.removeIf(FastList.newList(), IntegerPredicates.isEven()));
         Verify.assertContainsAll(newIntegers, 1, 3, 5);
         Verify.assertSize(3, newIntegers);
     }
@@ -1624,7 +1630,7 @@ public class IterateTest
     public void removeIfAll()
     {
         MutableList<Integer> integers = Interval.oneTo(5).toList();
-        Assert.assertTrue(Iterate.removeIf(integers, ignored -> true));
+        assertTrue(Iterate.removeIf(integers, ignored -> true));
         Verify.assertSize(0, integers);
     }
 
@@ -1632,7 +1638,7 @@ public class IterateTest
     public void removeIfNone()
     {
         MutableList<Integer> integers = Interval.oneTo(5).toList();
-        Assert.assertFalse(Iterate.removeIf(integers, ignored -> false));
+        assertFalse(Iterate.removeIf(integers, ignored -> false));
         Verify.assertSize(5, integers);
     }
 
@@ -1640,7 +1646,7 @@ public class IterateTest
     public void removeIfFromSet()
     {
         MutableSet<Integer> integers = Interval.toSet(1, 5);
-        Assert.assertTrue(Iterate.removeIf(integers, IntegerPredicates.isEven()));
+        assertTrue(Iterate.removeIf(integers, IntegerPredicates.isEven()));
         Verify.assertContainsAll(integers, 1, 3, 5);
         Verify.assertSize(3, integers);
     }
@@ -1649,11 +1655,11 @@ public class IterateTest
     public void removeIfWithFastList()
     {
         MutableList<Integer> objects = FastList.newListWith(1, 2, 3, null);
-        Assert.assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
+        assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
         MutableList<Integer> objects1 = FastList.newListWith(null, 1, 2, 3);
-        Assert.assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
+        assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
         Verify.assertSize(3, objects1);
         Verify.assertContainsAll(objects1, 1, 2, 3);
     }
@@ -1662,12 +1668,12 @@ public class IterateTest
     public void removeIfWithRandomAccess()
     {
         List<Integer> objects = Collections.synchronizedList(new ArrayList<>(Lists.fixedSize.of(1, 2, 3, null)));
-        Assert.assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
+        assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
         List<Integer> objects1 =
                 Collections.synchronizedList(new ArrayList<>(Lists.fixedSize.of(null, 1, 2, 3)));
-        Assert.assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
+        assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
         Verify.assertSize(3, objects1);
         Verify.assertContainsAll(objects1, 1, 2, 3);
     }
@@ -1676,11 +1682,11 @@ public class IterateTest
     public void removeIfWithLinkedList()
     {
         List<Integer> objects = new LinkedList<>(Lists.fixedSize.of(1, 2, 3, null));
-        Assert.assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
+        assertTrue(Iterate.removeIfWith(objects, (each1, ignored1) -> each1 == null, null));
         Verify.assertSize(3, objects);
         Verify.assertContainsAll(objects, 1, 2, 3);
         List<Integer> objects1 = new LinkedList<>(Lists.fixedSize.of(null, 1, 2, 3));
-        Assert.assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
+        assertTrue(Iterate.removeIfWith(objects1, (each, ignored) -> each == null, null));
         Verify.assertSize(3, objects1);
         Verify.assertContainsAll(objects1, 1, 2, 3);
     }
@@ -1727,29 +1733,29 @@ public class IterateTest
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(Iterate.isEmpty(null));
-        Assert.assertTrue(Iterate.isEmpty(Lists.fixedSize.of()));
-        Assert.assertFalse(Iterate.isEmpty(Lists.fixedSize.of("1")));
-        Assert.assertTrue(Iterate.isEmpty(Maps.fixedSize.of()));
-        Assert.assertFalse(Iterate.isEmpty(Maps.fixedSize.of("1", "1")));
-        Assert.assertTrue(Iterate.isEmpty(new IterableAdapter<>(Lists.fixedSize.of())));
-        Assert.assertFalse(Iterate.isEmpty(new IterableAdapter<>(Lists.fixedSize.of("1"))));
-        Assert.assertTrue(Iterate.isEmpty(Lists.fixedSize.of().asLazy()));
-        Assert.assertFalse(Iterate.isEmpty(Lists.fixedSize.of("1").asLazy()));
+        assertTrue(Iterate.isEmpty(null));
+        assertTrue(Iterate.isEmpty(Lists.fixedSize.of()));
+        assertFalse(Iterate.isEmpty(Lists.fixedSize.of("1")));
+        assertTrue(Iterate.isEmpty(Maps.fixedSize.of()));
+        assertFalse(Iterate.isEmpty(Maps.fixedSize.of("1", "1")));
+        assertTrue(Iterate.isEmpty(new IterableAdapter<>(Lists.fixedSize.of())));
+        assertFalse(Iterate.isEmpty(new IterableAdapter<>(Lists.fixedSize.of("1"))));
+        assertTrue(Iterate.isEmpty(Lists.fixedSize.of().asLazy()));
+        assertFalse(Iterate.isEmpty(Lists.fixedSize.of("1").asLazy()));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(Iterate.notEmpty(null));
-        Assert.assertFalse(Iterate.notEmpty(Lists.fixedSize.of()));
-        Assert.assertTrue(Iterate.notEmpty(Lists.fixedSize.of("1")));
-        Assert.assertFalse(Iterate.notEmpty(Maps.fixedSize.of()));
-        Assert.assertTrue(Iterate.notEmpty(Maps.fixedSize.of("1", "1")));
-        Assert.assertFalse(Iterate.notEmpty(new IterableAdapter<>(Lists.fixedSize.of())));
-        Assert.assertTrue(Iterate.notEmpty(new IterableAdapter<>(Lists.fixedSize.of("1"))));
-        Assert.assertFalse(Iterate.notEmpty(Lists.fixedSize.of().asLazy()));
-        Assert.assertTrue(Iterate.notEmpty(Lists.fixedSize.of("1").asLazy()));
+        assertFalse(Iterate.notEmpty(null));
+        assertFalse(Iterate.notEmpty(Lists.fixedSize.of()));
+        assertTrue(Iterate.notEmpty(Lists.fixedSize.of("1")));
+        assertFalse(Iterate.notEmpty(Maps.fixedSize.of()));
+        assertTrue(Iterate.notEmpty(Maps.fixedSize.of("1", "1")));
+        assertFalse(Iterate.notEmpty(new IterableAdapter<>(Lists.fixedSize.of())));
+        assertTrue(Iterate.notEmpty(new IterableAdapter<>(Lists.fixedSize.of("1"))));
+        assertFalse(Iterate.notEmpty(Lists.fixedSize.of().asLazy()));
+        assertTrue(Iterate.notEmpty(Lists.fixedSize.of("1").asLazy()));
     }
 
     @Test
@@ -1773,9 +1779,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.select(each, Predicates.greaterThan(3));
-            Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
+            assertTrue(result.containsAll(FastList.newListWith(4, 5)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null));
     }
 
     @Test
@@ -1783,9 +1789,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.select(each, Predicates.greaterThan(3), FastList.newList());
-            Assert.assertTrue(result.containsAll(FastList.newListWith(4, 5)));
+            assertTrue(result.containsAll(FastList.newListWith(4, 5)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.select(null, null, null));
     }
 
     @Test
@@ -1793,9 +1799,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.reject(each, Predicates.greaterThan(3));
-            Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
+            assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null));
     }
 
     @Test
@@ -1803,9 +1809,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             Collection<Integer> result = Iterate.reject(each, Predicates.greaterThan(3), FastList.newList());
-            Assert.assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
+            assertTrue(result.containsAll(FastList.newListWith(1, 2, 3)));
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.reject(null, null, null));
     }
 
     @Test
@@ -1823,7 +1829,7 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             int result = Iterate.count(each, Predicates.greaterThan(3));
-            Assert.assertEquals(2, result);
+            assertEquals(2, result);
         });
     }
 
@@ -1838,7 +1844,7 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             int result = Iterate.countWith(each, Predicates2.greaterThan(), 3);
-            Assert.assertEquals(2, result);
+            assertEquals(2, result);
         });
     }
 
@@ -1870,7 +1876,7 @@ public class IterateTest
     {
         Function3<Sum, Integer, Integer, Sum> function = (sum, element, withValue) -> sum.add(element.intValue() * withValue.intValue());
         Sum sumOfDoubledValues = Iterate.injectIntoWith(newResult, newIntegers, function, newParameter);
-        Assert.assertEquals(30, sumOfDoubledValues.getValue().intValue());
+        assertEquals(30, sumOfDoubledValues.getValue().intValue());
     }
 
     @Test
@@ -1888,7 +1894,7 @@ public class IterateTest
         this.iterables.each(each -> {
             Sum result = new IntegerSum(0);
             Iterate.forEachWith(each, (integer, parm) -> result.add(integer.intValue() * parm.intValue()), 2);
-            Assert.assertEquals(30, result.getValue().intValue());
+            assertEquals(30, result.getValue().intValue());
         });
     }
 
@@ -1898,7 +1904,7 @@ public class IterateTest
         Sum result = new IntegerSum(0);
         MutableSet<Integer> integers = Interval.toSet(1, 5);
         Iterate.forEachWith(integers, (each, parm) -> result.add(each.intValue() * parm.intValue()), 2);
-        Assert.assertEquals(30, result.getValue().intValue());
+        assertEquals(30, result.getValue().intValue());
     }
 
     @Test
@@ -1912,7 +1918,7 @@ public class IterateTest
         List<Integer> listOfSizeOne = new LinkedList<>();
         listOfSizeOne.add(1);
         Iterate.sortThis(listOfSizeOne);
-        Assert.assertEquals(FastList.newListWith(1), listOfSizeOne);
+        assertEquals(FastList.newListWith(1), listOfSizeOne);
     }
 
     @Test
@@ -1939,8 +1945,8 @@ public class IterateTest
         Interval.oneTo(5).addAllTo(list);
         list.shuffleThis();
         MutableList<Integer> sortedList = Iterate.sortThisBy(list, String::valueOf);
-        Assert.assertSame(list, sortedList);
-        Assert.assertEquals(Lists.immutable.of(1, 1, 2, 2, 3, 3, 4, 4, 5, 5), list);
+        assertSame(list, sortedList);
+        assertEquals(Lists.immutable.of(1, 1, 2, 2, 3, 3, 4, 4, 5, 5), list);
     }
 
     @Test
@@ -2022,7 +2028,7 @@ public class IterateTest
     public void getOnlySingleton()
     {
         Object value = new Object();
-        Assert.assertSame(value, Iterate.getOnly(Lists.fixedSize.of(value)));
+        assertSame(value, Iterate.getOnly(Lists.fixedSize.of(value)));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2062,18 +2068,18 @@ public class IterateTest
         this.zip(new HashSet<>(FastList.newListWith("1", "2", "3", "4", "5", "6", "7")));
         this.zip(FastList.newListWith("1", "2", "3", "4", "5", "6", "7").asLazy());
         this.zip(new ArrayList<>(Interval.oneTo(101).collect(String::valueOf).toList()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.zip(null, null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.zip(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.zip(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.zip(null, null, null));
     }
 
     private void zip(Iterable<String> iterable)
     {
         List<Object> nulls = Collections.nCopies(Iterate.sizeOf(iterable), null);
         Collection<Pair<String, Object>> pairs = Iterate.zip(iterable, nulls);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSet(iterable),
                 Iterate.collect(pairs, (Function<Pair<String, ?>, String>) Pair::getOne, UnifiedSet.newSet()));
-        Assert.assertEquals(
+        assertEquals(
                 nulls,
                 Iterate.collect(pairs, (Function<Pair<?, Object>, Object>) Pair::getTwo, Lists.mutable.of()));
     }
@@ -2087,17 +2093,17 @@ public class IterateTest
         this.zipWithIndex(FastList.newListWith("1", "2", "3", "4", "5", "6", "7").asLazy());
         this.zipWithIndex(Lists.immutable.of("1", "2", "3", "4", "5", "6", "7"));
         this.zipWithIndex(new ArrayList<>(Interval.oneTo(101).collect(String::valueOf).toList()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.zipWithIndex(null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.zipWithIndex(null, null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.zipWithIndex(null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.zipWithIndex(null, null));
     }
 
     private void zipWithIndex(Iterable<String> iterable)
     {
         Collection<Pair<String, Integer>> pairs = Iterate.zipWithIndex(iterable);
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedSet.newSet(iterable),
                 Iterate.collect(pairs, (Function<Pair<String, ?>, String>) Pair::getOne, UnifiedSet.newSet()));
-        Assert.assertEquals(
+        assertEquals(
                 Interval.zeroTo(Iterate.sizeOf(iterable) - 1).toSet(),
                 Iterate.collect(pairs, (Function<Pair<?, Integer>, Integer>) Pair::getTwo, UnifiedSet.newSet()));
     }
@@ -2108,23 +2114,23 @@ public class IterateTest
         MutableList<String> fastList = FastList.newListWith("1", "2", "3", "4", "5", "6", "7");
         RichIterable<RichIterable<String>> groups1 = Iterate.chunk(fastList, 2);
         RichIterable<Integer> sizes1 = groups1.collect(Functions.getSizeOf());
-        Assert.assertEquals(FastList.newListWith(2, 2, 2, 1), sizes1);
+        assertEquals(FastList.newListWith(2, 2, 2, 1), sizes1);
 
         List<String> arrayList = new ArrayList<>(fastList);
         RichIterable<RichIterable<String>> groups2 = Iterate.chunk(arrayList, 2);
         RichIterable<Integer> sizes2 = groups2.collect(Functions.getSizeOf());
-        Assert.assertEquals(FastList.newListWith(2, 2, 2, 1), sizes2);
+        assertEquals(FastList.newListWith(2, 2, 2, 1), sizes2);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.chunk(null, 1));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.chunk(null, 1));
     }
 
     @Test
     public void getOnly()
     {
-        Assert.assertEquals("first", Iterate.getOnly(FastList.newListWith("first")));
-        Assert.assertEquals("first", Iterate.getOnly(FastList.newListWith("first").asLazy()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.getOnly(FastList.newListWith("first", "second")));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.getOnly(null));
+        assertEquals("first", Iterate.getOnly(FastList.newListWith("first")));
+        assertEquals("first", Iterate.getOnly(FastList.newListWith("first").asLazy()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.getOnly(FastList.newListWith("first", "second")));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.getOnly(null));
     }
 
     private static class WordToItsLetters implements Function<String, Set<Character>>
@@ -2143,9 +2149,9 @@ public class IterateTest
     {
         this.iterables.each(each -> {
             String result = Iterate.makeString(each);
-            Assert.assertEquals("1, 2, 3, 4, 5", result);
+            assertEquals("1, 2, 3, 4, 5", result);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.makeString(null));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.makeString(null));
     }
 
     @Test
@@ -2155,9 +2161,9 @@ public class IterateTest
             StringBuilder stringBuilder = new StringBuilder();
             Iterate.appendString(each, stringBuilder);
             String result = stringBuilder.toString();
-            Assert.assertEquals("1, 2, 3, 4, 5", result);
+            assertEquals("1, 2, 3, 4, 5", result);
         });
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.appendString(null, new StringBuilder()));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.appendString(null, new StringBuilder()));
     }
 
     @Test
@@ -2170,7 +2176,7 @@ public class IterateTest
         this.aggregateByMutableResult(new LinkedList<>(FastList.newListWith(1, 1, 1, 2, 2, 3)));
         this.aggregateByMutableResult(new ArrayList<>(FastList.newListWith(1, 1, 1, 2, 2, 3)));
         this.aggregateByMutableResult(Arrays.asList(1, 1, 1, 2, 2, 3));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.aggregateByMutableResult(null));
+        assertThrows(IllegalArgumentException.class, () -> this.aggregateByMutableResult(null));
     }
 
     private void aggregateByMutableResult(Iterable<Integer> iterable)
@@ -2180,15 +2186,15 @@ public class IterateTest
         MapIterable<String, AtomicInteger> aggregation = Iterate.aggregateInPlaceBy(iterable, String::valueOf, valueCreator, sumAggregator);
         if (iterable instanceof Set)
         {
-            Assert.assertEquals(1, aggregation.get("1").intValue());
-            Assert.assertEquals(2, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(1, aggregation.get("1").intValue());
+            assertEquals(2, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
         else
         {
-            Assert.assertEquals(3, aggregation.get("1").intValue());
-            Assert.assertEquals(4, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(3, aggregation.get("1").intValue());
+            assertEquals(4, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
     }
 
@@ -2202,7 +2208,7 @@ public class IterateTest
         this.aggregateByImmutableResult(new LinkedList<>(FastList.newListWith(1, 1, 1, 2, 2, 3)));
         this.aggregateByImmutableResult(new ArrayList<>(FastList.newListWith(1, 1, 1, 2, 2, 3)));
         this.aggregateByImmutableResult(Arrays.asList(1, 1, 1, 2, 2, 3));
-        Assert.assertThrows(IllegalArgumentException.class, () -> this.aggregateByImmutableResult(null));
+        assertThrows(IllegalArgumentException.class, () -> this.aggregateByImmutableResult(null));
     }
 
     private void aggregateByImmutableResult(Iterable<Integer> iterable)
@@ -2212,62 +2218,62 @@ public class IterateTest
         MapIterable<String, Integer> aggregation = Iterate.aggregateBy(iterable, String::valueOf, valueCreator, sumAggregator);
         if (iterable instanceof Set)
         {
-            Assert.assertEquals(1, aggregation.get("1").intValue());
-            Assert.assertEquals(2, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(1, aggregation.get("1").intValue());
+            assertEquals(2, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
         else
         {
-            Assert.assertEquals(3, aggregation.get("1").intValue());
-            Assert.assertEquals(4, aggregation.get("2").intValue());
-            Assert.assertEquals(3, aggregation.get("3").intValue());
+            assertEquals(3, aggregation.get("1").intValue());
+            assertEquals(4, aggregation.get("2").intValue());
+            assertEquals(3, aggregation.get("3").intValue());
         }
     }
 
     @Test
     public void sumOfInt()
     {
-        this.iterables.each(each -> Assert.assertEquals(15L, Iterate.sumOfLong(each, value -> value)));
+        this.iterables.each(each -> assertEquals(15L, Iterate.sumOfLong(each, value -> value)));
         long result = Iterate.sumOfInt(FastList.newListWith(2_000_000_000, 2_000_000_000, 2_000_000_000), e -> e);
-        Assert.assertEquals(6_000_000_000L, result);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfInt(null, null));
+        assertEquals(6_000_000_000L, result);
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfInt(null, null));
     }
 
     @Test
     public void sumOfLong()
     {
-        this.iterables.each(each -> Assert.assertEquals(15L, Iterate.sumOfLong(each, Integer::longValue)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfLong(null, null));
+        this.iterables.each(each -> assertEquals(15L, Iterate.sumOfLong(each, Integer::longValue)));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfLong(null, null));
     }
 
     @Test
     public void sumOfFloat()
     {
-        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.sumOfFloat(each, Integer::floatValue), 0.0d));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfFloat(null, null));
+        this.iterables.each(each -> assertEquals(15.0d, Iterate.sumOfFloat(each, Integer::floatValue), 0.0d));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfFloat(null, null));
         double result = Iterate.sumOfFloat(FastList.newListWith(2_000_000_000, 2_000_000_000, 2_000_000_000), e -> e);
-        Assert.assertEquals((double) 6_000_000_000L, result, 0.0d);
+        assertEquals((double) 6_000_000_000L, result, 0.0d);
     }
 
     @Test
     public void sumOfDouble()
     {
-        this.iterables.each(each -> Assert.assertEquals(15.0d, Iterate.sumOfDouble(each, Integer::doubleValue), 0.0d));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfDouble(null, null));
+        this.iterables.each(each -> assertEquals(15.0d, Iterate.sumOfDouble(each, Integer::doubleValue), 0.0d));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfDouble(null, null));
     }
 
     @Test
     public void sumOfBigDecimal()
     {
-        this.iterables.each(each -> Assert.assertEquals(new BigDecimal(15), Iterate.sumOfBigDecimal(each, BigDecimal::new)));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigDecimal(null, null));
+        this.iterables.each(each -> assertEquals(new BigDecimal(15), Iterate.sumOfBigDecimal(each, BigDecimal::new)));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigDecimal(null, null));
     }
 
     @Test
     public void sumOfBigInteger()
     {
-        this.iterables.each(each -> Assert.assertEquals(new BigInteger("15"), Iterate.sumOfBigInteger(each, integer -> new BigInteger(integer.toString()))));
-        Assert.assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigDecimal(null, null));
+        this.iterables.each(each -> assertEquals(new BigInteger("15"), Iterate.sumOfBigInteger(each, integer -> new BigInteger(integer.toString()))));
+        assertThrows(IllegalArgumentException.class, () -> Iterate.sumOfBigDecimal(null, null));
     }
 
     @Test
@@ -2276,8 +2282,8 @@ public class IterateTest
         this.iterables.each(each ->
         {
             MutableMap<Integer, BigDecimal> result = Iterate.sumByBigDecimal(each, e -> e % 2, BigDecimal::new);
-            Assert.assertEquals(new BigDecimal(9), result.get(1));
-            Assert.assertEquals(new BigDecimal(6), result.get(0));
+            assertEquals(new BigDecimal(9), result.get(1));
+            assertEquals(new BigDecimal(6), result.get(0));
         });
     }
 
@@ -2287,8 +2293,8 @@ public class IterateTest
         this.iterables.each(each ->
         {
             MutableMap<Integer, BigInteger> result = Iterate.sumByBigInteger(each, e -> e % 2, i -> new BigInteger(i.toString()));
-            Assert.assertEquals(new BigInteger("9"), result.get(1));
-            Assert.assertEquals(new BigInteger("6"), result.get(0));
+            assertEquals(new BigInteger("9"), result.get(1));
+            assertEquals(new BigInteger("6"), result.get(0));
         });
     }
 
@@ -2298,13 +2304,13 @@ public class IterateTest
         this.iterables.each(each ->
         {
             ObjectLongMap<Integer> result = Iterate.sumByInt(each, i -> i % 2, e -> e);
-            Assert.assertEquals(9, result.get(1));
-            Assert.assertEquals(6, result.get(0));
+            assertEquals(9, result.get(1));
+            assertEquals(6, result.get(0));
         });
         ObjectLongMap<Integer> map =
                 Iterate.sumByInt(FastList.newListWith(2_000_000_000, 2_000_000_001, 2_000_000_000, 2_000_000_001, 2_000_000_000), i -> i % 2, e -> e);
-        Assert.assertEquals(4_000_000_002L, map.get(1));
-        Assert.assertEquals(6_000_000_000L, map.get(0));
+        assertEquals(4_000_000_002L, map.get(1));
+        assertEquals(6_000_000_000L, map.get(0));
     }
 
     @Test
@@ -2313,13 +2319,13 @@ public class IterateTest
         this.iterables.each(each ->
         {
             ObjectDoubleMap<Integer> result = Iterate.sumByFloat(each, f -> f % 2, e -> e);
-            Assert.assertEquals(9.0d, result.get(1), 0.0);
-            Assert.assertEquals(6.0d, result.get(0), 0.0);
+            assertEquals(9.0d, result.get(1), 0.0);
+            assertEquals(6.0d, result.get(0), 0.0);
         });
         ObjectDoubleMap<Integer> map =
                 Iterate.sumByFloat(FastList.newListWith(2_000_000_000, 2_000_001, 2_000_000_000, 2_000_001, 2_000_000_000), i -> i % 2, e -> e);
-        Assert.assertEquals((double) 4_000_002L, map.get(1), 0.00001d);
-        Assert.assertEquals((double) 6_000_000_000L, map.get(0), 0.00001d);
+        assertEquals((double) 4_000_002L, map.get(1), 0.00001d);
+        assertEquals((double) 6_000_000_000L, map.get(0), 0.00001d);
     }
 
     @Test
@@ -2328,8 +2334,8 @@ public class IterateTest
         this.iterables.each(each ->
         {
             ObjectLongMap<Integer> result = Iterate.sumByLong(each, l -> l % 2, e -> e);
-            Assert.assertEquals(9, result.get(1));
-            Assert.assertEquals(6, result.get(0));
+            assertEquals(9, result.get(1));
+            assertEquals(6, result.get(0));
         });
     }
 
@@ -2339,31 +2345,31 @@ public class IterateTest
         this.iterables.each(each ->
         {
             ObjectDoubleMap<Integer> result = Iterate.sumByDouble(each, d -> d % 2, e -> e);
-            Assert.assertEquals(9.0d, result.get(1), 0.0);
-            Assert.assertEquals(6.0d, result.get(0), 0.0);
+            assertEquals(9.0d, result.get(1), 0.0);
+            assertEquals(6.0d, result.get(0), 0.0);
         });
     }
 
     @Test
     public void minBy()
     {
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(1, 2, 3), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(3, 2, 1), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(1, 2, 3).asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(3, 2, 1).asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(Arrays.asList(1, 2, 3), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(Arrays.asList(3, 2, 1), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(new LinkedList<>(Arrays.asList(1, 2, 3)), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(1), Iterate.minBy(new LinkedList<>(Arrays.asList(3, 2, 1)), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(1, 2, 3), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(3, 2, 1), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(1, 2, 3).asSynchronized(), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(FastList.newListWith(3, 2, 1).asSynchronized(), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(Arrays.asList(1, 2, 3), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(Arrays.asList(3, 2, 1), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(new LinkedList<>(Arrays.asList(1, 2, 3)), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(1), Iterate.minBy(new LinkedList<>(Arrays.asList(3, 2, 1)), Functions.getIntegerPassThru()));
     }
 
     @Test
     public void minByThrowsOnEmpty()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.minBy(FastList.newList(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.minBy(FastList.<Integer>newList().asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.minBy(Arrays.asList(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.minBy(new LinkedList<>(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.minBy(FastList.newList(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.minBy(FastList.<Integer>newList().asSynchronized(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.minBy(Arrays.asList(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.minBy(new LinkedList<>(), Functions.getIntegerPassThru()));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2375,23 +2381,23 @@ public class IterateTest
     @Test
     public void maxBy()
     {
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(1, 2, 3), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(3, 2, 1), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(1, 2, 3).asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(3, 2, 1).asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(Arrays.asList(1, 2, 3), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(Arrays.asList(3, 2, 1), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(new LinkedList<>(Arrays.asList(1, 2, 3)), Functions.getIntegerPassThru()));
-        Assert.assertEquals(Integer.valueOf(3), Iterate.maxBy(new LinkedList<>(Arrays.asList(3, 2, 1)), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(1, 2, 3), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(3, 2, 1), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(1, 2, 3).asSynchronized(), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(FastList.newListWith(3, 2, 1).asSynchronized(), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(Arrays.asList(1, 2, 3), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(Arrays.asList(3, 2, 1), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(new LinkedList<>(Arrays.asList(1, 2, 3)), Functions.getIntegerPassThru()));
+        assertEquals(Integer.valueOf(3), Iterate.maxBy(new LinkedList<>(Arrays.asList(3, 2, 1)), Functions.getIntegerPassThru()));
     }
 
     @Test
     public void maxByThrowsOnEmpty()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(FastList.newList(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(FastList.<Integer>newList().asSynchronized(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(Arrays.asList(), Functions.getIntegerPassThru()));
-        Assert.assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(new LinkedList<>(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(FastList.newList(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(FastList.<Integer>newList().asSynchronized(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(Arrays.asList(), Functions.getIntegerPassThru()));
+        assertThrows(NoSuchElementException.class, () -> Iterate.maxBy(new LinkedList<>(), Functions.getIntegerPassThru()));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2409,7 +2415,7 @@ public class IterateTest
     @Test
     public void groupByUniqueKey()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), Iterate.groupByUniqueKey(FastList.newListWith(1, 2, 3), id -> id));
+        assertEquals(UnifiedMap.newWithKeysValues(1, 1, 2, 2, 3, 3), Iterate.groupByUniqueKey(FastList.newListWith(1, 2, 3), id -> id));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -2421,7 +2427,7 @@ public class IterateTest
     @Test
     public void groupByUniqueKey_target()
     {
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), Iterate.groupByUniqueKey(FastList.newListWith(1, 2, 3), id -> id, UnifiedMap.newWithKeysValues(0, 0)));
+        assertEquals(UnifiedMap.newWithKeysValues(0, 0, 1, 1, 2, 2, 3, 3), Iterate.groupByUniqueKey(FastList.newListWith(1, 2, 3), id -> id, UnifiedMap.newWithKeysValues(0, 0)));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
@@ -29,8 +29,9 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class LazyIterateTest
 {
@@ -39,7 +40,7 @@ public class LazyIterateTest
     {
         LazyIterable<Integer> select = LazyIterate.select(Interval.oneTo(5), Predicates.lessThan(5));
         int sum = select.injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(10, sum);
+        assertEquals(10, sum);
     }
 
     @Test
@@ -51,7 +52,7 @@ public class LazyIterateTest
             sum.add(object);
             sum.add(index);
         });
-        Assert.assertEquals(16, sum.getValue().intValue());
+        assertEquals(16, sum.getValue().intValue());
     }
 
     @Test
@@ -63,7 +64,7 @@ public class LazyIterateTest
         {
             sum.add(each);
         }
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Test
@@ -72,7 +73,7 @@ public class LazyIterateTest
         LazyIterable<Integer> select = LazyIterate.select(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(10, sum.getValue().intValue());
+        assertEquals(10, sum.getValue().intValue());
     }
 
     @Test
@@ -80,7 +81,7 @@ public class LazyIterateTest
     {
         LazyIterable<Integer> select = LazyIterate.reject(Interval.oneTo(5), Predicates.lessThan(5));
         int sum = select.injectInto(0, AddFunction.INTEGER_TO_INT);
-        Assert.assertEquals(5, sum);
+        assertEquals(5, sum);
     }
 
     @Test
@@ -92,7 +93,7 @@ public class LazyIterateTest
             sum.add(object);
             sum.add(index);
         });
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Test
@@ -104,7 +105,7 @@ public class LazyIterateTest
         {
             sum.add(each);
         }
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Test
@@ -113,7 +114,7 @@ public class LazyIterateTest
         LazyIterable<Integer> select = LazyIterate.reject(Interval.oneTo(5), Predicates.lessThan(5));
         Sum sum = new IntegerSum(0);
         select.forEachWith((each, aSum) -> aSum.add(each), sum);
-        Assert.assertEquals(5, sum.getValue().intValue());
+        assertEquals(5, sum.getValue().intValue());
     }
 
     @Test
@@ -123,7 +124,7 @@ public class LazyIterateTest
         Appendable builder = new StringBuilder();
         Procedure<String> appendProcedure = Procedures.append(builder);
         select.forEach(appendProcedure);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -135,7 +136,7 @@ public class LazyIterateTest
             builder.append(object);
             builder.append(index);
         });
-        Assert.assertEquals("1021324354", builder.toString());
+        assertEquals("1021324354", builder.toString());
     }
 
     @Test
@@ -147,7 +148,7 @@ public class LazyIterateTest
         {
             builder.append(each);
         }
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -156,7 +157,7 @@ public class LazyIterateTest
         LazyIterable<String> select = LazyIterate.collect(Interval.oneTo(5), String::valueOf);
         StringBuilder builder = new StringBuilder();
         select.forEachWith((each, aBuilder) -> aBuilder.append(each), builder);
-        Assert.assertEquals("12345", builder.toString());
+        assertEquals("12345", builder.toString());
     }
 
     @Test
@@ -171,14 +172,14 @@ public class LazyIterateTest
         MutableList<Integer> actual5 = actual2.asLazy().select(ignored -> true).toList();
         MutableList<Integer> actual6 = actual2.toImmutable().asLazy().toList();
         ImmutableList<Integer> actual7 = actual2.asLazy().toList().toImmutable();
-        Assert.assertEquals(expected, actual0);
-        Assert.assertEquals(expected, actual1);
-        Assert.assertEquals(expected, actual2);
-        Assert.assertEquals(expected, actual3);
-        Assert.assertEquals(expected, actual4);
-        Assert.assertEquals(expected, actual5);
-        Assert.assertEquals(expected, actual6);
-        Assert.assertEquals(expected, actual7);
+        assertEquals(expected, actual0);
+        assertEquals(expected, actual1);
+        assertEquals(expected, actual2);
+        assertEquals(expected, actual3);
+        assertEquals(expected, actual4);
+        assertEquals(expected, actual5);
+        assertEquals(expected, actual6);
+        assertEquals(expected, actual7);
     }
 
     @Test
@@ -199,7 +200,7 @@ public class LazyIterateTest
                 Tuples.pair(2, 3),
                 Tuples.pair(1, 4),
                 Tuples.pair(2, 4));
-        Assert.assertEquals(expectedCartesianProduct1, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
+        assertEquals(expectedCartesianProduct1, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
         MutableBag<Pair<Integer, Integer>> expectedCartesianProduct2 = Bags.mutable.with(
                 Tuples.pair(2, 1),
                 Tuples.pair(3, 1),
@@ -207,7 +208,7 @@ public class LazyIterateTest
                 Tuples.pair(2, 2),
                 Tuples.pair(3, 2),
                 Tuples.pair(4, 2));
-        Assert.assertEquals(expectedCartesianProduct2, LazyIterate.cartesianProduct(iterable2, iterable1).toBag());
+        assertEquals(expectedCartesianProduct2, LazyIterate.cartesianProduct(iterable2, iterable1).toBag());
     }
 
     @Test
@@ -220,15 +221,15 @@ public class LazyIterateTest
                 Tuples.pair(1, 2),
                 Tuples.pair(1, 2),
                 Tuples.pair(1, 2));
-        Assert.assertEquals(expectedBag, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
+        assertEquals(expectedBag, LazyIterate.cartesianProduct(iterable1, iterable2).toBag());
         MutableSet<Pair<Integer, Integer>> expectedSet = Sets.mutable.with(Tuples.pair(1, 2));
-        Assert.assertEquals(expectedSet, LazyIterate.cartesianProduct(iterable1, iterable2).toSet());
+        assertEquals(expectedSet, LazyIterate.cartesianProduct(iterable1, iterable2).toSet());
         MutableList<Pair<Integer, Integer>> expectedList = Lists.mutable.with(
                 Tuples.pair(1, 2),
                 Tuples.pair(1, 2),
                 Tuples.pair(1, 2),
                 Tuples.pair(1, 2));
-        Assert.assertEquals(expectedList, LazyIterate.cartesianProduct(iterable1, iterable2).toList());
+        assertEquals(expectedList, LazyIterate.cartesianProduct(iterable1, iterable2).toList());
     }
 
     @Test
@@ -243,7 +244,7 @@ public class LazyIterateTest
                 Tuples.pair(2, 3),
                 Tuples.pair(1, 4),
                 Tuples.pair(2, 4));
-        Assert.assertEquals(
+        assertEquals(
                 expectedCartesianProduct,
                 LazyIterate.cartesianProduct(iterable1, iterable2, Tuples::pair).toBag());
         MutableBag<MutableList<Integer>> expectedCartesianProduct2 = Bags.mutable.with(
@@ -253,7 +254,7 @@ public class LazyIterateTest
                 Lists.mutable.with(2, 2),
                 Lists.mutable.with(3, 2),
                 Lists.mutable.with(4, 2));
-        Assert.assertEquals(
+        assertEquals(
                 expectedCartesianProduct2,
                 LazyIterate.cartesianProduct(iterable2, iterable1, Lists.mutable::with).toBag());
     }
@@ -261,7 +262,7 @@ public class LazyIterateTest
     @Test
     public void cartesianProduct_empty()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Bags.mutable.empty(),
                 LazyIterate.cartesianProduct(
                         Lists.mutable.with(1, 2),

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
@@ -48,11 +48,19 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ListIterateTest
 {
@@ -61,8 +69,8 @@ public class ListIterateTest
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
         List<Integer> linked = new LinkedList<>(list);
-        Assert.assertEquals(Integer.valueOf(7), ListIterate.injectInto(1, list, AddFunction.INTEGER));
-        Assert.assertEquals(Integer.valueOf(7), ListIterate.injectInto(1, linked, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(7), ListIterate.injectInto(1, list, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(7), ListIterate.injectInto(1, linked, AddFunction.INTEGER));
     }
 
     @Test
@@ -71,12 +79,12 @@ public class ListIterateTest
         List<Integer> notAnArrayList = new LinkedList<>(Interval.oneTo(10));
         Integer[] target1 = {1, 2, null, null};
         ListIterate.toArray(notAnArrayList, target1, 2, 2);
-        Assert.assertArrayEquals(target1, new Integer[]{1, 2, 1, 2});
+        assertArrayEquals(target1, new Integer[]{1, 2, 1, 2});
 
         ArrayList<Integer> arrayList = new ArrayList<>(Interval.oneTo(10));
         Integer[] target2 = {1, 2, null, null};
         ListIterate.toArray(arrayList, target2, 2, 2);
-        Assert.assertArrayEquals(target2, new Integer[]{1, 2, 1, 2});
+        assertArrayEquals(target2, new Integer[]{1, 2, 1, 2});
     }
 
     @Test(expected = ArrayIndexOutOfBoundsException.class)
@@ -97,8 +105,8 @@ public class ListIterateTest
 
     private void assertDetectIndex(List<Integer> integerList)
     {
-        Assert.assertEquals(3, ListIterate.detectIndex(integerList, Predicates.equal(2)));
-        Assert.assertEquals(-1, ListIterate.detectIndex(integerList, Predicates.equal(20)));
+        assertEquals(3, ListIterate.detectIndex(integerList, Predicates.equal(2)));
+        assertEquals(-1, ListIterate.detectIndex(integerList, Predicates.equal(20)));
     }
 
     @Test
@@ -111,8 +119,8 @@ public class ListIterateTest
 
     private void assertDetectLastIndex(List<Integer> integerList)
     {
-        Assert.assertEquals(4, ListIterate.detectLastIndex(integerList, IntegerPredicates.isPositive()));
-        Assert.assertEquals(-1, ListIterate.detectLastIndex(integerList, IntegerPredicates.isNegative()));
+        assertEquals(4, ListIterate.detectLastIndex(integerList, IntegerPredicates.isPositive()));
+        assertEquals(-1, ListIterate.detectLastIndex(integerList, IntegerPredicates.isNegative()));
     }
 
     @Test
@@ -125,10 +133,10 @@ public class ListIterateTest
 
     private void assertDetectWithIndex(List<Integer> list)
     {
-        Assert.assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
-        Assert.assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(iList(), Object::equals, 5));
-        Assert.assertEquals(-1, Iterate.detectIndexWith(iSet(), Object::equals, 5));
+        assertEquals(4, Iterate.detectIndexWith(list, Object::equals, 1));
+        assertEquals(0, Iterate.detectIndexWith(list, Object::equals, 5));
+        assertEquals(-1, Iterate.detectIndexWith(iList(), Object::equals, 5));
+        assertEquals(-1, Iterate.detectIndexWith(iSet(), Object::equals, 5));
     }
 
     @Test
@@ -137,12 +145,12 @@ public class ListIterateTest
         MutableList<Integer> result = FastList.newList();
         MutableList<Integer> list = FastList.newListWith(1, 2, 3, 4);
         ListIterate.forEachWith(list, (argument1, argument2) -> result.add(argument1 + argument2), 1);
-        Assert.assertEquals(FastList.newListWith(2, 3, 4, 5), result);
+        assertEquals(FastList.newListWith(2, 3, 4, 5), result);
 
         List<Integer> result2 = new LinkedList<>();
         List<Integer> linkedList = new LinkedList<>(FastList.newListWith(1, 2, 3, 4));
         ListIterate.forEachWith(linkedList, (argument1, argument2) -> result2.add(argument1 + argument2), 1);
-        Assert.assertEquals(FastList.newListWith(2, 3, 4, 5), result2);
+        assertEquals(FastList.newListWith(2, 3, 4, 5), result2);
     }
 
     @Test
@@ -150,8 +158,8 @@ public class ListIterateTest
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
         List<Integer> linked = new LinkedList<>(list);
-        Assert.assertEquals(7, ListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
-        Assert.assertEquals(7, ListIterate.injectInto(1, linked, AddFunction.INTEGER_TO_INT));
+        assertEquals(7, ListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
+        assertEquals(7, ListIterate.injectInto(1, linked, AddFunction.INTEGER_TO_INT));
     }
 
     @Test
@@ -159,8 +167,8 @@ public class ListIterateTest
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
         List<Integer> linked = new LinkedList<>(list);
-        Assert.assertEquals(7, ListIterate.injectInto(1, list, AddFunction.INTEGER_TO_LONG));
-        Assert.assertEquals(7, ListIterate.injectInto(1, linked, AddFunction.INTEGER_TO_LONG));
+        assertEquals(7, ListIterate.injectInto(1, list, AddFunction.INTEGER_TO_LONG));
+        assertEquals(7, ListIterate.injectInto(1, linked, AddFunction.INTEGER_TO_LONG));
     }
 
     @Test
@@ -168,11 +176,11 @@ public class ListIterateTest
     {
         MutableList<Double> list = Lists.fixedSize.of(1.0d, 2.0d, 3.0d);
         List<Double> linked = new LinkedList<>(list);
-        Assert.assertEquals(7.0d, ListIterate.injectInto(1.0, list, AddFunction.DOUBLE), 0.001);
-        Assert.assertEquals(7.0d, ListIterate.injectInto(1.0, linked, AddFunction.DOUBLE), 0.001);
+        assertEquals(7.0d, ListIterate.injectInto(1.0, list, AddFunction.DOUBLE), 0.001);
+        assertEquals(7.0d, ListIterate.injectInto(1.0, linked, AddFunction.DOUBLE), 0.001);
 
-        Assert.assertEquals(7.0d, ListIterate.injectInto(1.0, list, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
-        Assert.assertEquals(7.0d, ListIterate.injectInto(1.0, linked, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
+        assertEquals(7.0d, ListIterate.injectInto(1.0, list, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
+        assertEquals(7.0d, ListIterate.injectInto(1.0, linked, AddFunction.DOUBLE_TO_DOUBLE), 0.001);
     }
 
     @Test
@@ -180,11 +188,11 @@ public class ListIterateTest
     {
         MutableList<Float> list = Lists.fixedSize.of(1.0f, 2.0f, 3.0f);
         List<Float> linked = new LinkedList<>(list);
-        Assert.assertEquals(7.0f, ListIterate.injectInto(1.0f, list, AddFunction.FLOAT), 0.001);
-        Assert.assertEquals(7.0f, ListIterate.injectInto(1.0f, linked, AddFunction.FLOAT), 0.001);
+        assertEquals(7.0f, ListIterate.injectInto(1.0f, list, AddFunction.FLOAT), 0.001);
+        assertEquals(7.0f, ListIterate.injectInto(1.0f, linked, AddFunction.FLOAT), 0.001);
 
-        Assert.assertEquals(7.0f, ListIterate.injectInto(1.0f, list, AddFunction.FLOAT_TO_FLOAT), 0.001);
-        Assert.assertEquals(7.0f, ListIterate.injectInto(1.0f, linked, AddFunction.FLOAT_TO_FLOAT), 0.001);
+        assertEquals(7.0f, ListIterate.injectInto(1.0f, list, AddFunction.FLOAT_TO_FLOAT), 0.001);
+        assertEquals(7.0f, ListIterate.injectInto(1.0f, linked, AddFunction.FLOAT_TO_FLOAT), 0.001);
     }
 
     @Test
@@ -192,8 +200,8 @@ public class ListIterateTest
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3");
         List<String> linked = new LinkedList<>(list);
-        Assert.assertEquals("0123", ListIterate.injectInto("0", list, AddFunction.STRING));
-        Assert.assertEquals("0123", ListIterate.injectInto("0", linked, AddFunction.STRING));
+        assertEquals("0123", ListIterate.injectInto("0", list, AddFunction.STRING));
+        assertEquals("0123", ListIterate.injectInto("0", linked, AddFunction.STRING));
     }
 
     @Test
@@ -202,8 +210,8 @@ public class ListIterateTest
         MutableList<String> list = Lists.fixedSize.of("1", "12", "123");
         List<String> linked = new LinkedList<>(list);
         Function2<Integer, String, Integer> function = MaxSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(3), ListIterate.injectInto(Integer.MIN_VALUE, list, function));
-        Assert.assertEquals(Integer.valueOf(3), ListIterate.injectInto(Integer.MIN_VALUE, linked, function));
+        assertEquals(Integer.valueOf(3), ListIterate.injectInto(Integer.MIN_VALUE, list, function));
+        assertEquals(Integer.valueOf(3), ListIterate.injectInto(Integer.MIN_VALUE, linked, function));
     }
 
     @Test
@@ -212,8 +220,8 @@ public class ListIterateTest
         MutableList<String> list = Lists.fixedSize.of("1", "12", "123");
         List<String> linked = new LinkedList<>(list);
         Function2<Integer, String, Integer> function = MinSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(1), ListIterate.injectInto(Integer.MAX_VALUE, list, function));
-        Assert.assertEquals(Integer.valueOf(1), ListIterate.injectInto(Integer.MAX_VALUE, linked, function));
+        assertEquals(Integer.valueOf(1), ListIterate.injectInto(Integer.MAX_VALUE, list, function));
+        assertEquals(Integer.valueOf(1), ListIterate.injectInto(Integer.MAX_VALUE, linked, function));
     }
 
     @Test
@@ -289,36 +297,36 @@ public class ListIterateTest
     @Test
     public void getFirstAndLast()
     {
-        Assert.assertNull(ListIterate.getFirst(null));
-        Assert.assertNull(ListIterate.getLast(null));
+        assertNull(ListIterate.getFirst(null));
+        assertNull(ListIterate.getLast(null));
 
         MutableList<Boolean> list = Lists.fixedSize.of(true, null, false);
-        Assert.assertEquals(Boolean.TRUE, ListIterate.getFirst(list));
-        Assert.assertEquals(Boolean.FALSE, ListIterate.getLast(list));
+        assertEquals(Boolean.TRUE, ListIterate.getFirst(list));
+        assertEquals(Boolean.FALSE, ListIterate.getLast(list));
 
         List<Boolean> linked = new LinkedList<>(list);
-        Assert.assertEquals(Boolean.TRUE, ListIterate.getFirst(linked));
-        Assert.assertEquals(Boolean.FALSE, ListIterate.getLast(linked));
+        assertEquals(Boolean.TRUE, ListIterate.getFirst(linked));
+        assertEquals(Boolean.FALSE, ListIterate.getLast(linked));
 
         List<Boolean> arrayList = new ArrayList<>(list);
-        Assert.assertEquals(Boolean.TRUE, ListIterate.getFirst(arrayList));
-        Assert.assertEquals(Boolean.FALSE, ListIterate.getLast(arrayList));
+        assertEquals(Boolean.TRUE, ListIterate.getFirst(arrayList));
+        assertEquals(Boolean.FALSE, ListIterate.getLast(arrayList));
     }
 
     @Test
     public void getFirstAndLastOnEmpty()
     {
         List<?> list = new ArrayList<>();
-        Assert.assertNull(ListIterate.getFirst(list));
-        Assert.assertNull(ListIterate.getLast(list));
+        assertNull(ListIterate.getFirst(list));
+        assertNull(ListIterate.getLast(list));
 
         List<?> linked = new LinkedList<>();
-        Assert.assertNull(ListIterate.getFirst(linked));
-        Assert.assertNull(ListIterate.getLast(linked));
+        assertNull(ListIterate.getFirst(linked));
+        assertNull(ListIterate.getLast(linked));
 
         List<?> synchronizedList = Collections.synchronizedList(linked);
-        Assert.assertNull(ListIterate.getFirst(synchronizedList));
-        Assert.assertNull(ListIterate.getLast(synchronizedList));
+        assertNull(ListIterate.getFirst(synchronizedList));
+        assertNull(ListIterate.getLast(synchronizedList));
     }
 
     @Test
@@ -332,9 +340,9 @@ public class ListIterateTest
     private void assertOccurrencesOfAttributeNamedOnList(List<Integer> list)
     {
         int result = ListIterate.count(list, Predicates.attributeEqual(Number::intValue, 3));
-        Assert.assertEquals(1, result);
+        assertEquals(1, result);
         int result2 = ListIterate.count(list, Predicates.attributeEqual(Number::intValue, 6));
-        Assert.assertEquals(0, result2);
+        assertEquals(0, result2);
     }
 
     private MutableList<Integer> getIntegerList()
@@ -353,7 +361,7 @@ public class ListIterateTest
     private void assertForEachWithIndex(List<Integer> list)
     {
         Iterate.sortThis(list);
-        ListIterate.forEachWithIndex(list, (object, index) -> Assert.assertEquals(index, object - 1));
+        ListIterate.forEachWithIndex(list, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -371,18 +379,18 @@ public class ListIterateTest
     {
         MutableList<Integer> results = Lists.mutable.of();
         ListIterate.forEach(integers, 0, 4, results::add);
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.of();
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 4, -1, reverseResults::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, -1, 4, reverseResults::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 0, 5, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 4, -1, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, -1, 4, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 0, 5, reverseResults::add));
     }
 
     private void assertReverseForEachUsingFromTo(List<Integer> integers, MutableList<Integer> reverseResults, Procedure<Integer> procedure)
     {
         ListIterate.forEach(integers, 4, 0, procedure);
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
     }
 
     @Test
@@ -400,17 +408,17 @@ public class ListIterateTest
     {
         MutableList<Integer> results = Lists.mutable.of();
         ListIterate.forEachWithIndex(integers, 0, 4, ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(results)));
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.of();
         ObjectIntProcedure<Integer> objectIntProcedure = ObjectIntProcedures.fromProcedure(CollectionAddProcedure.on(reverseResults));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
     }
 
     private void assertReverseForEachIndexUsingFromTo(List<Integer> integers, MutableList<Integer> reverseResults, ObjectIntProcedure<Integer> objectIntProcedure)
     {
         ListIterate.forEachWithIndex(integers, 4, 0, objectIntProcedure);
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
     }
 
     @Test
@@ -419,7 +427,7 @@ public class ListIterateTest
         MutableList<Integer> integers = Interval.oneTo(5).toList();
         MutableList<Integer> reverseResults = Lists.mutable.of();
         ListIterate.reverseForEach(integers, CollectionAddProcedure.on(reverseResults));
-        Assert.assertEquals(ListIterate.reverseThis(integers), reverseResults);
+        assertEquals(ListIterate.reverseThis(integers), reverseResults);
     }
 
     @Test
@@ -428,7 +436,7 @@ public class ListIterateTest
         MutableList<Integer> integers = Lists.mutable.of();
         MutableList<Integer> results = Lists.mutable.of();
         ListIterate.reverseForEach(integers, CollectionAddProcedure.on(results));
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
     }
 
     @Test
@@ -437,11 +445,11 @@ public class ListIterateTest
         MutableList<Integer> list = this.getIntegerList();
         this.assertReverseForEachWithIndex(list);
         this.assertReverseForEachWithIndex(new LinkedList<>(list));
-        ListIterate.reverseForEachWithIndex(Lists.mutable.empty(), (ignored1, index) -> Assert.fail());
+        ListIterate.reverseForEachWithIndex(Lists.mutable.empty(), (ignored1, index) -> fail());
 
         MutableList<Twin<Integer>> result = Lists.mutable.empty();
         ListIterate.reverseForEachWithIndex(list, (each, parameter) -> result.add(Tuples.twin(each, parameter)));
-        Assert.assertEquals(Lists.mutable.of(
+        assertEquals(Lists.mutable.of(
                 Tuples.twin(1, 4),
                 Tuples.twin(2, 3),
                 Tuples.twin(3, 2),
@@ -467,8 +475,8 @@ public class ListIterateTest
 
     private void assertSumOfInt(List<Integer> list)
     {
-        Assert.assertEquals(150, ListIterate.sumOfInt(list, anObject -> anObject * 10));
-        Assert.assertEquals(150, ListIterate.sumOfInt(new LinkedList<>(list), anObject -> anObject * 10));
+        assertEquals(150, ListIterate.sumOfInt(list, anObject -> anObject * 10));
+        assertEquals(150, ListIterate.sumOfInt(new LinkedList<>(list), anObject -> anObject * 10));
     }
 
     @Test
@@ -484,16 +492,16 @@ public class ListIterateTest
     @Test
     public void min()
     {
-        Assert.assertEquals((Integer) 3,
+        assertEquals((Integer) 3,
                 ListIterate.min(Lists.mutable.of(2, 1, 3), Comparators.reverseNaturalOrder()));
 
-        Assert.assertEquals((Integer) 1,
+        assertEquals((Integer) 1,
                 ListIterate.min(Lists.mutable.of(2, 1, 3)));
 
-        Assert.assertEquals((Integer) 3,
+        assertEquals((Integer) 3,
                 ListIterate.min(new LinkedList<>(Lists.mutable.of(2, 1, 3)), Comparators.reverseNaturalOrder()));
 
-        Assert.assertEquals((Integer) 1,
+        assertEquals((Integer) 1,
                 ListIterate.min(new LinkedList<>(Lists.mutable.of(2, 1, 3))));
     }
 
@@ -503,27 +511,27 @@ public class ListIterateTest
         Twin<Integer> twinOne = Tuples.twin(3, 1);
         Twin<Integer> twinTwo = Tuples.twin(2, 5);
         MutableList<Twin<Integer>> list = Lists.mutable.of(twinOne, twinTwo);
-        Assert.assertEquals(twinTwo, ListIterate.minBy(list, Functions.firstOfPair()));
-        Assert.assertEquals(twinOne, ListIterate.minBy(list, Functions.secondOfPair()));
+        assertEquals(twinTwo, ListIterate.minBy(list, Functions.firstOfPair()));
+        assertEquals(twinOne, ListIterate.minBy(list, Functions.secondOfPair()));
 
         List<Twin<Integer>> linkedList = new LinkedList<>(Lists.mutable.of(twinOne, twinTwo));
-        Assert.assertEquals(twinTwo, ListIterate.minBy(linkedList, Functions.firstOfPair()));
-        Assert.assertEquals(twinOne, ListIterate.minBy(linkedList, Functions.secondOfPair()));
+        assertEquals(twinTwo, ListIterate.minBy(linkedList, Functions.firstOfPair()));
+        assertEquals(twinOne, ListIterate.minBy(linkedList, Functions.secondOfPair()));
     }
 
     @Test
     public void max()
     {
-        Assert.assertEquals((Integer) 1,
+        assertEquals((Integer) 1,
                 ListIterate.max(Lists.mutable.of(2, 1, 3), Comparators.reverseNaturalOrder()));
 
-        Assert.assertEquals((Integer) 3,
+        assertEquals((Integer) 3,
                 ListIterate.max(Lists.mutable.of(2, 1, 3)));
 
-        Assert.assertEquals((Integer) 1,
+        assertEquals((Integer) 1,
                 ListIterate.max(new LinkedList<>(Lists.mutable.of(2, 1, 3)), Comparators.reverseNaturalOrder()));
 
-        Assert.assertEquals((Integer) 3,
+        assertEquals((Integer) 3,
                 ListIterate.max(new LinkedList<>(Lists.mutable.of(2, 1, 3))));
     }
 
@@ -533,12 +541,12 @@ public class ListIterateTest
         Twin<Integer> twinOne = Tuples.twin(3, 1);
         Twin<Integer> twinTwo = Tuples.twin(2, 5);
         MutableList<Twin<Integer>> list = Lists.mutable.of(twinOne, twinTwo);
-        Assert.assertEquals(twinOne, ListIterate.maxBy(list, Functions.firstOfPair()));
-        Assert.assertEquals(twinTwo, ListIterate.maxBy(list, Functions.secondOfPair()));
+        assertEquals(twinOne, ListIterate.maxBy(list, Functions.firstOfPair()));
+        assertEquals(twinTwo, ListIterate.maxBy(list, Functions.secondOfPair()));
 
         List<Twin<Integer>> linkedList = new LinkedList<>(Lists.mutable.of(twinOne, twinTwo));
-        Assert.assertEquals(twinOne, ListIterate.maxBy(linkedList, Functions.firstOfPair()));
-        Assert.assertEquals(twinTwo, ListIterate.maxBy(linkedList, Functions.secondOfPair()));
+        assertEquals(twinOne, ListIterate.maxBy(linkedList, Functions.firstOfPair()));
+        assertEquals(twinTwo, ListIterate.maxBy(linkedList, Functions.secondOfPair()));
     }
 
     private void assertGroupByEach(List<Integer> list)
@@ -546,7 +554,7 @@ public class ListIterateTest
         FastListMultimap<Integer, Integer> multimap =
                 ListIterate.groupByEach(list, each -> Lists.mutable.of(each, each));
 
-        Assert.assertEquals(FastListMultimap.newMultimap(
+        assertEquals(FastListMultimap.newMultimap(
                 Tuples.pair(1, 1),
                 Tuples.pair(1, 1),
                 Tuples.pair(2, 2),
@@ -560,7 +568,7 @@ public class ListIterateTest
         FastListMultimap<Integer, Integer> multimap =
                 ListIterate.groupByEach(list, each -> Lists.mutable.of(each, each), FastListMultimap.newMultimap());
 
-        Assert.assertEquals(FastListMultimap.newMultimap(
+        assertEquals(FastListMultimap.newMultimap(
                 Tuples.pair(1, 1),
                 Tuples.pair(1, 1),
                 Tuples.pair(2, 2),
@@ -579,8 +587,8 @@ public class ListIterateTest
 
     private void assertAllSatisfy(List<Integer> list)
     {
-        Assert.assertFalse(ListIterate.allSatisfy(list, IntegerPredicates.isOdd()));
-        Assert.assertTrue(ListIterate.allSatisfy(list, IntegerPredicates.isPositive()));
+        assertFalse(ListIterate.allSatisfy(list, IntegerPredicates.isOdd()));
+        assertTrue(ListIterate.allSatisfy(list, IntegerPredicates.isPositive()));
     }
 
     @Test
@@ -595,9 +603,9 @@ public class ListIterateTest
     {
         Optional<Integer> integerOptional =
                 ListIterate.detectWithOptional(list, Predicates2.attributeEqual(Functions.getPassThru()), 3);
-        Assert.assertTrue(integerOptional.isPresent());
-        Assert.assertEquals((Integer) 3, integerOptional.get());
-        Assert.assertFalse(ListIterate.detectWithOptional(
+        assertTrue(integerOptional.isPresent());
+        assertEquals((Integer) 3, integerOptional.get());
+        assertFalse(ListIterate.detectWithOptional(
                 list,
                 Predicates2.attributeEqual(Functions.getPassThru()), 7).isPresent());
     }
@@ -605,9 +613,9 @@ public class ListIterateTest
     private void assertDetectOptional(List<Integer> list)
     {
         Optional<Integer> integerOptional = ListIterate.detectOptional(list, Predicates.equal(2));
-        Assert.assertTrue(integerOptional.isPresent());
-        Assert.assertEquals((Integer) 2, integerOptional.get());
-        Assert.assertFalse(ListIterate.detectOptional(list, Predicates.alwaysFalse()).isPresent());
+        assertTrue(integerOptional.isPresent());
+        assertEquals((Integer) 2, integerOptional.get());
+        assertFalse(ListIterate.detectOptional(list, Predicates.alwaysFalse()).isPresent());
     }
 
     private void assertReverseForEachWithIndex(List<Integer> list)
@@ -615,8 +623,8 @@ public class ListIterateTest
         Counter counter = new Counter();
         ListIterate.reverseForEachWithIndex(list, (object, index) ->
         {
-            Assert.assertEquals(counter.getCount() + 1, object.longValue());
-            Assert.assertEquals(4 - counter.getCount(), index);
+            assertEquals(counter.getCount() + 1, object.longValue());
+            assertEquals(4 - counter.getCount(), index);
             counter.increment();
         });
     }
@@ -633,11 +641,11 @@ public class ListIterateTest
     {
         FastList<Integer> target = FastList.newList();
         ListIterate.forEach(list, 1, 3, new FastListSelectProcedure<>(Predicates.alwaysTrue(), target));
-        Assert.assertEquals(Lists.mutable.of(4, 3, 2), target);
+        assertEquals(Lists.mutable.of(4, 3, 2), target);
 
         target.clear();
         ListIterate.forEach(list, 3, 1, new FastListSelectProcedure<>(Predicates.alwaysTrue(), target));
-        Assert.assertEquals(Lists.mutable.of(2, 3, 4), target);
+        assertEquals(Lists.mutable.of(2, 3, 4), target);
     }
 
     @Test
@@ -650,20 +658,20 @@ public class ListIterateTest
         this.assertForEachInBoth(new LinkedList<>(list1), list2);
         this.assertForEachInBoth(new LinkedList<>(list1), new LinkedList<>(list2));
 
-        ListIterate.forEachInBoth(null, null, (argument1, argument2) -> Assert.fail());
+        ListIterate.forEachInBoth(null, null, (argument1, argument2) -> fail());
     }
 
     @Test(expected = RuntimeException.class)
     public void forEachInBothThrowsOnDifferentLengthLists()
     {
-        ListIterate.forEachInBoth(FastList.newListWith(1, 2, 3), FastList.newListWith(1, 2), (argument1, argument2) -> Assert.fail());
+        ListIterate.forEachInBoth(FastList.newListWith(1, 2, 3), FastList.newListWith(1, 2), (argument1, argument2) -> fail());
     }
 
     private void assertForEachInBoth(List<String> list1, List<String> list2)
     {
         List<Pair<String, String>> list = new ArrayList<>();
         ListIterate.forEachInBoth(list1, list2, (argument1, argument2) -> list.add(Tuples.twin(argument1, argument2)));
-        Assert.assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
+        assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
     }
 
     @Test
@@ -676,27 +684,27 @@ public class ListIterateTest
 
     private void assertDetectWith(List<Integer> list)
     {
-        Assert.assertEquals(Integer.valueOf(1), ListIterate.detectWith(list, Object::equals, 1));
+        assertEquals(Integer.valueOf(1), ListIterate.detectWith(list, Object::equals, 1));
         MutableList<Integer> list2 = Lists.fixedSize.of(1, 2, 2);
-        Assert.assertSame(list2.get(1), ListIterate.detectWith(list2, Object::equals, 2));
+        assertSame(list2.get(1), ListIterate.detectWith(list2, Object::equals, 2));
     }
 
     @Test
     public void detectIfNone()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertNull(ListIterate.detectIfNone(list, Integer.valueOf(6)::equals, null));
-        Assert.assertEquals(Integer.valueOf(5), ListIterate.detectIfNone(list, Integer.valueOf(5)::equals, 0));
-        Assert.assertNull(ListIterate.detectIfNone(new LinkedList<>(list), Integer.valueOf(6)::equals, null));
+        assertNull(ListIterate.detectIfNone(list, Integer.valueOf(6)::equals, null));
+        assertEquals(Integer.valueOf(5), ListIterate.detectIfNone(list, Integer.valueOf(5)::equals, 0));
+        assertNull(ListIterate.detectIfNone(new LinkedList<>(list), Integer.valueOf(6)::equals, null));
     }
 
     @Test
     public void detectWithIfNone()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertNull(ListIterate.detectWithIfNone(list, Object::equals, 6, null));
-        Assert.assertEquals(Integer.valueOf(5), ListIterate.detectWithIfNone(list, Object::equals, 5, 0));
-        Assert.assertNull(ListIterate.detectWithIfNone(new LinkedList<>(list), Object::equals, 6, null));
+        assertNull(ListIterate.detectWithIfNone(list, Object::equals, 6, null));
+        assertEquals(Integer.valueOf(5), ListIterate.detectWithIfNone(list, Object::equals, 5, 0));
+        assertNull(ListIterate.detectWithIfNone(new LinkedList<>(list), Object::equals, 6, null));
     }
 
     @Test
@@ -704,8 +712,8 @@ public class ListIterateTest
     {
         MutableList<Integer> list = this.getIntegerList();
         MutableList<Integer> expected = Lists.mutable.of(4, 2);
-        Assert.assertEquals(expected, ListIterate.select(list, IntegerPredicates.isEven(), Lists.mutable.empty()));
-        Assert.assertEquals(expected,
+        assertEquals(expected, ListIterate.select(list, IntegerPredicates.isEven(), Lists.mutable.empty()));
+        assertEquals(expected,
                 ListIterate.select(new LinkedList<>(list), IntegerPredicates.isEven(), Lists.mutable.empty()));
     }
 
@@ -726,8 +734,8 @@ public class ListIterateTest
         String def = "def";
         MutableList<? extends Serializable> list = Lists.mutable.of(new Integer(1), abc, new Long(2), def);
         MutableList<String> expected = Lists.mutable.of(abc, def);
-        Assert.assertEquals(expected, ListIterate.selectInstancesOf(list, String.class));
-        Assert.assertEquals(expected, ListIterate.selectInstancesOf(new LinkedList<>(list), String.class));
+        assertEquals(expected, ListIterate.selectInstancesOf(list, String.class));
+        assertEquals(expected, ListIterate.selectInstancesOf(new LinkedList<>(list), String.class));
     }
 
     @Test
@@ -765,9 +773,9 @@ public class ListIterateTest
     public void reject()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Lists.mutable.of(4, 2),
+        assertEquals(Lists.mutable.of(4, 2),
                 ListIterate.reject(list, IntegerPredicates.isOdd(), Lists.mutable.empty()));
-        Assert.assertEquals(Lists.mutable.of(4, 2),
+        assertEquals(Lists.mutable.of(4, 2),
                 ListIterate.reject(new LinkedList<>(list), IntegerPredicates.isOdd(), Lists.mutable.empty()));
     }
 
@@ -800,8 +808,8 @@ public class ListIterateTest
     {
         List<Integer> list = new LinkedList<>(Interval.oneTo(101));
         PartitionMutableList<Integer> partition = ListIterate.partitionWith(list, Predicates2.in(), Interval.oneToBy(101, 2));
-        Assert.assertEquals(Interval.oneToBy(101, 2), partition.getSelected());
-        Assert.assertEquals(Interval.fromToBy(2, 100, 2), partition.getRejected());
+        assertEquals(Interval.oneToBy(101, 2), partition.getSelected());
+        assertEquals(Interval.fromToBy(2, 100, 2), partition.getRejected());
     }
 
     @Test
@@ -822,14 +830,14 @@ public class ListIterateTest
 
     private void assertAnySatisfy(List<Integer> list)
     {
-        Assert.assertTrue(ListIterate.anySatisfy(list, IntegerPredicates.isPositive()));
-        Assert.assertFalse(ListIterate.anySatisfy(list, IntegerPredicates.isNegative()));
+        assertTrue(ListIterate.anySatisfy(list, IntegerPredicates.isPositive()));
+        assertFalse(ListIterate.anySatisfy(list, IntegerPredicates.isNegative()));
     }
 
     private void assertAnySatisyWith(List<Integer> undertest)
     {
-        Assert.assertTrue(ListIterate.anySatisfyWith(undertest, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(ListIterate.anySatisfyWith(undertest, Predicates2.instanceOf(), Double.class));
+        assertTrue(ListIterate.anySatisfyWith(undertest, Predicates2.instanceOf(), Integer.class));
+        assertFalse(ListIterate.anySatisfyWith(undertest, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
@@ -842,9 +850,9 @@ public class ListIterateTest
 
     private void assertAllSatisfyWith(List<Integer> list)
     {
-        Assert.assertTrue(ListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertTrue(ListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(ListIterate.allSatisfyWith(list, greaterThanPredicate, 2));
+        assertFalse(ListIterate.allSatisfyWith(list, greaterThanPredicate, 2));
     }
 
     @Test
@@ -857,8 +865,8 @@ public class ListIterateTest
 
     private void assertNoneSatisfy(List<Integer> list)
     {
-        Assert.assertTrue(ListIterate.noneSatisfy(list, IntegerPredicates.isZero()));
-        Assert.assertFalse(ListIterate.noneSatisfy(list, IntegerPredicates.isEven()));
+        assertTrue(ListIterate.noneSatisfy(list, IntegerPredicates.isZero()));
+        assertFalse(ListIterate.noneSatisfy(list, IntegerPredicates.isEven()));
     }
 
     @Test
@@ -871,16 +879,16 @@ public class ListIterateTest
 
     private void assertNoneSatisfyWith(List<Integer> list)
     {
-        Assert.assertTrue(ListIterate.noneSatisfyWith(list, Predicates2.instanceOf(), String.class));
+        assertTrue(ListIterate.noneSatisfyWith(list, Predicates2.instanceOf(), String.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertTrue(ListIterate.noneSatisfyWith(list, greaterThanPredicate, 6));
+        assertTrue(ListIterate.noneSatisfyWith(list, greaterThanPredicate, 6));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(5, ListIterate.countWith(this.getIntegerList(), Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(5, ListIterate.countWith(
+        assertEquals(5, ListIterate.countWith(this.getIntegerList(), Predicates2.instanceOf(), Integer.class));
+        assertEquals(5, ListIterate.countWith(
                 new LinkedList<>(this.getIntegerList()),
                 Predicates2.instanceOf(),
                 Integer.class));
@@ -890,8 +898,8 @@ public class ListIterateTest
     public void count()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(3, ListIterate.count(list, IntegerPredicates.isOdd()));
-        Assert.assertEquals(3, ListIterate.count(new LinkedList<>(list), IntegerPredicates.isOdd()));
+        assertEquals(3, ListIterate.count(list, IntegerPredicates.isOdd()));
+        assertEquals(3, ListIterate.count(new LinkedList<>(list), IntegerPredicates.isOdd()));
     }
 
     @Test
@@ -911,8 +919,8 @@ public class ListIterateTest
     @Test
     public void reverseThis()
     {
-        Assert.assertEquals(FastList.newListWith(2, 3, 1), ListIterate.reverseThis(Lists.fixedSize.of(1, 3, 2)));
-        Assert.assertEquals(FastList.newListWith(2, 3, 1), ListIterate.reverseThis(new LinkedList<>(Lists.fixedSize.of(1, 3, 2))));
+        assertEquals(FastList.newListWith(2, 3, 1), ListIterate.reverseThis(Lists.fixedSize.of(1, 3, 2)));
+        assertEquals(FastList.newListWith(2, 3, 1), ListIterate.reverseThis(new LinkedList<>(Lists.fixedSize.of(1, 3, 2))));
     }
 
     @Test
@@ -926,8 +934,8 @@ public class ListIterateTest
         Verify.assertSize(0, ListIterate.take(new LinkedList<>(), 2));
         Verify.assertSize(0, ListIterate.take(new LinkedList<>(), Integer.MAX_VALUE));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ListIterate.take(this.getIntegerList(), -1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ListIterate.take(this.getIntegerList(), -1, FastList.newList()));
+        assertThrows(IllegalArgumentException.class, () -> ListIterate.take(this.getIntegerList(), -1));
+        assertThrows(IllegalArgumentException.class, () -> ListIterate.take(this.getIntegerList(), -1, FastList.newList()));
     }
 
     private void assertTake(List<Integer> integers)
@@ -940,7 +948,7 @@ public class ListIterateTest
         Verify.assertListsEqual(FastList.newListWith(5, 4, 3, 2, 1), ListIterate.take(integers, 10, FastList.newList()));
         Verify.assertListsEqual(FastList.newListWith(5, 4, 3, 2), ListIterate.take(integers, integers.size() - 1));
         Verify.assertListsEqual(FastList.newListWith(5, 4, 3, 2, 1), ListIterate.take(integers, integers.size()));
-        Assert.assertNotSame(integers, ListIterate.take(integers, integers.size()));
+        assertNotSame(integers, ListIterate.take(integers, integers.size()));
 
         Verify.assertEmpty(ListIterate.take(Lists.fixedSize.of(), 2));
     }
@@ -963,14 +971,14 @@ public class ListIterateTest
         Verify.assertSize(0, ListIterate.drop(new LinkedList<>(), 2));
         Verify.assertSize(0, ListIterate.drop(new LinkedList<>(), Integer.MAX_VALUE));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ListIterate.drop(FastList.newList(), -1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> ListIterate.drop(FastList.newList(), -1, FastList.newList()));
+        assertThrows(IllegalArgumentException.class, () -> ListIterate.drop(FastList.newList(), -1));
+        assertThrows(IllegalArgumentException.class, () -> ListIterate.drop(FastList.newList(), -1, FastList.newList()));
     }
 
     private void assertDrop(List<Integer> integers)
     {
         Verify.assertListsEqual(FastList.newListWith(5, 4, 3, 2, 1), ListIterate.drop(integers, 0));
-        Assert.assertNotSame(integers, ListIterate.drop(integers, 0));
+        assertNotSame(integers, ListIterate.drop(integers, 0));
         Verify.assertListsEqual(FastList.newListWith(3, 2, 1), ListIterate.drop(integers, 2));
         Verify.assertListsEqual(FastList.newListWith(1), ListIterate.drop(integers, integers.size() - 1));
         Verify.assertEmpty(ListIterate.drop(integers, 5));
@@ -994,7 +1002,7 @@ public class ListIterateTest
         MutableList<String> list = FastList.newListWith("1", "2", "3", "4", "5", "6", "7");
         RichIterable<RichIterable<String>> groups = ListIterate.chunk(list, 2);
         RichIterable<Integer> sizes = groups.collect(RichIterable::size);
-        Assert.assertEquals(FastList.newListWith(2, 2, 2, 1), sizes);
+        assertEquals(FastList.newListWith(2, 2, 2, 1), sizes);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1011,27 +1019,27 @@ public class ListIterateTest
         List<Integer> list2 = new LinkedList<>(list1);
         MutableList<Integer> resultList2 = Lists.mutable.of();
 
-        Assert.assertTrue(ListIterate.removeIf(list1,
+        assertTrue(ListIterate.removeIf(list1,
                 IntegerPredicates.isEven(), CollectionAddProcedure.on(resultList1)));
         FastList<Integer> expected = FastList.newListWith(1, 3, 5);
-        Assert.assertEquals(expected, list1);
+        assertEquals(expected, list1);
         FastList<Integer> expectedToCollect = FastList.newListWith(2, 4);
-        Assert.assertEquals(expectedToCollect, resultList1);
+        assertEquals(expectedToCollect, resultList1);
 
-        Assert.assertFalse(ListIterate.removeIf(list1,
+        assertFalse(ListIterate.removeIf(list1,
                 IntegerPredicates.isNegative(), CollectionAddProcedure.on(resultList1)));
-        Assert.assertEquals(expected, list1);
-        Assert.assertEquals(expectedToCollect, resultList1);
+        assertEquals(expected, list1);
+        assertEquals(expectedToCollect, resultList1);
 
-        Assert.assertTrue(ListIterate.removeIf(list2, IntegerPredicates.isEven(),
+        assertTrue(ListIterate.removeIf(list2, IntegerPredicates.isEven(),
                 CollectionAddProcedure.on(resultList2)));
-        Assert.assertEquals(expected, list2);
-        Assert.assertEquals(expectedToCollect, resultList2);
+        assertEquals(expected, list2);
+        assertEquals(expectedToCollect, resultList2);
 
-        Assert.assertFalse(ListIterate.removeIf(list2,
+        assertFalse(ListIterate.removeIf(list2,
                 IntegerPredicates.isNegative(), CollectionAddProcedure.on(resultList2)));
-        Assert.assertEquals(expected, list2);
-        Assert.assertEquals(expectedToCollect, resultList2);
+        assertEquals(expected, list2);
+        assertEquals(expectedToCollect, resultList2);
     }
 
     @Test
@@ -1045,16 +1053,16 @@ public class ListIterateTest
     private void assertRemoveIfWithProcedureAndParameter(List<Integer> list)
     {
         MutableList<Integer> target = Lists.mutable.empty();
-        Assert.assertTrue(
+        assertTrue(
                 ListIterate.removeIfWith(list, Predicates2.equal(), 3, CollectionAddProcedure.on(target)));
         MutableList<Integer> expected = Lists.mutable.of(1, 2, 4, 5);
-        Assert.assertEquals(expected, list);
-        Assert.assertEquals(Lists.mutable.of(3), target);
+        assertEquals(expected, list);
+        assertEquals(Lists.mutable.of(3), target);
 
         target.clear();
-        Assert.assertFalse(
+        assertFalse(
                 ListIterate.removeIfWith(list, Predicates2.equal(), 3, CollectionAddProcedure.on(target)));
-        Assert.assertEquals(expected, list);
+        assertEquals(expected, list);
         Verify.assertEmpty(target);
     }
 
@@ -1064,18 +1072,18 @@ public class ListIterateTest
         MutableList<Integer> list1 = FastList.newListWith(1, 2, 3, 4, 5);
         List<Integer> list2 = new LinkedList<>(list1);
 
-        Assert.assertTrue(ListIterate.removeIf(list1, IntegerPredicates.isEven()));
+        assertTrue(ListIterate.removeIf(list1, IntegerPredicates.isEven()));
         MutableList<Integer> expected = Lists.mutable.of(1, 3, 5);
-        Assert.assertEquals(expected, list1);
+        assertEquals(expected, list1);
 
-        Assert.assertTrue(ListIterate.removeIf(list2, IntegerPredicates.isEven()));
-        Assert.assertEquals(expected, list2);
+        assertTrue(ListIterate.removeIf(list2, IntegerPredicates.isEven()));
+        assertEquals(expected, list2);
 
-        Assert.assertFalse(ListIterate.removeIf(list1, IntegerPredicates.isZero()));
-        Assert.assertEquals(expected, list1);
+        assertFalse(ListIterate.removeIf(list1, IntegerPredicates.isZero()));
+        assertEquals(expected, list1);
 
-        Assert.assertFalse(ListIterate.removeIf(list2, IntegerPredicates.isZero()));
-        Assert.assertEquals(expected, list2);
+        assertFalse(ListIterate.removeIf(list2, IntegerPredicates.isZero()));
+        assertEquals(expected, list2);
     }
 
     @Test
@@ -1083,7 +1091,7 @@ public class ListIterateTest
     {
         MutableList<Integer> objects = FastList.newListWith(1, 2, 3, 4);
         ListIterate.removeIfWith(objects, Predicates2.lessThan(), 3);
-        Assert.assertEquals(FastList.newListWith(3, 4), objects);
+        assertEquals(FastList.newListWith(3, 4), objects);
     }
 
     @Test
@@ -1094,12 +1102,12 @@ public class ListIterateTest
                 Tuples.twin(1, 1),
                 Tuples.twin(2, 2),
                 Tuples.twin(3, 3));
-        Assert.assertEquals(expected, ListIterate.zip(integers, integers));
-        Assert.assertEquals(expected, ListIterate.zip(integers, integers::iterator));
+        assertEquals(expected, ListIterate.zip(integers, integers));
+        assertEquals(expected, ListIterate.zip(integers, integers::iterator));
 
         List<Integer> linkedList = new LinkedList<>(Interval.oneTo(3));
-        Assert.assertEquals(expected, ListIterate.zip(linkedList, linkedList));
-        Assert.assertEquals(expected, ListIterate.zip(linkedList, linkedList::iterator));
+        assertEquals(expected, ListIterate.zip(linkedList, linkedList));
+        assertEquals(expected, ListIterate.zip(linkedList, linkedList::iterator));
     }
 
     @Test
@@ -1111,8 +1119,8 @@ public class ListIterateTest
                 Tuples.twin(2, 1),
                 Tuples.twin(3, 2));
 
-        Assert.assertEquals(expected, ListIterate.zipWithIndex(integers, Lists.mutable.empty()));
-        Assert.assertEquals(expected, ListIterate.zipWithIndex(new LinkedList<>(integers), Lists.mutable.empty()));
+        assertEquals(expected, ListIterate.zipWithIndex(integers, Lists.mutable.empty()));
+        assertEquals(expected, ListIterate.zipWithIndex(new LinkedList<>(integers), Lists.mutable.empty()));
     }
 
     @Test
@@ -1126,8 +1134,8 @@ public class ListIterateTest
     {
         List<Integer> integers = this.getIntegerList();
         MutableList<Integer> expected = Lists.mutable.of(5, 4);
-        Assert.assertEquals(expected, ListIterate.takeWhile(integers, Predicates.notEqual(3)));
-        Assert.assertEquals(expected, ListIterate.takeWhile(new LinkedList<>(integers), Predicates.notEqual(3)));
+        assertEquals(expected, ListIterate.takeWhile(integers, Predicates.notEqual(3)));
+        assertEquals(expected, ListIterate.takeWhile(new LinkedList<>(integers), Predicates.notEqual(3)));
     }
 
     @Test
@@ -1135,8 +1143,8 @@ public class ListIterateTest
     {
         List<Integer> integers = this.getIntegerList();
         MutableList<Integer> expected = Lists.mutable.of(3, 2, 1);
-        Assert.assertEquals(expected, ListIterate.dropWhile(integers, Predicates.notEqual(3)));
-        Assert.assertEquals(expected, ListIterate.dropWhile(new LinkedList<>(integers), Predicates.notEqual(3)));
+        assertEquals(expected, ListIterate.dropWhile(integers, Predicates.notEqual(3)));
+        assertEquals(expected, ListIterate.dropWhile(new LinkedList<>(integers), Predicates.notEqual(3)));
     }
 
     @Test
@@ -1150,7 +1158,7 @@ public class ListIterateTest
     private void assertPartitionWhile(List<Integer> integers)
     {
         PartitionMutableList<Integer> actual = ListIterate.partitionWhile(integers, Predicates.notEqual(3));
-        Assert.assertEquals(Lists.mutable.of(5, 4), actual.getSelected());
-        Assert.assertEquals(Lists.mutable.of(3, 2, 1), actual.getRejected());
+        assertEquals(Lists.mutable.of(5, 4), actual.getSelected());
+        assertEquals(Lists.mutable.of(3, 2, 1), actual.getRejected());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/MapIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/MapIterateTest.java
@@ -58,8 +58,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MapIterateTest
 {
@@ -67,18 +73,18 @@ public class MapIterateTest
     public void occurrencesOf()
     {
         MutableMap<String, Integer> map = this.getIntegerMap();
-        Assert.assertEquals(0, MapIterate.occurrencesOf(map, -1));
-        Assert.assertEquals(1, MapIterate.occurrencesOf(map, 1));
-        Assert.assertEquals(1, MapIterate.occurrencesOf(map, 2));
+        assertEquals(0, MapIterate.occurrencesOf(map, -1));
+        assertEquals(1, MapIterate.occurrencesOf(map, 1));
+        assertEquals(1, MapIterate.occurrencesOf(map, 2));
     }
 
     @Test
     public void occurrencesOfAttribute()
     {
         MutableMap<String, Integer> map = this.getIntegerMap();
-        Assert.assertEquals(0, MapIterate.occurrencesOfAttribute(map, String::valueOf, "-1"));
-        Assert.assertEquals(1, MapIterate.occurrencesOfAttribute(map, String::valueOf, "1"));
-        Assert.assertEquals(1, MapIterate.occurrencesOfAttribute(map, String::valueOf, "2"));
+        assertEquals(0, MapIterate.occurrencesOfAttribute(map, String::valueOf, "-1"));
+        assertEquals(1, MapIterate.occurrencesOfAttribute(map, String::valueOf, "1"));
+        assertEquals(1, MapIterate.occurrencesOfAttribute(map, String::valueOf, "2"));
     }
 
     @Test
@@ -98,7 +104,7 @@ public class MapIterateTest
     public void injectInto()
     {
         MutableMap<String, Integer> map = this.getIntegerMap();
-        Assert.assertEquals(Integer.valueOf(1 + 2 + 3 + 4 + 5), MapIterate.injectInto(0, map, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(1 + 2 + 3 + 4 + 5), MapIterate.injectInto(0, map, AddFunction.INTEGER));
     }
 
     @Test
@@ -168,7 +174,7 @@ public class MapIterateTest
         MutableMap<String, Integer> integers = this.getIntegerMap();
         MutableList<Integer> list = MapIterate.toSortedList(integers, Collections.reverseOrder());
         MutableList<Integer> expected = FastList.newList(integers.values()).sortThis(Collections.reverseOrder());
-        Assert.assertEquals(expected, list);
+        assertEquals(expected, list);
     }
 
     @Test
@@ -200,14 +206,14 @@ public class MapIterateTest
     {
         MutableMap<String, Integer> map = this.getIntegerMap();
         Collection<Integer> results = MapIterate.select(map, Integer.class::isInstance, FastList.newList());
-        Assert.assertEquals(Bags.mutable.of(1, 2, 3, 4, 5), HashBag.newBag(results));
+        assertEquals(Bags.mutable.of(1, 2, 3, 4, 5), HashBag.newBag(results));
     }
 
     @Test
     public void count()
     {
         MutableMap<String, Integer> map = this.getIntegerMap();
-        Assert.assertEquals(5, MapIterate.count(map, Integer.class::isInstance));
+        assertEquals(5, MapIterate.count(map, Integer.class::isInstance));
     }
 
     @Test
@@ -228,7 +234,7 @@ public class MapIterateTest
         MapIterate.forEachValue(new HashMap<>(map), CollectionAddProcedure.on(list));
         MapIterate.forEachValue(new HashMap<>(), CollectionAddProcedure.on(list));
         Verify.assertSize(10, list);
-        Assert.assertEquals(30, list.injectInto(0, AddFunction.INTEGER_TO_INT));
+        assertEquals(30, list.injectInto(0, AddFunction.INTEGER_TO_INT));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -265,7 +271,7 @@ public class MapIterateTest
         MapIterate.forEachKey(map, CollectionAddProcedure.on(bag));
         MapIterate.forEachKey(new HashMap<>(map), CollectionAddProcedure.on(bag));
         MapIterate.forEachKey(new HashMap<>(), CollectionAddProcedure.on(bag));
-        Assert.assertEquals(HashBag.newBagWith("1", "1", "2", "2", "3", "3", "4", "4", "5", "5"), bag);
+        assertEquals(HashBag.newBagWith("1", "1", "2", "2", "3", "3", "4", "4", "5", "5"), bag);
     }
 
     @Test
@@ -294,12 +300,12 @@ public class MapIterateTest
         String value = "value";
         String value1 = MapIterate.getIfAbsentPut(unifiedMap, "key", () -> value);
         String value2 = MapIterate.getIfAbsentPut(unifiedMap, "key", () -> value);
-        Assert.assertEquals("value", value1);
-        Assert.assertSame(value1, value2);
+        assertEquals("value", value1);
+        assertSame(value1, value2);
         String value3 = MapIterate.getIfAbsentPut(hashMap, "key", () -> value);
         String value4 = MapIterate.getIfAbsentPut(hashMap, "key", () -> value);
-        Assert.assertEquals("value", value3);
-        Assert.assertSame(value3, value4);
+        assertEquals("value", value3);
+        assertSame(value3, value4);
     }
 
     @Test
@@ -309,7 +315,7 @@ public class MapIterateTest
         Function<String, String> function = object -> "value:" + object;
         String value1 = MapIterate.getIfAbsentPutWith(map, "key", function, "1");
         String value2 = MapIterate.getIfAbsentPutWith(map, "key", function, "2");
-        Assert.assertSame(value1, value2);
+        assertSame(value1, value2);
     }
 
     @Test
@@ -317,7 +323,7 @@ public class MapIterateTest
     {
         MutableMap<String, String> map = UnifiedMap.newMap();
         map.put("nullValueKey", null);
-        Assert.assertNull(MapIterate.getIfAbsentPut(map, "nullValueKey", () -> "aValue"));
+        assertNull(MapIterate.getIfAbsentPut(map, "nullValueKey", () -> "aValue"));
     }
 
     @SuppressWarnings("StringOperationCanBeSimplified")
@@ -329,21 +335,21 @@ public class MapIterateTest
         String value1 = MapIterate.getIfAbsent(unifiedMap, "key", () -> new String("value"));
         String value2 = MapIterate.getIfAbsent(unifiedMap, "key", () -> new String("value"));
         String value3 = MapIterate.getIfAbsent(hashMap, "key", () -> new String("value"));
-        Assert.assertEquals("value", value1);
-        Assert.assertEquals("value", value2);
-        Assert.assertEquals("value", value3);
-        Assert.assertNotSame(value1, value2);
-        Assert.assertNotSame(value1, value3);
-        Assert.assertEquals("key1Value", MapIterate.getIfAbsent(hashMap, "key1", () -> "value"));
-        Assert.assertEquals("key1Value", MapIterate.getIfAbsent(unifiedMap, "key1", () -> "value"));
+        assertEquals("value", value1);
+        assertEquals("value", value2);
+        assertEquals("value", value3);
+        assertNotSame(value1, value2);
+        assertNotSame(value1, value3);
+        assertEquals("key1Value", MapIterate.getIfAbsent(hashMap, "key1", () -> "value"));
+        assertEquals("key1Value", MapIterate.getIfAbsent(unifiedMap, "key1", () -> "value"));
     }
 
     @Test
     public void getIfAbsentDefault()
     {
         MutableMap<String, String> map = UnifiedMap.<String, String>newMap().withKeysValues("key", "value");
-        Assert.assertEquals("value", MapIterate.getIfAbsentDefault(map, "key", "defaultValue1"));
-        Assert.assertEquals("defaultValue2", MapIterate.getIfAbsentDefault(map, "noKey", "defaultValue2"));
+        assertEquals("value", MapIterate.getIfAbsentDefault(map, "key", "defaultValue1"));
+        assertEquals("defaultValue2", MapIterate.getIfAbsentDefault(map, "noKey", "defaultValue2"));
         Verify.assertNotContainsKey("noKey", map);
         Verify.assertSize(1, map);
     }
@@ -356,10 +362,10 @@ public class MapIterateTest
         Map<String, Integer> hashMap = new HashMap<>(unifiedMap);
         Function<Integer, Integer> function = Functions.getPassThru();
         Integer ifAbsentValue = Integer.valueOf(6);
-        Assert.assertEquals(ifAbsentValue, MapIterate.getIfAbsentWith(unifiedMap, "six", function, ifAbsentValue));
-        Assert.assertEquals(Integer.valueOf(5), MapIterate.getIfAbsentWith(unifiedMap, "5", function, ifAbsentValue));
-        Assert.assertEquals(ifAbsentValue, MapIterate.getIfAbsentWith(hashMap, "six", function, ifAbsentValue));
-        Assert.assertEquals(Integer.valueOf(5), MapIterate.getIfAbsentWith(hashMap, "5", function, ifAbsentValue));
+        assertEquals(ifAbsentValue, MapIterate.getIfAbsentWith(unifiedMap, "six", function, ifAbsentValue));
+        assertEquals(Integer.valueOf(5), MapIterate.getIfAbsentWith(unifiedMap, "5", function, ifAbsentValue));
+        assertEquals(ifAbsentValue, MapIterate.getIfAbsentWith(hashMap, "six", function, ifAbsentValue));
+        assertEquals(Integer.valueOf(5), MapIterate.getIfAbsentWith(hashMap, "5", function, ifAbsentValue));
     }
 
     @Test
@@ -367,9 +373,9 @@ public class MapIterateTest
     {
         MutableMap<String, String> map = UnifiedMap.newWithKeysValues("key", null);
         String value = "value";
-        Assert.assertNull(MapIterate.getIfAbsent(map, "key", () -> value));
-        Assert.assertNull(MapIterate.getIfAbsentPut(map, "key", () -> value));
-        Assert.assertEquals("result", MapIterate.ifPresentApply(map, "key", object -> "result"));
+        assertNull(MapIterate.getIfAbsent(map, "key", () -> value));
+        assertNull(MapIterate.getIfAbsentPut(map, "key", () -> value));
+        assertEquals("result", MapIterate.ifPresentApply(map, "key", object -> "result"));
     }
 
     @Test
@@ -377,8 +383,8 @@ public class MapIterateTest
     {
         MutableMap<String, String> unifiedMap = UnifiedMap.newWithKeysValues("testKey", "testValue");
         Map<String, String> hashMap = new HashMap<>(unifiedMap);
-        Assert.assertEquals("TESTVALUE", MapIterate.ifPresentApply(unifiedMap, "testKey", String::toUpperCase));
-        Assert.assertEquals("TESTVALUE", MapIterate.ifPresentApply(hashMap, "testKey", String::toUpperCase));
+        assertEquals("TESTVALUE", MapIterate.ifPresentApply(unifiedMap, "testKey", String::toUpperCase));
+        assertEquals("TESTVALUE", MapIterate.ifPresentApply(hashMap, "testKey", String::toUpperCase));
     }
 
     @Test
@@ -413,7 +419,7 @@ public class MapIterateTest
                 "1", "2",
                 "2", "1",
                 "3", "3");
-        Assert.assertEquals(FastList.newListWith("1"), MapIterate.select(map, "1"::equals));
+        assertEquals(FastList.newListWith("1"), MapIterate.select(map, "1"::equals));
     }
 
     @Test
@@ -441,7 +447,7 @@ public class MapIterateTest
                 "2", "1",
                 "3", "3");
         MutableMap<String, String> resultMap = MapIterate.selectMapOnKey(map, "1"::equals);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("1", "2"), resultMap);
+        assertEquals(UnifiedMap.newWithKeysValues("1", "2"), resultMap);
     }
 
     @Test
@@ -452,7 +458,7 @@ public class MapIterateTest
                 "2", "1",
                 "3", "3");
         MutableMap<String, String> resultMap = MapIterate.selectMapOnValue(map, "1"::equals);
-        Assert.assertEquals(UnifiedMap.newWithKeysValues("2", "1"), resultMap);
+        assertEquals(UnifiedMap.newWithKeysValues("2", "1"), resultMap);
     }
 
     @Test
@@ -463,9 +469,9 @@ public class MapIterateTest
                 "2", "1",
                 "3", "3");
         String resultFound = MapIterate.detect(map, "1"::equals);
-        Assert.assertEquals("1", resultFound);
+        assertEquals("1", resultFound);
         String resultNotFound = MapIterate.detect(map, "4"::equals);
-        Assert.assertNull(resultNotFound);
+        assertNull(resultNotFound);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -482,9 +488,9 @@ public class MapIterateTest
                 "2", "1",
                 "3", "3");
         String resultNotFound = MapIterate.detectIfNone(map, "4"::equals, "0");
-        Assert.assertEquals("0", resultNotFound);
+        assertEquals("0", resultNotFound);
         String resultFound = MapIterate.detectIfNone(map, "1"::equals, "0");
-        Assert.assertEquals("1", resultFound);
+        assertEquals("1", resultFound);
     }
 
     @Test
@@ -494,9 +500,9 @@ public class MapIterateTest
                 "1", "2",
                 "2", "1",
                 "3", "3");
-        Assert.assertTrue(MapIterate.anySatisfy(map, "1"::equals));
-        Assert.assertTrue(MapIterate.anySatisfy(map, "3"::equals));
-        Assert.assertFalse(MapIterate.anySatisfy(map, "4"::equals));
+        assertTrue(MapIterate.anySatisfy(map, "1"::equals));
+        assertTrue(MapIterate.anySatisfy(map, "3"::equals));
+        assertFalse(MapIterate.anySatisfy(map, "4"::equals));
     }
 
     @Test
@@ -506,9 +512,9 @@ public class MapIterateTest
                 "1", "2",
                 "2", "1",
                 "3", "3");
-        Assert.assertFalse(MapIterate.allSatisfy(map, Predicates.notEqual("1")));
-        Assert.assertFalse(MapIterate.allSatisfy(map, Predicates.notEqual("3")));
-        Assert.assertTrue(MapIterate.anySatisfy(map, Predicates.notEqual("4")));
+        assertFalse(MapIterate.allSatisfy(map, Predicates.notEqual("1")));
+        assertFalse(MapIterate.allSatisfy(map, Predicates.notEqual("3")));
+        assertTrue(MapIterate.anySatisfy(map, Predicates.notEqual("4")));
     }
 
     @Test
@@ -518,25 +524,25 @@ public class MapIterateTest
                 "1", "2",
                 "2", "1",
                 "3", "3");
-        Assert.assertFalse(MapIterate.noneSatisfy(map, "1"::equals));
-        Assert.assertFalse(MapIterate.noneSatisfy(map, "3"::equals));
-        Assert.assertTrue(MapIterate.noneSatisfy(map, "4"::equals));
+        assertFalse(MapIterate.noneSatisfy(map, "1"::equals));
+        assertFalse(MapIterate.noneSatisfy(map, "3"::equals));
+        assertTrue(MapIterate.noneSatisfy(map, "4"::equals));
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(MapIterate.isEmpty(null));
-        Assert.assertTrue(MapIterate.isEmpty(UnifiedMap.newMap()));
-        Assert.assertFalse(MapIterate.isEmpty(Maps.fixedSize.of("1", "1")));
+        assertTrue(MapIterate.isEmpty(null));
+        assertTrue(MapIterate.isEmpty(UnifiedMap.newMap()));
+        assertFalse(MapIterate.isEmpty(Maps.fixedSize.of("1", "1")));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(MapIterate.notEmpty(null));
-        Assert.assertFalse(MapIterate.notEmpty(UnifiedMap.newMap()));
-        Assert.assertTrue(MapIterate.notEmpty(Maps.fixedSize.of("1", "1")));
+        assertFalse(MapIterate.notEmpty(null));
+        assertFalse(MapIterate.notEmpty(UnifiedMap.newMap()));
+        assertTrue(MapIterate.notEmpty(Maps.fixedSize.of("1", "1")));
     }
 
     @Test
@@ -545,7 +551,7 @@ public class MapIterateTest
         MutableList<Integer> result = MapIterate.reject(
                 newLittleMap(),
                 Predicates.greaterThanOrEqualTo(2));
-        Assert.assertEquals(FastList.newListWith(1), result);
+        assertEquals(FastList.newListWith(1), result);
     }
 
     private static MutableMap<Character, Integer> newLittleMap()
@@ -558,7 +564,7 @@ public class MapIterateTest
     {
         MutableList<Character> target = Lists.mutable.of();
         MapIterate.addAllKeysTo(newLittleMap(), target);
-        Assert.assertEquals(FastList.newListWith('a', 'b').toBag(), target.toBag());
+        assertEquals(FastList.newListWith('a', 'b').toBag(), target.toBag());
     }
 
     @Test
@@ -566,21 +572,21 @@ public class MapIterateTest
     {
         MutableList<Integer> target = Lists.mutable.of();
         MapIterate.addAllValuesTo(newLittleMap(), target);
-        Assert.assertEquals(FastList.newListWith(1, 2).toBag(), target.toBag());
+        assertEquals(FastList.newListWith(1, 2).toBag(), target.toBag());
     }
 
     @Test
     public void collect()
     {
         MutableList<String> result = MapIterate.collect(newLittleMap(), Functions.getToString());
-        Assert.assertEquals(FastList.newListWith("1", "2").toBag(), result.toBag());
+        assertEquals(FastList.newListWith("1", "2").toBag(), result.toBag());
     }
 
     @Test
     public void collectBoolean()
     {
         MutableBooleanCollection result = MapIterate.collectBoolean(MapIterateTest.newLittleMap(), PrimitiveFunctions.integerIsPositive());
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true), result.toBag());
+        assertEquals(BooleanHashBag.newBagWith(true, true), result.toBag());
     }
 
     @Test
@@ -588,15 +594,15 @@ public class MapIterateTest
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = MapIterate.collectBoolean(MapIterateTest.newLittleMap(), PrimitiveFunctions.integerIsPositive(), target);
-        Assert.assertEquals(BooleanHashBag.newBagWith(true, true), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(BooleanHashBag.newBagWith(true, true), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectByte()
     {
         MutableByteCollection result = MapIterate.collectByte(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToByte());
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2), result.toBag());
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2), result.toBag());
     }
 
     @Test
@@ -604,15 +610,15 @@ public class MapIterateTest
     {
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = MapIterate.collectByte(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToByte(), target);
-        Assert.assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectChar()
     {
         MutableCharCollection result = MapIterate.collectChar(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToChar());
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2), result.toBag());
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2), result.toBag());
     }
 
     @Test
@@ -620,15 +626,15 @@ public class MapIterateTest
     {
         CharHashBag target = new CharHashBag();
         CharHashBag result = MapIterate.collectChar(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToChar(), target);
-        Assert.assertEquals(CharHashBag.newBagWith((char) 1, (char) 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(CharHashBag.newBagWith((char) 1, (char) 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectDouble()
     {
         MutableDoubleCollection result = MapIterate.collectDouble(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToDouble());
-        Assert.assertEquals(DoubleHashBag.newBagWith(1, 2), result.toBag());
+        assertEquals(DoubleHashBag.newBagWith(1, 2), result.toBag());
     }
 
     @Test
@@ -636,15 +642,15 @@ public class MapIterateTest
     {
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = MapIterate.collectDouble(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToDouble(), target);
-        Assert.assertEquals(DoubleHashBag.newBagWith(1, 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(DoubleHashBag.newBagWith(1, 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectFloat()
     {
         MutableFloatCollection result = MapIterate.collectFloat(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToFloat());
-        Assert.assertEquals(FloatHashBag.newBagWith(1, 2), result.toBag());
+        assertEquals(FloatHashBag.newBagWith(1, 2), result.toBag());
     }
 
     @Test
@@ -652,15 +658,15 @@ public class MapIterateTest
     {
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = MapIterate.collectFloat(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToFloat(), target);
-        Assert.assertEquals(FloatHashBag.newBagWith(1, 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(FloatHashBag.newBagWith(1, 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectInt()
     {
         MutableIntCollection result = MapIterate.collectInt(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToInt());
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2), result.toBag());
+        assertEquals(IntHashBag.newBagWith(1, 2), result.toBag());
     }
 
     @Test
@@ -668,15 +674,15 @@ public class MapIterateTest
     {
         IntHashBag target = new IntHashBag();
         IntHashBag result = MapIterate.collectInt(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToInt(), target);
-        Assert.assertEquals(IntHashBag.newBagWith(1, 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(IntHashBag.newBagWith(1, 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectLong()
     {
         MutableLongCollection result = MapIterate.collectLong(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToLong());
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L), result.toBag());
+        assertEquals(LongHashBag.newBagWith(1L, 2L), result.toBag());
     }
 
     @Test
@@ -684,15 +690,15 @@ public class MapIterateTest
     {
         LongHashBag target = new LongHashBag();
         LongHashBag result = MapIterate.collectLong(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToLong(), target);
-        Assert.assertEquals(LongHashBag.newBagWith(1L, 2L), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(LongHashBag.newBagWith(1L, 2L), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectShort()
     {
         MutableShortCollection result = MapIterate.collectShort(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToShort());
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2), result.toBag());
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2), result.toBag());
     }
 
     @Test
@@ -700,15 +706,15 @@ public class MapIterateTest
     {
         ShortHashBag target = new ShortHashBag();
         MutableShortCollection result = MapIterate.collectShort(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToShort(), target);
-        Assert.assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2), result.toBag());
-        Assert.assertSame("Target sent as parameter was not returned as result", target, result);
+        assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2), result.toBag());
+        assertSame("Target sent as parameter was not returned as result", target, result);
     }
 
     @Test
     public void collectValues()
     {
         MutableMap<Character, String> result = MapIterate.collectValues(newLittleMap(), (argument1, argument2) -> argument2.toString());
-        Assert.assertEquals(UnifiedMap.newWithKeysValues('a', "1", 'b', "2").toBag(), result.toBag());
+        assertEquals(UnifiedMap.newWithKeysValues('a', "1", 'b', "2").toBag(), result.toBag());
     }
 
     @Test
@@ -716,8 +722,8 @@ public class MapIterateTest
     {
         MutableList<String> target = Lists.mutable.of();
         MutableList<String> result = MapIterate.collect(newLittleMap(), String::valueOf, target);
-        Assert.assertEquals(FastList.newListWith("1", "2").toBag(), result.toBag());
-        Assert.assertSame(target, result);
+        assertEquals(FastList.newListWith("1", "2").toBag(), result.toBag());
+        assertSame(target, result);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/StringIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/StringIterateTest.java
@@ -41,8 +41,15 @@ import org.eclipse.collections.impl.string.immutable.CodePointAdapter;
 import org.eclipse.collections.impl.string.immutable.CodePointList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * JUnit test for {@link StringIterate}.
@@ -67,9 +74,9 @@ public class StringIterateTest
                         .reject(CharAdapter.adapt("LE")::contains)
                         .newWith('!');
 
-        Assert.assertEquals("OH!", answer.toString());
-        Assert.assertEquals("OH!", answer.toStringBuilder().toString());
-        Assert.assertEquals("OH!", answer.makeString(""));
+        assertEquals("OH!", answer.toString());
+        assertEquals("OH!", answer.toStringBuilder().toString());
+        assertEquals("OH!", answer.makeString(""));
 
         CharList charList = StringIterate.asCharAdapter("HelloHellow")
                 .asLazy()
@@ -81,44 +88,44 @@ public class StringIterateTest
                 .reject(CharAdapter.adapt("LE")::contains)
                 .with('!');
 
-        Assert.assertEquals("OH!", CharAdapter.from(charList).toString());
-        Assert.assertEquals("OH!", CharAdapter.from(CharAdapter.from(charList)).toString());
+        assertEquals("OH!", CharAdapter.from(charList).toString());
+        assertEquals("OH!", CharAdapter.from(CharAdapter.from(charList)).toString());
 
         String helloUppercase2 = StringIterate.asCharAdapter("Hello")
                 .asLazy()
                 .collectChar(Character::toUpperCase)
                 .makeString("");
-        Assert.assertEquals("HELLO", helloUppercase2);
+        assertEquals("HELLO", helloUppercase2);
 
         CharArrayList arraylist = new CharArrayList();
         StringIterate.asCharAdapter("Hello".toUpperCase())
                 .chars()
                 .sorted()
                 .forEach(e -> arraylist.add((char) e));
-        Assert.assertEquals(StringIterate.asCharAdapter("EHLLO"), arraylist);
+        assertEquals(StringIterate.asCharAdapter("EHLLO"), arraylist);
 
         ImmutableCharList arrayList2 =
                 StringIterate.asCharAdapter("Hello".toUpperCase())
                         .toSortedList()
                         .toImmutable();
 
-        Assert.assertEquals(StringIterate.asCharAdapter("EHLLO"), arrayList2);
+        assertEquals(StringIterate.asCharAdapter("EHLLO"), arrayList2);
 
-        Assert.assertEquals(StringIterate.asCharAdapter("HELLO"), CharAdapter.adapt("hello").collectChar(Character::toUpperCase));
+        assertEquals(StringIterate.asCharAdapter("HELLO"), CharAdapter.adapt("hello").collectChar(Character::toUpperCase));
     }
 
     @Test
     public void asCharAdapterExtra()
     {
-        Assert.assertEquals(
+        assertEquals(
                 9,
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(c -> !Character.isLetter(c)));
 
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).anySatisfy(Character::isWhitespace));
 
-        Assert.assertEquals(
+        assertEquals(
                 8,
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(Character::isWhitespace));
@@ -132,17 +139,17 @@ public class StringIterateTest
 
         ImmutableCharSet alphaCharAdapter =
                 StringIterate.asCharAdapter(ALPHABET_LOWERCASE).toSet().toImmutable();
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).containsAll(alphaCharAdapter));
-        Assert.assertEquals(
+        assertEquals(
                 CharSets.immutable.empty(),
                 alphaCharAdapter.newWithoutAll(StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())));
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_1,
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.asCharAdapter(HALF_ABET.getOne()))
                         .toString());
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_2,
                 StringIterate.asCharAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.asCharAdapter(HALF_ABET.getTwo()))
@@ -157,7 +164,7 @@ public class StringIterateTest
                 .newWithAll(StringIterate.asCharAdapter(HALF_ABET.getOne()))
                 .newWithAll(StringIterate.asCharAdapter(HALF_ABET.getTwo()))
                 .newWithout('a').toString();
-        Assert.assertEquals(ALPHABET_LOWERCASE, alphabet);
+        assertEquals(ALPHABET_LOWERCASE, alphabet);
     }
 
     @Test
@@ -172,9 +179,9 @@ public class StringIterateTest
                         .reject(CodePointAdapter.adapt("LE")::contains)
                         .newWith('!');
 
-        Assert.assertEquals("OH!", answer.toString());
-        Assert.assertEquals("OH!", answer.toStringBuilder().toString());
-        Assert.assertEquals("OH!", answer.makeString(""));
+        assertEquals("OH!", answer.toString());
+        assertEquals("OH!", answer.toStringBuilder().toString());
+        assertEquals("OH!", answer.makeString(""));
 
         IntList intList = StringIterate.asCodePointAdapter("HelloHellow")
                 .asLazy()
@@ -186,22 +193,22 @@ public class StringIterateTest
                 .reject(CodePointAdapter.adapt("LE")::contains)
                 .with('!');
 
-        Assert.assertEquals("OH!", CodePointAdapter.from(intList).toString());
-        Assert.assertEquals("OH!", CodePointAdapter.from(CodePointAdapter.from(intList)).toString());
+        assertEquals("OH!", CodePointAdapter.from(intList).toString());
+        assertEquals("OH!", CodePointAdapter.from(CodePointAdapter.from(intList)).toString());
     }
 
     @Test
     public void asCodePointAdapterExtra()
     {
-        Assert.assertEquals(
+        assertEquals(
                 9,
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(i -> !Character.isLetter(i)));
 
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).anySatisfy(Character::isWhitespace));
 
-        Assert.assertEquals(
+        assertEquals(
                 8,
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(Character::isWhitespace));
@@ -215,17 +222,17 @@ public class StringIterateTest
 
         ImmutableIntSet alphaints =
                 StringIterate.asCodePointAdapter(ALPHABET_LOWERCASE).toSet().toImmutable();
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).containsAll(alphaints));
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.immutable.empty(),
                 alphaints.newWithoutAll(StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())));
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_1,
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.asCodePointAdapter(HALF_ABET.getOne()))
                         .toString());
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_2,
                 StringIterate.asCodePointAdapter(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.asCodePointAdapter(HALF_ABET.getTwo()))
@@ -244,9 +251,9 @@ public class StringIterateTest
                         .reject(CodePointList.from("LE")::contains)
                         .newWith('!');
 
-        Assert.assertEquals("OH!", answer.toString());
-        Assert.assertEquals("OH!", answer.toStringBuilder().toString());
-        Assert.assertEquals("OH!", answer.makeString(""));
+        assertEquals("OH!", answer.toString());
+        assertEquals("OH!", answer.toStringBuilder().toString());
+        assertEquals("OH!", answer.makeString(""));
 
         IntList intList = StringIterate.toCodePointList("HelloHellow")
                 .asLazy()
@@ -258,22 +265,22 @@ public class StringIterateTest
                 .reject(CodePointList.from("LE")::contains)
                 .with('!');
 
-        Assert.assertEquals("OH!", CodePointList.from(intList).toString());
-        Assert.assertEquals("OH!", CodePointList.from(CodePointList.from(intList)).toString());
+        assertEquals("OH!", CodePointList.from(intList).toString());
+        assertEquals("OH!", CodePointList.from(CodePointList.from(intList)).toString());
     }
 
     @Test
     public void toCodePointListExtra()
     {
-        Assert.assertEquals(
+        assertEquals(
                 9,
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(i -> !Character.isLetter(i)));
 
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).anySatisfy(Character::isWhitespace));
 
-        Assert.assertEquals(
+        assertEquals(
                 8,
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .count(Character::isWhitespace));
@@ -287,20 +294,20 @@ public class StringIterateTest
 
         ImmutableIntSet alphaints =
                 StringIterate.toCodePointList(ALPHABET_LOWERCASE).toSet().toImmutable();
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG).containsAll(alphaints));
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.immutable.empty(),
                 alphaints.newWithoutAll(StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())));
-        Assert.assertTrue(
+        assertTrue(
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG)
                         .containsAll(StringIterate.toCodePointList(HALF_ABET.getOne())));
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_1,
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.toCodePointList(HALF_ABET.getOne()))
                         .toString());
-        Assert.assertEquals(
+        assertEquals(
                 TQBFJOTLD_MINUS_HALF_ABET_2,
                 StringIterate.toCodePointList(THE_QUICK_BROWN_FOX_JUMPS_OVER_THE_LAZY_DOG.toLowerCase())
                         .newWithoutAll(StringIterate.toCodePointList(HALF_ABET.getTwo()))
@@ -310,45 +317,45 @@ public class StringIterateTest
     @Test
     public void englishToUpperLowerCase()
     {
-        Assert.assertEquals("ABC", StringIterate.englishToUpperCase("abc"));
-        Assert.assertEquals("abc", StringIterate.englishToLowerCase("ABC"));
+        assertEquals("ABC", StringIterate.englishToUpperCase("abc"));
+        assertEquals("abc", StringIterate.englishToLowerCase("ABC"));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals("ABC", StringIterate.collect("abc", CharToCharFunctions.toUpperCase()));
-        Assert.assertEquals("abc", StringIterate.collect("abc", CharToCharFunctions.toLowerCase()));
+        assertEquals("ABC", StringIterate.collect("abc", CharToCharFunctions.toUpperCase()));
+        assertEquals("abc", StringIterate.collect("abc", CharToCharFunctions.toLowerCase()));
     }
 
     @Test
     public void collectCodePoint()
     {
-        Assert.assertEquals("ABC", StringIterate.collect("abc", CodePointFunction.TO_UPPERCASE));
-        Assert.assertEquals("abc", StringIterate.collect("abc", CodePointFunction.TO_LOWERCASE));
+        assertEquals("ABC", StringIterate.collect("abc", CodePointFunction.TO_UPPERCASE));
+        assertEquals("abc", StringIterate.collect("abc", CodePointFunction.TO_LOWERCASE));
     }
 
     @Test
     public void collectCodePointUnicode()
     {
-        Assert.assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", StringIterate.collect("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", CodePointFunction.PASS_THRU));
-        Assert.assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", StringIterate.collect("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", CodePointFunction.PASS_THRU));
+        assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", StringIterate.collect("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", CodePointFunction.PASS_THRU));
+        assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", StringIterate.collect("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", CodePointFunction.PASS_THRU));
     }
 
     @Test
     public void englishToUpperCase()
     {
-        Assert.assertEquals("ABC", StringIterate.englishToUpperCase("abc"));
-        Assert.assertEquals("A,B,C", StringIterate.englishToUpperCase("a,b,c"));
-        Assert.assertSame("A,B,C", StringIterate.englishToUpperCase("A,B,C"));
+        assertEquals("ABC", StringIterate.englishToUpperCase("abc"));
+        assertEquals("A,B,C", StringIterate.englishToUpperCase("a,b,c"));
+        assertSame("A,B,C", StringIterate.englishToUpperCase("A,B,C"));
     }
 
     @Test
     public void englishToLowerCase()
     {
-        Assert.assertEquals("abc", StringIterate.englishToLowerCase("ABC"));
-        Assert.assertEquals("a,b,c", StringIterate.englishToLowerCase("A,B,C"));
-        Assert.assertSame("a,b,c", StringIterate.englishToLowerCase("a,b,c"));
+        assertEquals("abc", StringIterate.englishToLowerCase("ABC"));
+        assertEquals("a,b,c", StringIterate.englishToLowerCase("A,B,C"));
+        assertSame("a,b,c", StringIterate.englishToLowerCase("a,b,c"));
     }
 
     @Test
@@ -357,135 +364,135 @@ public class StringIterateTest
         String allValues = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890~`!@#$%^&*()_-+=[]{};<>,.?/|";
         String jdkUpper = allValues.toUpperCase();
         String upper = StringIterate.englishToUpperCase(allValues);
-        Assert.assertEquals(jdkUpper.length(), upper.length());
-        Assert.assertEquals(jdkUpper, upper);
+        assertEquals(jdkUpper.length(), upper.length());
+        assertEquals(jdkUpper, upper);
         String jdkLower = allValues.toLowerCase();
         String lower = StringIterate.englishToLowerCase(allValues);
-        Assert.assertEquals(jdkLower.length(), lower.length());
-        Assert.assertEquals(jdkLower, lower);
+        assertEquals(jdkLower.length(), lower.length());
+        assertEquals(jdkLower, lower);
     }
 
     @Test
     public void select()
     {
         String string = StringIterate.select("1a2a3", CharPredicates.isDigit());
-        Assert.assertEquals("123", string);
+        assertEquals("123", string);
     }
 
     @Test
     public void selectCodePoint()
     {
         String string = StringIterate.select("1a2a3", CodePointPredicate.IS_DIGIT);
-        Assert.assertEquals("123", string);
+        assertEquals("123", string);
     }
 
     @Test
     public void selectCodePointUnicode()
     {
         String string = StringIterate.select("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", CodePointPredicate.IS_BMP);
-        Assert.assertEquals("\u3042\u3044\u3046", string);
+        assertEquals("\u3042\u3044\u3046", string);
     }
 
     @Test
     public void detect()
     {
         char character = StringIterate.detect("1a2a3", CharPredicates.isLetter());
-        Assert.assertEquals('a', character);
+        assertEquals('a', character);
     }
 
     @Test
     public void detectIfNone()
     {
         char character = StringIterate.detectIfNone("123", CharPredicates.isLetter(), "b".charAt(0));
-        Assert.assertEquals('b', character);
+        assertEquals('b', character);
     }
 
     @Test
     public void detectIfNoneWithString()
     {
         char character = StringIterate.detectIfNone("123", CharPredicates.isLetter(), "b");
-        Assert.assertEquals('b', character);
+        assertEquals('b', character);
     }
 
     @Test
     public void allSatisfy()
     {
-        Assert.assertTrue(StringIterate.allSatisfy("MARY", CharPredicates.isUpperCase()));
-        Assert.assertFalse(StringIterate.allSatisfy("Mary", CharPredicates.isUpperCase()));
+        assertTrue(StringIterate.allSatisfy("MARY", CharPredicates.isUpperCase()));
+        assertFalse(StringIterate.allSatisfy("Mary", CharPredicates.isUpperCase()));
     }
 
     @Test
     public void allSatisfyCodePoint()
     {
-        Assert.assertTrue(StringIterate.allSatisfy("MARY", CodePointPredicate.IS_UPPERCASE));
-        Assert.assertFalse(StringIterate.allSatisfy("Mary", CodePointPredicate.IS_UPPERCASE));
+        assertTrue(StringIterate.allSatisfy("MARY", CodePointPredicate.IS_UPPERCASE));
+        assertFalse(StringIterate.allSatisfy("Mary", CodePointPredicate.IS_UPPERCASE));
     }
 
     @Test
     public void allSatisfyCodePointUnicode()
     {
-        Assert.assertTrue(StringIterate.allSatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
-        Assert.assertFalse(StringIterate.allSatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
+        assertTrue(StringIterate.allSatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
+        assertFalse(StringIterate.allSatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
     }
 
     @Test
     public void anySatisfy()
     {
-        Assert.assertTrue(StringIterate.anySatisfy("MARY", CharPredicates.isUpperCase()));
-        Assert.assertFalse(StringIterate.anySatisfy("mary", CharPredicates.isUpperCase()));
+        assertTrue(StringIterate.anySatisfy("MARY", CharPredicates.isUpperCase()));
+        assertFalse(StringIterate.anySatisfy("mary", CharPredicates.isUpperCase()));
     }
 
     @Test
     public void anySatisfyCodePoint()
     {
-        Assert.assertTrue(StringIterate.anySatisfy("MARY", CodePointPredicate.IS_UPPERCASE));
-        Assert.assertFalse(StringIterate.anySatisfy("mary", CodePointPredicate.IS_UPPERCASE));
+        assertTrue(StringIterate.anySatisfy("MARY", CodePointPredicate.IS_UPPERCASE));
+        assertFalse(StringIterate.anySatisfy("mary", CodePointPredicate.IS_UPPERCASE));
     }
 
     @Test
     public void anySatisfyCodePointUnicode()
     {
-        Assert.assertTrue(StringIterate.anySatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
-        Assert.assertFalse(StringIterate.anySatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
+        assertTrue(StringIterate.anySatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
+        assertFalse(StringIterate.anySatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
     }
 
     @Test
     public void noneSatisfy()
     {
-        Assert.assertFalse(StringIterate.noneSatisfy("MaRy", CharPredicates.isUpperCase()));
-        Assert.assertTrue(StringIterate.noneSatisfy("mary", CharPredicates.isUpperCase()));
+        assertFalse(StringIterate.noneSatisfy("MaRy", CharPredicates.isUpperCase()));
+        assertTrue(StringIterate.noneSatisfy("mary", CharPredicates.isUpperCase()));
     }
 
     @Test
     public void noneSatisfyCodePoint()
     {
-        Assert.assertFalse(StringIterate.noneSatisfy("MaRy", CodePointPredicate.IS_UPPERCASE));
-        Assert.assertTrue(StringIterate.noneSatisfy("mary", CodePointPredicate.IS_UPPERCASE));
+        assertFalse(StringIterate.noneSatisfy("MaRy", CodePointPredicate.IS_UPPERCASE));
+        assertTrue(StringIterate.noneSatisfy("mary", CodePointPredicate.IS_UPPERCASE));
     }
 
     @Test
     public void noneSatisfyCodePointUnicode()
     {
-        Assert.assertFalse(StringIterate.noneSatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
-        Assert.assertTrue(StringIterate.noneSatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
+        assertFalse(StringIterate.noneSatisfy("\u3042\u3044\u3046", CodePointPredicate.IS_BMP));
+        assertTrue(StringIterate.noneSatisfy("\uD840\uDC00\uD840\uDC03\uD83D\uDE09", CodePointPredicate.IS_BMP));
     }
 
     @Test
     public void isNumber()
     {
-        Assert.assertTrue(StringIterate.isNumber("123"));
-        Assert.assertFalse(StringIterate.isNumber("abc"));
-        Assert.assertFalse(StringIterate.isNumber(""));
+        assertTrue(StringIterate.isNumber("123"));
+        assertFalse(StringIterate.isNumber("abc"));
+        assertFalse(StringIterate.isNumber(""));
     }
 
     @Test
     public void isAlphaNumeric()
     {
-        Assert.assertTrue(StringIterate.isAlphaNumeric("123"));
-        Assert.assertTrue(StringIterate.isAlphaNumeric("abc"));
-        Assert.assertTrue(StringIterate.isAlphaNumeric("123abc"));
-        Assert.assertFalse(StringIterate.isAlphaNumeric("!@#"));
-        Assert.assertFalse(StringIterate.isAlphaNumeric(""));
+        assertTrue(StringIterate.isAlphaNumeric("123"));
+        assertTrue(StringIterate.isAlphaNumeric("abc"));
+        assertTrue(StringIterate.isAlphaNumeric("123abc"));
+        assertFalse(StringIterate.isAlphaNumeric("!@#"));
+        assertFalse(StringIterate.isAlphaNumeric(""));
     }
 
     @Test
@@ -557,35 +564,35 @@ public class StringIterateTest
     public void reject()
     {
         String string = StringIterate.reject("1a2b3c", CharPredicates.isDigit());
-        Assert.assertEquals("abc", string);
+        assertEquals("abc", string);
     }
 
     @Test
     public void rejectCodePoint()
     {
         String string = StringIterate.reject("1a2b3c", CodePointPredicate.IS_DIGIT);
-        Assert.assertEquals("abc", string);
+        assertEquals("abc", string);
     }
 
     @Test
     public void count()
     {
         int count = StringIterate.count("1a2a3", CharPredicates.isDigit());
-        Assert.assertEquals(3, count);
+        assertEquals(3, count);
     }
 
     @Test
     public void countCodePoint()
     {
         int count = StringIterate.count("1a2a3", CodePointPredicate.IS_DIGIT);
-        Assert.assertEquals(3, count);
+        assertEquals(3, count);
     }
 
     @Test
     public void occurrencesOf()
     {
         int count = StringIterate.occurrencesOf("1a2a3", 'a');
-        Assert.assertEquals(2, count);
+        assertEquals(2, count);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -598,28 +605,28 @@ public class StringIterateTest
     public void occurrencesOfCodePoint()
     {
         int count = StringIterate.occurrencesOf("1a2a3", "a".codePointAt(0));
-        Assert.assertEquals(2, count);
+        assertEquals(2, count);
     }
 
     @Test
     public void occurrencesOfString()
     {
         int count = StringIterate.occurrencesOf("1a2a3", "a");
-        Assert.assertEquals(2, count);
+        assertEquals(2, count);
     }
 
     @Test
     public void count2()
     {
         int count = StringIterate.count("1a2a3", CharPredicates.isUndefined());
-        Assert.assertEquals(0, count);
+        assertEquals(0, count);
     }
 
     @Test
     public void count2CodePoint()
     {
         int count = StringIterate.count("1a2a3", CodePointPredicate.IS_UNDEFINED);
-        Assert.assertEquals(0, count);
+        assertEquals(0, count);
     }
 
     @Test
@@ -627,7 +634,7 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.forEach("1a2b3c", (CharProcedure) builder::append);
-        Assert.assertEquals("1a2b3c", builder.toString());
+        assertEquals("1a2b3c", builder.toString());
     }
 
     @Test
@@ -635,7 +642,7 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.forEach("1a2b3c", (CodePointProcedure) builder::appendCodePoint);
-        Assert.assertEquals("1a2b3c", builder.toString());
+        assertEquals("1a2b3c", builder.toString());
     }
 
     @Test
@@ -643,7 +650,7 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.forEach("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", (CodePointProcedure) builder::appendCodePoint);
-        Assert.assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", builder.toString());
+        assertEquals("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", builder.toString());
     }
 
     @Test
@@ -651,9 +658,9 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.reverseForEach("1a2b3c", (CharProcedure) builder::append);
-        Assert.assertEquals("c3b2a1", builder.toString());
+        assertEquals("c3b2a1", builder.toString());
 
-        StringIterate.reverseForEach("", (char character) -> Assert.fail());
+        StringIterate.reverseForEach("", (char character) -> fail());
     }
 
     @Test
@@ -661,9 +668,9 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.reverseForEach("1a2b3c", (CodePointProcedure) builder::appendCodePoint);
-        Assert.assertEquals("c3b2a1", builder.toString());
+        assertEquals("c3b2a1", builder.toString());
 
-        StringIterate.reverseForEach("", (int codePoint) -> Assert.fail());
+        StringIterate.reverseForEach("", (int codePoint) -> fail());
     }
 
     @Test
@@ -671,8 +678,8 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.reverseForEach("\u3042\uD840\uDC00\u3044\uD840\uDC03\u3046\uD83D\uDE09", (CodePointProcedure) builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
-        StringIterate.reverseForEach("", (int codePoint) -> Assert.fail());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        StringIterate.reverseForEach("", (int codePoint) -> fail());
     }
 
     @Test
@@ -680,17 +687,17 @@ public class StringIterateTest
     {
         StringBuilder builder = new StringBuilder();
         StringIterate.reverseForEach("\u3042\uDC00\uD840\u3044\uDC03\uD840\u3046\uDE09\uD83D", (CodePointProcedure) builder::appendCodePoint);
-        Assert.assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
+        assertEquals("\uD83D\uDE09\u3046\uD840\uDC03\u3044\uD840\uDC00\u3042", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         StringIterate.reverseForEach("\u3042\uD840\u3044\uD840\u3046\uD840", (CodePointProcedure) builder2::appendCodePoint);
-        Assert.assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
+        assertEquals("\uD840\u3046\uD840\u3044\uD840\u3042", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         StringIterate.reverseForEach("\u3042\uDC00\u3044\uDC03\u3046\uDC06", (CodePointProcedure) builder3::appendCodePoint);
-        Assert.assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
+        assertEquals("\uDC06\u3046\uDC03\u3044\uDC00\u3042", builder3.toString());
 
-        StringIterate.reverseForEach("", (int codePoint) -> Assert.fail());
+        StringIterate.reverseForEach("", (int codePoint) -> fail());
     }
 
     @Test
@@ -719,108 +726,108 @@ public class StringIterateTest
     public void csvTrimmedTokenToList()
     {
         String tokens = " 1,2 ";
-        Assert.assertEquals(FastList.newListWith("1", "2"), StringIterate.csvTrimmedTokensToList(tokens));
+        assertEquals(FastList.newListWith("1", "2"), StringIterate.csvTrimmedTokensToList(tokens));
     }
 
     @Test
     public void injectIntoTokens()
     {
-        Assert.assertEquals("123", StringIterate.injectIntoTokens("1,2,3", ",", null, AddFunction.STRING));
+        assertEquals("123", StringIterate.injectIntoTokens("1,2,3", ",", null, AddFunction.STRING));
     }
 
     @Test
     public void getLastToken()
     {
-        Assert.assertEquals("charlie", StringIterate.getLastToken("alpha~|~beta~|~charlie", "~|~"));
-        Assert.assertEquals("123", StringIterate.getLastToken("123", "~|~"));
-        Assert.assertEquals("", StringIterate.getLastToken("", "~|~"));
-        Assert.assertNull(StringIterate.getLastToken(null, "~|~"));
-        Assert.assertEquals("", StringIterate.getLastToken("123~|~", "~|~"));
-        Assert.assertEquals("123", StringIterate.getLastToken("~|~123", "~|~"));
+        assertEquals("charlie", StringIterate.getLastToken("alpha~|~beta~|~charlie", "~|~"));
+        assertEquals("123", StringIterate.getLastToken("123", "~|~"));
+        assertEquals("", StringIterate.getLastToken("", "~|~"));
+        assertNull(StringIterate.getLastToken(null, "~|~"));
+        assertEquals("", StringIterate.getLastToken("123~|~", "~|~"));
+        assertEquals("123", StringIterate.getLastToken("~|~123", "~|~"));
     }
 
     @Test
     public void getFirstToken()
     {
-        Assert.assertEquals("alpha", StringIterate.getFirstToken("alpha~|~beta~|~charlie", "~|~"));
-        Assert.assertEquals("123", StringIterate.getFirstToken("123", "~|~"));
-        Assert.assertEquals("", StringIterate.getFirstToken("", "~|~"));
-        Assert.assertNull(StringIterate.getFirstToken(null, "~|~"));
-        Assert.assertEquals("123", StringIterate.getFirstToken("123~|~", "~|~"));
-        Assert.assertEquals("", StringIterate.getFirstToken("~|~123,", "~|~"));
+        assertEquals("alpha", StringIterate.getFirstToken("alpha~|~beta~|~charlie", "~|~"));
+        assertEquals("123", StringIterate.getFirstToken("123", "~|~"));
+        assertEquals("", StringIterate.getFirstToken("", "~|~"));
+        assertNull(StringIterate.getFirstToken(null, "~|~"));
+        assertEquals("123", StringIterate.getFirstToken("123~|~", "~|~"));
+        assertEquals("", StringIterate.getFirstToken("~|~123,", "~|~"));
     }
 
     @Test
     public void isEmptyOrWhitespace()
     {
-        Assert.assertTrue(StringIterate.isEmptyOrWhitespace("   "));
-        Assert.assertFalse(StringIterate.isEmptyOrWhitespace(" 1  "));
+        assertTrue(StringIterate.isEmptyOrWhitespace("   "));
+        assertFalse(StringIterate.isEmptyOrWhitespace(" 1  "));
     }
 
     @Test
     public void notEmptyOrWhitespace()
     {
-        Assert.assertFalse(StringIterate.notEmptyOrWhitespace("   "));
-        Assert.assertTrue(StringIterate.notEmptyOrWhitespace(" 1  "));
+        assertFalse(StringIterate.notEmptyOrWhitespace("   "));
+        assertTrue(StringIterate.notEmptyOrWhitespace(" 1  "));
     }
 
     @Test
     public void isEmpty()
     {
-        Assert.assertTrue(StringIterate.isEmpty(""));
-        Assert.assertFalse(StringIterate.isEmpty("   "));
-        Assert.assertFalse(StringIterate.isEmpty("1"));
+        assertTrue(StringIterate.isEmpty(""));
+        assertFalse(StringIterate.isEmpty("   "));
+        assertFalse(StringIterate.isEmpty("1"));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertFalse(StringIterate.notEmpty(""));
-        Assert.assertTrue(StringIterate.notEmpty("   "));
-        Assert.assertTrue(StringIterate.notEmpty("1"));
+        assertFalse(StringIterate.notEmpty(""));
+        assertTrue(StringIterate.notEmpty("   "));
+        assertTrue(StringIterate.notEmpty("1"));
     }
 
     @Test
     public void repeat()
     {
-        Assert.assertEquals("", StringIterate.repeat("", 42));
-        Assert.assertEquals("    ", StringIterate.repeat(' ', 4));
-        Assert.assertEquals("        ", StringIterate.repeat(" ", 8));
-        Assert.assertEquals("CubedCubedCubed", StringIterate.repeat("Cubed", 3));
+        assertEquals("", StringIterate.repeat("", 42));
+        assertEquals("    ", StringIterate.repeat(' ', 4));
+        assertEquals("        ", StringIterate.repeat(" ", 8));
+        assertEquals("CubedCubedCubed", StringIterate.repeat("Cubed", 3));
     }
 
     @Test
     public void padOrTrim()
     {
-        Assert.assertEquals("abcdefghijkl", StringIterate.padOrTrim("abcdefghijkl", 12));
-        Assert.assertEquals("this n", StringIterate.padOrTrim("this needs to be trimmed", 6));
-        Assert.assertEquals("pad this      ", StringIterate.padOrTrim("pad this", 14));
+        assertEquals("abcdefghijkl", StringIterate.padOrTrim("abcdefghijkl", 12));
+        assertEquals("this n", StringIterate.padOrTrim("this needs to be trimmed", 6));
+        assertEquals("pad this      ", StringIterate.padOrTrim("pad this", 14));
     }
 
     @Test
     public void string()
     {
-        Assert.assertEquals("Token2", StringIterate.getLastToken("Token1DelimiterToken2", "Delimiter"));
+        assertEquals("Token2", StringIterate.getLastToken("Token1DelimiterToken2", "Delimiter"));
     }
 
     @Test
     public void toList()
     {
-        Assert.assertEquals(FastList.newListWith('a', 'a', 'b', 'c', 'd', 'e'), StringIterate.toList("aabcde"));
+        assertEquals(FastList.newListWith('a', 'a', 'b', 'c', 'd', 'e'), StringIterate.toList("aabcde"));
     }
 
     @Test
     public void toLowercaseList()
     {
         MutableList<Character> set = StringIterate.toLowercaseList("America");
-        Assert.assertEquals(FastList.newListWith('a', 'm', 'e', 'r', 'i', 'c', 'a'), set);
+        assertEquals(FastList.newListWith('a', 'm', 'e', 'r', 'i', 'c', 'a'), set);
     }
 
     @Test
     public void toUppercaseList()
     {
         MutableList<Character> set = StringIterate.toUppercaseList("America");
-        Assert.assertEquals(FastList.newListWith('A', 'M', 'E', 'R', 'I', 'C', 'A'), set);
+        assertEquals(FastList.newListWith('A', 'M', 'E', 'R', 'I', 'C', 'A'), set);
     }
 
     @Test
@@ -832,27 +839,27 @@ public class StringIterateTest
     @Test
     public void chunk()
     {
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with("ab", "cd", "ef"),
                 StringIterate.chunk("abcdef", 2));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with("abc", "def"),
                 StringIterate.chunk("abcdef", 3));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with("abc", "def", "g"),
                 StringIterate.chunk("abcdefg", 3));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with("abcdef"),
                 StringIterate.chunk("abcdef", 6));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with("abcdef"),
                 StringIterate.chunk("abcdef", 7));
 
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(),
                 StringIterate.chunk("", 2));
     }
@@ -873,16 +880,16 @@ public class StringIterateTest
     public void toLowercaseSet()
     {
         MutableSet<Character> set = StringIterate.toLowercaseSet("America");
-        Assert.assertEquals(UnifiedSet.newSetWith('a', 'm', 'e', 'r', 'i', 'c'), set);
-        Assert.assertEquals(StringIterate.asLowercaseSet("America"), set);
+        assertEquals(UnifiedSet.newSetWith('a', 'm', 'e', 'r', 'i', 'c'), set);
+        assertEquals(StringIterate.asLowercaseSet("America"), set);
     }
 
     @Test
     public void toUppercaseSet()
     {
         MutableSet<Character> set = StringIterate.toUppercaseSet("America");
-        Assert.assertEquals(UnifiedSet.newSetWith('A', 'M', 'E', 'R', 'I', 'C'), set);
-        Assert.assertEquals(StringIterate.asUppercaseSet("America"), set);
+        assertEquals(UnifiedSet.newSetWith('A', 'M', 'E', 'R', 'I', 'C'), set);
+        assertEquals(StringIterate.asUppercaseSet("America"), set);
     }
 
     @Test
@@ -890,51 +897,51 @@ public class StringIterateTest
     {
         String oompaLoompa = "oompaloompa";
 
-        Assert.assertEquals(Tuples.twin("oompa", "loompa"), StringIterate.splitAtIndex(oompaLoompa, 5));
-        Assert.assertEquals(Tuples.twin("", oompaLoompa), StringIterate.splitAtIndex(oompaLoompa, 0));
-        Assert.assertEquals(Tuples.twin(oompaLoompa, ""), StringIterate.splitAtIndex(oompaLoompa, oompaLoompa.length()));
+        assertEquals(Tuples.twin("oompa", "loompa"), StringIterate.splitAtIndex(oompaLoompa, 5));
+        assertEquals(Tuples.twin("", oompaLoompa), StringIterate.splitAtIndex(oompaLoompa, 0));
+        assertEquals(Tuples.twin(oompaLoompa, ""), StringIterate.splitAtIndex(oompaLoompa, oompaLoompa.length()));
 
-        Assert.assertEquals(Tuples.twin("", ""), StringIterate.splitAtIndex("", 0));
+        assertEquals(Tuples.twin("", ""), StringIterate.splitAtIndex("", 0));
 
-        Assert.assertThrows(StringIndexOutOfBoundsException.class, () -> StringIterate.splitAtIndex(oompaLoompa, 17));
-        Assert.assertThrows(StringIndexOutOfBoundsException.class, () -> StringIterate.splitAtIndex(oompaLoompa, -8));
+        assertThrows(StringIndexOutOfBoundsException.class, () -> StringIterate.splitAtIndex(oompaLoompa, 17));
+        assertThrows(StringIndexOutOfBoundsException.class, () -> StringIterate.splitAtIndex(oompaLoompa, -8));
     }
 
     @Test
     public void toLowercaseBag()
     {
         MutableBag<Character> lowercaseBag = StringIterate.toLowercaseBag("America");
-        Assert.assertEquals(2, lowercaseBag.occurrencesOf(Character.valueOf('a')));
-        Assert.assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('m')));
-        Assert.assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('e')));
-        Assert.assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('r')));
-        Assert.assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('i')));
-        Assert.assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('c')));
+        assertEquals(2, lowercaseBag.occurrencesOf(Character.valueOf('a')));
+        assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('m')));
+        assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('e')));
+        assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('r')));
+        assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('i')));
+        assertEquals(1, lowercaseBag.occurrencesOf(Character.valueOf('c')));
     }
 
     @Test
     public void toUppercaseBag()
     {
         MutableBag<Character> uppercaseBag = StringIterate.toUppercaseBag("America");
-        Assert.assertEquals(2, uppercaseBag.occurrencesOf(Character.valueOf('A')));
-        Assert.assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('M')));
-        Assert.assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('E')));
-        Assert.assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('R')));
-        Assert.assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('I')));
-        Assert.assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('C')));
+        assertEquals(2, uppercaseBag.occurrencesOf(Character.valueOf('A')));
+        assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('M')));
+        assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('E')));
+        assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('R')));
+        assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('I')));
+        assertEquals(1, uppercaseBag.occurrencesOf(Character.valueOf('C')));
     }
 
     @Test
     public void toBag()
     {
         MutableBag<Character> bag = StringIterate.toBag("America");
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('A')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('m')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('e')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('r')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('i')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('c')));
-        Assert.assertEquals(1, bag.occurrencesOf(Character.valueOf('a')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('A')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('m')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('e')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('r')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('i')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('c')));
+        assertEquals(1, bag.occurrencesOf(Character.valueOf('a')));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterateTest.java
@@ -26,8 +26,9 @@ import org.eclipse.collections.impl.factory.primitive.FloatLists;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class InternalArrayIterateTest
 {
@@ -39,7 +40,7 @@ public class InternalArrayIterateTest
         MutableBooleanList result = InternalArrayIterate.collectBoolean(
                 items, 3, anObject -> anObject % 2 == 0, BooleanLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, BooleanLists.mutable.of(false, true, false));
+        assertEquals(result, BooleanLists.mutable.of(false, true, false));
     }
 
     @Test
@@ -50,7 +51,7 @@ public class InternalArrayIterateTest
         MutableByteList result = InternalArrayIterate.collectByte(
                 items, 3, Integer::byteValue, ByteLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, ByteLists.mutable.of((byte) 1, (byte) 2, (byte) 3));
+        assertEquals(result, ByteLists.mutable.of((byte) 1, (byte) 2, (byte) 3));
     }
 
     @Test
@@ -61,7 +62,7 @@ public class InternalArrayIterateTest
         MutableCharList result = InternalArrayIterate.collectChar(
                 items, 3, Character::toUpperCase, CharLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, CharLists.mutable.of('A', 'B', 'C'));
+        assertEquals(result, CharLists.mutable.of('A', 'B', 'C'));
     }
 
     @Test
@@ -72,7 +73,7 @@ public class InternalArrayIterateTest
         MutableDoubleList result = InternalArrayIterate.collectDouble(
                 items, 3, Integer::doubleValue, DoubleLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, DoubleLists.mutable.of(1.0, 2.0, 3.0));
+        assertEquals(result, DoubleLists.mutable.of(1.0, 2.0, 3.0));
     }
 
     @Test
@@ -83,7 +84,7 @@ public class InternalArrayIterateTest
         MutableFloatList result = InternalArrayIterate.collectFloat(
                 items, 3, Integer::floatValue, FloatLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, FloatLists.mutable.of(1.0F, 2.0F, 3.0F));
+        assertEquals(result, FloatLists.mutable.of(1.0F, 2.0F, 3.0F));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class InternalArrayIterateTest
         MutableIntList result = InternalArrayIterate.collectInt(
                 items, 3, anObject -> anObject + 1, IntLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, IntLists.mutable.of(2, 3, 4));
+        assertEquals(result, IntLists.mutable.of(2, 3, 4));
     }
 
     @Test
@@ -105,7 +106,7 @@ public class InternalArrayIterateTest
         MutableLongList result = InternalArrayIterate.collectLong(
                 items, 3, Integer::longValue, LongLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, LongLists.mutable.of(1L, 2L, 3L));
+        assertEquals(result, LongLists.mutable.of(1L, 2L, 3L));
     }
 
     @Test
@@ -116,6 +117,6 @@ public class InternalArrayIterateTest
         MutableShortList result = InternalArrayIterate.collectShort(
                 items, 3, Integer::shortValue, ShortLists.mutable.withInitialCapacity(3));
 
-        Assert.assertEquals(result, ShortLists.mutable.of((short) 1, (short) 2, (short) 3));
+        assertEquals(result, ShortLists.mutable.of((short) 1, (short) 2, (short) 3));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
@@ -41,11 +41,17 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * JUnit test for {@link IterableIterate}.
@@ -56,7 +62,7 @@ public class IterableIterateTest
     public void injectInto()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(iList(1, 2, 3));
-        Assert.assertEquals(
+        assertEquals(
                 1 + 1 + 2 + 3,
                 Iterate.injectInto(1, iterable, AddFunction.INTEGER).intValue());
     }
@@ -70,14 +76,14 @@ public class IterableIterateTest
             list.add(1);
         }
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(32, Iterate.injectInto(1, iterable, AddFunction.INTEGER).intValue());
+        assertEquals(32, Iterate.injectInto(1, iterable, AddFunction.INTEGER).intValue());
     }
 
     @Test
     public void injectIntoDouble()
     {
         Iterable<Double> iterable = new IterableAdapter<>(iList(1.0, 2.0, 3.0));
-        Assert.assertEquals(
+        assertEquals(
                 1.0 + 1.0 + 2.0 + 3.0,
                 Iterate.injectInto(1.0, iterable, AddFunction.DOUBLE).doubleValue(),
                 0.0);
@@ -87,21 +93,21 @@ public class IterableIterateTest
     public void injectIntoString()
     {
         Iterable<String> iterable = new IterableAdapter<>(iList("1", "2", "3"));
-        Assert.assertEquals("0123", Iterate.injectInto("0", iterable, AddFunction.STRING));
+        assertEquals("0123", Iterate.injectInto("0", iterable, AddFunction.STRING));
     }
 
     @Test
     public void injectIntoMaxString()
     {
         Iterable<String> iterable = new IterableAdapter<>(iList("1", "12", "123"));
-        Assert.assertEquals(3, Iterate.injectInto(Integer.MIN_VALUE, iterable, MaxSizeFunction.STRING).intValue());
+        assertEquals(3, Iterate.injectInto(Integer.MIN_VALUE, iterable, MaxSizeFunction.STRING).intValue());
     }
 
     @Test
     public void injectIntoMinString()
     {
         Iterable<String> iterable = new IterableAdapter<>(iList("1", "12", "123"));
-        Assert.assertEquals(1, Iterate.injectInto(Integer.MAX_VALUE, iterable, MinSizeFunction.STRING).intValue());
+        assertEquals(1, Iterate.injectInto(Integer.MAX_VALUE, iterable, MinSizeFunction.STRING).intValue());
     }
 
     @Test
@@ -109,7 +115,7 @@ public class IterableIterateTest
     {
         Iterable<Boolean> iterable = new IterableAdapter<>(iList(Boolean.TRUE, Boolean.FALSE, null));
         Collection<String> result = Iterate.collect(iterable, String::valueOf);
-        Assert.assertEquals(iList("true", "false", "null"), result);
+        assertEquals(iList("true", "false", "null"), result);
     }
 
     @Test
@@ -117,7 +123,7 @@ public class IterableIterateTest
     {
         Iterable<Boolean> iterable = new IterableAdapter<>(iList(Boolean.TRUE, Boolean.FALSE, null));
         Collection<String> result = Iterate.collect(iterable, String::valueOf, FastList.newList());
-        Assert.assertEquals(iList("true", "false", "null"), result);
+        assertEquals(iList("true", "false", "null"), result);
     }
 
     @Test
@@ -125,7 +131,7 @@ public class IterableIterateTest
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
         Collection<Class<?>> result = Iterate.collect(iterable, Object::getClass);
-        Assert.assertEquals(Collections.nCopies(31, Integer.class), result);
+        assertEquals(Collections.nCopies(31, Integer.class), result);
     }
 
     private List<Integer> getIntegerList()
@@ -137,28 +143,28 @@ public class IterableIterateTest
     public void forEachWithIndex()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Iterate.sortThis(this.getIntegerList()));
-        Iterate.forEachWithIndex(iterable, (object, index) -> Assert.assertEquals(index, object - 1));
+        Iterate.forEachWithIndex(iterable, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
     public void forEachWithIndexOver30()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Iterate.sortThis(Interval.oneTo(31).toList()));
-        Iterate.forEachWithIndex(iterable, (object, index) -> Assert.assertEquals(index, object - 1));
+        Iterate.forEachWithIndex(iterable, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
     public void detect()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertEquals(1, Iterate.detect(iterable, Integer.valueOf(1)::equals).intValue());
+        assertEquals(1, Iterate.detect(iterable, Integer.valueOf(1)::equals).intValue());
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer firstInt = new Integer(2);
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer secondInt = new Integer(2);
-        Assert.assertNotSame(firstInt, secondInt);
+        assertNotSame(firstInt, secondInt);
         ImmutableList<Integer> list2 = iList(1, firstInt, secondInt);
-        Assert.assertSame(list2.get(1), Iterate.detect(list2, Integer.valueOf(2)::equals));
+        assertSame(list2.get(1), Iterate.detect(list2, Integer.valueOf(2)::equals));
     }
 
     @Test
@@ -166,45 +172,45 @@ public class IterableIterateTest
     {
         List<Integer> list = Interval.oneTo(31);
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(1, Iterate.detect(iterable, Integer.valueOf(1)::equals).intValue());
+        assertEquals(1, Iterate.detect(iterable, Integer.valueOf(1)::equals).intValue());
     }
 
     @Test
     public void detectWith()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
+        assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer firstInt = new Integer(2);
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer secondInt = new Integer(2);
-        Assert.assertNotSame(firstInt, secondInt);
+        assertNotSame(firstInt, secondInt);
         ImmutableList<Integer> list2 = iList(1, firstInt, secondInt);
-        Assert.assertSame(list2.get(1), Iterate.detectWith(list2, Object::equals, 2));
+        assertSame(list2.get(1), Iterate.detectWith(list2, Object::equals, 2));
     }
 
     @Test
     public void detectWithOver30()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
-        Assert.assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
+        assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
     }
 
     @Test
     public void detectOptional()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertEquals(Optional.of(1), Iterate.detectOptional(iterable, Integer.valueOf(1)::equals));
+        assertEquals(Optional.of(1), Iterate.detectOptional(iterable, Integer.valueOf(1)::equals));
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer firstInt = new Integer(2);
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer secondInt = new Integer(2);
-        Assert.assertNotSame(firstInt, secondInt);
+        assertNotSame(firstInt, secondInt);
         ImmutableList<Integer> list2 = iList(1, firstInt, secondInt);
         Optional<Integer> result = Iterate.detectOptional(list2, Integer.valueOf(2)::equals);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertSame(list2.get(1), result.get());
-        Assert.assertEquals(Optional.empty(), Iterate.detectOptional(list2, Integer.valueOf(3)::equals));
+        assertTrue(result.isPresent());
+        assertSame(list2.get(1), result.get());
+        assertEquals(Optional.empty(), Iterate.detectOptional(list2, Integer.valueOf(3)::equals));
     }
 
     @Test
@@ -212,8 +218,8 @@ public class IterableIterateTest
     {
         List<Integer> list = Interval.oneTo(31);
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(Optional.of(1), Iterate.detectOptional(iterable, Integer.valueOf(1)::equals));
-        Assert.assertEquals(Optional.empty(), Iterate.detectOptional(iterable, Integer.valueOf(32)::equals));
+        assertEquals(Optional.of(1), Iterate.detectOptional(iterable, Integer.valueOf(1)::equals));
+        assertEquals(Optional.empty(), Iterate.detectOptional(iterable, Integer.valueOf(32)::equals));
     }
 
     @Test
@@ -222,24 +228,24 @@ public class IterableIterateTest
         MutableList<Integer> objects = mList(1, null, 3);
         Iterable<Integer> iterable = new IterableAdapter<>(objects);
 
-        Assert.assertThrows(NullPointerException.class, () -> Iterate.detectOptional(iterable, Objects::isNull));
+        assertThrows(NullPointerException.class, () -> Iterate.detectOptional(iterable, Objects::isNull));
     }
 
     @Test
     public void detectWithOptional()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
+        assertEquals(1, Iterate.detectWith(iterable, Object::equals, 1).intValue());
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer firstInt = new Integer(2);
         //noinspection CachedNumberConstructorCall,UnnecessaryBoxing
         Integer secondInt = new Integer(2);
-        Assert.assertNotSame(firstInt, secondInt);
+        assertNotSame(firstInt, secondInt);
         ImmutableList<Integer> list2 = iList(1, firstInt, secondInt);
         Optional<Integer> result = Iterate.detectWithOptional(list2, Object::equals, 2);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertSame(list2.get(1), result.get());
-        Assert.assertEquals(Optional.empty(), Iterate.detectOptional(list2, Integer.valueOf(3)::equals));
+        assertTrue(result.isPresent());
+        assertSame(list2.get(1), result.get());
+        assertEquals(Optional.empty(), Iterate.detectOptional(list2, Integer.valueOf(3)::equals));
     }
 
     @Test
@@ -248,43 +254,43 @@ public class IterableIterateTest
         MutableList<Integer> objects = mList(1, null, 3);
         Iterable<Integer> iterable = new IterableAdapter<>(objects);
 
-        Assert.assertThrows(NullPointerException.class, () -> Iterate.detectWithOptional(iterable, (i, object) -> i == object, null));
+        assertThrows(NullPointerException.class, () -> Iterate.detectWithOptional(iterable, (i, object) -> i == object, null));
     }
 
     @Test
     public void detectWithOptionalNull()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
-        Assert.assertEquals(Optional.of(1), Iterate.detectWithOptional(iterable, Object::equals, 1));
-        Assert.assertEquals(Optional.empty(), Iterate.detectWithOptional(iterable, Object::equals, 32));
+        assertEquals(Optional.of(1), Iterate.detectWithOptional(iterable, Object::equals, 1));
+        assertEquals(Optional.empty(), Iterate.detectWithOptional(iterable, Object::equals, 32));
     }
 
     @Test
     public void detectIfNone()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertNull(Iterate.detectIfNone(iterable, Integer.valueOf(6)::equals, null));
+        assertNull(Iterate.detectIfNone(iterable, Integer.valueOf(6)::equals, null));
     }
 
     @Test
     public void detectIfNoneOver30()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
-        Assert.assertNull(Iterate.detectIfNone(iterable, Integer.valueOf(32)::equals, null));
+        assertNull(Iterate.detectIfNone(iterable, Integer.valueOf(32)::equals, null));
     }
 
     @Test
     public void detectWithIfNone()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertNull(Iterate.detectWithIfNone(iterable, Object::equals, 6, null));
+        assertNull(Iterate.detectWithIfNone(iterable, Object::equals, 6, null));
     }
 
     @Test
     public void detectWithIfNoneOver30()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
-        Assert.assertNull(Iterate.detectWithIfNone(iterable, Object::equals, 32, null));
+        assertNull(Iterate.detectWithIfNone(iterable, Object::equals, 32, null));
     }
 
     @Test
@@ -318,15 +324,15 @@ public class IterableIterateTest
 
         Iterable<Integer> iterable1 = FastList.newListWith(1, 2, 5, 7, 7, 4);
         MutableList<Integer> result2 = IterableIterate.distinct(iterable1);
-        Assert.assertEquals(result2, FastList.newListWith(1, 2, 5, 7, 4));
+        assertEquals(result2, FastList.newListWith(1, 2, 5, 7, 4));
 
         Iterable<Integer> iterable2 = new IterableAdapter<>(Interval.oneTo(2));
         MutableList<Integer> result3 = IterableIterate.distinct(iterable2);
-        Assert.assertEquals(result3, FastList.newListWith(1, 2));
+        assertEquals(result3, FastList.newListWith(1, 2));
 
         Iterable<Integer> iterable3 = new IterableAdapter<>(FastList.newListWith(2, 2, 4, 5));
         MutableList<Integer> result4 = IterableIterate.distinct(iterable3);
-        Assert.assertEquals(result4, FastList.newListWith(2, 4, 5));
+        assertEquals(result4, FastList.newListWith(2, 4, 5));
     }
 
     @Test
@@ -335,7 +341,7 @@ public class IterableIterateTest
         MutableList<String> list = FastList.newList();
         list.addAll(FastList.newListWith("A", "a", "b", "c", "B", "D", "e", "e", "E", "D"));
         list = IterableIterate.distinct(list, HashingStrategies.fromFunction(String::toLowerCase));
-        Assert.assertEquals(FastList.newListWith("A", "b", "c", "D", "e"), list);
+        assertEquals(FastList.newListWith("A", "b", "c", "D", "e"), list);
     }
 
     @Test
@@ -365,7 +371,7 @@ public class IterableIterateTest
     {
         Iterable<Number> iterable = new IterableAdapter<>(FastList.newListWith(1, 2.0, 3, 4.0, 5));
         Collection<Integer> result = Iterate.selectInstancesOf(iterable, Integer.class);
-        Assert.assertEquals(iList(1, 3, 5), result);
+        assertEquals(iList(1, 3, 5), result);
     }
 
     @Test
@@ -375,7 +381,7 @@ public class IterableIterateTest
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(5));
         Function3<Sum, Integer, Integer, Sum> function = (sum, element, withValue) -> sum.add(element.intValue() * withValue.intValue());
         Sum sumOfDoubledValues = Iterate.injectIntoWith(result, iterable, function, 2);
-        Assert.assertEquals(30, sumOfDoubledValues.getValue().intValue());
+        assertEquals(30, sumOfDoubledValues.getValue().intValue());
     }
 
     @Test
@@ -383,8 +389,8 @@ public class IterableIterateTest
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
         Twin<MutableList<Integer>> result = Iterate.selectAndRejectWith(iterable, Predicates2.in(), iList(1));
-        Assert.assertEquals(iList(1), result.getOne());
-        Assert.assertEquals(iList(5, 4, 3, 2), result.getTwo());
+        assertEquals(iList(1), result.getOne());
+        assertEquals(iList(5, 4, 3, 2), result.getTwo());
     }
 
     @Test
@@ -392,64 +398,64 @@ public class IterableIterateTest
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
         PartitionIterable<Integer> partition = Iterate.partition(iterable, IntegerPredicates.isEven());
-        Assert.assertEquals(iList(4, 2), partition.getSelected());
-        Assert.assertEquals(iList(5, 3, 1), partition.getRejected());
+        assertEquals(iList(4, 2), partition.getSelected());
+        assertEquals(iList(5, 3, 1), partition.getRejected());
     }
 
     @Test
     public void anySatisfyWith()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.anySatisfyWith(iterable, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(Iterate.anySatisfyWith(iterable, Predicates2.instanceOf(), Double.class));
+        assertTrue(Iterate.anySatisfyWith(iterable, Predicates2.instanceOf(), Integer.class));
+        assertFalse(Iterate.anySatisfyWith(iterable, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
     public void anySatisfy()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.anySatisfy(iterable, Integer.class::isInstance));
-        Assert.assertFalse(Iterate.anySatisfy(iterable, Double.class::isInstance));
+        assertTrue(Iterate.anySatisfy(iterable, Integer.class::isInstance));
+        assertFalse(Iterate.anySatisfy(iterable, Double.class::isInstance));
     }
 
     @Test
     public void allSatisfyWith()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.allSatisfyWith(iterable, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(Iterate.allSatisfyWith(iterable, Predicates2.greaterThan(), 2));
+        assertTrue(Iterate.allSatisfyWith(iterable, Predicates2.instanceOf(), Integer.class));
+        assertFalse(Iterate.allSatisfyWith(iterable, Predicates2.greaterThan(), 2));
     }
 
     @Test
     public void allSatisfy()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.allSatisfy(iterable, Integer.class::isInstance));
-        Assert.assertFalse(Iterate.allSatisfy(iterable, Predicates.greaterThan(2)));
+        assertTrue(Iterate.allSatisfy(iterable, Integer.class::isInstance));
+        assertFalse(Iterate.allSatisfy(iterable, Predicates.greaterThan(2)));
     }
 
     @Test
     public void noneSatisfy()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.noneSatisfy(iterable, String.class::isInstance));
-        Assert.assertFalse(Iterate.noneSatisfy(iterable, Predicates.greaterThan(0)));
+        assertTrue(Iterate.noneSatisfy(iterable, String.class::isInstance));
+        assertFalse(Iterate.noneSatisfy(iterable, Predicates.greaterThan(0)));
     }
 
     @Test
     public void noneSatisfyWith()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertTrue(Iterate.noneSatisfyWith(iterable, Predicates2.instanceOf(), String.class));
-        Assert.assertFalse(Iterate.noneSatisfyWith(iterable, Predicates2.greaterThan(), 0));
+        assertTrue(Iterate.noneSatisfyWith(iterable, Predicates2.instanceOf(), String.class));
+        assertFalse(Iterate.noneSatisfyWith(iterable, Predicates2.greaterThan(), 0));
     }
 
     @Test
     public void countWith()
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
-        Assert.assertEquals(5, Iterate.countWith(iterable, Predicates2.instanceOf(), Integer.class));
-        Assert.assertEquals(0, Iterate.countWith(iterable, Predicates2.instanceOf(), Double.class));
+        assertEquals(5, Iterate.countWith(iterable, Predicates2.instanceOf(), Integer.class));
+        assertEquals(0, Iterate.countWith(iterable, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
@@ -457,7 +463,7 @@ public class IterableIterateTest
     {
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
         Collection<Integer> results = Iterate.selectWith(iterable, Predicates2.instanceOf(), Integer.class);
-        Assert.assertEquals(iList(5, 4, 3, 2, 1), results);
+        assertEquals(iList(5, 4, 3, 2, 1), results);
         Verify.assertSize(5, results);
     }
 
@@ -467,7 +473,7 @@ public class IterableIterateTest
         Iterable<Integer> iterable = new IterableAdapter<>(this.getIntegerList());
         MutableList<Integer> results =
                 Iterate.selectWith(iterable, Predicates2.instanceOf(), Integer.class, FastList.newList());
-        Assert.assertEquals(iList(5, 4, 3, 2, 1), results);
+        assertEquals(iList(5, 4, 3, 2, 1), results);
         Verify.assertSize(5, results);
     }
 
@@ -476,7 +482,7 @@ public class IterableIterateTest
     {
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
         Collection<Class<?>> result = Iterate.collectIf(iterable, Integer.valueOf(31)::equals, Object::getClass);
-        Assert.assertEquals(iList(Integer.class), result);
+        assertEquals(iList(Integer.class), result);
     }
 
     @Test
@@ -485,7 +491,7 @@ public class IterableIterateTest
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(31));
         Collection<Class<?>> result =
                 Iterate.collectIf(iterable, Integer.valueOf(31)::equals, Object::getClass, FastList.newList());
-        Assert.assertEquals(iList(Integer.class), result);
+        assertEquals(iList(Integer.class), result);
     }
 
     @Test
@@ -504,8 +510,8 @@ public class IterableIterateTest
     {
         MutableList<Integer> list = Interval.toReverseList(1, 31);
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(30, Iterate.detectIndex(iterable, Integer.valueOf(1)::equals));
-        Assert.assertEquals(0, Iterate.detectIndex(iterable, Integer.valueOf(31)::equals));
+        assertEquals(30, Iterate.detectIndex(iterable, Integer.valueOf(1)::equals));
+        assertEquals(0, Iterate.detectIndex(iterable, Integer.valueOf(31)::equals));
     }
 
     @Test
@@ -513,8 +519,8 @@ public class IterableIterateTest
     {
         MutableList<Integer> list = Interval.toReverseList(1, 31);
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(30, Iterate.detectIndexWith(iterable, Object::equals, 1));
-        Assert.assertEquals(0, Iterate.detectIndexWith(iterable, Object::equals, 31));
+        assertEquals(30, Iterate.detectIndexWith(iterable, Object::equals, 1));
+        assertEquals(0, Iterate.detectIndexWith(iterable, Object::equals, 31));
     }
 
     @Test
@@ -525,7 +531,7 @@ public class IterableIterateTest
         List<Integer> integers = Interval.oneTo(31);
         Function3<Sum, Integer, Integer, Sum> function = (sum, element, withValue) -> sum.add((element.intValue() - element.intValue()) * withValue.intValue());
         Sum sumOfDoubledValues = Iterate.injectIntoWith(result, integers, function, parameter);
-        Assert.assertEquals(0, sumOfDoubledValues.getValue().intValue());
+        assertEquals(0, sumOfDoubledValues.getValue().intValue());
     }
 
     @Test
@@ -563,17 +569,17 @@ public class IterableIterateTest
         MutableList<Integer> objects1 = mList(1, 2, 3, null);
         Iterable<Integer> iterable = new IterableAdapter<>(objects1);
         Iterate.removeIfWith(iterable, (each5, ignored5) -> each5 == null, null);
-        Assert.assertEquals(iList(1, 2, 3), objects1);
+        assertEquals(iList(1, 2, 3), objects1);
 
         MutableList<Integer> objects2 = mList(null, 1, 2, 3);
         Iterable<Integer> iterable4 = new IterableAdapter<>(objects2);
         Iterate.removeIfWith(iterable4, (each4, ignored4) -> each4 == null, null);
-        Assert.assertEquals(iList(1, 2, 3), objects2);
+        assertEquals(iList(1, 2, 3), objects2);
 
         MutableList<Integer> objects3 = mList(1, null, 2, 3);
         Iterable<Integer> iterable3 = new IterableAdapter<>(objects3);
         Iterate.removeIfWith(iterable3, (each3, ignored3) -> each3 == null, null);
-        Assert.assertEquals(iList(1, 2, 3), objects3);
+        assertEquals(iList(1, 2, 3), objects3);
 
         MutableList<Integer> objects4 = mList(null, null, null, null);
         Iterable<Integer> iterable2 = new IterableAdapter<>(objects4);
@@ -582,12 +588,12 @@ public class IterableIterateTest
 
         MutableList<Integer> objects5 = mList(null, 1, 2, 3, null);
         Iterate.removeIfWith(objects5, (each1, ignored1) -> each1 == null, null);
-        Assert.assertEquals(iList(1, 2, 3), objects5);
+        assertEquals(iList(1, 2, 3), objects5);
 
         MutableList<Integer> objects6 = mList(1, 2, 3);
         Iterable<Integer> iterable1 = new IterableAdapter<>(objects6);
         Iterate.removeIfWith(iterable1, (each, ignored) -> each == null, null);
-        Assert.assertEquals(iList(1, 2, 3), objects6);
+        assertEquals(iList(1, 2, 3), objects6);
     }
 
     @Test
@@ -596,7 +602,7 @@ public class IterableIterateTest
         MutableList<Integer> newCollection = Lists.mutable.of();
         Iterable<Integer> iterable = new IterableAdapter<>(Interval.oneTo(10));
         Iterate.forEach(iterable, newCollection::add);
-        Assert.assertEquals(Interval.oneTo(10), newCollection);
+        assertEquals(Interval.oneTo(10), newCollection);
     }
 
     @Test
@@ -605,7 +611,7 @@ public class IterableIterateTest
         Sum result = new IntegerSum(0);
         Iterable<Integer> integers = new IterableAdapter<>(Interval.oneTo(5));
         Iterate.forEachWith(integers, (each, parm) -> result.add(each.intValue() * parm.intValue()), 2);
-        Assert.assertEquals(30, result.getValue().intValue());
+        assertEquals(30, result.getValue().intValue());
     }
 
     @Test
@@ -613,7 +619,7 @@ public class IterableIterateTest
     {
         Iterable<Boolean> iterable =
                 new IterableAdapter<>(FastList.<Boolean>newList().with(Boolean.TRUE, Boolean.FALSE));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("true", "false"),
                 Iterate.collectWith(iterable, (argument1, argument2) -> Boolean.toString(argument1.booleanValue() && argument2.booleanValue()), Boolean.TRUE));
     }
@@ -623,7 +629,7 @@ public class IterableIterateTest
     {
         Iterable<Boolean> iterable =
                 new IterableAdapter<>(FastList.<Boolean>newList().with(Boolean.TRUE, Boolean.FALSE));
-        Assert.assertEquals(
+        assertEquals(
                 FastList.newListWith("true", "false"),
                 Iterate.collectWith(iterable, (argument1, argument2) -> Boolean.toString(argument1.booleanValue() && argument2.booleanValue()), Boolean.TRUE, new ArrayList<>()));
     }
@@ -634,12 +640,12 @@ public class IterableIterateTest
         List<Integer> list = this.getIntegerList();
         Iterable<Integer> iterable = new IterableAdapter<>(list);
         Verify.assertEmpty(Iterate.take(iterable, 0));
-        Assert.assertEquals(FastList.newListWith(5), Iterate.take(iterable, 1));
-        Assert.assertEquals(FastList.newListWith(5, 4), Iterate.take(iterable, 2));
-        Assert.assertEquals(list, Iterate.take(iterable, 5));
-        Assert.assertEquals(list, Iterate.take(iterable, 6));
-        Assert.assertEquals(list, Iterate.take(iterable, Integer.MAX_VALUE));
-        Assert.assertNotSame(iterable, Iterate.take(iterable, Integer.MAX_VALUE));
+        assertEquals(FastList.newListWith(5), Iterate.take(iterable, 1));
+        assertEquals(FastList.newListWith(5, 4), Iterate.take(iterable, 2));
+        assertEquals(list, Iterate.take(iterable, 5));
+        assertEquals(list, Iterate.take(iterable, 6));
+        assertEquals(list, Iterate.take(iterable, Integer.MAX_VALUE));
+        assertNotSame(iterable, Iterate.take(iterable, Integer.MAX_VALUE));
     }
 
     @Test
@@ -665,10 +671,10 @@ public class IterableIterateTest
     {
         List<Integer> list = this.getIntegerList();
         Iterable<Integer> iterable = new IterableAdapter<>(list);
-        Assert.assertEquals(FastList.newListWith(5, 4, 3, 2, 1), Iterate.drop(iterable, 0));
-        Assert.assertEquals(FastList.newListWith(4, 3, 2, 1), Iterate.drop(iterable, 1));
-        Assert.assertEquals(FastList.newListWith(3, 2, 1), Iterate.drop(iterable, 2));
-        Assert.assertEquals(FastList.newListWith(1), Iterate.drop(iterable, 4));
+        assertEquals(FastList.newListWith(5, 4, 3, 2, 1), Iterate.drop(iterable, 0));
+        assertEquals(FastList.newListWith(4, 3, 2, 1), Iterate.drop(iterable, 1));
+        assertEquals(FastList.newListWith(3, 2, 1), Iterate.drop(iterable, 2));
+        assertEquals(FastList.newListWith(1), Iterate.drop(iterable, 4));
         Verify.assertEmpty(Iterate.drop(iterable, 5));
         Verify.assertEmpty(Iterate.drop(iterable, 6));
         Verify.assertEmpty(Iterate.drop(iterable, Integer.MAX_VALUE));
@@ -713,28 +719,28 @@ public class IterableIterateTest
     public void maxWithoutComparator()
     {
         Iterable<Integer> iterable = FastList.newListWith(1, 5, 2, 99, 7);
-        Assert.assertEquals(99, IterableIterate.max(iterable).intValue());
+        assertEquals(99, IterableIterate.max(iterable).intValue());
     }
 
     @Test
     public void minWithoutComparator()
     {
         Iterable<Integer> iterable = FastList.newListWith(99, 5, 2, 1, 7);
-        Assert.assertEquals(1, IterableIterate.min(iterable).intValue());
+        assertEquals(1, IterableIterate.min(iterable).intValue());
     }
 
     @Test
     public void max()
     {
         Iterable<Integer> iterable = FastList.newListWith(1, 5, 2, 99, 7);
-        Assert.assertEquals(99, IterableIterate.max(iterable, Integer::compareTo).intValue());
+        assertEquals(99, IterableIterate.max(iterable, Integer::compareTo).intValue());
     }
 
     @Test
     public void min()
     {
         Iterable<Integer> iterable = FastList.newListWith(99, 5, 2, 1, 7);
-        Assert.assertEquals(1, IterableIterate.min(iterable, Integer::compareTo).intValue());
+        assertEquals(1, IterableIterate.min(iterable, Integer::compareTo).intValue());
     }
 
     @Test
@@ -750,11 +756,11 @@ public class IterableIterateTest
     {
         MutableList<Integer> results = Lists.mutable.of();
         IterableIterate.forEach(integers, 0, 4, results::add);
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.of();
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 4, -1, reverseResults::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, -1, 4, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, 4, -1, reverseResults::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> ListIterate.forEach(integers, -1, 4, reverseResults::add));
     }
 
     @Test
@@ -769,11 +775,11 @@ public class IterableIterateTest
     {
         MutableList<Integer> results = Lists.mutable.of();
         IterableIterate.forEachWithIndex(integers, 0, 4, ObjectIntProcedures.fromProcedure(results::add));
-        Assert.assertEquals(integers, results);
+        assertEquals(integers, results);
         MutableList<Integer> reverseResults = Lists.mutable.of();
         ObjectIntProcedure<Integer> objectIntProcedure = ObjectIntProcedures.fromProcedure(reverseResults::add);
-        Assert.assertThrows(IllegalArgumentException.class, () -> IterableIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
-        Assert.assertThrows(IllegalArgumentException.class, () -> IterableIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
+        assertThrows(IllegalArgumentException.class, () -> IterableIterate.forEachWithIndex(integers, 4, -1, objectIntProcedure));
+        assertThrows(IllegalArgumentException.class, () -> IterableIterate.forEachWithIndex(integers, -1, 4, objectIntProcedure));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterateTest.java
@@ -39,11 +39,17 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RandomAccessListIterateTest
 {
@@ -76,54 +82,54 @@ public class RandomAccessListIterateTest
     @Test
     public void removeIf()
     {
-        Assert.assertTrue(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(1)));
-        Assert.assertTrue(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(0)));
-        Assert.assertFalse(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(4)));
-        Assert.assertFalse(RandomAccessListIterate.removeIf(FastList.newList(), Predicates.greaterThan(4)));
+        assertTrue(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(1)));
+        assertTrue(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(0)));
+        assertFalse(RandomAccessListIterate.removeIf(FastList.newListWith(1, 2, 3), Predicates.greaterThan(4)));
+        assertFalse(RandomAccessListIterate.removeIf(FastList.newList(), Predicates.greaterThan(4)));
     }
 
     @Test
     public void removeIfWith()
     {
-        Assert.assertTrue(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 1));
-        Assert.assertTrue(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 0));
-        Assert.assertFalse(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 4));
-        Assert.assertFalse(RandomAccessListIterate.removeIfWith(FastList.newList(), Predicates2.greaterThan(), 1));
+        assertTrue(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 1));
+        assertTrue(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 0));
+        assertFalse(RandomAccessListIterate.removeIfWith(FastList.newListWith(1, 2, 3), Predicates2.greaterThan(), 4));
+        assertFalse(RandomAccessListIterate.removeIfWith(FastList.newList(), Predicates2.greaterThan(), 1));
     }
 
     @Test
     public void injectInto()
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
-        Assert.assertEquals(Integer.valueOf(7), RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER));
+        assertEquals(Integer.valueOf(7), RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER));
     }
 
     @Test
     public void injectIntoInt()
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
-        Assert.assertEquals(7, RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
+        assertEquals(7, RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER_TO_INT));
     }
 
     @Test
     public void injectIntoLong()
     {
         MutableList<Integer> list = Lists.fixedSize.of(1, 2, 3);
-        Assert.assertEquals(7, RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER_TO_LONG));
+        assertEquals(7, RandomAccessListIterate.injectInto(1, list, AddFunction.INTEGER_TO_LONG));
     }
 
     @Test
     public void injectIntoDouble()
     {
         MutableList<Double> list = Lists.fixedSize.of(1.0, 2.0, 3.0);
-        Assert.assertEquals(7.0d, RandomAccessListIterate.injectInto(1.0, list, AddFunction.DOUBLE), 0.001);
+        assertEquals(7.0d, RandomAccessListIterate.injectInto(1.0, list, AddFunction.DOUBLE), 0.001);
     }
 
     @Test
     public void injectIntoString()
     {
         MutableList<String> list = Lists.fixedSize.of("1", "2", "3");
-        Assert.assertEquals("0123", RandomAccessListIterate.injectInto("0", list, AddFunction.STRING));
+        assertEquals("0123", RandomAccessListIterate.injectInto("0", list, AddFunction.STRING));
     }
 
     @Test
@@ -131,7 +137,7 @@ public class RandomAccessListIterateTest
     {
         MutableList<String> list = Lists.fixedSize.of("1", "12", "123");
         Function2<Integer, String, Integer> function = MaxSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(3), RandomAccessListIterate.injectInto(Integer.MIN_VALUE, list, function));
+        assertEquals(Integer.valueOf(3), RandomAccessListIterate.injectInto(Integer.MIN_VALUE, list, function));
     }
 
     @Test
@@ -139,13 +145,13 @@ public class RandomAccessListIterateTest
     {
         MutableList<String> list = Lists.fixedSize.of("1", "12", "123");
         Function2<Integer, String, Integer> function = MinSizeFunction.STRING;
-        Assert.assertEquals(Integer.valueOf(1), RandomAccessListIterate.injectInto(Integer.MAX_VALUE, list, function));
+        assertEquals(Integer.valueOf(1), RandomAccessListIterate.injectInto(Integer.MAX_VALUE, list, function));
     }
 
     @Test
     public void collect()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList("true", "false", "null"),
                 RandomAccessListIterate.collect(mList(true, false, null), String::valueOf));
     }
@@ -179,11 +185,11 @@ public class RandomAccessListIterateTest
     @Test
     public void collectReflective()
     {
-        Assert.assertEquals(
+        assertEquals(
                 iList("true", "false", "null"),
                 RandomAccessListIterate.collect(mList(true, false, null), String::valueOf));
 
-        Assert.assertEquals(
+        assertEquals(
                 iList("true", "false", "null"),
                 RandomAccessListIterate.collect(mList(true, false, null), String::valueOf, new ArrayList<>()));
     }
@@ -209,14 +215,14 @@ public class RandomAccessListIterateTest
     public void getLast()
     {
         MutableList<Boolean> list = Lists.fixedSize.of(true, null, false);
-        Assert.assertEquals(Boolean.FALSE, RandomAccessListIterate.getLast(list));
+        assertEquals(Boolean.FALSE, RandomAccessListIterate.getLast(list));
     }
 
     @Test
     public void getLastOnEmpty()
     {
         List<?> list = new ArrayList<>();
-        Assert.assertNull(RandomAccessListIterate.getLast(list));
+        assertNull(RandomAccessListIterate.getLast(list));
     }
 
     @Test
@@ -224,9 +230,9 @@ public class RandomAccessListIterateTest
     {
         MutableList<Integer> list = this.getIntegerList();
         int result = RandomAccessListIterate.count(list, Predicates.attributeEqual(Number::intValue, 3));
-        Assert.assertEquals(1, result);
+        assertEquals(1, result);
         int result2 = RandomAccessListIterate.count(list, Predicates.attributeEqual(Number::intValue, 6));
-        Assert.assertEquals(0, result2);
+        assertEquals(0, result2);
     }
 
     private MutableList<Integer> getIntegerList()
@@ -239,7 +245,7 @@ public class RandomAccessListIterateTest
     {
         MutableList<Integer> list = this.getIntegerList();
         Iterate.sortThis(list);
-        RandomAccessListIterate.forEachWithIndex(list, (object, index) -> Assert.assertEquals(index, object - 1));
+        RandomAccessListIterate.forEachWithIndex(list, (object, index) -> assertEquals(index, object - 1));
     }
 
     @Test
@@ -249,22 +255,22 @@ public class RandomAccessListIterateTest
 
         MutableList<Integer> result = Lists.mutable.empty();
         RandomAccessListIterate.forEach(integers, 5, 7, result::add);
-        Assert.assertEquals(Lists.immutable.with(3, 3, 2), result);
+        assertEquals(Lists.immutable.with(3, 3, 2), result);
 
         MutableList<Integer> result2 = Lists.mutable.empty();
         RandomAccessListIterate.forEach(integers, 5, 5, result2::add);
-        Assert.assertEquals(Lists.immutable.with(3), result2);
+        assertEquals(Lists.immutable.with(3), result2);
 
         MutableList<Integer> result3 = Lists.mutable.empty();
         RandomAccessListIterate.forEach(integers, 0, 9, result3::add);
-        Assert.assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
+        assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result3);
 
         MutableList<Integer> result4 = Lists.mutable.empty();
         RandomAccessListIterate.forEach(integers, 7, 5, result4::add);
-        Assert.assertEquals(Lists.immutable.with(2, 3, 3), result4);
+        assertEquals(Lists.immutable.with(2, 3, 3), result4);
 
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEach(integers, -1, 0, result::add));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEach(integers, 0, -1, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEach(integers, -1, 0, result::add));
+        assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEach(integers, 0, -1, result::add));
     }
 
     @Test
@@ -274,23 +280,23 @@ public class RandomAccessListIterateTest
 
         StringBuilder builder = new StringBuilder();
         RandomAccessListIterate.forEachWithIndex(integers, 5, 7, (each, index) -> builder.append(each).append(index));
-        Assert.assertEquals("353627", builder.toString());
+        assertEquals("353627", builder.toString());
 
         StringBuilder builder2 = new StringBuilder();
         RandomAccessListIterate.forEachWithIndex(integers, 5, 5, (each, index) -> builder2.append(each).append(index));
-        Assert.assertEquals("35", builder2.toString());
+        assertEquals("35", builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         RandomAccessListIterate.forEachWithIndex(integers, 0, 9, (each, index) -> builder3.append(each).append(index));
-        Assert.assertEquals("40414243343536272819", builder3.toString());
+        assertEquals("40414243343536272819", builder3.toString());
 
         StringBuilder builder4 = new StringBuilder();
         RandomAccessListIterate.forEachWithIndex(integers, 7, 5, (each, index) -> builder4.append(each).append(index));
-        Assert.assertEquals("273635", builder4.toString());
+        assertEquals("273635", builder4.toString());
 
         MutableList<Integer> result = Lists.mutable.of();
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEachWithIndex(integers, -1, 0, new AddToList(result)));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEachWithIndex(integers, 0, -1, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEachWithIndex(integers, -1, 0, new AddToList(result)));
+        assertThrows(IndexOutOfBoundsException.class, () -> RandomAccessListIterate.forEachWithIndex(integers, 0, -1, new AddToList(result)));
     }
 
     @Test
@@ -300,16 +306,16 @@ public class RandomAccessListIterateTest
         MutableList<String> list2 = Lists.fixedSize.of("a", "b");
         List<Pair<String, String>> list = new ArrayList<>();
         RandomAccessListIterate.forEachInBoth(list1, list2, (argument1, argument2) -> list.add(Tuples.twin(argument1, argument2)));
-        Assert.assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
+        assertEquals(FastList.newListWith(Tuples.twin("1", "a"), Tuples.twin("2", "b")), list);
     }
 
     @Test
     public void detectWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertEquals(Integer.valueOf(1), RandomAccessListIterate.detectWith(list, Object::equals, 1));
+        assertEquals(Integer.valueOf(1), RandomAccessListIterate.detectWith(list, Object::equals, 1));
         MutableList<Integer> list2 = Lists.fixedSize.of(1, 2, 2);
-        Assert.assertSame(list2.get(1), RandomAccessListIterate.detectWith(list2, Object::equals, 2));
+        assertSame(list2.get(1), RandomAccessListIterate.detectWith(list2, Object::equals, 2));
     }
 
     @Test
@@ -349,23 +355,23 @@ public class RandomAccessListIterateTest
     public void anySatisfyWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(RandomAccessListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
-        Assert.assertFalse(RandomAccessListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
+        assertTrue(RandomAccessListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertFalse(RandomAccessListIterate.anySatisfyWith(list, Predicates2.instanceOf(), Double.class));
     }
 
     @Test
     public void allSatisfyWith()
     {
         MutableList<Integer> list = this.getIntegerList();
-        Assert.assertTrue(RandomAccessListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
+        assertTrue(RandomAccessListIterate.allSatisfyWith(list, Predicates2.instanceOf(), Integer.class));
         Predicate2<Integer, Integer> greaterThanPredicate = Predicates2.greaterThan();
-        Assert.assertFalse(RandomAccessListIterate.allSatisfyWith(list, greaterThanPredicate, 2));
+        assertFalse(RandomAccessListIterate.allSatisfyWith(list, greaterThanPredicate, 2));
     }
 
     @Test
     public void countWith()
     {
-        Assert.assertEquals(5, RandomAccessListIterate.countWith(this.getIntegerList(), Predicates2.instanceOf(), Integer.class));
+        assertEquals(5, RandomAccessListIterate.countWith(this.getIntegerList(), Predicates2.instanceOf(), Integer.class));
     }
 
     @Test
@@ -505,8 +511,8 @@ public class RandomAccessListIterateTest
                 Tuples.twin(1, 1),
                 Tuples.twin(2, 2),
                 Tuples.twin(3, 3));
-        Assert.assertEquals(expected, RandomAccessListIterate.zip(integers, integers));
-        Assert.assertEquals(expected, RandomAccessListIterate.zip(integers, integers::iterator));
+        assertEquals(expected, RandomAccessListIterate.zip(integers, integers));
+        assertEquals(expected, RandomAccessListIterate.zip(integers, integers::iterator));
     }
 
     private static class FailProcedure2 implements Procedure2<Object, Integer>
@@ -516,7 +522,7 @@ public class RandomAccessListIterateTest
         @Override
         public void value(Object argument1, Integer argument2)
         {
-            Assert.fail();
+            fail();
         }
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterablesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterablesTest.java
@@ -12,8 +12,9 @@ package org.eclipse.collections.impl.utility.internal;
 
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.SetIterable;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class SetIterablesTest
 {
@@ -73,8 +74,8 @@ public class SetIterablesTest
     {
         SetIterable<? extends Number> actual1 = SetIterables.union(set1, set2);
         SetIterable<? extends Number> actual2 = SetIterables.union(set2, set1);
-        Assert.assertEquals(expected, actual1);
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual1);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -123,8 +124,8 @@ public class SetIterablesTest
     {
         SetIterable<? extends Number> actual1 = SetIterables.intersect(set1, set2);
         SetIterable<? extends Number> actual2 = SetIterables.intersect(set2, set1);
-        Assert.assertEquals(expected, actual1);
-        Assert.assertEquals(expected, actual2);
+        assertEquals(expected, actual1);
+        assertEquals(expected, actual2);
     }
 
     @Test
@@ -162,6 +163,6 @@ public class SetIterablesTest
             SetIterable<? extends Number> expected)
     {
         SetIterable<? extends Number> actual = SetIterables.difference(set1, set2);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterateTest.java
@@ -15,8 +15,11 @@ import java.util.Set;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SetIterateTest
 {
@@ -24,16 +27,16 @@ public class SetIterateTest
     public void removeAllIterableOne()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertTrue(SetIterate.removeAllIterable(set, Sets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        Assert.assertEquals(Sets.mutable.of(25), set);
+        assertTrue(SetIterate.removeAllIterable(set, Sets.mutable.of(1, 2, 3, 4, 5, 6, 7, 8, 9)));
+        assertEquals(Sets.mutable.of(25), set);
     }
 
     @Test
     public void removeAllIterableTwo()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertFalse(SetIterate.removeAllIterable(set, Sets.mutable.of(31, 32, 33, 34, 35, 36, 37)));
-        Assert.assertEquals(this.newSet(), set);
+        assertFalse(SetIterate.removeAllIterable(set, Sets.mutable.of(31, 32, 33, 34, 35, 36, 37)));
+        assertEquals(this.newSet(), set);
     }
 
     private MutableSet<Integer> newSet()
@@ -45,31 +48,31 @@ public class SetIterateTest
     public void removeAllIterableThree()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertTrue(SetIterate.removeAllIterable(set, Sets.mutable.of(25)));
-        Assert.assertEquals(Sets.mutable.of(5, 9), set);
+        assertTrue(SetIterate.removeAllIterable(set, Sets.mutable.of(25)));
+        assertEquals(Sets.mutable.of(5, 9), set);
     }
 
     @Test
     public void removeAllIterableFour()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertFalse(SetIterate.removeAllIterable(set, Sets.mutable.of(250)));
-        Assert.assertEquals(this.newSet(), set);
+        assertFalse(SetIterate.removeAllIterable(set, Sets.mutable.of(250)));
+        assertEquals(this.newSet(), set);
     }
 
     @Test
     public void removeAllIterableFive()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertTrue(SetIterate.removeAllIterable(set, Lists.mutable.of(5, 5, 5, 9, 9, 100, 200, 300)));
-        Assert.assertEquals(Sets.mutable.of(25), set);
+        assertTrue(SetIterate.removeAllIterable(set, Lists.mutable.of(5, 5, 5, 9, 9, 100, 200, 300)));
+        assertEquals(Sets.mutable.of(25), set);
     }
 
     @Test
     public void removeAllIterableSix()
     {
         Set<Integer> set = this.newSet();
-        Assert.assertFalse(SetIterate.removeAllIterable(set, Lists.mutable.of(90)));
-        Assert.assertEquals(this.newSet(), set);
+        assertFalse(SetIterate.removeAllIterable(set, Lists.mutable.of(90)));
+        assertEquals(this.newSet(), set);
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIterableIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIterableIterateTest.java
@@ -15,8 +15,11 @@ import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BooleanIterableIterateTest
 {
@@ -29,7 +32,7 @@ public class BooleanIterableIterateTest
         sum[0] = "";
         sum[1] = "";
         BooleanIterableIterate.forEach(this.iterable, each -> sum[0] += each + " ");
-        Assert.assertEquals("true false true ", sum[0]);
+        assertEquals("true false true ", sum[0]);
     }
 
     @Test
@@ -55,12 +58,12 @@ public class BooleanIterableIterateTest
     @Test
     public void isEmpty()
     {
-        Assert.assertFalse(BooleanIterableIterate.isEmpty(this.iterable));
+        assertFalse(BooleanIterableIterate.isEmpty(this.iterable));
     }
 
     @Test
     public void notEmpty()
     {
-        Assert.assertTrue(BooleanIterableIterate.notEmpty(this.iterable));
+        assertTrue(BooleanIterableIterate.notEmpty(this.iterable));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/primitive/LazyBooleanIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/primitive/LazyBooleanIterateTest.java
@@ -15,8 +15,10 @@ import org.eclipse.collections.api.LazyBooleanIterable;
 import org.eclipse.collections.api.block.procedure.primitive.BooleanProcedure;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LazyBooleanIterateTest
 {
@@ -25,19 +27,19 @@ public class LazyBooleanIterateTest
     @Test
     public void adapt()
     {
-        Assert.assertEquals(this.iterable, LazyBooleanIterate.adapt(this.iterable).toList());
+        assertEquals(this.iterable, LazyBooleanIterate.adapt(this.iterable).toList());
     }
 
     @Test
     public void collectIf()
     {
-        Assert.assertEquals(this.iterable.collect(each -> each), LazyBooleanIterate.collectIf(this.iterable, each -> true, each -> each).toList());
+        assertEquals(this.iterable.collect(each -> each), LazyBooleanIterate.collectIf(this.iterable, each -> true, each -> each).toList());
     }
 
     @Test
     public void empty()
     {
-        Assert.assertTrue(LazyBooleanIterate.empty().isEmpty());
+        assertTrue(LazyBooleanIterate.empty().isEmpty());
     }
 
     @Test
@@ -45,7 +47,7 @@ public class LazyBooleanIterateTest
     {
         MutableBooleanList list = BooleanLists.mutable.empty();
         LazyBooleanIterable booleanIterable = LazyBooleanIterate.tap(this.iterable, (BooleanProcedure) list::add);
-        Assert.assertEquals(this.iterable, BooleanLists.mutable.ofAll(booleanIterable));
-        Assert.assertEquals(this.iterable, list);
+        assertEquals(this.iterable, BooleanLists.mutable.ofAll(booleanIterable));
+        assertEquals(this.iterable, list);
     }
 }


### PR DESCRIPTION
Relates to #1578, but:

- Affects java code, not primitive templates
- Affects all Assert methods, not just assertEquals and assertThrows
- Isolated to just the imports change