### PR TITLE
Migrate to Junit5 friendly syntax - 2 more classes

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
 {
@@ -101,9 +102,9 @@ public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
         assertEquals(iList(-3, -1, 1, 3, 5, 7, 9), result.getRejected());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullCheck()
     {
-        SynchronizedRichIterable.of(null, null);
+        assertThrows(IllegalArgumentException.class, () -> SynchronizedRichIterable.of(null, null));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
@@ -913,10 +913,11 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         assertEquals(expectedMap, strings2.take(Integer.MAX_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void take_throws()
     {
-        this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4").take(-1);
+        assertThrows(IllegalArgumentException.class,
+                () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4").take(-1));
     }
 
     @Test
@@ -937,9 +938,10 @@ public abstract class MutableSortedMapTestCase extends MutableMapIterableTestCas
         assertEquals(expectedMap, strings2.drop(Integer.MAX_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void drop_throws()
     {
-        this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4").drop(-1);
+        assertThrows(IllegalArgumentException.class,
+                () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4").drop(-1));
     }
 }


### PR DESCRIPTION
Migrate to Junit5 friendly syntax - MutableSortedMapTestCase and SynchronizedRichIterableTest

@donraab / @motlin - 1 more pls :-) 