### PR TITLE
Fix NullPointerException in IterableTestCase.assertEquals

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -110,8 +110,8 @@ public interface IterableTestCase
 
         Assert.assertEquals(o1, o2);
 
-        assertFalse("Neither item should equal null", o1.equals(null));
-        assertFalse("Neither item should equal null", o2.equals(null));
+        Assert.assertNotNull("Neither item should equal null", o1);
+        Assert.assertNotNull("Neither item should equal null", o2);
         assertNotEquals("Neither item should equal new Object()", o1.equals(new Object()));
         assertNotEquals("Neither item should equal new Object()", o2.equals(new Object()));
         Assert.assertEquals(o1, o1);
@@ -171,8 +171,8 @@ public interface IterableTestCase
         Assert.assertNotEquals(o1, o2);
         Assert.assertNotEquals(o2, o1);
 
-        assertFalse("Neither item should equal null", o1.equals(null));
-        assertFalse("Neither item should equal null", o2.equals(null));
+        Assert.assertNotNull("Neither item should equal null", o1);
+        Assert.assertNotNull("Neither item should equal null", o2);
         Assert.assertNotEquals("Neither item should equal new Object()", o1.equals(new Object()));
         Assert.assertNotEquals("Neither item should equal new Object()", o2.equals(new Object()));
         Assert.assertEquals(o1, o1);


### PR DESCRIPTION
This one is a bit odd because it's an obvious bug fix inside test utility that I'm contributing without new tests. I ran into this while writing some Map tests that I'm about to put up in a separate PR, so I know that the fix helps.