### PR TITLE
Revert "Add `--color=always` to .mvn/maven.config"

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,3 @@
 --show-version
 --errors
 --no-transfer-progress
---color=always


### PR DESCRIPTION
This reverts commit 985defb2df44bf46a8a2a653a00dc70a7579971b.

Adding --color broke the CodeQL build, which doesn't run on pull_request, and uses an auto-configured but old version of maven.