### PR TITLE
Set .idea to linguist-generated=false in .gitattributes so that it shows up in code review diffs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,5 @@
 *.class         binary
 *.jar           binary
 *.zip           binary
+
+/.idea/** linguist-generated=false


### PR DESCRIPTION
In code reviews like #1606, the diffs are collapsed by default because files under .idea/ are considered generated sources (screenshot below).

Similar to the changes in #1608, I followed [GitHub's documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) on how to configure .gitattributes to control which files are considered generated.

Before:

<img width="760" alt="Screenshot 2024-05-28 at 9 54 35 AM" src="https://github.com/eclipse/eclipse-collections/assets/244258/8cd5fbeb-69d6-4ce5-985a-b2c1d509bea9">

After:

the diff will simply appear
