### PR TITLE
fix java version in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Build
 -----
 The Eclipse Collections build requires below as dependencies.
 
-- Java 1.8
+- Java 11+ 
 - Maven 3.1.0+
 
 The Eclipse Collections build performs code generation to create primitive collections. Run the full build once before opening your IDE.


### PR DESCRIPTION
Eclipse Collections 12.x will be compatible with Java 11+. The project build failed when I use java 1.8. 