### PR TITLE
Specify the version of maven-wrapper-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,11 @@
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <artifactId>maven-wrapper-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+
         </plugins>
 
     </build>


### PR DESCRIPTION
We're already running this plugin as part of continuous integration so the usual thing would be to lock down the version. Maven 4.x together with the enforcer plugin will require this, and I'm running maven 4 locally.