### PR TITLE
Add module unit-tests-guava-testlib.

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -132,4 +132,7 @@
     <!-- Replicated with violations from JUnit 4 project -->
     <suppress checks="[a-zA-Z0-0]*" files="AssertTest.java" />
 
+    <!-- Fluent builder API with anonymous inner classes results in deep nesting beyond checkstyle indentation limits -->
+    <suppress checks="Indentation" files="MapsTest.java" />
+
 </suppressions>

--- a/p2-site/pom.xml
+++ b/p2-site/pom.xml
@@ -96,6 +96,9 @@
                                     <ignoredUnusedDeclaredDependency>
                                         org.eclipse.collections:unit-tests-thread-safety:jar
                                     </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        org.eclipse.collections:unit-tests-guava-testlib:jar
+                                    </ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
                             </configuration>
                             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
         <module>unit-tests-thread-safety</module>
         <module>serialization-tests</module>
         <module>jcstress-tests</module>
+        <module>unit-tests-guava-testlib</module>
         <module>unit-tests-java8</module>
         <module>test-coverage</module>
         <module>p2-site</module>

--- a/unit-tests-guava-testlib/pom.xml
+++ b/unit-tests-guava-testlib/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.collections</groupId>
+        <artifactId>eclipse-collections-parent</artifactId>
+        <version>14.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>unit-tests-guava-testlib</artifactId>
+
+    <name>Eclipse Collections Guava Testlib Unit Test Suite</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>${guava.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
+++ b/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2024 Craig Motlin and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.test.guavalib.map;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+
+import com.google.common.collect.testing.MapTestSuiteBuilder;
+import com.google.common.collect.testing.SortedMapTestSuiteBuilder;
+import com.google.common.collect.testing.TestStringMapGenerator;
+import com.google.common.collect.testing.TestStringSortedMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.SortedMaps;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
+import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy;
+
+public class MapsTest
+{
+    public static Test suite()
+    {
+        return new MapsTest().allTests();
+    }
+
+    public Test allTests()
+    {
+        TestSuite suite = new TestSuite("Eclipse Collections Maps");
+        suite.addTest(testsForImmutableEmptyMap());
+        suite.addTest(testsForEmptyMap());
+        suite.addTest(testsForImmutableEmptySortedMap());
+        suite.addTest(testsForImmutableSingletonMap());
+        suite.addTest(testsForUnifiedMap());
+        suite.addTest(testsForUnifiedMapWithHashingStrategy());
+        suite.addTest(testsForTreeSortedMapNatural());
+        suite.addTest(testsForTreeMapWithComparator());
+        suite.addTest(testsForUnmodifiableMutableMap());
+        suite.addTest(testsForUnmodifiableMutableSortedMap());
+        suite.addTest(testsForConcurrentHashMap());
+        suite.addTest(testsForConcurrentHashMapUnsafe());
+        return suite;
+    }
+
+    public Test testsForImmutableEmptyMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return (Map<String, String>) Maps.immutable.empty();
+                            }
+                        })
+                .named("ImmutableEmptyMap")
+                .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForEmptyMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return Maps.fixedSize.empty();
+                            }
+                        })
+                .named("FixedSizeEmptyMap")
+                .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForImmutableEmptySortedMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringSortedMapGenerator()
+                        {
+                            @Override
+                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return (SortedMap<String, String>) SortedMaps.immutable.<String, String>empty();
+                            }
+                        })
+                .named("ImmutableEmptySortedMap")
+                .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForImmutableSingletonMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return (Map<String, String>) Maps.immutable.of(entries[0].getKey(), entries[0].getValue());
+                            }
+                        })
+                .named("ImmutableSingletonMap")
+                .withFeatures(
+                        MapFeature.ALLOWS_NULL_KEYS,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ONE)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForUnifiedMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new UnifiedMap<>(), entries);
+                            }
+                        })
+                .named("UnifiedMap")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_KEYS,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .createTestSuite();
+    }
+
+    public Test testsForUnifiedMapWithHashingStrategy()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new UnifiedMapWithHashingStrategy<>(HashingStrategies.nullSafeHashingStrategy(
+                                        HashingStrategies.defaultStrategy())), entries);
+                            }
+                        })
+                .named("UnifiedMapWithHashingStrategy / nullSafeHashingStrategy")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_KEYS,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .createTestSuite();
+    }
+
+    public Test testsForTreeSortedMapNatural()
+    {
+        return SortedMapTestSuiteBuilder.using(
+                        new TestStringSortedMapGenerator()
+                        {
+                            @Override
+                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new TreeSortedMap<>(), entries);
+                            }
+                        })
+                .named("TreeSortedMap, natural")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.KNOWN_ORDER,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForTreeMapWithComparator()
+    {
+        return SortedMapTestSuiteBuilder.using(
+                        new TestStringSortedMapGenerator()
+                        {
+                            @Override
+                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(
+                                        new TreeSortedMap<>(arbitraryNullFriendlyComparator()), entries);
+                            }
+                        })
+                .named("TreeSortedMap, with comparator")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_KEYS,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.KNOWN_ORDER,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForUnmodifiableMutableMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new UnifiedMap<>(), entries).asUnmodifiable();
+                            }
+                        })
+                .named("UnifiedMap/asUnmodifiable")
+                .withFeatures(
+                        MapFeature.ALLOWS_NULL_KEYS,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        MapFeature.ALLOWS_ANY_NULL_QUERIES,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForUnmodifiableMutableSortedMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringSortedMapGenerator()
+                        {
+                            @Override
+                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new TreeSortedMap<>(), entries).asUnmodifiable();
+                            }
+                        })
+                .named("TreeSortedMap/asUnmodifiable, natural")
+                .withFeatures(
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        CollectionFeature.KNOWN_ORDER,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .suppressing(Collections.emptySet())
+                .createTestSuite();
+    }
+
+    public Test testsForConcurrentHashMap()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new ConcurrentHashMap<>(), entries);
+                            }
+                        })
+                .named("ConcurrentHashMap")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .createTestSuite();
+    }
+
+    public Test testsForConcurrentHashMapUnsafe()
+    {
+        return MapTestSuiteBuilder.using(
+                        new TestStringMapGenerator()
+                        {
+                            @Override
+                            protected Map<String, String> create(Entry<String, String>[] entries)
+                            {
+                                return populate(new ConcurrentHashMapUnsafe<>(), entries);
+                            }
+                        })
+                .named("ConcurrentHashMapUnsafe")
+                .withFeatures(
+                        MapFeature.GENERAL_PURPOSE,
+                        MapFeature.ALLOWS_NULL_VALUES,
+                        CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                        CollectionFeature.SERIALIZABLE,
+                        CollectionSize.ANY)
+                .createTestSuite();
+    }
+
+    private static <T, M extends Map<T, String>> M populate(M map, Entry<T, String>[] entries)
+    {
+        for (Entry<T, String> entry : entries)
+        {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+
+    static <T> Comparator<T> arbitraryNullFriendlyComparator()
+    {
+        return new NullFriendlyComparator<>();
+    }
+
+    private static final class NullFriendlyComparator<T>
+            implements Comparator<T>,
+            Serializable
+    {
+        @Override
+        public int compare(T left, T right)
+        {
+            return String.valueOf(left).compareTo(String.valueOf(right));
+        }
+    }
+}

--- a/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
+++ b/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.test.guavalib.map;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
@@ -330,7 +330,7 @@ public class MapsTest
     {
         try
         {
-            return Arrays.asList(
+            return List.of(
                     CollectionSpliteratorTester.class.getDeclaredMethod("testSpliteratorNullable"),
                     MapComputeIfAbsentTester.class.getDeclaredMethod("testComputeIfAbsent_nullTreatedAsAbsent"),
                     MapComputeIfPresentTester.class.getDeclaredMethod("testComputeIfPresent_nullTreatedAsAbsent"),

--- a/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
+++ b/unit-tests-guava-testlib/src/test/java/org/eclipse/collections/test/guavalib/map/MapsTest.java
@@ -11,6 +11,9 @@
 package org.eclipse.collections.test.guavalib.map;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -24,6 +27,10 @@ import com.google.common.collect.testing.TestStringSortedMapGenerator;
 import com.google.common.collect.testing.features.CollectionFeature;
 import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
+import com.google.common.collect.testing.testers.CollectionSpliteratorTester;
+import com.google.common.collect.testing.testers.MapComputeIfAbsentTester;
+import com.google.common.collect.testing.testers.MapComputeIfPresentTester;
+import com.google.common.collect.testing.testers.MapPutIfAbsentTester;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.collections.api.factory.Maps;
@@ -62,15 +69,15 @@ public class MapsTest
 
     public Test testsForImmutableEmptyMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return (Map<String, String>) Maps.immutable.empty();
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return (Map<String, String>) Maps.immutable.empty();
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("ImmutableEmptyMap")
                 .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
                 .suppressing(Collections.emptySet())
@@ -79,15 +86,15 @@ public class MapsTest
 
     public Test testsForEmptyMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return Maps.fixedSize.empty();
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return Maps.fixedSize.empty();
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("FixedSizeEmptyMap")
                 .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
                 .suppressing(Collections.emptySet())
@@ -96,15 +103,15 @@ public class MapsTest
 
     public Test testsForImmutableEmptySortedMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringSortedMapGenerator()
-                        {
-                            @Override
-                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return (SortedMap<String, String>) SortedMaps.immutable.<String, String>empty();
-                            }
-                        })
+        TestStringSortedMapGenerator generator = new TestStringSortedMapGenerator()
+        {
+            @Override
+            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+            {
+                return (SortedMap<String, String>) SortedMaps.immutable.<String, String>empty();
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("ImmutableEmptySortedMap")
                 .withFeatures(CollectionFeature.SERIALIZABLE, CollectionSize.ZERO)
                 .suppressing(Collections.emptySet())
@@ -113,15 +120,15 @@ public class MapsTest
 
     public Test testsForImmutableSingletonMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return (Map<String, String>) Maps.immutable.of(entries[0].getKey(), entries[0].getValue());
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return (Map<String, String>) Maps.immutable.of(entries[0].getKey(), entries[0].getValue());
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("ImmutableSingletonMap")
                 .withFeatures(
                         MapFeature.ALLOWS_NULL_KEYS,
@@ -135,15 +142,15 @@ public class MapsTest
 
     public Test testsForUnifiedMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new UnifiedMap<>(), entries);
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new UnifiedMap<>(), entries);
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("UnifiedMap")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -158,16 +165,16 @@ public class MapsTest
 
     public Test testsForUnifiedMapWithHashingStrategy()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new UnifiedMapWithHashingStrategy<>(HashingStrategies.nullSafeHashingStrategy(
-                                        HashingStrategies.defaultStrategy())), entries);
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new UnifiedMapWithHashingStrategy<>(HashingStrategies.nullSafeHashingStrategy(
+                        HashingStrategies.defaultStrategy())), entries);
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("UnifiedMapWithHashingStrategy / nullSafeHashingStrategy")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -182,15 +189,15 @@ public class MapsTest
 
     public Test testsForTreeSortedMapNatural()
     {
-        return SortedMapTestSuiteBuilder.using(
-                        new TestStringSortedMapGenerator()
-                        {
-                            @Override
-                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new TreeSortedMap<>(), entries);
-                            }
-                        })
+        TestStringSortedMapGenerator generator = new TestStringSortedMapGenerator()
+        {
+            @Override
+            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new TreeSortedMap<>(), entries);
+            }
+        };
+        return SortedMapTestSuiteBuilder.using(generator)
                 .named("TreeSortedMap, natural")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -206,16 +213,16 @@ public class MapsTest
 
     public Test testsForTreeMapWithComparator()
     {
-        return SortedMapTestSuiteBuilder.using(
-                        new TestStringSortedMapGenerator()
-                        {
-                            @Override
-                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(
-                                        new TreeSortedMap<>(arbitraryNullFriendlyComparator()), entries);
-                            }
-                        })
+        TestStringSortedMapGenerator generator = new TestStringSortedMapGenerator()
+        {
+            @Override
+            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(
+                        new TreeSortedMap<>(arbitraryNullFriendlyComparator()), entries);
+            }
+        };
+        return SortedMapTestSuiteBuilder.using(generator)
                 .named("TreeSortedMap, with comparator")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -233,15 +240,15 @@ public class MapsTest
 
     public Test testsForUnmodifiableMutableMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new UnifiedMap<>(), entries).asUnmodifiable();
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new UnifiedMap<>(), entries).asUnmodifiable();
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("UnifiedMap/asUnmodifiable")
                 .withFeatures(
                         MapFeature.ALLOWS_NULL_KEYS,
@@ -255,15 +262,15 @@ public class MapsTest
 
     public Test testsForUnmodifiableMutableSortedMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringSortedMapGenerator()
-                        {
-                            @Override
-                            protected SortedMap<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new TreeSortedMap<>(), entries).asUnmodifiable();
-                            }
-                        })
+        TestStringSortedMapGenerator generator = new TestStringSortedMapGenerator()
+        {
+            @Override
+            protected SortedMap<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new TreeSortedMap<>(), entries).asUnmodifiable();
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("TreeSortedMap/asUnmodifiable, natural")
                 .withFeatures(
                         MapFeature.ALLOWS_NULL_VALUES,
@@ -276,15 +283,15 @@ public class MapsTest
 
     public Test testsForConcurrentHashMap()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new ConcurrentHashMap<>(), entries);
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new ConcurrentHashMap<>(), entries);
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("ConcurrentHashMap")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -292,20 +299,21 @@ public class MapsTest
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.SERIALIZABLE,
                         CollectionSize.ANY)
+                .suppressing(concurrentHashMapNullValueBugMethods())
                 .createTestSuite();
     }
 
     public Test testsForConcurrentHashMapUnsafe()
     {
-        return MapTestSuiteBuilder.using(
-                        new TestStringMapGenerator()
-                        {
-                            @Override
-                            protected Map<String, String> create(Entry<String, String>[] entries)
-                            {
-                                return populate(new ConcurrentHashMapUnsafe<>(), entries);
-                            }
-                        })
+        TestStringMapGenerator generator = new TestStringMapGenerator()
+        {
+            @Override
+            protected Map<String, String> create(Entry<String, String>[] entries)
+            {
+                return populate(new ConcurrentHashMapUnsafe<>(), entries);
+            }
+        };
+        return MapTestSuiteBuilder.using(generator)
                 .named("ConcurrentHashMapUnsafe")
                 .withFeatures(
                         MapFeature.GENERAL_PURPOSE,
@@ -313,7 +321,25 @@ public class MapsTest
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.SERIALIZABLE,
                         CollectionSize.ANY)
+                .suppressing(concurrentHashMapNullValueBugMethods())
                 .createTestSuite();
+    }
+
+    // TODO: Fix null-value-as-absent bugs in ConcurrentHashMap/ConcurrentHashMapUnsafe and remove this suppression.
+    private static Collection<Method> concurrentHashMapNullValueBugMethods()
+    {
+        try
+        {
+            return Arrays.asList(
+                    CollectionSpliteratorTester.class.getDeclaredMethod("testSpliteratorNullable"),
+                    MapComputeIfAbsentTester.class.getDeclaredMethod("testComputeIfAbsent_nullTreatedAsAbsent"),
+                    MapComputeIfPresentTester.class.getDeclaredMethod("testComputeIfPresent_nullTreatedAsAbsent"),
+                    MapPutIfAbsentTester.class.getDeclaredMethod("testPutIfAbsent_replacesNullValue"));
+        }
+        catch (NoSuchMethodException exception)
+        {
+            throw new RuntimeException(exception);
+        }
     }
 
     private static <T, M extends Map<T, String>> M populate(M map, Entry<T, String>[] entries)


### PR DESCRIPTION
This is an experiment to run Guava's testlib tests on Eclipse Collections containers. I started with just maps, and this test suite is based on https://github.com/google/guava/blob/master/guava-testlib/src/com/google/common/collect/testing/TestsForMapsInJavaUtil.java.

A few tests fail, just on compute() and merge() methods, and just on edge cases involving replacing nulls.