### PR TITLE
Set *.stg to linguist-linguist=StringTemplate in .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,5 @@
 *.class         binary
 *.jar           binary
 *.zip           binary
+
+*.stg     linguist-language=StringTemplate


### PR DESCRIPTION
This project's StringTemplate files are rendering in GitHub as plain text. Looking in the [Linguist supported languages](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml), I see that [StringTemplate is present](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml#L6867) but is set to match `*.st` files and not `*.stg` files. Following the [GitHub docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) I set *.stg to linguist-linguist=StringTemplate in .gitattributes.

Before:

<img width="795" alt="Screenshot 2024-05-28 at 9 57 24 AM" src="https://github.com/eclipse/eclipse-collections/assets/244258/29a94585-4c5d-46d6-85b5-a7ba255d187e">

After:

<img width="787" alt="Screenshot 2024-05-28 at 10 01 37 AM" src="https://github.com/eclipse/eclipse-collections/assets/244258/130fdc97-6a24-4ac2-9d74-ee763a5969a7">
