### PR TITLE
Add maven profiles and caching to speed up builds.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,15 +11,83 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-test-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-test-
+            maven-
+
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Set up Java 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
-      - run: ./mvnw --color=always verify
+      - run: ./mvnw --threads 2C --color=always verify
         env:
           MAVEN_OPTS: "-Xmx1g"
+
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
+
+  enforcer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-enforcer-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-enforcer-
+            maven-
+
+      - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Run maven-enforcer-plugin
+        run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-enforcer-plugin -DskipTests
+        env:
+          MAVEN_OPTS: "-Xmx1g"
+
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
+
+  dependency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-dependency-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-dependency-
+            maven-
+
+      - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Run maven-dependency-plugin
+        run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-dependency-plugin -DskipTests
+        env:
+          MAVEN_OPTS: "-Xmx1g"
+
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
 
   unit-tests-no-p2:
     name: Unit Tests ${{ matrix.java-version }}
@@ -29,6 +97,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-test-no-p2-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-test-no-p2-
+            maven-test-
+            maven-
+
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Set up Java ${{ matrix.java-version }}
         uses: actions/setup-java@v4
@@ -40,11 +118,24 @@ jobs:
         env:
           MAVEN_OPTS: "-Xmx1g"
 
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
+
   unit-tests-early-access:
     name: Unit Test Early Access
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-test-early-access-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-test-early-access-
+            maven-test-
+            maven-
+
       - name: Download JDK 23 from jdk.java.net
         uses: oracle-actions/setup-java@v1
         id: download-jdk
@@ -69,6 +160,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-acceptance-test-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-acceptance-test-
+            maven-test-
+            maven-
+
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Set up Java 11
         uses: actions/setup-java@v4
@@ -79,21 +180,36 @@ jobs:
         env:
           MAVEN_OPTS: "-Xmx1g"
 
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
+
   performance-tests:
     name: Performance Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-performance-test-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-performance-test-
+            maven-test-
+            maven-
+
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Set up Java 11
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Performance Tests
-        run: ./mvnw --color=always install --projects performance-tests --also-make --activate-profiles all -DskipTests=true
+      - run: ./mvnw --color=always install --projects performance-tests --also-make --activate-profiles all -DskipTests=true
         env:
           MAVEN_OPTS: "-Xmx1g"
+
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
 
   checkstyle:
     name: Checkstyle
@@ -116,6 +232,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-javadoc-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-javadoc-
+            maven-
+
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Set up Java 11
         uses: actions/setup-java@v4
@@ -125,19 +250,33 @@ jobs:
       - name: Build Generator
         run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
       - name: JavaDoc Aggregate
-        run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
+        run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: "-Xmx1g"
       - name: JavaDoc Jar
-        run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean install javadoc:jar --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
+        run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean install javadoc:jar --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: "-Xmx1g"
+
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections
 
   javadoc-early-access:
     name: Javadoc Early Access
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          key: maven-javadoc-ea-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-javadoc-ea-
+            maven-javadoc-
+            maven-
+
+      - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Download JDK 23 from jdk.java.net
         uses: oracle-actions/setup-java@v1
         id: download-jdk
@@ -150,11 +289,12 @@ jobs:
           echo 'Outputs'
           echo "steps.download-jdk.outputs.archive = ${{ steps.download-jdk.outputs.archive }}"
           echo "steps.download-jdk.outputs.version = ${{ steps.download-jdk.outputs.version }}"
-      - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - run: java --version
       - name: Build Generator
-        run: ./mvnw -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
+        run: ./mvnw --threads 2C --color=always -DskipTests install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
       - name: Javadoc
-        run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
+        run: ./mvnw --threads 2C --color=always --activate-profiles maven-javadoc-plugin -DskipTests javadoc:aggregate install --projects '!unit-tests,!serialization-tests,!jcstress-tests,!junit-trait-runner,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: "-Xmx2g"
+      - name: 'Clean Maven cache'
+        run: rm -rf ~/.m2/repository/org/eclipse/collections

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -94,41 +94,7 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <goals>
-                            <goal>analyze-only</goal>
-                        </goals>
-                        <configuration>
-                            <failOnWarning>true</failOnWarning>
-                            <ignoredUnusedDeclaredDependencies>
-                                <ignoredUnusedDeclaredDependency>
-                                    com.google.code.findbugs:jsr305:jar
-                                </ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>
-                                    org.slf4j:slf4j-simple:jar
-                                </ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>
-                                    org.junit.jupiter:junit-jupiter-api:jar
-                                </ignoredUnusedDeclaredDependency>
-                            </ignoredUnusedDeclaredDependencies>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -70,10 +70,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
             </plugin>
@@ -89,24 +85,6 @@
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections API - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections API - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -126,4 +104,27 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <configuration>
+                            <doctitle>Eclipse Collections API - ${project.version}</doctitle>
+                            <windowtitle>Eclipse Collections API - ${project.version}</windowtitle>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+    </profiles>
 </project>

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -76,32 +76,7 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -165,4 +140,46 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+
+        <!--region Phase 1: validate-->
+        <profile>
+            <id>maven-enforcer-plugin</id>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 1: validate-->
+
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+
+    </profiles>
 </project>

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -53,32 +53,30 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
         </plugins>
     </build>
+
+    <profiles>
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+    </profiles>
 
 </project>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -69,38 +69,11 @@
         <plugins>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections Fork Join Utilities - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections Fork Join Utilities - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -120,4 +93,44 @@
 
         </plugins>
     </build>
+
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doctitle>Eclipse Collections Fork Join Utilities - ${project.version}</doctitle>
+                            <windowtitle>Eclipse Collections Fork Join Utilities - ${project.version}</windowtitle>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+
+    </profiles>
+
 </project>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -69,38 +69,11 @@
         <plugins>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections Test Utilities - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections Test Utilities - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -120,4 +93,44 @@
 
         </plugins>
     </build>
+
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doctitle>Eclipse Collections Test Utilities - ${project.version}</doctitle>
+                            <windowtitle>Eclipse Collections Test Utilities - ${project.version}</windowtitle>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+
+    </profiles>
+
 </project>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -79,10 +79,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
             </plugin>
@@ -98,24 +94,6 @@
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doctitle>Eclipse Collections - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <links>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>none</doclint>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -135,4 +113,24 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -306,31 +306,6 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.2</version>
-                    <executions>
-                        <execution>
-                            <id>analyze</id>
-                            <goals>
-                                <goal>analyze-only</goal>
-                            </goals>
-                            <configuration>
-                                <failOnWarning>true</failOnWarning>
-                                <ignoredUnusedDeclaredDependencies>
-                                    <ignoredUnusedDeclaredDependency>
-                                        com.google.code.findbugs:jsr305:jar
-                                    </ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>
-                                        ch.qos.logback:logback-classic:jar
-                                    </ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>
-                                        org.slf4j:slf4j-nop:jar
-                                    </ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>
-                                        org.junit.jupiter:junit-jupiter-api:jar
-                                    </ignoredUnusedDeclaredDependency>
-                                </ignoredUnusedDeclaredDependencies>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <plugin>
@@ -350,7 +325,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
 
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.3</version>
                 </plugin>
 
                 <plugin>
@@ -375,47 +350,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
 
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <executions>
-                        <execution>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>jar-no-fork</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.4.1</version>
-                    <executions>
-                        <execution>
-                            <id>enforce</id>
-                            <configuration>
-                                <rules>
-                                    <DependencyConvergence />
-                                    <requireJavaVersion>
-                                        <version>1.8.0</version>
-                                    </requireJavaVersion>
-                                    <requireMavenVersion>
-                                        <version>3.3.9</version>
-                                    </requireMavenVersion>
-                                    <requirePluginVersions>
-                                        <unCheckedPluginList>
-                                            org.eclipse.collections:eclipse-collections-code-generator-maven-plugin,
-                                            org.eclipse.ebr:ebr-maven-plugin,
-                                            org.eclipse.ebr:ebr-tycho-extras-plugin
-                                        </unCheckedPluginList>
-                                    </requirePluginVersions>
-                                </rules>
-                            </configuration>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                        </execution>
-                    </executions>
+                    <version>3.3.1</version>
                 </plugin>
 
                 <plugin>
@@ -448,26 +383,6 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                 </plugin>
 
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco.plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>report</id>
-                            <phase>prepare-package</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
@@ -475,7 +390,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                         <includes>
                             <include>**/*Test.java</include>
                         </includes>
-                        <argLine>-XX:-OmitStackTraceInFastThrow -Xms1024m -Xmx2048m @{argLine}</argLine>
+                        <argLine>-XX:-OmitStackTraceInFastThrow -Xms1024m -Xmx2048m --add-opens java.base/java.lang=ALL-UNNAMED @{argLine}</argLine>
                         <runOrder>random</runOrder>
                         <!--<forkCount>2C</forkCount>-->
                     </configuration>
@@ -589,47 +504,8 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
             </plugin>
 
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <doctitle>Eclipse Collections - ${project.version}</doctitle>
-                    <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
-                    <show>public</show>
-                    <detectJavaApiLink>true</detectJavaApiLink>
-                    <links>
-                        <link>https://junit.org/junit4/javadoc/latest</link>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
-                    </links>
-                    <destDir>${project.version}</destDir>
-                    <doclint>html,syntax,accessibility</doclint>
-                    <excludePackageNames>
-                        org.openjdk,org.eclipse.collections.impl.jmh,org.eclipse.collections.codegenerator.maven
-                    </excludePackageNames>
-
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>aggregate</id>
-                        <inherited>false</inherited>
-                        <goals>
-                            <goal>aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -846,10 +722,12 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                             </execution>
                         </executions>
                     </plugin>
+
+                    <!--region Phase 21: verify-->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -858,6 +736,8 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                                     <goal>sign</goal>
                                 </goals>
                                 <configuration>
+                                    <!-- Prevent `gpg` from using pinentry programs -->
+                                    <!-- https://github.com/samuelmeuli/action-maven-publish/issues/1 -->
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>
@@ -866,6 +746,23 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                             </execution>
                         </executions>
                     </plugin>
+                    <!--endregion Phase 21: verify-->
+
+                    <!--region Phase 17: package-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>create source jar</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--endregion Phase 17: package-->
                 </plugins>
             </build>
             <distributionManagement>
@@ -879,5 +776,185 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                 </repository>
             </distributionManagement>
         </profile>
+
+        <!--region Phase 1: validate-->
+        <profile>
+            <id>maven-enforcer-plugin</id>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.4.1</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>extra-enforcer-rules</artifactId>
+                                <version>1.8.0</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>enforce</id>
+                                <configuration>
+                                    <rules>
+                                        <dependencyConvergence />
+                                        <requireJavaVersion>
+                                            <version>1.8.0</version>
+                                        </requireJavaVersion>
+                                        <requirePluginVersions>
+                                            <banLatest>true</banLatest>
+                                            <banRelease>true</banRelease>
+                                            <unCheckedPluginList>
+                                                org.eclipse.collections:eclipse-collections-code-generator-maven-plugin,
+                                                org.eclipse.ebr:ebr-maven-plugin,
+                                                org.eclipse.ebr:ebr-tycho-extras-plugin,
+                                                org.apache.maven.plugins:maven-site-plugin,
+                                                org.apache.maven.plugins:maven-deploy-plugin
+                                            </unCheckedPluginList>
+                                        </requirePluginVersions>
+                                        <banDuplicatePomDependencyVersions />
+                                        <banDuplicateClasses>
+                                            <findAllDuplicates>true</findAllDuplicates>
+                                            <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                        </banDuplicateClasses>
+                                    </rules>
+                                </configuration>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 1: validate-->
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <version>${jacoco.plugin.version}</version>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>prepare-agent</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>report</id>
+                                    <phase>prepare-package</phase>
+                                    <goals>
+                                        <goal>report</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+        <!--region Phase 17: package-->
+        <profile>
+            <id>maven-javadoc-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <doctitle>Eclipse Collections - ${project.version}</doctitle>
+                            <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
+                            <show>public</show>
+                            <detectJavaApiLink>true</detectJavaApiLink>
+                            <links>
+                                <link>https://junit.org/junit4/javadoc/latest</link>
+                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                            </links>
+                            <destDir>${project.version}</destDir>
+                            <doclint>html,syntax,accessibility</doclint>
+                            <excludePackageNames>
+                                org.openjdk,org.eclipse.collections.impl.jmh,org.eclipse.collections.codegenerator.maven
+                            </excludePackageNames>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>aggregate</id>
+                                <inherited>false</inherited>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 17: package-->
+
+        <!--region Phase 21: verify-->
+        <profile>
+            <id>maven-dependency-plugin</id>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <version>3.1.2</version>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <ignoredUnusedDeclaredDependency>
+                                        com.google.code.findbugs:jsr305:jar
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        ch.qos.logback:logback-classic:jar
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        org.slf4j:slf4j-nop:jar
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        org.junit.jupiter:junit-jupiter-api:jar
+                                    </ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <id>analyze</id>
+                                    <goals>
+                                        <goal>analyze-only</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 21: verify-->
+
     </profiles>
+
 </project>

--- a/serialization-tests/pom.xml
+++ b/serialization-tests/pom.xml
@@ -70,23 +70,29 @@
         <plugins>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
         </plugins>
     </build>
+
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+    </profiles>
 
 </project>

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -67,28 +67,6 @@
 
     <build>
 
-        <plugins>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
-        </plugins>
-
         <pluginManagement>
             <plugins>
                 <!--This plugin's configuration is used to store Eclipse m2e
@@ -126,5 +104,33 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+    </profiles>
 
 </project>

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -91,27 +91,32 @@
         <plugins>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
         </plugins>
     </build>
 
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+    </profiles>
 </project>

--- a/unit-tests/pom.xml
+++ b/unit-tests/pom.xml
@@ -95,27 +95,33 @@
             </plugin>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
 
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-            </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+
+        <!--region Phase 16: prepare-package-->
+        <profile>
+            <id>jacoco-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 16: prepare-package-->
+
+    </profiles>
 
 </project>


### PR DESCRIPTION
I have two changes here:

- Separating maven plugins into profiles and only enabling the relevant profiles in the relevant workflows
- Adding the GitHub shared action for caching the .m2 directory

These are only related in that they both are intended to speed up the build and they both were created by comparing with another open source GitHub workflow which is written in this style.

The maven profile thing creates a third related change, splitting the "test" configuration into separate test, enforcer, and dependency:analyze-only jobs.

If this is too much, I can definitely split out the caching, and possibly more.