### PR TITLE
Optimize equals for primitive Bags using allSatisfyKeyValue on primitivePrimitive Maps

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/map/primitivePrimitiveMap.stg
@@ -83,6 +83,14 @@ public interface <name1><name2>Map extends <name2>ValuesMap
     void forEachKeyValue(<name1><name2>Procedure procedure);
 
     /**
+     * @since 12.0
+     */
+    default boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        return this.keyValuesView().allSatisfy(pair -> predicate.accept(pair.getOne(), pair.getTwo()));
+    }
+
+    /**
      * Implements the injectInto pattern with each key/value pair of the map.
      * @param value to be injected into the map
      * @param function to apply to the injected value and key/value pairs

--- a/eclipse-collections-code-generator/src/main/resources/copyrightOf.stg
+++ b/eclipse-collections-code-generator/src/main/resources/copyrightOf.stg
@@ -1,6 +1,6 @@
 copyrightOf(copyrightHolders) ::= <<
 /*
- * Copyright (c) 2022 <copyrightHolders>.
+ * Copyright (c) 2024 <copyrightHolders>.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
@@ -576,8 +576,7 @@ public class <name>HashBag
             return false;
         }
 
-        return this.items.keysView().allSatisfy((<type> key) ->
-                <name>HashBag.this.occurrencesOf(key) == bag.occurrencesOf(key));
+        return this.items.allSatisfyKeyValue((key, count) -> bag.occurrencesOf(key) == count);
     }
 
     @Override

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveEmptyMap.stg
@@ -126,6 +126,14 @@ final class Immutable<name1><name2>EmptyMap implements Immutable<name1><name2>Ma
     {
     }
 
+    /**
+     * @since 12.0
+     */
+    public boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        return true;
+    }
+
     @Override
     public Lazy<name1>Iterable keysView()
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveHashMap.stg
@@ -128,6 +128,14 @@ final class Immutable<name1><name2>HashMap implements Immutable<name1><name2>Map
         this.delegate.forEachKeyValue(procedure);
     }
 
+    /**
+     * @since 12.0
+     */
+    public boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        return this.delegate.allSatisfyKeyValue(predicate);
+    }
+
     @Override
     public Lazy<name1>Iterable keysView()
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/immutable/immutablePrimitivePrimitiveSingletonMap.stg
@@ -135,6 +135,14 @@ final class Immutable<name1><name2>SingletonMap implements Immutable<name1><name
         procedure.value(this.key1, this.value1);
     }
 
+    /**
+     * @since 12.0
+     */
+    public boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        return predicate.accept(this.key1, this.value1);
+    }
+
     @Override
     public Lazy<name1>Iterable keysView()
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/primitivePrimitiveHashMap.stg
@@ -852,6 +852,41 @@ public class <name1><name2>HashMap extends AbstractMutable<name2>ValuesMap imple
         <forEachKeyValue(template = {procedure.value(<key>, <value>)})>
     }
 
+    /**
+     * @since 12.0
+     */
+    public boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        if (this.sentinelValues != null)
+        {
+            if (this.sentinelValues.containsZeroKey)
+            {
+                if (!predicate.accept(EMPTY_KEY, this.sentinelValues.zeroValue))
+                {
+                    return false;
+                }
+            }
+            if (this.sentinelValues.containsOneKey)
+            {
+                if (!predicate.accept(REMOVED_KEY, this.sentinelValues.oneValue))
+                {
+                    return false;
+                }
+            }
+        }
+        for (int i = 0; i \< this.<keyArray>.length; i<increment>)
+        {
+            if (isNonSentinel(this.<keyArray>[i]))
+            {
+                if (!predicate.accept(this.<keyArray>[i], this.<valueArray>[i<valueIndex>]))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     @Override
     public Lazy<name1>Iterable keysView()
     {

--- a/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/map/mutable/synchronizedPrimitivePrimitiveMap.stg
@@ -290,6 +290,17 @@ public class Synchronized<name1><name2>Map
         }
     }
 
+    /**
+     * @since 12.0
+     */
+    public boolean allSatisfyKeyValue(<name1><name2>Predicate predicate)
+    {
+        synchronized (this.lock)
+        {
+            return this.map.allSatisfyKeyValue(predicate);
+        }
+    }
+
     @Override
     public Lazy<name1>Iterable keysView()
     {

--- a/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/map/abstractPrimitivePrimitiveMapTestCase.stg
@@ -672,6 +672,18 @@ public abstract class Abstract<name1><name2>MapTestCase
     }
 
     @Test
+    public void allSatisfyKeyValue()
+    {
+        Assert.assertTrue(this.getEmptyMap().allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        <name1><name2>Map map1 = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);
+        Assert.assertTrue(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        Assert.assertFalse(map1.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
+        <name1><name2>Map map2 = this.newWithKeysValues(<["0"]:keyValue(); separator=", ">);
+        Assert.assertTrue(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.equal(v).accept((<type2>) k)));
+        Assert.assertFalse(map2.allSatisfyKeyValue((k, v) -> <name2>Predicates.lessThan(v).accept((<type2>) k)));
+    }
+
+    @Test
     public void noneSatisfy()
     {
         <name1><name2>Map map = this.newWithKeysValues(<["0", "1", "2", "3"]:keyValue(); separator=", ">);

--- a/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntBagEqualsTest.java
+++ b/jmh-tests/src/main/java/org/eclipse/collections/impl/jmh/IntBagEqualsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.impl.jmh;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.collections.api.bag.primitive.MutableIntBag;
+import org.eclipse.collections.api.factory.primitive.IntBags;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 2)
+@Measurement(iterations = 10, time = 2)
+public class IntBagEqualsTest
+{
+    private final MutableIntBag bag = IntBags.mutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
+    private final MutableIntBag equalBag = IntBags.mutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
+    private final MutableIntBag unequalBag1 = IntBags.mutable.with(1, 1, 1, 1, 2, 2, 2, 3, 3, 4);
+    private final MutableIntBag unequalBag2 = IntBags.mutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4);
+    private final Map<Integer, Long> map =
+            this.bag.collect(Integer::valueOf).stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<Integer, Long> equalMap =
+            this.bag.collect(Integer::valueOf).stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<Integer, Long> unequalMap1 =
+            this.unequalBag1.collect(Integer::valueOf).stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+    private final Map<Integer, Long> unequalMap2 =
+            this.unequalBag2.collect(Integer::valueOf).stream().collect(Collectors.groupingBy(each -> each, Collectors.counting()));
+
+    @Benchmark
+    public boolean[] bagEquals()
+    {
+        boolean equals = this.bag.equals(this.equalBag);
+        boolean unequals1 = this.bag.equals(this.unequalBag1);
+        boolean unequals2 = this.bag.equals(this.unequalBag2);
+        return new boolean[]{equals, unequals1, unequals2};
+    }
+
+    @Benchmark
+    public boolean[] mapEquals()
+    {
+        boolean equals = this.map.equals(this.equalMap);
+        boolean unequals1 = this.map.equals(this.unequalMap1);
+        boolean unequals2 = this.map.equals(this.unequalMap2);
+        return new boolean[]{equals, unequals1, unequals2};
+    }
+}


### PR DESCRIPTION
Before changes:

```
Benchmark                    Mode  Cnt      Score     Error   Units
IntBagEqualsTest.bagEquals  thrpt   20  16872.887 ±  46.903  ops/ms
IntBagEqualsTest.mapEquals  thrpt   20  15838.773 ± 103.729  ops/ms

```
After using allSatisfyKeyValue in primitive Bag equals:

```
Benchmark                    Mode  Cnt      Score     Error   Units
IntBagEqualsTest.bagEquals  thrpt   20  51903.988 ± 237.046  ops/ms
IntBagEqualsTest.mapEquals  thrpt   20  15964.766 ± 172.302  ops/ms
```