### PR TITLE
Moving unit-tests to Junit5

### DIFF
--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/function/Function0Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/function/Function0Test.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.api.block.function;
 
 import org.eclipse.collections.impl.block.factory.Functions0;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Function0Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/Predicate2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/Predicate2Test.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.api.block.predicate;
 
 import org.eclipse.collections.impl.block.factory.Predicates2;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Predicate2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/PredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/predicate/PredicateTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.api.block.predicate;
 
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PredicateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/api/block/procedure/Procedure2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/block/procedure/Procedure2Test.java
@@ -15,9 +15,9 @@ import java.util.List;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Procedures2;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Procedure2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/api/factory/bag/MutableBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/factory/bag/MutableBagFactoryTest.java
@@ -12,7 +12,7 @@ package org.eclipse.collections.api.factory.bag;
 
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MutableBagFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/api/factory/stack/MutableStackFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/api/factory/stack/MutableStackFactoryTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MutableStackFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AbstractRichIterableTestCase.java
@@ -171,16 +171,16 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractRichIterableTestCase
 {
@@ -502,7 +502,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableBooleanCollection target = new BooleanArrayList();
         BooleanIterable result = this.newWith(1, 0).collectBoolean(PrimitiveFunctions.integerIsPositive(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(BooleanBags.mutable.of(true, false), result.toBag());
     }
 
@@ -511,7 +511,7 @@ public abstract class AbstractRichIterableTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newWith(1, 0).collectBoolean(PrimitiveFunctions.integerIsPositive(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(BooleanHashBag.newBagWith(true, false), result);
     }
 
@@ -528,7 +528,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableByteCollection target = new ByteArrayList();
         ByteIterable result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result.toBag());
     }
 
@@ -537,7 +537,7 @@ public abstract class AbstractRichIterableTestCase
     {
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = this.newWith(1, 2, 3, 4).collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3, (byte) 4), result);
     }
 
@@ -554,7 +554,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableCharCollection target = new CharArrayList();
         CharIterable result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result.toBag());
     }
 
@@ -563,7 +563,7 @@ public abstract class AbstractRichIterableTestCase
     {
         CharHashBag target = new CharHashBag();
         CharHashBag result = this.newWith(1, 2, 3, 4).collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(CharHashBag.newBagWith((char) 1, (char) 2, (char) 3, (char) 4), result);
     }
 
@@ -580,7 +580,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableDoubleCollection target = new DoubleArrayList();
         DoubleIterable result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result.toBag());
     }
 
@@ -589,7 +589,7 @@ public abstract class AbstractRichIterableTestCase
     {
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = this.newWith(1, 2, 3, 4).collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d, 4.0d), result);
     }
 
@@ -606,7 +606,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableFloatCollection target = new FloatArrayList();
         FloatIterable result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result.toBag());
     }
 
@@ -615,7 +615,7 @@ public abstract class AbstractRichIterableTestCase
     {
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = this.newWith(1, 2, 3, 4).collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f, 4.0f), result);
     }
 
@@ -632,7 +632,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableIntCollection target = new IntArrayList();
         IntIterable result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result.toBag());
     }
 
@@ -641,7 +641,7 @@ public abstract class AbstractRichIterableTestCase
     {
         IntHashBag target = new IntHashBag();
         IntHashBag result = this.newWith(1, 2, 3, 4).collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(IntHashBag.newBagWith(1, 2, 3, 4), result);
     }
 
@@ -658,7 +658,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableLongCollection target = new LongArrayList();
         LongIterable result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result.toBag());
     }
 
@@ -667,7 +667,7 @@ public abstract class AbstractRichIterableTestCase
     {
         LongHashBag target = new LongHashBag();
         LongHashBag result = this.newWith(1, 2, 3, 4).collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(LongHashBag.newBagWith(1, 2, 3, 4), result);
     }
 
@@ -684,7 +684,7 @@ public abstract class AbstractRichIterableTestCase
     {
         MutableShortCollection target = new ShortArrayList();
         ShortIterable result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result.toBag());
     }
 
@@ -693,7 +693,7 @@ public abstract class AbstractRichIterableTestCase
     {
         ShortHashBag target = new ShortHashBag();
         ShortHashBag result = this.newWith(1, 2, 3, 4).collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
         assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3, (short) 4), result);
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/AnagramTest.java
@@ -22,11 +22,11 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests various algorithms for calculating anagrams from a list of words.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/CounterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/CounterTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class CounterTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/EmptyIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/EmptyIteratorTest.java
@@ -12,18 +12,18 @@ package org.eclipse.collections.impl;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EmptyIteratorTest
 {
     private EmptyIterator<Object> emptyIterator;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.emptyIterator = EmptyIterator.getInstance();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/NonInstantiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/NonInstantiableTest.java
@@ -42,7 +42,7 @@ import org.eclipse.collections.impl.utility.internal.SortedSetIterables;
 import org.eclipse.collections.impl.utility.internal.primitive.BooleanIterableIterate;
 import org.eclipse.collections.impl.utility.internal.primitive.BooleanIteratorIterate;
 import org.eclipse.collections.impl.utility.primitive.LazyBooleanIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NonInstantiableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/PersonAndPetKataTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/PersonAndPetKataTest.java
@@ -52,19 +52,19 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PersonAndPetKataTest
 {
     private MutableList<Person> people;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.people = Lists.mutable.with(

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SpreadFunctionsTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SpreadFunctionsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/SynchronizedRichIterableTest.java
@@ -21,12 +21,12 @@ import org.eclipse.collections.impl.lazy.LazyIterableAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SynchronizedRichIterableTest extends AbstractRichIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapEntrySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapEntrySetTest.java
@@ -33,13 +33,13 @@ import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.ShortHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMap#entrySet()} .

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableMapTest.java
@@ -17,12 +17,12 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnmodifiableMapTest
 {
@@ -33,7 +33,7 @@ public class UnmodifiableMapTest
     private MutableMap<String, List<String>> mutableMap;
     private UnmodifiableMap<String, List<String>> unmodifiableMap;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableMap = Maps.mutable.of(

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableRichIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/UnmodifiableRichIterableTest.java
@@ -18,15 +18,15 @@ import org.eclipse.collections.api.partition.PartitionIterable;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableRichIterable}.
@@ -48,7 +48,7 @@ public class UnmodifiableRichIterableTest extends AbstractRichIterableTestCase
         return UnmodifiableRichIterable.of(Lists.mutable.of(elements));
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableCollection = Lists.mutable.of(METALLICA, BON_JOVI, EUROPE, SCORPIONS);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/WordleTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/WordleTest.java
@@ -22,7 +22,7 @@ import org.eclipse.collections.impl.factory.primitive.CharBags;
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WordleTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableArrayBagTest.java
@@ -24,13 +24,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableArrayBagTest extends ImmutableBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagFactoryTest.java
@@ -15,12 +15,12 @@ import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableBagFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableBagTestCase.java
@@ -84,16 +84,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 {
@@ -534,7 +534,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(2, result.sizeDistinct());
         assertEquals(4, result.occurrencesOf(true));
         assertEquals(6, result.occurrencesOf(false));
@@ -562,7 +562,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = this.newBag().collectByte(Byte::parseByte, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
@@ -592,7 +592,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         CharHashBag target = new CharHashBag();
         CharHashBag result = this.newBag().collectChar((CharFunction<String>) string -> string.charAt(0), target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
@@ -622,7 +622,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = this.newBag().collectDouble(Double::parseDouble, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
@@ -652,7 +652,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = this.newBag().collectFloat(Float::parseFloat, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
@@ -682,7 +682,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         IntHashBag target = new IntHashBag();
         IntHashBag result = this.newBag().collectInt(Integer::parseInt, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {
@@ -712,7 +712,7 @@ public abstract class ImmutableBagTestCase extends AbstractRichIterableTestCase
 
         LongHashBag target = new LongHashBag();
         LongHashBag result = this.newBag().collectLong(Long::parseLong, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(this.numKeys(), result.sizeDistinct());
         for (int i = 1; i <= this.numKeys(); i++)
         {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableEmptyBagTest.java
@@ -46,16 +46,16 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableEmptyBagTest extends ImmutableBagTestCase
 {
@@ -531,7 +531,7 @@ public class ImmutableEmptyBagTest extends ImmutableBagTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(0, result.sizeDistinct());
         assertEquals(0, result.occurrencesOf(true));
         assertEquals(0, result.occurrencesOf(false));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableHashBagTest.java
@@ -27,12 +27,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableHashBagTest extends ImmutableBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/ImmutableSingletonBagTest.java
@@ -39,18 +39,18 @@ import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableSingletonBagTest extends ImmutableBagTestCase
 {
@@ -713,7 +713,7 @@ public class ImmutableSingletonBagTest extends ImmutableBagTestCase
     {
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = this.newBag().collectBoolean("4"::equals, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(1, result.sizeDistinct());
         assertEquals(0, result.occurrencesOf(true));
         assertEquals(1, result.occurrencesOf(false));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/AbstractImmutableBooleanBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/AbstractImmutableBooleanBagTestCase.java
@@ -25,13 +25,13 @@ import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanBag}.
@@ -210,9 +210,10 @@ public abstract class AbstractImmutableBooleanBagTestCase extends AbstractImmuta
         StringBuilder appendable2 = new StringBuilder();
         ImmutableBooleanBag bag1 = this.newWith(false, false, true);
         bag1.appendString(appendable2);
-        assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
+        assertTrue("false, false, true".equals(appendable2.toString())
                 || "true, false, false".equals(appendable2.toString())
-                || "false, true, false".equals(appendable2.toString()));
+                || "false, true, false".equals(appendable2.toString()),
+                appendable2.toString());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanEmptyBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanEmptyBagTest.java
@@ -15,10 +15,10 @@ import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptyBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanHashBagTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.bag.immutable.primitive;
 import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableBooleanHashBagTest extends AbstractImmutableBooleanBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanSingletonBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableBooleanSingletonBagTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.set.primitive.ImmutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link ImmutableBooleanSingletonBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/immutable/primitive/ImmutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntBags;
 import org.eclipse.collections.impl.factory.primitive.LongBags;
 import org.eclipse.collections.impl.factory.primitive.ShortBags;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/HashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/HashBagTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HashBagTest extends MutableBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsReadUntouchableTest.java
@@ -15,10 +15,10 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderHashBagAsReadUntouchableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsUnmodifiableTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiReaderHashBagAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagAsWriteUntouchableTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderHashBagAsWriteUntouchableTest extends AbstractCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MultiReaderHashBagTest.java
@@ -40,15 +40,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link MultiReaderHashBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/MutableBagTestCase.java
@@ -42,15 +42,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class MutableBagTestCase extends AbstractCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/SynchronizedBagTest.java
@@ -33,12 +33,12 @@ import org.eclipse.collections.impl.collection.mutable.AbstractSynchronizedColle
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * JUnit test for {@link SynchronizedBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/UnmodifiableBagTest.java
@@ -41,11 +41,11 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/AbstractMutableBooleanBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/AbstractMutableBooleanBagTestCase.java
@@ -25,14 +25,14 @@ import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanBag}.
@@ -260,9 +260,9 @@ public abstract class AbstractMutableBooleanBagTestCase extends AbstractMutableB
         StringBuilder appendable2 = new StringBuilder();
         MutableBooleanBag bag1 = this.newWith(false, false, true);
         bag1.appendString(appendable2);
-        assertTrue(appendable2.toString(), "false, false, true".equals(appendable2.toString())
+        assertTrue("false, false, true".equals(appendable2.toString())
                 || "true, false, false".equals(appendable2.toString())
-                || "false, true, false".equals(appendable2.toString()));
+                || "false, true, false".equals(appendable2.toString()), appendable2.toString());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/BooleanHashBagTest.java
@@ -19,13 +19,13 @@ import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link BooleanHashBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/MutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/MutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntBags;
 import org.eclipse.collections.impl.factory.primitive.LongBags;
 import org.eclipse.collections.impl.factory.primitive.ShortBags;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/SynchronizedBooleanBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/SynchronizedBooleanBagTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl.bag.mutable.primitive;
 import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/UnmodifiableBooleanBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/mutable/primitive/UnmodifiableBooleanBagTest.java
@@ -15,13 +15,13 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/AbstractImmutableSortedBagTestCase.java
@@ -78,18 +78,18 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableSortedBagTestCase extends AbstractImmutableCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableEmptySortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableEmptySortedBagTest.java
@@ -63,16 +63,16 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableEmptySortedBagTest extends AbstractImmutableSortedBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagFactoryTest.java
@@ -18,10 +18,10 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableSortedBagFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplNoIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplNoIteratorTest.java
@@ -17,7 +17,7 @@ import org.eclipse.collections.api.bag.sorted.ImmutableSortedBag;
 import org.eclipse.collections.api.bag.sorted.SortedBag;
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.impl.factory.SortedBags;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ImmutableSortedBagImplNoIteratorTest extends ImmutableSortedBagImplTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/immutable/ImmutableSortedBagImplTest.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ImmutableSortedBagImplTest extends AbstractImmutableSortedBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/AbstractMutableSortedBagTestCase.java
@@ -72,18 +72,18 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableSortedBag}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/MutableSortedBagFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/MutableSortedBagFactoryTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedBags;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MutableSortedBagFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/SynchronizedSortedBagTest.java
@@ -25,10 +25,10 @@ import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.SynchronizedRichIterable;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedSortedBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/TreeBagTest.java
@@ -25,10 +25,10 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link TreeBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/sorted/mutable/UnmodifiableSortedBagTest.java
@@ -24,13 +24,13 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableSortedBag}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bag/strategy/mutable/HashBagWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bag/strategy/mutable/HashBagWithHashingStrategyTest.java
@@ -20,14 +20,14 @@ import org.eclipse.collections.impl.bag.mutable.MutableBagTestCase;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test suite for {@link HashBagWithHashingStrategy}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/AbstractImmutableBiMapTestCase.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.api.bimap.ImmutableBiMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.immutable.ImmutableMapIterableTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableBiMapTestCase extends ImmutableMapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMap2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMap2Test.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableHashBiMap2Test extends MapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapInverse2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapInverse2Test.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableHashBiMapInverse2Test extends MapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/immutable/ImmutableHashBiMapTest.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.impl.factory.BiMaps;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableHashBiMapTest extends AbstractImmutableBiMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapEntrySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapEntrySetTest.java
@@ -23,14 +23,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMutableBiMapEntrySetTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapKeySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapKeySetTestCase.java
@@ -19,13 +19,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMutableBiMapKeySetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapTestCase.java
@@ -27,15 +27,15 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMutableBiMapTestCase extends MutableMapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapValuesTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/AbstractMutableBiMapValuesTestCase.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMutableBiMapValuesTestCase
 {
@@ -144,10 +144,10 @@ public abstract class AbstractMutableBiMapValuesTestCase
         assertThrows(IllegalStateException.class, iterator1::remove);
         iterator1.next();
         iterator1.remove();
-        assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").equals(map1)
-                || HashBiMap.newWithKeysValues(1.0f, null).equals(map1));
-        assertTrue(map1.toString(), HashBiMap.newWithKeysValues(0.0f, "zero").inverse().equals(map1.inverse())
-                || HashBiMap.newWithKeysValues(1.0f, null).inverse().equals(map1.inverse()));
+        assertTrue(HashBiMap.newWithKeysValues(0.0f, "zero").equals(map1)
+                || HashBiMap.newWithKeysValues(1.0f, null).equals(map1), map1.toString());
+        assertTrue(HashBiMap.newWithKeysValues(0.0f, "zero").inverse().equals(map1.inverse())
+                || HashBiMap.newWithKeysValues(1.0f, null).inverse().equals(map1.inverse()), map1.toString());
         iterator1.next();
         iterator1.remove();
         assertEquals(HashBiMap.newMap(), map1);
@@ -158,10 +158,10 @@ public abstract class AbstractMutableBiMapValuesTestCase
         assertThrows(IllegalStateException.class, iterator2::remove);
         iterator2.next();
         iterator2.remove();
-        assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).equals(map2)
-                || HashBiMap.newWithKeysValues(9.0f, "nine").equals(map2));
-        assertTrue(map2.toString(), HashBiMap.newWithKeysValues(0.0f, null).inverse().equals(map2.inverse())
-                || HashBiMap.newWithKeysValues(9.0f, "nine").inverse().equals(map2.inverse()));
+        assertTrue(HashBiMap.newWithKeysValues(0.0f, null).equals(map2)
+                || HashBiMap.newWithKeysValues(9.0f, "nine").equals(map2), map2.toString());
+        assertTrue(HashBiMap.newWithKeysValues(0.0f, null).inverse().equals(map2.inverse())
+                || HashBiMap.newWithKeysValues(9.0f, "nine").inverse().equals(map2.inverse()), map2.toString());
         iterator2.next();
         iterator2.remove();
         assertEquals(HashBiMap.newMap(), map2);
@@ -171,8 +171,8 @@ public abstract class AbstractMutableBiMapValuesTestCase
         assertThrows(IllegalStateException.class, iterator3::remove);
         iterator3.next();
         iterator3.remove();
-        assertTrue(map3.toString(), HashBiMap.newWithKeysValues(8.0f, "eight").equals(map3)
-                || HashBiMap.newWithKeysValues(9.0f, null).equals(map3));
+        assertTrue(HashBiMap.newWithKeysValues(8.0f, "eight").equals(map3)
+                || HashBiMap.newWithKeysValues(9.0f, null).equals(map3), map3.toString());
         iterator3.next();
         iterator3.remove();
         assertEquals(HashBiMap.newMap(), map3);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapInverseTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapInverseTest.java
@@ -13,7 +13,7 @@ package org.eclipse.collections.impl.bimap.mutable;
 import org.eclipse.collections.api.bimap.MutableBiMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HashBiMapInverseTest extends AbstractMutableBiMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/HashBiMapTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.bimap.MutableBiMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HashBiMapTest extends AbstractMutableBiMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
@@ -27,14 +27,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/CheckedBlocksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/CheckedBlocksTest.java
@@ -35,12 +35,12 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.eclipse.collections.impl.utility.MapIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CheckedBlocksTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/comparator/FunctionComparatorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/comparator/FunctionComparatorTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FunctionComparatorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/ComparatorsTest.java
@@ -38,14 +38,14 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ComparatorsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/FunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/FunctionsTest.java
@@ -35,16 +35,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FunctionsTest
 {
@@ -251,7 +251,7 @@ public class FunctionsTest
     {
         String result = "1";
         assertSame(result, Functions.ifTrue(Predicates.alwaysTrue(), Functions.getPassThru()).valueOf(result));
-        assertNull(result, Functions.ifTrue(Predicates.alwaysFalse(), Functions.getPassThru()).valueOf(result));
+        assertNull(Functions.ifTrue(Predicates.alwaysFalse(), Functions.getPassThru()).valueOf(result), result);
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/HashingStrategiesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/HashingStrategiesTest.java
@@ -21,12 +21,12 @@ import org.eclipse.collections.api.block.function.primitive.LongFunction;
 import org.eclipse.collections.api.block.function.primitive.ShortFunction;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HashingStrategiesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/IntegerPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/IntegerPredicatesTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IntegerPredicatesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/LongPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/LongPredicatesTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LongPredicatesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/MultimapFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/MultimapFunctionsTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultimapFunctionsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/Predicates2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/Predicates2Test.java
@@ -18,13 +18,13 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Predicates2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/PredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/PredicatesTest.java
@@ -29,13 +29,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PredicatesTest
 {
@@ -46,7 +46,7 @@ public class PredicatesTest
 
     private MutableList<Employee> employees;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.alice = new Employee(new Address(State.ARIZONA));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/SerializableComparatorsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/SerializableComparatorsTest.java
@@ -15,10 +15,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SerializableComparatorsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicates2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicates2Test.java
@@ -11,11 +11,11 @@
 package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringPredicates2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/StringPredicatesTest.java
@@ -12,11 +12,11 @@ package org.eclipse.collections.impl.block.factory;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringPredicatesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/BooleanPredicatesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/BooleanPredicatesTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.block.factory.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class BooleanPredicatesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/CharPredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/factory/primitive/CharPredicateTest.java
@@ -13,8 +13,10 @@ package org.eclipse.collections.impl.block.factory.primitive;
 import org.eclipse.collections.api.list.primitive.CharList;
 import org.eclipse.collections.impl.block.predicate.primitive.CharPredicate;
 import org.eclipse.collections.impl.factory.primitive.CharLists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Junit test for {@link CharPredicate}.
@@ -27,74 +29,74 @@ public class CharPredicateTest
     @Test
     public void isUpperCase()
     {
-        assertTrue(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_UPPERCASE);
-        assertFalse(CharLists.mutable.of('a', 'b', 'c', '1', '.'), CharPredicate.IS_UPPERCASE);
+        assertTrueHelper(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_UPPERCASE);
+        assertFalseHelper(CharLists.mutable.of('a', 'b', 'c', '1', '.'), CharPredicate.IS_UPPERCASE);
     }
 
     @Test
     public void isLowerCase()
     {
-        assertTrue(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_LOWERCASE);
-        assertFalse(CharLists.mutable.of('A', 'B', 'C', '1', '.'), CharPredicate.IS_LOWERCASE);
+        assertTrueHelper(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_LOWERCASE);
+        assertFalseHelper(CharLists.mutable.of('A', 'B', 'C', '1', '.'), CharPredicate.IS_LOWERCASE);
     }
 
     @Test
     public void isDigit()
     {
-        assertTrue(CharLists.mutable.of('0', '1', '2', '3'), CharPredicate.IS_DIGIT);
-        assertFalse(CharLists.mutable.of('A', 'B', 'C', '.'), CharPredicate.IS_DIGIT);
-        assertFalse(CharLists.mutable.of('a', 'b', 'c', '.'), CharPredicate.IS_DIGIT);
+        assertTrueHelper(CharLists.mutable.of('0', '1', '2', '3'), CharPredicate.IS_DIGIT);
+        assertFalseHelper(CharLists.mutable.of('A', 'B', 'C', '.'), CharPredicate.IS_DIGIT);
+        assertFalseHelper(CharLists.mutable.of('a', 'b', 'c', '.'), CharPredicate.IS_DIGIT);
     }
 
     @Test
     public void isDigitOrDot()
     {
-        assertTrue(CharLists.mutable.of('0', '1', '2', '3', '.'), CharPredicate.IS_DIGIT_OR_DOT);
-        assertFalse(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_DIGIT_OR_DOT);
-        assertFalse(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_DIGIT_OR_DOT);
+        assertTrueHelper(CharLists.mutable.of('0', '1', '2', '3', '.'), CharPredicate.IS_DIGIT_OR_DOT);
+        assertFalseHelper(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_DIGIT_OR_DOT);
+        assertFalseHelper(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_DIGIT_OR_DOT);
     }
 
     @Test
     public void isLetter()
     {
-        assertTrue(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_LETTER);
-        assertTrue(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_LETTER);
-        assertFalse(CharLists.mutable.of('0', '1', '2', '3', '.'), CharPredicate.IS_LETTER);
+        assertTrueHelper(CharLists.mutable.of('A', 'B', 'C'), CharPredicate.IS_LETTER);
+        assertTrueHelper(CharLists.mutable.of('a', 'b', 'c'), CharPredicate.IS_LETTER);
+        assertFalseHelper(CharLists.mutable.of('0', '1', '2', '3', '.'), CharPredicate.IS_LETTER);
     }
 
     @Test
     public void isLetterOrDigit()
     {
-        assertTrue(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_LETTER_OR_DIGIT);
-        assertTrue(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_LETTER_OR_DIGIT);
-        assertFalse(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_LETTER_OR_DIGIT);
+        assertTrueHelper(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_LETTER_OR_DIGIT);
+        assertTrueHelper(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_LETTER_OR_DIGIT);
+        assertFalseHelper(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_LETTER_OR_DIGIT);
     }
 
     @Test
     public void isWhitespace()
     {
-        assertTrue(CharLists.mutable.of(' '), CharPredicate.IS_WHITESPACE);
-        assertFalse(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_WHITESPACE);
-        assertFalse(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_WHITESPACE);
-        assertFalse(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_WHITESPACE);
+        assertTrueHelper(CharLists.mutable.of(' '), CharPredicate.IS_WHITESPACE);
+        assertFalseHelper(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_WHITESPACE);
+        assertFalseHelper(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_WHITESPACE);
+        assertFalseHelper(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_WHITESPACE);
     }
 
     @Test
     public void isUndefined()
     {
-        Assert.assertTrue(CharPredicates.isUndefined().accept((char) 888));
-        assertFalse(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_UNDEFINED);
-        assertFalse(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_UNDEFINED);
-        assertFalse(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_UNDEFINED);
+        assertTrue(CharPredicates.isUndefined().accept((char) 888));
+        assertFalseHelper(CharLists.mutable.of('A', 'B', 'C', '0', '1', '2', '3'), CharPredicate.IS_UNDEFINED);
+        assertFalseHelper(CharLists.mutable.of('a', 'b', 'c', '0', '1', '2', '3'), CharPredicate.IS_UNDEFINED);
+        assertFalseHelper(CharLists.mutable.of('.', '$', '*'), CharPredicate.IS_UNDEFINED);
     }
 
-    private static void assertTrue(CharList charList, CharPredicate predicate)
+    private static void assertTrueHelper(CharList charList, CharPredicate predicate)
     {
-        charList.forEach(element -> Assert.assertTrue(predicate.accept(element)));
+        charList.forEach(element -> assertTrue(predicate.accept(element)));
     }
 
-    private static void assertFalse(CharList charList, CharPredicate predicate)
+    private static void assertFalseHelper(CharList charList, CharPredicate predicate)
     {
-        charList.forEach(element -> Assert.assertFalse(predicate.accept(element)));
+        charList.forEach(element -> assertFalse(predicate.accept(element)));
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/AddFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/AddFunctionTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // This class is not a full test of AddFunction at present, but serves as a
 // holder for the addStringBlockHandlesNulls() test which had been put in the

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/CaseFunctionTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class CaseFunctionTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions0Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions0Test.java
@@ -22,12 +22,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Functions0Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/Functions2Test.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.impl.block.factory.Functions2;
 import org.eclipse.collections.impl.block.function.checked.ThrowingFunction2;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Functions2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/IfFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/IfFunctionTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IfFunctionTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MaxSizeFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MaxSizeFunctionTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link MaxSizeFunction}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinAndMaxBlocksTest.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.collections.impl.block.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class MinAndMaxBlocksTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinSizeFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MinSizeFunctionTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link MinSizeFunction}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/MultiplyFunctionTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.block.function;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiplyFunctionTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/PrimitiveFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/PrimitiveFunctionsTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.impl.set.mutable.primitive.DoubleHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.FloatHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link PrimitiveFunctions}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/StringFunctionsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/StringFunctionsTest.java
@@ -14,14 +14,14 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.impl.block.factory.StringFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class StringFunctionsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/SubtractFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/SubtractFunctionTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link SubtractFunction}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/checked/CheckedFunction2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/checked/CheckedFunction2Test.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.collections.impl.block.function.checked;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CheckedFunction2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/BooleanCaseFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/BooleanCaseFunctionTest.java
@@ -12,11 +12,11 @@ package org.eclipse.collections.impl.block.function.primitive;
 
 import org.eclipse.collections.api.block.function.primitive.BooleanToObjectFunction;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BooleanCaseFunctionTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/CharFunctionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/CharFunctionTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link CharFunction}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/DoubleFunctionImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/DoubleFunctionImplTest.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public final class DoubleFunctionImplTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/LongFunctionImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/function/primitive/LongFunctionImplTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.function.primitive;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Junit test for {@link LongFunctionImpl}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/MapEntryPredicateTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.block.predicate;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MapEntryPredicateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/PairPredicateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/predicate/PairPredicateTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.block.predicate;
 
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PairPredicateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AdaptObjectIntProcedureToProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AdaptObjectIntProcedureToProcedureTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AdaptObjectIntProcedureToProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AtomicCountProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/AtomicCountProcedureTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AtomicCountProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/BagAddOccurrencesProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/BagAddOccurrencesProcedureTest.java
@@ -13,11 +13,11 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BagAddOccurrencesProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CaseProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CaseProcedureTest.java
@@ -16,10 +16,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class CaseProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ChainedProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ChainedProcedureTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChainedProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectIfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectIfProcedureTest.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectIfProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectProcedureTest.java
@@ -13,7 +13,7 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CollectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionAddProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionAddProcedureTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectionAddProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CollectionRemoveProcedureTest.java
@@ -13,11 +13,11 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectionRemoveProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CounterProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/CounterProcedureTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CounterProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectIfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectIfProcedureTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FastListCollectIfProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListCollectProcedureTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FastListCollectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListRejectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListRejectProcedureTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FastListRejectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListSelectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FastListSelectProcedureTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FastListSelectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FlatCollectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/FlatCollectProcedureTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FlatCollectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/IfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/IfProcedureTest.java
@@ -17,13 +17,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.StringIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IfProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxByProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxByProcedureTest.java
@@ -13,12 +13,12 @@ package org.eclipse.collections.impl.block.procedure;
 import java.util.Optional;
 
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MaxByProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxComparatorProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxComparatorProcedureTest.java
@@ -15,11 +15,11 @@ import java.util.Optional;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MaxComparatorProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MaxProcedureTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MaxProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinByProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinByProcedureTest.java
@@ -13,12 +13,12 @@ package org.eclipse.collections.impl.block.procedure;
 import java.util.Optional;
 
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MinByProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinComparatorProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinComparatorProcedureTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class MinComparatorProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/MinProcedureTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.block.procedure;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MinProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ObjectIntProceduresTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ObjectIntProceduresTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.ObjectIntProcedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ObjectIntProceduresTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/Procedures2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/Procedures2Test.java
@@ -25,10 +25,10 @@ import org.eclipse.collections.impl.block.procedure.checked.ThrowingProcedure2;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Procedures2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ProceduresTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/ProceduresTest.java
@@ -30,12 +30,12 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProceduresTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/RejectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/RejectProcedureTest.java
@@ -13,7 +13,7 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RejectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SelectInstancesOfProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SelectInstancesOfProcedureTest.java
@@ -12,7 +12,7 @@ package org.eclipse.collections.impl.block.procedure;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SelectInstancesOfProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SelectProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SelectProcedureTest.java
@@ -13,7 +13,7 @@ package org.eclipse.collections.impl.block.procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SelectProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfDoubleProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfDoubleProcedureTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SumOfDoubleProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfFloatProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfFloatProcedureTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SumOfFloatProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfIntProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfIntProcedureTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SumOfIntProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfLongProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/SumOfLongProcedureTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.block.procedure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SumOfLongProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/CheckedProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/CheckedProcedureTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CheckedProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/MultimapKeyValuesSerializingProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/MultimapKeyValuesSerializingProcedureTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultimapKeyValuesSerializingProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/primitive/CheckedBooleanIntProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/checked/primitive/CheckedBooleanIntProcedureTest.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.primitive.BooleanIntPair;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CheckedBooleanIntProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/BooleanCaseProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/BooleanCaseProcedureTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BooleanCaseProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/block/procedure/primitive/CollectBooleanProcedureTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CollectBooleanProcedureTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/AbstractImmutableCollectionTestCase.java
@@ -59,17 +59,17 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/primitive/AbstractImmutableBooleanCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/immutable/primitive/AbstractImmutableBooleanCollectionTestCase.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.collection.immutable.primitive;
 import org.eclipse.collections.api.collection.primitive.ImmutableBooleanCollection;
 import org.eclipse.collections.api.collection.primitive.MutableBooleanCollection;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBooleanIterableTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanCollection}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractCollectionTestCase.java
@@ -28,15 +28,15 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableCollection}s.
@@ -109,11 +109,11 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
         boolean result = collection.addAll(FastList.newListWith(1, 2, 3));
         if (collection.size() == 3)
         {
-            assertFalse("addAll did not modify the collection", result);
+            assertFalse(result, "addAll did not modify the collection");
         }
         else
         {
-            assertTrue("addAll modified the collection", result);
+            assertTrue(result, "addAll modified the collection");
         }
         Verify.assertContainsAll(collection, 1, 2, 3);
     }
@@ -128,11 +128,11 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
         boolean result1 = collection1.addAllIterable(FastList.newListWith(1, 2, 3));
         if (collection1.size() == 3)
         {
-            assertFalse("addAllIterable did not modify the collection", result1);
+            assertFalse(result1, "addAllIterable did not modify the collection");
         }
         else
         {
-            assertTrue("addAllIterable modified the collection", result1);
+            assertTrue(result1, "addAllIterable modified the collection");
         }
         Verify.assertContainsAll(collection1, 1, 2, 3);
 
@@ -143,11 +143,11 @@ public abstract class AbstractCollectionTestCase extends AbstractRichIterableTes
         boolean result2 = collection2.addAllIterable(UnifiedSet.newSetWith(1, 2, 3));
         if (collection1.size() == 3)
         {
-            assertFalse("addAllIterable did not modify the collection", result2);
+            assertFalse(result2, "addAllIterable did not modify the collection");
         }
         else
         {
-            assertTrue("addAllIterable modified the collection", result2);
+            assertTrue(result2, "addAllIterable modified the collection");
         }
         Verify.assertContainsAll(collection2, 1, 2, 3);
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/AbstractSynchronizedCollectionTestCase.java
@@ -11,11 +11,11 @@
 package org.eclipse.collections.impl.collection.mutable;
 
 import org.eclipse.collections.api.collection.MutableCollection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractSynchronizedCollectionTestCase extends AbstractCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterAsUnmodifiableTest.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.partition.PartitionMutableCollection;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.factory.Functions2;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class CollectionAdapterAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/CollectionAdapterTest.java
@@ -42,12 +42,12 @@ import org.eclipse.collections.impl.set.mutable.SetAdapter;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link CollectionAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/SynchronizedMutableCollectionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/SynchronizedMutableCollectionTest.java
@@ -23,12 +23,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.SynchronizedMutableList;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedMutableCollection}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTest.java
@@ -55,13 +55,13 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableCollection}.
@@ -73,7 +73,7 @@ public class UnmodifiableMutableCollectionTest
     private MutableCollection<String> mutableCollection;
     private MutableCollection<String> unmodifiableCollection;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableCollection = FastList.<String>newList().with(METALLICA, "Bon Jovi", "Europe", "Scorpions");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/UnmodifiableMutableCollectionTestCase.java
@@ -36,13 +36,13 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMutableCollection}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
@@ -26,13 +26,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link BooleanIterable}s.
@@ -561,10 +561,10 @@ public abstract class AbstractBooleanIterableTestCase
         BooleanIterable iterable = this.newWith(true, false);
         assertTrue("true, false".equals(iterable.makeString())
                 || "false, true".equals(iterable.makeString()));
-        assertTrue(iterable.makeString("/"), "true/false".equals(iterable.makeString("/"))
-                || "false/true".equals(iterable.makeString("/")));
-        assertTrue(iterable.makeString("[", "/", "]"), "[true/false]".equals(iterable.makeString("[", "/", "]"))
-                || "[false/true]".equals(iterable.makeString("[", "/", "]")));
+        assertTrue("true/false".equals(iterable.makeString("/"))
+                || "false/true".equals(iterable.makeString("/")), iterable.makeString("/"));
+        assertTrue("[true/false]".equals(iterable.makeString("[", "/", "]"))
+                || "[false/true]".equals(iterable.makeString("[", "/", "]")), iterable.makeString("[", "/", "]"));
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanCollectionTestCase.java
@@ -19,13 +19,13 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanCollection}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractMutableBooleanStackTestCase.java
@@ -19,12 +19,12 @@ import org.eclipse.collections.impl.stack.mutable.primitive.SynchronizedBooleanS
 import org.eclipse.collections.impl.stack.mutable.primitive.UnmodifiableBooleanStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigDecimalSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigDecimalSummaryStatisticsTest.java
@@ -16,11 +16,11 @@ import java.util.List;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BigDecimalSummaryStatisticsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigIntegerSummaryStatisticsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/BigIntegerSummaryStatisticsTest.java
@@ -17,11 +17,11 @@ import java.util.List;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BigIntegerSummaryStatisticsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2AdditionalTest.java
@@ -49,11 +49,11 @@ import org.eclipse.collections.impl.partition.set.PartitionUnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
 Do not merge this test with Collectors2Test. Doing so will fail the build. This is due to a bug in ASM.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collector/Collectors2Test.java
@@ -55,10 +55,10 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.partition.bag.PartitionHashBag;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class Collectors2Test
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BagsTest.java
@@ -28,14 +28,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BagsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BiMapsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/FixedSizeMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/FixedSizeMapFactoryTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl.factory;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FixedSizeMapFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyBagsTest.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HashingStrategyBagsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategyMapsTest.java
@@ -22,9 +22,9 @@ import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingSt
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HashingStrategyMapsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategySetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/HashingStrategySetsTest.java
@@ -20,9 +20,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HashingStrategySetsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/IterablesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/IterablesTest.java
@@ -32,7 +32,7 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IterablesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/ListsTest.java
@@ -30,14 +30,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ListsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -26,12 +26,12 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MapsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MultimapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MultimapsTest.java
@@ -32,11 +32,11 @@ import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MultimapsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SetsTest.java
@@ -40,16 +40,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SetsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedMapsTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.factory;
 
 import org.eclipse.collections.api.factory.map.sorted.MutableSortedMapFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SortedMapsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/SortedSetsTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SortedSetsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StacksTest.java
@@ -18,10 +18,10 @@ import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StacksTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StringsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/StringsTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.factory;
 
 import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.string.immutable.CodePointAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanBagsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanBagsTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.bag.primitive.ImmutableBooleanBag;
 import org.eclipse.collections.api.factory.bag.primitive.ImmutableBooleanBagFactory;
 import org.eclipse.collections.impl.bag.mutable.primitive.BooleanHashBag;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BooleanBagsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanListsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanListsTest.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BooleanListsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanSetsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanSetsTest.java
@@ -23,10 +23,10 @@ import org.eclipse.collections.api.tuple.primitive.BooleanBooleanPair;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BooleanSetsTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanStacksTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/primitive/BooleanStacksTest.java
@@ -16,10 +16,10 @@ import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BooleanStacksTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/iterator/SingletonBooleanIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/iterator/SingletonBooleanIteratorTest.java
@@ -13,12 +13,12 @@ package org.eclipse.collections.impl.iterator;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.iterator.BooleanIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SingletonBooleanIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/AbstractLazyIterableTestCase.java
@@ -67,17 +67,17 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractLazyIterableTestCase
 {
@@ -214,7 +214,7 @@ public abstract class AbstractLazyIterableTestCase
         assertEquals(
                 BooleanArrayList.newListWith(true, true, true, true, true, true, true),
                 result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -229,7 +229,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableByteCollection target = new ByteArrayList();
         MutableByteCollection result = this.lazyIterable.collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
         assertEquals(ByteArrayList.newListWith((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -246,7 +246,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableCharCollection target = new CharArrayList();
         MutableCharCollection result = this.lazyIterable.collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
         assertEquals(CharArrayList.newListWith((char) 1, (char) 2, (char) 3, (char) 4, (char) 5, (char) 6, (char) 7), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -262,7 +262,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableDoubleCollection result = this.lazyIterable.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
         assertEquals(
                 DoubleArrayList.newListWith(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -280,7 +280,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableFloatCollection result = this.lazyIterable.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
         assertEquals(
                 FloatArrayList.newListWith(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -295,7 +295,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableIntCollection target = new IntArrayList();
         MutableIntCollection result = this.lazyIterable.collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
         assertEquals(IntArrayList.newListWith(1, 2, 3, 4, 5, 6, 7), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -312,7 +312,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableLongCollection target = new LongArrayList();
         MutableLongCollection result = this.lazyIterable.collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
         assertEquals(LongArrayList.newListWith(1L, 2L, 3L, 4L, 5L, 6L, 7L), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test
@@ -329,7 +329,7 @@ public abstract class AbstractLazyIterableTestCase
         MutableShortCollection target = new ShortArrayList();
         MutableShortCollection result = this.lazyIterable.collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
         assertEquals(ShortArrayList.newListWith((short) 1, (short) 2, (short) 3, (short) 4, (short) 5, (short) 6, (short) 7), result.toList());
-        assertSame("Target list sent as parameter not returned", target, result);
+        assertSame(target, result, "Target list sent as parameter not returned");
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ChunkIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ChunkIterableTest.java
@@ -12,17 +12,17 @@ package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ChunkIterableTest
 {
     private final StringBuffer buffer = new StringBuffer();
     private ChunkIterable<Integer> undertest;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.undertest = new ChunkIterable<>(FastList.newListWith(1, 2, 3, 4, 5), 2);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CollectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CollectIterableTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CollectIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/CompositeIterableTest.java
@@ -21,11 +21,11 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CompositeIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DistinctIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DistinctIterableTest.java
@@ -19,11 +19,11 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.lazy.iterator.DistinctIterator;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DistinctIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropIterableTest.java
@@ -19,11 +19,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DropIterableTest extends AbstractLazyIterableTestCase
 {
@@ -34,7 +34,7 @@ public class DropIterableTest extends AbstractLazyIterableTestCase
     private DropIterable<Integer> sameCountDropIterable;
     private DropIterable<Integer> higherCountDropIterable;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.dropIterable = new DropIterable<>(Interval.oneTo(5), 2);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/DropWhileIterableTest.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DropWhileIterableTest extends AbstractLazyIterableTestCase
 {
@@ -33,7 +33,7 @@ public class DropWhileIterableTest extends AbstractLazyIterableTestCase
     private DropWhileIterable<Integer> mostlyFalseDropWhileIterable;
     private DropWhileIterable<Integer> alwaysTrueDropWhileIterable;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.dropWhileIterable = new DropWhileIterable<>(Interval.oneTo(5), each -> each <= 2);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/FlatCollectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/FlatCollectIterableTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FlatCollectIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/LazyIterableAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/LazyIterableAdapterTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LazyIterableAdapterTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/RejectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/RejectIterableTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RejectIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectInstancesOfIterableTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SelectInstancesOfIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/SelectIterableTest.java
@@ -18,11 +18,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SelectIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeIterableTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TakeIterableTest extends AbstractLazyIterableTestCase
 {
@@ -34,7 +34,7 @@ public class TakeIterableTest extends AbstractLazyIterableTestCase
     private TakeIterable<Integer> sameCountTakeIterable;
     private TakeIterable<Integer> higherCountTakeIterable;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.takeIterable = new TakeIterable<>(Interval.oneTo(5), 2);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TakeWhileIterableTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
 {
@@ -33,7 +33,7 @@ public class TakeWhileIterableTest extends AbstractLazyIterableTestCase
     private TakeWhileIterable<Integer> alwaysFalseTakeWhileIterable;
     private TakeWhileIterable<Integer> alwaysTrueTakeWhileIterable;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.takeWhileIterable = new TakeWhileIterable<>(Interval.oneTo(5), each -> each <= 2);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TapIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/TapIterableTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TapIterableTest extends AbstractLazyIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipIterableTest.java
@@ -11,16 +11,16 @@
 package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ZipIterableTest
 {
     private ZipIterable<Character, Integer> zipIterable;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.zipIterable = new ZipIterable<>(

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipWithIndexIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/ZipWithIndexIterableTest.java
@@ -12,17 +12,17 @@ package org.eclipse.collections.impl.lazy;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Procedures;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ZipWithIndexIterableTest
 {
     private ZipWithIndexIterable<Integer> iterableUnderTest;
     private final StringBuilder buffer = new StringBuilder();
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.iterableUnderTest = new ZipWithIndexIterable<>(Lists.immutable.of(1, 2, 3, 4));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/CollectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/CollectIteratorTest.java
@@ -14,13 +14,13 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DistinctIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DistinctIteratorTest.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DistinctIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/DropIteratorTest.java
@@ -15,12 +15,12 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link DropIterator}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/FlatCollectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/FlatCollectIteratorTest.java
@@ -15,10 +15,10 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Functions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FlatCollectIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectInstancesOfIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectInstancesOfIteratorTest.java
@@ -16,10 +16,10 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SelectInstancesOfIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/SelectIteratorTest.java
@@ -16,12 +16,12 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SelectIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeIteratorTest.java
@@ -15,12 +15,12 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link TakeIterator}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TakeWhileIteratorTest.java
@@ -16,12 +16,12 @@ import java.util.NoSuchElementException;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link TakeWhileIterator}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TapIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/TapIteratorTest.java
@@ -17,11 +17,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TapIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/ZipIteratorTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/iterator/ZipIteratorTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.iterator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZipIteratorTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/ParallelIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/ParallelIterableTestCase.java
@@ -50,16 +50,16 @@ import org.eclipse.collections.impl.block.procedure.checked.CheckedProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ParallelIterableTestCase
 {
@@ -67,7 +67,7 @@ public abstract class ParallelIterableTestCase
     protected ExecutorService executorService;
     protected int batchSize = 2;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.executorService = Executors.newFixedThreadPool(10);
@@ -75,7 +75,7 @@ public abstract class ParallelIterableTestCase
         assertFalse(Thread.interrupted());
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         this.executorService.shutdownNow();
@@ -892,10 +892,10 @@ public abstract class ParallelIterableTestCase
 
             ParallelIterable<Integer> testCollection = this.newWith(list.toArray(new Integer[]{}));
             assertEquals(
-                    "Batch size: " + this.batchSize,
                     baseline,
                     testCollection.sumOfFloat(roundingSensitiveElementFunction),
-                    1.0e-15d);
+                    1.0e-15,
+                    "Batch size: " + this.batchSize);
         }
     }
 
@@ -923,10 +923,10 @@ public abstract class ParallelIterableTestCase
 
             ParallelIterable<Integer> testCollection = this.newWith(list.toArray(new Integer[]{}));
             assertEquals(
-                    "Batch size: " + this.batchSize,
                     baseline,
                     testCollection.sumOfDouble(roundingSensitiveElementFunction),
-                    1.0e-15d);
+                    1.0e-15d,
+                    "Batch size: " + this.batchSize);
         }
     }
 

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.parallel.bag;
 
 import org.eclipse.collections.api.bag.ParallelBag;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelBagTest extends ParallelBagTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/bag/ParallelBagTestCase.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.bag.ParallelBag;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ParallelBagTestCase extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/ImmutableListParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/ImmutableListParallelListIterableTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.parallel.list;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ParallelListIterable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableListParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/MultiReaderFastListParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/MultiReaderFastListParallelListIterableTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.ParallelListIterable;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderFastListParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/NonParallelListIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/NonParallelListIterableTestCase.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.collections.impl.lazy.parallel.list;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class NonParallelListIterableTestCase extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/ParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/ParallelListIterableTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.parallel.list;
 
 import org.eclipse.collections.api.list.ParallelListIterable;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/RandomAccessListAdapterParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/RandomAccessListAdapterParallelListIterableTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.ParallelListIterable;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.list.mutable.RandomAccessListAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RandomAccessListAdapterParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/SynchronizedMutableListParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/SynchronizedMutableListParallelListIterableTest.java
@@ -23,11 +23,11 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.block.procedure.checked.CheckedProcedure;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SynchronizedMutableListParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/UnmodifiableMutableListParallelListIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/list/UnmodifiableMutableListParallelListIterableTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.ParallelListIterable;
 import org.eclipse.collections.impl.list.mutable.ArrayListAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnmodifiableMutableListParallelListIterableTest extends ParallelListIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ImmutableUnifiedSetParallelSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ImmutableUnifiedSetParallelSetIterableTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.lazy.parallel.set;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableUnifiedSetParallelSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/MemoryEfficientMutableSetParallelSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/MemoryEfficientMutableSetParallelSetIterableTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MemoryEfficientMutableSetParallelSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/NonParallelUnsortedSetIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/NonParallelUnsortedSetIterableTestCase.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.collections.impl.lazy.parallel.set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class NonParallelUnsortedSetIterableTestCase extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectDistinctSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectDistinctSetIterableTest.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectDistinctSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectMultiReaderSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectMultiReaderSetIterableTest.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectMultiReaderSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSelectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSelectSetIterableTest.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectSelectSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSetIterableTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSynchronizedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelCollectSynchronizedSetIterableTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectSynchronizedSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectDistinctSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectDistinctSetIterableTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectDistinctSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectMultiReaderSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectMultiReaderSetIterableTest.java
@@ -20,9 +20,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectMultiReaderSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSelectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSelectSetIterableTest.java
@@ -20,9 +20,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectSelectSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSetIterableTest.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSynchronizedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelFlatCollectSynchronizedSetIterableTest.java
@@ -19,9 +19,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.lazy.parallel.ParallelIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectSynchronizedSetIterableTest extends ParallelIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelUnsortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/ParallelUnsortedSetIterableTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.parallel.set;
 
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelUnsortedSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyDefaultParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyDefaultParallelTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.lazy.parallel.set;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnifiedSetWithHashingStrategyDefaultParallelTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelCollectDistinctTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelCollectDistinctTest.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UnifiedSetWithHashingStrategyParallelCollectDistinctTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnifiedSetWithHashingStrategyParallelTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnifiedSetWithHashingStrategyParallelTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnmodifiableUnsortedSetParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/UnmodifiableUnsortedSetParallelTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.lazy.parallel.set;
 
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnmodifiableUnsortedSetParallelTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableEmptySortedSetParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableEmptySortedSetParallelTest.java
@@ -21,13 +21,13 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableEmptySortedSetParallelTest extends NonParallelSortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableSortedSetParallelTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ImmutableSortedSetParallelTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.lazy.parallel.set.sorted;
 import org.eclipse.collections.api.set.sorted.ParallelSortedSetIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedSets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableSortedSetParallelTest extends ParallelSortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/NonParallelSortedSetIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/NonParallelSortedSetIterableTestCase.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.collections.impl.lazy.parallel.set.sorted;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class NonParallelSortedSetIterableTestCase extends ParallelSortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelCollectDistinctSortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelCollectDistinctSortedSetIterableTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.lazy.parallel.set.ParallelUnsortedSetIterableTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelCollectDistinctSortedSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelFlatCollectDistinctSortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelFlatCollectDistinctSortedSetIterableTest.java
@@ -18,9 +18,9 @@ import org.eclipse.collections.impl.block.function.NegativeIntervalFunction;
 import org.eclipse.collections.impl.factory.SortedSets;
 import org.eclipse.collections.impl.lazy.parallel.set.ParallelUnsortedSetIterableTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelFlatCollectDistinctSortedSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelSortedSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/parallel/set/sorted/ParallelSortedSetIterableTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.lazy.parallel.set.sorted;
 import org.eclipse.collections.api.set.sorted.ParallelSortedSetIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelSortedSetIterableTest extends NonParallelSortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanIterableTest.java
@@ -21,11 +21,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectBooleanIterableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanToObjectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/CollectBooleanToObjectIterableTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CollectBooleanToObjectIterableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/FlatCollectBooleanToObjectIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/FlatCollectBooleanToObjectIterableTest.java
@@ -20,13 +20,13 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FlatCollectBooleanToObjectIterableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyBooleanIterableAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/LazyBooleanIterableAdapterTest.java
@@ -27,11 +27,11 @@ import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link LazyByteIterableAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/ReverseBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/ReverseBooleanIterableTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ReverseBooleanIterable}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/SelectBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/SelectBooleanIterableTest.java
@@ -14,11 +14,11 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SelectBooleanIterableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/TapBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/lazy/primitive/TapBooleanIterableTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.api.list.primitive.BooleanList;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.math.MutableInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TapBooleanIterableTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/IntervalTest.java
@@ -40,14 +40,14 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IntervalTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/AbstractMemoryEfficientMutableListTestCase.java
@@ -29,20 +29,20 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMemoryEfficientMutableListTestCase
 {
     protected MutableList<String> list;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.list = this.classUnderTest();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/ArrayAdapterTest.java
@@ -33,19 +33,19 @@ import org.eclipse.collections.impl.list.mutable.UnmodifiableMutableList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ArrayAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/DoubletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/DoubletonListTest.java
@@ -21,13 +21,13 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link DoubletonList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/EmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/EmptyListTest.java
@@ -22,13 +22,13 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EmptyListTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/FixedSizeListFactoryTest.java
@@ -20,15 +20,15 @@ import org.eclipse.collections.impl.block.factory.Procedures2;
 import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link FixedSizeListFactoryImpl}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuadrupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuadrupletonListTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link QuadrupletonList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuintupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/QuintupletonListTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuintupletonListTest extends AbstractMemoryEfficientMutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SextupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SextupletonListTest.java
@@ -20,14 +20,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SextupletonListTest extends AbstractMemoryEfficientMutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/SingletonListTest.java
@@ -31,15 +31,15 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.SynchronizedMutableList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SingletonList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/TripletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/TripletonListTest.java
@@ -19,14 +19,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link TripletonList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/UnmodifiableMemoryEfficientListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/fixed/UnmodifiableMemoryEfficientListTestCase.java
@@ -17,13 +17,13 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test to check that {@link AbstractMemoryEfficientMutableList}s are Unmodifiable.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/AbstractImmutableListTestCase.java
@@ -59,16 +59,16 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableListTestCase extends AbstractImmutableCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayListTest.java
@@ -24,14 +24,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link ImmutableArrayList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDecapletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDecapletonListTest.java
@@ -14,11 +14,11 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableDecapletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDoubletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableDoubletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableDoubletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableEmptyListTest.java
@@ -34,17 +34,17 @@ import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ImmutableEmptyListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableNonupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableNonupletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableNonupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableOctupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableOctupletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableOctupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuadrupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuadrupletonListTest.java
@@ -14,11 +14,11 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableQuadrupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuintupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableQuintupletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableQuintupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSeptupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSeptupletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableSeptupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSextupletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSextupletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableSextupletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSingletonListTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableSingletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSubListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableSubListTest.java
@@ -14,12 +14,12 @@ import java.util.ListIterator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableSubListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableTripletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/ImmutableTripletonListTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.immutable;
 
 import org.eclipse.collections.api.list.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableTripletonListTest extends AbstractImmutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/AbstractImmutableBooleanListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/AbstractImmutableBooleanListTestCase.java
@@ -22,15 +22,15 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayListTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link ImmutableBooleanArrayList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanEmptyListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanEmptyListTest.java
@@ -14,13 +14,13 @@ import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableBooleanEmptyListTest extends AbstractImmutableBooleanListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanSingletonListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanSingletonListTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.list.immutable.primitive;
 
 import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ImmutableBooleanSingletonListTest extends AbstractImmutableBooleanListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/AbstractListTestCase.java
@@ -65,17 +65,17 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Abstract JUnit test for {@link MutableList}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ArrayListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ArrayListAdapterTest.java
@@ -22,14 +22,14 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ArrayListAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/CompositeFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/CompositeFastListTest.java
@@ -24,15 +24,15 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompositeFastListTest extends AbstractListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/FastListTest.java
@@ -52,20 +52,20 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link FastList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/ListAdapterTest.java
@@ -16,10 +16,10 @@ import java.util.LinkedList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link ListAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsReadUntouchableTest.java
@@ -14,9 +14,9 @@ import java.io.Serializable;
 
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.list.MutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class MultiReaderFastListAsReadUntouchableTest extends UnmodifiableMutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsUnmodifiableTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.list.mutable;
 
 import org.eclipse.collections.api.list.MutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderFastListAsUnmodifiableTest extends UnmodifiableMutableListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListAsWriteUntouchableTest.java
@@ -15,11 +15,11 @@ import java.util.Arrays;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderFastListAsWriteUntouchableTest extends AbstractListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/MultiReaderFastListTest.java
@@ -44,18 +44,18 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link MultiReaderFastList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/NullSafeSortingTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/NullSafeSortingTest.java
@@ -20,7 +20,7 @@ import java.util.RandomAccess;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NullSafeSortingTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/RandomAccessListAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/RandomAccessListAdapterTest.java
@@ -21,12 +21,12 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link RandomAccessListAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/SynchronizedMutableListTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.list.mutable;
 
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link SynchronizedMutableList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTest.java
@@ -28,16 +28,16 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableList}.
@@ -50,7 +50,7 @@ public class UnmodifiableMutableListTest
     private MutableList<String> mutableList;
     private MutableList<String> unmodifiableList;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableList = Lists.mutable.of(METALLICA, "Bon Jovi", "Europe", "Scorpions");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/UnmodifiableMutableListTestCase.java
@@ -16,12 +16,12 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.list.fixed.UnmodifiableMemoryEfficientListTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract JUnit test for {@link UnmodifiableMutableList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/AbstractBooleanListTestCase.java
@@ -24,15 +24,15 @@ import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableBooleanList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayListTest.java
@@ -16,12 +16,12 @@ import java.util.BitSet;
 import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link BooleanArrayList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BoxedMutableBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/BoxedMutableBooleanListTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BoxedMutableBooleanListTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/MutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/MutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanIterableTest.java
@@ -19,11 +19,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBoolean
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.primitive.SynchronizedBooleanIterable;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedBooleanIterable}s

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/SynchronizedBooleanListTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/UnmodifiableBooleanListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/mutable/primitive/UnmodifiableBooleanListTest.java
@@ -12,13 +12,13 @@ package org.eclipse.collections.impl.list.mutable.primitive;
 
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanList}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/IntIntervalTest.java
@@ -44,16 +44,16 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IntIntervalTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/list/primitive/LongIntervalTest.java
@@ -42,16 +42,16 @@ import org.eclipse.collections.impl.math.MutableLong;
 import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LongIntervalTest
 {
@@ -613,7 +613,7 @@ public class LongIntervalTest
 
             long actualSum = LongInterval.fromTo(l, l + i).sum();
 
-            assertEquals("interval size : " + (i + 1), expectedSum, actualSum);
+            assertEquals(expectedSum, actualSum, "interval size : " + (i + 1));
             assertTrue(actualSum > 0L);
         }
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/MapIterableTestCase.java
@@ -89,18 +89,18 @@ import org.eclipse.collections.impl.string.immutable.CharAdapter;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class MapIterableTestCase
 {
@@ -362,7 +362,7 @@ public abstract class MapIterableTestCase
         BooleanHashBag target = new BooleanHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "true", "Two", "nah", "Three", "TrUe");
         BooleanHashBag result = map.collectBoolean(Boolean::parseBoolean, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(BooleanHashBag.newBagWith(true, false, true), result.toBag());
     }
 
@@ -380,7 +380,7 @@ public abstract class MapIterableTestCase
         ByteHashBag target = new ByteHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ByteHashBag result = map.collectByte(Byte::parseByte, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2, (byte) 3), result.toBag());
     }
 
@@ -398,7 +398,7 @@ public abstract class MapIterableTestCase
         CharHashBag target = new CharHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "A1", "Two", "B", "Three", "C#++");
         CharHashBag result = map.collectChar((CharFunction<String>) string -> string.charAt(0), target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(CharHashBag.newBagWith('A', 'B', 'C'), result.toBag());
     }
 
@@ -416,7 +416,7 @@ public abstract class MapIterableTestCase
         DoubleHashBag target = new DoubleHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         DoubleHashBag result = map.collectDouble(Double::parseDouble, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(DoubleHashBag.newBagWith(1.0d, 2.0d, 3.0d), result.toBag());
     }
 
@@ -434,7 +434,7 @@ public abstract class MapIterableTestCase
         FloatHashBag target = new FloatHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         FloatHashBag result = map.collectFloat(Float::parseFloat, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(FloatHashBag.newBagWith(1.0f, 2.0f, 3.0f), result.toBag());
     }
 
@@ -452,7 +452,7 @@ public abstract class MapIterableTestCase
         IntHashBag target = new IntHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         IntHashBag result = map.collectInt(Integer::parseInt, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(IntHashBag.newBagWith(1, 2, 3), result.toBag());
     }
 
@@ -470,7 +470,7 @@ public abstract class MapIterableTestCase
         LongHashBag target = new LongHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         LongHashBag result = map.collectLong(Long::parseLong, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(LongHashBag.newBagWith(1L, 2L, 3L), result.toBag());
     }
 
@@ -488,7 +488,7 @@ public abstract class MapIterableTestCase
         ShortHashBag target = new ShortHashBag();
         MapIterable<String, String> map = this.newMapWithKeysValues("One", "1", "Two", "2", "Three", "3");
         ShortHashBag result = map.collectShort(Short::parseShort, target);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
         assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2, (short) 3), result.toBag());
     }
 
@@ -1005,7 +1005,7 @@ public abstract class MapIterableTestCase
 
         String value = map.getFirst();
         assertNotNull(value);
-        assertTrue(value, map.valuesView().contains(value));
+        assertTrue(map.valuesView().contains(value), value);
 
         assertNull(this.newMap().getFirst());
     }
@@ -1017,7 +1017,7 @@ public abstract class MapIterableTestCase
 
         String value = map.getLast();
         assertNotNull(value);
-        assertTrue(value, map.valuesView().contains(value));
+        assertTrue(map.valuesView().contains(value), value);
 
         assertNull(this.newMap().getLast());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/AbstractMemoryEfficientMutableMapTest.java
@@ -52,18 +52,18 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link AbstractMemoryEfficientMutableMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/DoubletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/DoubletonMapTest.java
@@ -26,13 +26,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link DoubletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/EmptyMapTest.java
@@ -27,14 +27,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link EmptyMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/SingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/SingletonMapTest.java
@@ -26,13 +26,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SingletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/TripletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/fixed/TripletonMapTest.java
@@ -28,13 +28,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link TripletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableDoubletonMapTest.java
@@ -22,12 +22,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableDoubletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableEmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableEmptyMapTest.java
@@ -16,13 +16,13 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptyMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ImmutableMapFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapIterableTestCase.java
@@ -31,14 +31,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ImmutableMapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMapTestCase.java
@@ -15,11 +15,11 @@ import java.util.Map;
 
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link ImmutableMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMemoryEfficientMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableMemoryEfficientMapTestCase.java
@@ -46,16 +46,16 @@ import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ImmutableMemoryEfficientMapTestCase extends ImmutableMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableQuadrupletonMapTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableQuadrupletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableSingletonMapTest.java
@@ -23,11 +23,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableSingletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableTripletonMapTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.block.procedure.CollectionAddProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableTripletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMap2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMap2Test.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.map.MapIterableTestCase;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableUnifiedMap2Test extends MapIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/ImmutableUnifiedMapTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableUnifiedMapTest extends ImmutableMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/AbstractImmutableObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/AbstractImmutableObjectBooleanMapTestCase.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.impl.map.mutable.primitive.AbstractObjectBooleanMapTestCase;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public abstract class AbstractImmutableObjectBooleanMapTestCase extends AbstractObjectBooleanMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableByteByteMapKeySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableByteByteMapKeySetTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.set.primitive.ByteSet;
 import org.eclipse.collections.api.set.primitive.ImmutableByteSet;
 import org.eclipse.collections.impl.map.mutable.primitive.ByteByteHashMap;
 import org.eclipse.collections.impl.set.immutable.primitive.AbstractImmutableByteHashSetTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableByteSet} created from the freeze() method.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanEmptyMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanEmptyMapTest.java
@@ -21,15 +21,15 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanEmptyMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanHashMapTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl.map.immutable.primitive;
 import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanHashMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanSingletonMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ImmutableObjectBooleanSingletonMapTest.java
@@ -22,14 +22,14 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableObjectBooleanSingletonMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ObjectBooleanMapFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/immutable/primitive/ObjectBooleanMapFactoryTest.java
@@ -15,11 +15,11 @@ import org.eclipse.collections.api.map.primitive.ImmutableObjectBooleanMap;
 import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.factory.primitive.ObjectBooleanMaps;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectBooleanMapFactoryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTest.java
@@ -34,15 +34,15 @@ import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentHashMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapTestCase.java
@@ -20,23 +20,23 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.parallel.ParallelIterate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
 {
     protected ExecutorService executor;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.executor = Executors.newFixedThreadPool(20);
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         this.executor.shutdown();
@@ -68,9 +68,9 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
         ParallelIterate.forEach(list, each -> map.updateValue(each % 50, () -> 0, integer -> integer + 1), 1, this.executor);
         assertEquals(Interval.zeroTo(49).toSet(), map.keySet());
         assertEquals(
-                HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(50, 2)),
-                FastList.newList(map.values()));
+                FastList.newList(map.values()),
+                HashBag.newBag(map.values()).toStringOfItemToCount());
     }
 
     @Override
@@ -102,8 +102,8 @@ public abstract class ConcurrentHashMapTestCase extends MutableMapTestCase
         }, "test"), 1, this.executor);
         assertEquals(Interval.zeroTo(99).toSet(), map.keySet());
         assertEquals(
-                HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(100, 2)),
-                FastList.newList(map.values()));
+                FastList.newList(map.values()),
+                HashBag.newBag(map.values()).toStringOfItemToCount());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafeTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafeTest.java
@@ -35,15 +35,15 @@ import org.eclipse.collections.impl.parallel.ParallelIterate;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentHashMapUnsafe}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMapTest.java
@@ -21,14 +21,14 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ConcurrentMutableHashMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MapAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MapAdapterTest.java
@@ -14,10 +14,10 @@ import java.util.HashMap;
 
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.factory.Maps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link MapAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
@@ -40,17 +40,17 @@ import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iMap;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit TestCase for {@link MutableMapIterable}s.
@@ -789,9 +789,9 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         Iterate.forEach(list, each -> map.updateValue(each % 1000, () -> 0, integer -> integer + 1));
         assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
         assertEquals(
-                HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(1000, 2)),
-                FastList.newList(map.values()));
+                FastList.newList(map.values()),
+                HashBag.newBag(map.values()).toStringOfItemToCount());
     }
 
     @Test
@@ -819,8 +819,8 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         }, "test"));
         assertEquals(Interval.zeroTo(999).toSet(), map.keySet());
         assertEquals(
-                HashBag.newBag(map.values()).toStringOfItemToCount(),
                 FastList.newList(Collections.nCopies(1000, 2)),
-                FastList.newList(map.values()));
+                FastList.newList(map.values()),
+                HashBag.newBag(map.values()).toStringOfItemToCount());
     }
 }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapTestCase.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Abstract JUnit TestCase for {@link MutableMap}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
@@ -36,14 +36,14 @@ import org.eclipse.collections.impl.test.ClassComparer;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UnifiedMapTest extends UnifiedMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTestCase.java
@@ -34,20 +34,20 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iMap;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class UnifiedMapTestCase extends MutableMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
@@ -19,11 +19,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableMutableMap}.
@@ -202,7 +202,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     @Test
     public void getIfAbsentPut()
     {
-        Assert.assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, (Function0<String>) () -> ""));
+        assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, (Function0<String>) () -> ""));
         assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, (Function0<String>) () -> ""));
     }
 
@@ -210,7 +210,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     @Test
     public void getIfAbsentPutValue()
     {
-        Assert.assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, ""));
+        assertEquals("3", this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(3, ""));
         assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues(1, "1", 2, "2", 3, "3").getIfAbsentPut(4, ""));
     }
 
@@ -438,7 +438,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
 
         assertThrows(UnsupportedOperationException.class, () -> Iterate.getFirst(map.entrySet()).setValue("Three"));
 
-        Assert.assertEquals(this.newMapWithKeysValues(1, "One", 2, "2"), map);
+        assertEquals(this.newMapWithKeysValues(1, "One", 2, "2"), map);
     }
 
     @Test
@@ -446,7 +446,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One").asUnmodifiable();
         Object[] entries = map.entrySet().toArray();
-        Assert.assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
+        assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
     }
 
     @Test
@@ -454,7 +454,7 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     {
         MutableMap<Integer, String> map = this.newMapWithKeyValue(1, "One").asUnmodifiable();
         Object[] entries = map.entrySet().toArray(new Object[]{});
-        Assert.assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
+        assertEquals(ImmutableEntry.of(1, "One"), entries[0]);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractMutableObjectBooleanMapTestCase.java
@@ -21,13 +21,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractMutableObjectBooleanMapTestCase extends AbstractObjectBooleanMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapKeyValuesViewTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapKeyValuesViewTestCase.java
@@ -49,13 +49,13 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ObjectBooleanMap#keyValuesView()}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/AbstractObjectBooleanMapTestCase.java
@@ -23,13 +23,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractObjectBooleanMapTestCase
 {
@@ -174,21 +174,21 @@ public abstract class AbstractObjectBooleanMapTestCase
 
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(0, true, 1, false);
         assertTrue(
-                map1.toString(),
                 "{0=true, 1=false}".equals(map1.toString())
-                        || "{1=false, 0=true}".equals(map1.toString()));
+                        || "{1=false, 0=true}".equals(map1.toString()),
+                map1.toString());
 
         ObjectBooleanMap<Integer> map2 = this.newWithKeysValues(1, false, null, true);
         assertTrue(
-                map2.toString(),
                 "{1=false, null=true}".equals(map2.toString())
-                        || "{null=true, 1=false}".equals(map2.toString()));
+                        || "{null=true, 1=false}".equals(map2.toString()),
+                map2.toString());
 
         ObjectBooleanMap<Integer> map3 = this.newWithKeysValues(1, true, null, true);
         assertTrue(
-                map3.toString(),
                 "{1=true, null=true}".equals(map3.toString())
-                        || "{null=true, 1=true}".equals(map3.toString()));
+                        || "{null=true, 1=true}".equals(map3.toString()),
+                map3.toString());
     }
 
     @Test
@@ -275,7 +275,7 @@ public abstract class AbstractObjectBooleanMapTestCase
             sumKey[0] += String.valueOf(eachKey);
             sumValue[0] += eachValue;
         });
-        assertTrue(sumKey[0], "3null".equals(sumKey[0]) || "null3".equals(sumKey[0]));
+        assertTrue("3null".equals(sumKey[0]) || "null3".equals(sumKey[0]), sumKey[0]);
         assertTrue("truefalse".equals(sumValue[0]) || "falsetrue".equals(sumValue[0]));
     }
 
@@ -289,14 +289,14 @@ public abstract class AbstractObjectBooleanMapTestCase
 
         ObjectBooleanMap<Integer> map2 = this.newWithKeysValues(1, true, 32, false);
         assertTrue(
-                map2.makeString("[", "/", "]"),
                 "[true/false]".equals(map2.makeString("[", "/", "]"))
-                        || "[false/true]".equals(map2.makeString("[", "/", "]")));
+                        || "[false/true]".equals(map2.makeString("[", "/", "]")),
+                map2.makeString("[", "/", "]"));
 
         assertTrue(
-                map2.makeString("/"),
                 "true/false".equals(map2.makeString("/"))
-                        || "false/true".equals(map2.makeString("/")));
+                        || "false/true".equals(map2.makeString("/")),
+                map2.makeString("/"));
     }
 
     @Test
@@ -322,23 +322,23 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<Integer> map1 = this.newWithKeysValues(0, true, 1, false);
         map1.appendString(appendable3);
         assertTrue(
-                appendable3.toString(),
                 "true, false".equals(appendable3.toString())
-                        || "false, true".equals(appendable3.toString()));
+                        || "false, true".equals(appendable3.toString()),
+                appendable3.toString());
 
         Appendable appendable4 = new StringBuilder();
         map1.appendString(appendable4, "/");
         assertTrue(
-                appendable4.toString(),
                 "true/false".equals(appendable4.toString())
-                        || "false/true".equals(appendable4.toString()));
+                        || "false/true".equals(appendable4.toString()),
+                appendable4.toString());
 
         Appendable appendable5 = new StringBuilder();
         map1.appendString(appendable5, "[", "/", "]");
         assertTrue(
-                appendable5.toString(),
                 "[true/false]".equals(appendable5.toString())
-                        || "[false/true]".equals(appendable5.toString()));
+                        || "[false/true]".equals(appendable5.toString()),
+                appendable5.toString());
     }
 
     @Test
@@ -482,8 +482,8 @@ public abstract class AbstractObjectBooleanMapTestCase
         ObjectBooleanMap<String> map2 = this.newWithKeysValues("0", true);
         ObjectBooleanMap<String> map3 = this.newWithKeysValues("0", false);
 
-        assertTrue(map1.toList().toString(), BooleanArrayList.newListWith(true, false).equals(map1.toList())
-                || BooleanArrayList.newListWith(false, true).equals(map1.toList()));
+        assertTrue(BooleanArrayList.newListWith(true, false).equals(map1.toList())
+                || BooleanArrayList.newListWith(false, true).equals(map1.toList()), map1.toList().toString());
         assertEquals(BooleanArrayList.newListWith(true), map2.toList());
         assertEquals(BooleanArrayList.newListWith(false), map3.toList());
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeySetTestCase.java
@@ -19,13 +19,13 @@ import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ObjectBooleanHashMapKeySetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeysViewTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapKeysViewTest.java
@@ -17,12 +17,12 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMap#keysView()}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapTestCase.java
@@ -19,12 +19,12 @@ import org.eclipse.collections.api.block.function.primitive.BooleanFunction0;
 import org.eclipse.collections.api.block.function.primitive.BooleanToBooleanFunction;
 import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObjectBooleanMapTestCase
 {
@@ -156,7 +156,7 @@ public abstract class ObjectBooleanHashMapTestCase extends AbstractMutableObject
 
         for (int i = 11; i < 75; i++)
         {
-            assertFalse(String.valueOf(i), hashMap.containsKey(i));
+            assertFalse(hashMap.containsKey(i), String.valueOf(i));
             hashMap.put(i, (i & 1) == 0);
         }
         assertEquals(256L, ((Object[]) keys.get(hashMap)).length);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapValuesTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapValuesTestCase.java
@@ -25,12 +25,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.UnmodifiableBoo
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class ObjectBooleanHashMapValuesTestCase extends AbstractMutableBooleanCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeySetTest.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.api.map.primitive.MutableObjectBooleanMap;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMapWithHashingStrategy#keySet()}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeysViewTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyKeysViewTest.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterableTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanHashMapWithHashingStrategy#keysView()}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/ObjectBooleanHashMapWithHashingStrategyTest.java
@@ -20,12 +20,12 @@ import org.eclipse.collections.impl.factory.primitive.ObjectBooleanMaps;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectBooleanHashMapWithHashingStrategyTest extends ObjectBooleanHashMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedObjectBooleanMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/SynchronizedObjectBooleanMapTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.collections.impl.map.mutable.primitive;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SynchronizedObjectBooleanMapTest extends AbstractMutableObjectBooleanMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableObjectBooleanMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/primitive/UnmodifiableObjectBooleanMapTest.java
@@ -17,12 +17,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnmodifiableObjectBooleanMapTest extends AbstractMutableObjectBooleanMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableEmptySortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableEmptySortedMapTest.java
@@ -28,15 +28,15 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptySortedMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableSortedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableSortedMapTestCase.java
@@ -41,14 +41,14 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link ImmutableSortedMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/immutable/ImmutableTreeMapTest.java
@@ -32,15 +32,15 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableTreeMapTest extends ImmutableSortedMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/MutableSortedMapTestCase.java
@@ -49,17 +49,17 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit TestCase for {@link MutableSortedMap}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/SortedMapAdapterTest.java
@@ -17,12 +17,12 @@ import java.util.TreeMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link SortedMapAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/TreeSortedMapTest.java
@@ -18,11 +18,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TreeSortedMapTest extends MutableSortedMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableSortedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableSortedMapTest.java
@@ -16,10 +16,10 @@ import java.util.TreeMap;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.factory.SortedMaps;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnmodifiableSortedMapTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
@@ -22,11 +22,11 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link UnmodifiableTreeMap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEmptyMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableEmptyMapWithHashingStrategyTest.java
@@ -19,13 +19,13 @@ import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
 import org.eclipse.collections.impl.map.immutable.ImmutableMemoryEfficientMapTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableEmptyMapWithHashingStrategy}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/immutable/ImmutableUnifiedMapWithHashingStrategyTest.java
@@ -20,9 +20,9 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableUnifiedMapWithHashingStrategyTest extends ImmutableMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategyTest.java
@@ -42,16 +42,16 @@ import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UnifiedMapWithHashingStrategyTest extends UnifiedMapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractImmutableMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractImmutableMultimapTestCase.java
@@ -26,12 +26,12 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMultimapTestCase.java
@@ -34,14 +34,14 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper class for testing {@link Multimap}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMutableMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/AbstractMutableMultimapTestCase.java
@@ -29,14 +29,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper class for testing {@link Multimap}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/UnifiedSetWithHashingStrategyMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/UnifiedSetWithHashingStrategyMultimapTest.java
@@ -32,10 +32,10 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test of {@link UnifiedSetWithHashingStrategyMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/AbstractMutableBagMultimapTestCase.java
@@ -22,10 +22,10 @@ import org.eclipse.collections.impl.multimap.AbstractMutableMultimapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class AbstractMutableBagMultimapTestCase extends AbstractMutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/ImmutableBagMultimapTest.java
@@ -22,9 +22,9 @@ import org.eclipse.collections.impl.multimap.AbstractImmutableMultimapTestCase;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableBagMultimapTest extends AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/MultiReaderHashBagMultimapTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
 import org.eclipse.collections.impl.bag.mutable.MultiReaderHashBag;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link MultiReaderHashBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/SynchronizedPutHashBagMultimapTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.multimap.bag;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.bag.mutable.HashBag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutHashBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/TreeBagMultimapTest.java
@@ -22,9 +22,9 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/AbstractMutableSortedBagMultimapTestCase.java
@@ -31,10 +31,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test of {@link TreeBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/TreeBagMultimapTest.java
@@ -21,9 +21,9 @@ import org.eclipse.collections.impl.block.factory.IntegerPredicates;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/immutable/ImmutableSortedBagMultimapImplTest.java
@@ -28,9 +28,9 @@ import org.eclipse.collections.impl.multimap.bag.sorted.mutable.TreeBagMultimap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableSortedBagMultimapImplTest extends AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/AbstractMutableSortedBagMultimapTestCase.java
@@ -32,11 +32,11 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test of {@link TreeBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/sorted/mutable/TreeBagMultimapTest.java
@@ -24,9 +24,9 @@ import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link TreeBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/bag/strategy/HashBagMultimapWithHashingStrategyTest.java
@@ -26,11 +26,11 @@ import org.eclipse.collections.impl.multimap.bag.AbstractMutableBagMultimapTestC
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Test of {@link HashBagMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/AbstractMutableListMultimapTestCase.java
@@ -27,9 +27,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractMutableListMultimapTestCase extends AbstractMutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/FastListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/FastListMultimapTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link FastListMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/ImmutableListMultimapTest.java
@@ -29,9 +29,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableListMultimapTest extends AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/list/MultiReaderFastListMultimapTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link MultiReaderFastListMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/AbstractMutableSetMultimapTestCase.java
@@ -29,10 +29,10 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class AbstractMutableSetMultimapTestCase extends AbstractMutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/ImmutableSetMultimapTest.java
@@ -26,9 +26,9 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableSetMultimapTest extends AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/MultiReaderUnifiedSetMultimapTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.set.mutable.MultiReaderUnifiedSet;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link MultiReaderUnifiedSetMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/SynchronizedPutUnifiedSetMultimapTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.multimap.set;
 import org.eclipse.collections.api.multimap.MutableMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutUnifiedSetMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/UnifiedSetMultimapTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link UnifiedSetMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/AbstractMutableSortedSetMultimapTestCase.java
@@ -32,10 +32,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public abstract class AbstractMutableSortedSetMultimapTestCase extends AbstractMutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/ImmutableSortedSetMultimapTest.java
@@ -36,11 +36,11 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ImmutableSortedSetMultimapTest extends AbstractImmutableMultimapTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/SynchronizedPutTreeSortedSetMultimapTest.java
@@ -17,9 +17,9 @@ import org.eclipse.collections.api.multimap.sortedset.MutableSortedSetMultimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of {@link SynchronizedPutTreeSortedSetMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/multimap/set/sorted/TreeSortedSetMultimapTest.java
@@ -23,9 +23,9 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link TreeSortedSetMultimap}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunnerTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ObjectIntProcedureFJTaskRunnerTest.java
@@ -17,16 +17,16 @@ import org.eclipse.collections.api.block.procedure.primitive.ObjectIntProcedure;
 import org.eclipse.collections.impl.block.factory.ObjectIntProcedures;
 import org.eclipse.collections.impl.block.procedure.DoNothingProcedure;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ObjectIntProcedureFJTaskRunnerTest
 {
     private ObjectIntProcedureFJTaskRunner<Integer, ObjectIntProcedure<Integer>> undertest;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.undertest = new ObjectIntProcedureFJTaskRunner<>(

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelArrayIterateTest.java
@@ -19,10 +19,10 @@ import org.eclipse.collections.impl.math.SumCombiner;
 import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParallelArrayIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterate2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterate2Test.java
@@ -17,9 +17,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.collections.impl.list.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link ParallelIterate}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelIterateTest.java
@@ -62,15 +62,15 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParallelIterateTest
 {
@@ -94,7 +94,7 @@ public class ParallelIterateTest
     private ImmutableList<RichIterable<Integer>> iterables;
     private final ExecutorService executor = Executors.newFixedThreadPool(2);
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         Interval interval = Interval.oneTo(200);
@@ -134,7 +134,7 @@ public class ParallelIterateTest
                 UnifiedSetWithHashingStrategy.<Integer>newSet(HashingStrategies.defaultStrategy()).withAll(interval).toImmutable());
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         this.executor.shutdown();
@@ -356,9 +356,9 @@ public class ParallelIterateTest
         Collection<Integer> actual2 = ParallelIterate.select(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = ParallelIterate.select(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected, actual1, expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected.toBag(), actual2, expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
+        assertEquals(expected, actual3, expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName());
     }
 
     @Test
@@ -370,8 +370,8 @@ public class ParallelIterateTest
         RichIterable<Integer> expected = iterable.select(Predicates.greaterThan(100));
         assertSame(expected.getClass(), actual1.getClass());
         assertSame(expected.getClass(), actual2.getClass());
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
+        assertEquals(expected, actual1, expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected, actual2, expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
     }
 
     @Test
@@ -400,9 +400,9 @@ public class ParallelIterateTest
         Collection<Integer> actual2 = ParallelIterate.reject(iterable, Predicates.greaterThan(100), HashBag.newBag(), 3, this.executor, true);
         Collection<Integer> actual3 = ParallelIterate.reject(iterable, Predicates.greaterThan(100), true);
         RichIterable<Integer> expected = iterable.reject(Predicates.greaterThan(100));
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected, actual1, expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected.toBag(), actual2, expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
+        assertEquals(expected, actual3, expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName());
     }
 
     @Test
@@ -419,9 +419,9 @@ public class ParallelIterateTest
         RichIterable<String> expected = iterable.collect(String::valueOf);
         Verify.assertSize(200, actual1);
         Verify.assertContains(String.valueOf(200), actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected.toBag(), actual2);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected.toBag(), HashBag.newBag(actual3));
+        assertEquals(expected, actual1, expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected.toBag(), actual2, expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
+        assertEquals(expected.toBag(), HashBag.newBag(actual3), expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName());
     }
 
     @Test
@@ -441,9 +441,9 @@ public class ParallelIterateTest
         Verify.assertNotContains(String.valueOf(90), actual1);
         Verify.assertNotContains(String.valueOf(210), actual1);
         Verify.assertContains(String.valueOf(159), actual1);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected, HashBag.newBag(actual1));
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected, actual2);
-        assertEquals(expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected, actual3);
+        assertEquals(expected, HashBag.newBag(actual1), expected.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected, actual2, expected.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
+        assertEquals(expected, actual3, expected.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName());
     }
 
     @Test
@@ -769,9 +769,9 @@ public class ParallelIterateTest
         RichIterable<String> expected1 = iterable.flatCollect(INT_TO_TWO_STRINGS);
         RichIterable<String> expected2 = iterable.flatCollect(INT_TO_TWO_STRINGS, HashBag.newBag());
         Verify.assertContains(String.valueOf(200), actual1);
-        assertEquals(expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName(), expected1, actual1);
-        assertEquals(expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName(), expected2, actual2);
-        assertEquals(expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName(), expected1, actual3);
+        assertEquals(expected1, actual1, expected1.getClass().getSimpleName() + '/' + actual1.getClass().getSimpleName());
+        assertEquals(expected2, actual2, expected2.getClass().getSimpleName() + '/' + actual2.getClass().getSimpleName());
+        assertEquals(expected1, actual3, expected1.getClass().getSimpleName() + '/' + actual3.getClass().getSimpleName());
     }
 
     public static final class IntegerSum

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelMapIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/parallel/ParallelMapIterateTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ParallelMapIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/PartitionHashBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/PartitionHashBagTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.partition.bag.PartitionImmutableBag;
 import org.eclipse.collections.api.partition.bag.PartitionMutableBag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionHashBagTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/sorted/PartitionTreeBagTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/bag/sorted/PartitionTreeBagTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.factory.SortedBags;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionImmutableSortedBag;
 import org.eclipse.collections.api.partition.bag.sorted.PartitionMutableSortedBag;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionTreeBagTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/list/PartitionFastListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/list/PartitionFastListTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.partition.list.PartitionImmutableList;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionFastListTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/PartitionUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/PartitionUnifiedSetTest.java
@@ -14,9 +14,9 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
 import org.eclipse.collections.api.set.MutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionUnifiedSetTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/sorted/PartitionTreeSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/sorted/PartitionTreeSortedSetTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.partition.set.sorted.PartitionImmutableSorted
 import org.eclipse.collections.api.partition.set.sorted.PartitionMutableSortedSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionTreeSortedSetTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/strategy/PartitionUnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/set/strategy/PartitionUnifiedSetWithHashingStrategyTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.api.partition.set.PartitionImmutableSet;
 import org.eclipse.collections.api.partition.set.PartitionMutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionUnifiedSetWithHashingStrategyTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/partition/stack/PartitionArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/partition/stack/PartitionArrayStackTest.java
@@ -14,10 +14,10 @@ import org.eclipse.collections.api.partition.stack.PartitionImmutableStack;
 import org.eclipse.collections.api.partition.stack.PartitionMutableStack;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PartitionArrayStackTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/AbstractMemoryEfficientMutableSetTestCase.java
@@ -44,15 +44,15 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.UnmodifiableMutableSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link AbstractMemoryEfficientMutableSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/DoubletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/DoubletonSetTest.java
@@ -27,15 +27,15 @@ import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link DoubletonSet}.
@@ -44,7 +44,7 @@ public class DoubletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
     private DoubletonSet<String> set;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.set = new DoubletonSet<>("1", "2");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/EmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/EmptySetTest.java
@@ -24,22 +24,22 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EmptySetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
     private EmptySet<Object> emptySet;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.emptySet = new EmptySet<>();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/FixedSizeSetFactoryTest.java
@@ -22,17 +22,17 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class FixedSizeSetFactoryTest
 {
     private FixedSizeSetFactory setFactory;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.setFactory = FixedSizeSetFactoryImpl.INSTANCE;

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetAsUnmodifiableTest.java
@@ -15,7 +15,7 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QuadrupletonSetAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<String>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/QuadrupletonSetTest.java
@@ -22,20 +22,20 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QuadrupletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
     private QuadrupletonSet<String> set;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.set = new QuadrupletonSet<>("1", "2", "3", "4");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/SingletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/SingletonSetTest.java
@@ -33,20 +33,20 @@ import org.eclipse.collections.impl.set.mutable.SynchronizedMutableSet;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link SingletonSet}.
@@ -56,7 +56,7 @@ public class SingletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
     private SingletonSet<String> set;
     private MutableSet<Integer> intSet;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.set = new SingletonSet<>("1");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/TripletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/fixed/TripletonSetTest.java
@@ -22,14 +22,14 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link TripletonSet}.
@@ -38,7 +38,7 @@ public class TripletonSetTest extends AbstractMemoryEfficientMutableSetTestCase
 {
     private TripletonSet<String> set;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.set = new TripletonSet<>("1", "2", "3");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableEmptySetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableEmptySetTestCase.java
@@ -26,14 +26,14 @@ import org.eclipse.collections.impl.block.factory.PrimitiveFunctions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableEmptySetTestCase extends AbstractImmutableSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableSetTestCase.java
@@ -35,13 +35,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableSetTestCase extends AbstractImmutableCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableUnifiedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/AbstractImmutableUnifiedSetTestCase.java
@@ -35,16 +35,16 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableUnifiedSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableDoubletonSetTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableDoubletonSetTest
         extends AbstractImmutableSetTestCase

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableEmptySetTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ImmutableEmptySetTest extends AbstractImmutableEmptySetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableQuadrupletonSetTest.java
@@ -12,11 +12,11 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableQuadrupletonSetTest
         extends AbstractImmutableSetTestCase

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableSingletonSetTest.java
@@ -12,10 +12,10 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableSingletonSetTest
         extends AbstractImmutableSetTestCase

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableTripletonSetTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.set.immutable;
 
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableTripletonSetTest
         extends AbstractImmutableSetTestCase

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/ImmutableUnifiedSetTest.java
@@ -17,10 +17,10 @@ import org.eclipse.collections.impl.math.SumProcedure;
 import org.eclipse.collections.impl.parallel.BatchIterable;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableUnifiedSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/AbstractImmutableByteHashSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/AbstractImmutableByteHashSetTestCase.java
@@ -29,13 +29,13 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.ByteHashSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableByteSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableBooleanEmptySetTest.java
@@ -22,13 +22,13 @@ import org.eclipse.collections.impl.collection.immutable.primitive.AbstractImmut
 import org.eclipse.collections.impl.factory.primitive.BooleanBags;
 import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptySet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/immutable/primitive/ImmutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.collections.impl.factory.primitive.ShortSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractMutableSetTestCase.java
@@ -38,20 +38,20 @@ import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link AbstractMutableSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractUnifiedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/AbstractUnifiedSetTestCase.java
@@ -15,11 +15,11 @@ import java.util.SortedSet;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.IntegerWithCast;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractUnifiedSetTestCase extends AbstractMutableSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderMutableCollectionTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderMutableCollectionTestCase.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class MultiReaderMutableCollectionTestCase extends AbstractCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsReadUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsReadUntouchableTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiReaderUnifiedSetAsReadUntouchableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsUnmodifiableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsUnmodifiableTest.java
@@ -12,7 +12,7 @@ package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.impl.collection.mutable.UnmodifiableMutableCollectionTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiReaderUnifiedSetAsUnmodifiableTest extends UnmodifiableMutableCollectionTestCase<Integer>
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsWriteUntouchableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetAsWriteUntouchableTest.java
@@ -19,12 +19,12 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.bag.sorted.mutable.TreeBag;
 import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MultiReaderUnifiedSetAsWriteUntouchableTest extends AbstractCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/MultiReaderUnifiedSetTest.java
@@ -32,14 +32,14 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiReaderUnifiedSetTest extends MultiReaderMutableCollectionTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetAdapterTest.java
@@ -25,14 +25,14 @@ import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SetAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetLogicTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SetLogicTest.java
@@ -12,17 +12,17 @@ package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.block.factory.Predicates;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SetLogicTest
 {
     private MutableSet<Integer> setA;
     private MutableSet<Integer> setB;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.setA = UnifiedSet.newSetWith(1, 2, 3, 4).asUnmodifiable();

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSet2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSet2Test.java
@@ -20,14 +20,14 @@ import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedMutableSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/SynchronizedMutableSetTest.java
@@ -24,11 +24,11 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.collection.mutable.AbstractSynchronizedCollectionTestCase;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedMutableSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetAsPoolTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.set.mutable;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class UnifiedSetAsPoolTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetTest.java
@@ -31,16 +31,16 @@ import org.eclipse.collections.impl.test.ClassComparer;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test suite for {@link UnifiedSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnifiedSetWithHashingStrategyTest.java
@@ -39,16 +39,16 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Key;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test suite for {@link UnifiedSetWithHashingStrategy}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnmodifiableMutableSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/UnmodifiableMutableSetTest.java
@@ -23,15 +23,15 @@ import org.eclipse.collections.impl.collection.mutable.AbstractCollectionTestCas
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableMutableSet}.
@@ -44,7 +44,7 @@ public class UnmodifiableMutableSetTest extends AbstractCollectionTestCase
     private MutableSet<String> mutableSet;
     private MutableSet<String> unmodifiableSet;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableSet = UnifiedSet.newSetWith(METALLICA, "Bon Jovi", "Europe", "Scorpions");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractBooleanSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractBooleanSetTestCase.java
@@ -30,15 +30,15 @@ import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanCollectionTestCase
 {
@@ -65,7 +65,7 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         return UnifiedSet.newSetWith(elements);
     }
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         this.emptySet = this.newWith();
@@ -771,14 +771,14 @@ public abstract class AbstractBooleanSetTestCase extends AbstractMutableBooleanC
         assertEquals("", this.emptySet.makeString("/"));
         assertEquals("false", this.setWithFalse.makeString("/"));
         assertEquals("true", this.setWithTrue.makeString("/"));
-        assertTrue(this.setWithTrueFalse.makeString("/"), "true/false".equals(this.setWithTrueFalse.makeString("/"))
-                || "false/true".equals(this.setWithTrueFalse.makeString("/")));
+        assertTrue("true/false".equals(this.setWithTrueFalse.makeString("/"))
+                || "false/true".equals(this.setWithTrueFalse.makeString("/")), this.setWithTrueFalse.makeString("/"));
 
         assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
         assertEquals("[false]", this.setWithFalse.makeString("[", "/", "]"));
         assertEquals("[true]", this.setWithTrue.makeString("[", "/", "]"));
-        assertTrue(this.setWithTrueFalse.makeString("[", "/", "]"), "[true/false]".equals(this.setWithTrueFalse.makeString("[", "/", "]"))
-                || "[false/true]".equals(this.setWithTrueFalse.makeString("[", "/", "]")));
+        assertTrue("[true/false]".equals(this.setWithTrueFalse.makeString("[", "/", "]"))
+                || "[false/true]".equals(this.setWithTrueFalse.makeString("[", "/", "]")), this.setWithTrueFalse.makeString("[", "/", "]"));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/AbstractByteSetTestCase.java
@@ -27,13 +27,13 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.map.mutable.primitive.CollisionGeneratorUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableByteSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BooleanHashSetTest.java
@@ -18,12 +18,12 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BooleanHashSetTest extends AbstractBooleanSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BoxedMutableBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/BoxedMutableBooleanSetTest.java
@@ -16,12 +16,12 @@ import java.util.HashSet;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BoxedMutableBooleanSetTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ByteHashSetTest.java
@@ -18,13 +18,13 @@ import org.eclipse.collections.impl.block.factory.primitive.BytePredicates;
 import org.eclipse.collections.impl.list.mutable.primitive.ByteArrayList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ByteHashSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ImmutableBooleanHashSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/ImmutableBooleanHashSetTest.java
@@ -31,14 +31,14 @@ import org.eclipse.collections.impl.math.MutableInteger;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollectionTestCase
 {
@@ -71,7 +71,7 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         return UnifiedSet.newSetWith(elements);
     }
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         this.emptySet = this.newWith();
@@ -465,14 +465,14 @@ public class ImmutableBooleanHashSetTest extends AbstractImmutableBooleanCollect
         assertEquals("", this.emptySet.makeString("/"));
         assertEquals("false", this.falseSet.makeString("/"));
         assertEquals("true", this.trueSet.makeString("/"));
-        assertTrue(this.trueFalseSet.makeString("/"), "true/false".equals(this.trueFalseSet.makeString("/"))
-                || "false/true".equals(this.trueFalseSet.makeString("/")));
+        assertTrue("true/false".equals(this.trueFalseSet.makeString("/"))
+                || "false/true".equals(this.trueFalseSet.makeString("/")), trueFalseSet.makeString("/"));
 
         assertEquals("[]", this.emptySet.makeString("[", "/", "]"));
         assertEquals("[false]", this.falseSet.makeString("[", "/", "]"));
         assertEquals("[true]", this.trueSet.makeString("[", "/", "]"));
-        assertTrue(this.trueFalseSet.makeString("[", "/", "]"), "[true/false]".equals(this.trueFalseSet.makeString("[", "/", "]"))
-                || "[false/true]".equals(this.trueFalseSet.makeString("[", "/", "]")));
+        assertTrue("[true/false]".equals(this.trueFalseSet.makeString("[", "/", "]"))
+                || "[false/true]".equals(this.trueFalseSet.makeString("[", "/", "]")), trueFalseSet.makeString("[", "/", "]"));
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/LongHashSetExtraTest.java
@@ -15,9 +15,9 @@ import java.util.Random;
 
 import org.eclipse.collections.api.block.predicate.primitive.LongPredicate;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // extra tests not covered in the generated portion
 public class LongHashSetExtraTest

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/MutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/MutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.collections.impl.factory.primitive.ShortSets;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/SynchronizedBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/SynchronizedBooleanSetTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.collections.impl.set.mutable.primitive;
 
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/UnmodifiableBooleanSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/mutable/primitive/UnmodifiableBooleanSetTest.java
@@ -13,13 +13,13 @@ package org.eclipse.collections.impl.set.mutable.primitive;
 import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/primitive/ImmutableBooleanSetFactoryImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/primitive/ImmutableBooleanSetFactoryImplTest.java
@@ -15,9 +15,9 @@ import org.eclipse.collections.impl.factory.primitive.BooleanSets;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.set.mutable.primitive.BooleanHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableBooleanSetFactoryImplTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/AbstractImmutableSortedSetTestCase.java
@@ -53,17 +53,17 @@ import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractImmutableSortedSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableEmptySortedSetTest.java
@@ -48,17 +48,17 @@ import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ImmutableEmptySortedSetTest extends AbstractImmutableSortedSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/immutable/ImmutableTreeSetTest.java
@@ -32,11 +32,11 @@ import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableTreeSetTest
         extends AbstractImmutableSortedSetTestCase

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/AbstractSortedSetTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/AbstractSortedSetTestCase.java
@@ -51,14 +51,14 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.test.domain.Person;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link MutableSortedSet}s.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SortedSetAdapterTest.java
@@ -28,13 +28,13 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link SortedSetAdapter}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet2Test.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSet2Test.java
@@ -15,11 +15,11 @@ import java.util.NoSuchElementException;
 
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link SynchronizedSortedSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/SynchronizedSortedSetTest.java
@@ -27,12 +27,12 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link SynchronizedSortedSet}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/TreeSortedSetTest.java
@@ -19,11 +19,11 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TreeSortedSetTest extends AbstractSortedSetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/sorted/mutable/UnmodifiableSortedSetTest.java
@@ -19,16 +19,16 @@ import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link UnmodifiableSortedSet}.
@@ -41,7 +41,7 @@ public class UnmodifiableSortedSetTest extends AbstractSortedSetTestCase
     private MutableSortedSet<String> mutableSet;
     private MutableSortedSet<String> unmodifiableSet;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableSet = TreeSortedSet.newSetWith(METALLICA, "Bon Jovi", "Europe", "Scorpions");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableEmptySetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableEmptySetWithHashingStrategyTest.java
@@ -20,10 +20,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.immutable.AbstractImmutableEmptySetTestCase;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ImmutableEmptySetWithHashingStrategyTest extends AbstractImmutableEmptySetTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyParallelSetIterableTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyParallelSetIterableTest.java
@@ -16,9 +16,9 @@ import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.impl.block.factory.HashingStrategies;
 import org.eclipse.collections.impl.lazy.parallel.set.ParallelUnsortedSetIterableTestCase;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableUnifiedSetWithHashingStrategyParallelSetIterableTest extends ParallelUnsortedSetIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/set/strategy/immutable/ImmutableUnifiedSetWithHashingStrategyTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.set.immutable.AbstractImmutableUnifiedSetTes
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableUnifiedSetWithHashingStrategy}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/StackIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/StackIterableTestCase.java
@@ -78,16 +78,16 @@ import org.eclipse.collections.impl.stack.mutable.primitive.ShortArrayStack;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class StackIterableTestCase
         extends AbstractRichIterableTestCase
@@ -306,7 +306,7 @@ public abstract class StackIterableTestCase
         StackIterable<String> stack = this.newStackFromTopToBottom("true", "nah", "TrUe", "false");
         BooleanHashSet result = stack.collectBoolean(Boolean::parseBoolean, target);
         assertEquals(BooleanHashSet.newSetWith(true, false, true, false), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -325,7 +325,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         ByteHashSet result = stack.collectByte(PrimitiveFunctions.unboxIntegerToByte(), target);
         assertEquals(ByteHashSet.newSetWith((byte) 1, (byte) 2, (byte) 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -344,7 +344,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         CharHashSet result = stack.collectChar(PrimitiveFunctions.unboxIntegerToChar(), target);
         assertEquals(CharHashSet.newSetWith((char) 1, (char) 2, (char) 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -363,7 +363,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         DoubleHashSet result = stack.collectDouble(PrimitiveFunctions.unboxIntegerToDouble(), target);
         assertEquals(DoubleHashSet.newSetWith(1, 2, 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -382,7 +382,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         FloatHashSet result = stack.collectFloat(PrimitiveFunctions.unboxIntegerToFloat(), target);
         assertEquals(FloatHashSet.newSetWith(1, 2, 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -401,7 +401,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         IntHashSet result = stack.collectInt(PrimitiveFunctions.unboxIntegerToInt(), target);
         assertEquals(IntHashSet.newSetWith(1, 2, 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -420,7 +420,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         LongHashSet result = stack.collectLong(PrimitiveFunctions.unboxIntegerToLong(), target);
         assertEquals(LongHashSet.newSetWith(1, 2, 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override
@@ -439,7 +439,7 @@ public abstract class StackIterableTestCase
         StackIterable<Integer> stack = this.newStackFromTopToBottom(1, 2, 3);
         ShortHashSet result = stack.collectShort(PrimitiveFunctions.unboxIntegerToShort(), target);
         assertEquals(ShortHashSet.newSetWith((short) 1, (short) 2, (short) 3), result);
-        assertSame("Target sent as parameter not returned", target, result);
+        assertSame(target, result, "Target sent as parameter not returned");
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableArrayStackTest.java
@@ -18,12 +18,12 @@ import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ImmutableArrayStackTest extends ImmutableStackTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/ImmutableStackTestCase.java
@@ -15,7 +15,7 @@ import org.eclipse.collections.api.map.primitive.ImmutableObjectLongMap;
 import org.eclipse.collections.api.stack.ImmutableStack;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ImmutableStackTestCase extends StackIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/AbstractImmutableBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/AbstractImmutableBooleanStackTestCase.java
@@ -18,13 +18,13 @@ import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link ImmutableBooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanArrayStackTest.java
@@ -13,9 +13,9 @@ package org.eclipse.collections.impl.stack.immutable.primitive;
 import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * JUnit test for {@link ImmutableBooleanArrayStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanEmptyStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanEmptyStackTest.java
@@ -16,12 +16,12 @@ import org.eclipse.collections.api.iterator.BooleanIterator;
 import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link ImmutableBooleanEmptyStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanSingletonStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/immutable/primitive/ImmutableBooleanSingletonStackTest.java
@@ -14,14 +14,14 @@ import org.eclipse.collections.api.stack.primitive.ImmutableBooleanStack;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.primitive.BooleanArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ImmutableBooleanSingletonStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/ArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/ArrayStackTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.stack.mutable;
 
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.factory.Stacks;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link ArrayStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/MutableStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/MutableStackTestCase.java
@@ -19,10 +19,10 @@ import org.eclipse.collections.impl.factory.Stacks;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class MutableStackTestCase extends StackIterableTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/SynchronizedStackTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.collections.impl.stack.mutable;
 
 import org.eclipse.collections.api.stack.MutableStack;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for {@link SynchronizedStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/UnmodifiableStackTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.impl.block.factory.StringPredicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.stack.StackIterableTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnmodifiableStackTest extends StackIterableTestCase
 {
@@ -29,7 +29,7 @@ public class UnmodifiableStackTest extends StackIterableTestCase
     private MutableStack<Integer> unmodifiableStack;
     private MutableStack<String> unmodifiableStackString;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.mutableStack = ArrayStack.newStackFromTopToBottom(1, 2, 3);

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/BooleanArrayStackTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutable
 import org.eclipse.collections.impl.factory.primitive.BooleanStacks;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link BooleanArrayStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/MutableEmptyPrimitiveTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/MutableEmptyPrimitiveTest.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.impl.factory.primitive.IntStacks;
 import org.eclipse.collections.impl.factory.primitive.LongStacks;
 import org.eclipse.collections.impl.factory.primitive.ShortStacks;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for empty() methods of primitive classes

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/SynchronizedBooleanStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/SynchronizedBooleanStackTest.java
@@ -13,10 +13,10 @@ package org.eclipse.collections.impl.stack.mutable.primitive;
 import org.eclipse.collections.api.BooleanIterable;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.collection.mutable.primitive.AbstractMutableBooleanStackTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * JUnit test for {@link SynchronizedBooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/UnmodifiableBooleanStackTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/mutable/primitive/UnmodifiableBooleanStackTest.java
@@ -14,11 +14,11 @@ import org.eclipse.collections.api.iterator.MutableBooleanIterator;
 import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
 import org.eclipse.collections.impl.stack.primitive.AbstractBooleanStackTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link UnmodifiableBooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stack/primitive/AbstractBooleanStackTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stack/primitive/AbstractBooleanStackTestCase.java
@@ -19,12 +19,12 @@ import org.eclipse.collections.impl.collection.mutable.primitive.AbstractBoolean
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.stack.mutable.ArrayStack;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract JUnit test for {@link BooleanStack}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/stream/PrimitiveStreamsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/stream/PrimitiveStreamsTest.java
@@ -52,9 +52,9 @@ import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.collections.impl.factory.primitive.LongStacks;
 import org.eclipse.collections.impl.list.primitive.IntInterval;
 import org.eclipse.collections.impl.list.primitive.LongInterval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @since 9.0

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CharAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CharAdapterTest.java
@@ -16,11 +16,11 @@ import org.eclipse.collections.api.list.primitive.ImmutableCharList;
 import org.eclipse.collections.impl.factory.Strings;
 import org.eclipse.collections.impl.factory.primitive.CharBags;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableCharListTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CharAdapterTest extends AbstractImmutableCharListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointAdapterTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointAdapterTest.java
@@ -20,15 +20,15 @@ import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.Strings;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableIntListTestCase;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CodePointAdapterTest extends AbstractImmutableIntListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointListTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/string/immutable/CodePointListTest.java
@@ -20,13 +20,13 @@ import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.list.immutable.primitive.AbstractImmutableIntListTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CodePointListTest extends AbstractImmutableIntListTestCase
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/AbstractImmutableEntryTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/AbstractImmutableEntryTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.tuple;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractImmutableEntryTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/TuplesTest.java
@@ -24,13 +24,13 @@ import org.eclipse.collections.api.tuple.Triplet;
 import org.eclipse.collections.api.tuple.Twin;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TuplesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanBooleanPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanBooleanPairImplTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link BooleanBooleanPairImpl}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanObjectPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/BooleanObjectPairImplTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link BooleanBooleanPairImpl}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/ObjectBooleanPairImplTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/ObjectBooleanPairImplTest.java
@@ -12,12 +12,12 @@ package org.eclipse.collections.impl.tuple.primitive;
 
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link ObjectBooleanPairImpl}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/PrimitiveTuplesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/tuple/primitive/PrimitiveTuplesTest.java
@@ -74,11 +74,11 @@ import org.eclipse.collections.api.tuple.primitive.ShortFloatPair;
 import org.eclipse.collections.api.tuple.primitive.ShortIntPair;
 import org.eclipse.collections.api.tuple.primitive.ShortLongPair;
 import org.eclipse.collections.api.tuple.primitive.ShortObjectPair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PrimitiveTuplesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayIterateTest.java
@@ -62,17 +62,17 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ArrayIterateTest
 {
@@ -357,7 +357,7 @@ public class ArrayIterateTest
         BooleanArrayList target = new BooleanArrayList();
         MutableBooleanList result = ArrayIterate.collectBoolean(objectArray, PrimitiveFunctions.integerIsPositive(), target);
         assertEquals(this.getExpectedBooleanResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private BooleanArrayList getExpectedBooleanResults()
@@ -381,7 +381,7 @@ public class ArrayIterateTest
         ByteArrayList target = new ByteArrayList();
         ByteArrayList result = ArrayIterate.collectByte(objectArray, PrimitiveFunctions.unboxIntegerToByte(), target);
         assertEquals(this.getExpectedByteResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private ByteArrayList getExpectedByteResults()
@@ -405,7 +405,7 @@ public class ArrayIterateTest
         CharArrayList target = new CharArrayList();
         CharArrayList result = ArrayIterate.collectChar(objectArray, PrimitiveFunctions.unboxIntegerToChar(), target);
         assertEquals(this.getExpectedCharResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private CharArrayList getExpectedCharResults()
@@ -429,7 +429,7 @@ public class ArrayIterateTest
         DoubleArrayList target = new DoubleArrayList();
         DoubleArrayList result = ArrayIterate.collectDouble(objectArray, PrimitiveFunctions.unboxIntegerToDouble(), target);
         assertEquals(this.getExpectedDoubleResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private DoubleArrayList getExpectedDoubleResults()
@@ -453,7 +453,7 @@ public class ArrayIterateTest
         FloatArrayList target = new FloatArrayList();
         FloatArrayList result = ArrayIterate.collectFloat(objectArray, PrimitiveFunctions.unboxIntegerToFloat(), target);
         assertEquals(this.getExpectedFloatResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private FloatArrayList getExpectedFloatResults()
@@ -477,7 +477,7 @@ public class ArrayIterateTest
         IntArrayList target = new IntArrayList();
         IntArrayList result = ArrayIterate.collectInt(objectArray, PrimitiveFunctions.unboxIntegerToInt(), target);
         assertEquals(this.getExpectedIntResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private IntArrayList getExpectedIntResults()
@@ -501,7 +501,7 @@ public class ArrayIterateTest
         LongArrayList target = new LongArrayList();
         LongArrayList result = ArrayIterate.collectLong(objectArray, PrimitiveFunctions.unboxIntegerToLong(), target);
         assertEquals(this.getExpectedLongResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private LongArrayList getExpectedLongResults()
@@ -525,7 +525,7 @@ public class ArrayIterateTest
         ShortArrayList target = new ShortArrayList();
         ShortArrayList result = ArrayIterate.collectShort(objectArray, PrimitiveFunctions.unboxIntegerToShort(), target);
         assertEquals(this.getExpectedShortResults(), result);
-        assertSame("Target List not returned as result", target, result);
+        assertSame(target, result, "Target List not returned as result");
     }
 
     private ShortArrayList getExpectedShortResults()

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ArrayListIterateTest.java
@@ -58,19 +58,19 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.multimap.list.FastListMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link ArrayListIterate}.
@@ -376,7 +376,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableBooleanList target = new BooleanArrayList();
         MutableBooleanList actual = ArrayListIterate.collectBoolean(list, PrimitiveFunctions.integerIsPositive(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(BooleanArrayList.newListWith(false, false, true), actual);
     }
 
@@ -407,7 +407,7 @@ public class ArrayListIterateTest
             expected.add(true);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -424,7 +424,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableByteList target = new ByteArrayList();
         MutableByteList actual = ArrayListIterate.collectByte(list, PrimitiveFunctions.unboxIntegerToByte(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(ByteArrayList.newListWith((byte) -1, (byte) 0, (byte) 4), actual);
     }
 
@@ -453,7 +453,7 @@ public class ArrayListIterateTest
             expected.add((byte) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -470,7 +470,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableCharList target = new CharArrayList();
         MutableCharList actual = ArrayListIterate.collectChar(list, PrimitiveFunctions.unboxIntegerToChar(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(CharArrayList.newListWith((char) -1, (char) 0, (char) 4), actual);
     }
 
@@ -499,7 +499,7 @@ public class ArrayListIterateTest
             expected.add((char) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -516,7 +516,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableDoubleList target = new DoubleArrayList();
         MutableDoubleList actual = ArrayListIterate.collectDouble(list, PrimitiveFunctions.unboxIntegerToDouble(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(DoubleArrayList.newListWith(-1.0d, 0.0d, 4.0d), actual);
     }
 
@@ -545,7 +545,7 @@ public class ArrayListIterateTest
             expected.add((double) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -562,7 +562,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableFloatList target = new FloatArrayList();
         MutableFloatList actual = ArrayListIterate.collectFloat(list, PrimitiveFunctions.unboxIntegerToFloat(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(FloatArrayList.newListWith(-1.0f, 0.0f, 4.0f), actual);
     }
 
@@ -591,7 +591,7 @@ public class ArrayListIterateTest
             expected.add((float) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -608,7 +608,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableIntList target = new IntArrayList();
         MutableIntList actual = ArrayListIterate.collectInt(list, PrimitiveFunctions.unboxIntegerToInt(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(IntArrayList.newListWith(-1, 0, 4), actual);
     }
 
@@ -637,7 +637,7 @@ public class ArrayListIterateTest
             expected.add(i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -654,7 +654,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableLongList target = new LongArrayList();
         MutableLongList actual = ArrayListIterate.collectLong(list, PrimitiveFunctions.unboxIntegerToLong(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(LongArrayList.newListWith(-1L, 0L, 4L), actual);
     }
 
@@ -683,7 +683,7 @@ public class ArrayListIterateTest
             expected.add((long) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -700,7 +700,7 @@ public class ArrayListIterateTest
         ArrayList<Integer> list = this.createIntegerList();
         MutableShortList target = new ShortArrayList();
         MutableShortList actual = ArrayListIterate.collectShort(list, PrimitiveFunctions.unboxIntegerToShort(), target);
-        assertSame("Target list sent as parameter not returned", target, actual);
+        assertSame(target, actual, "Target list sent as parameter not returned");
         assertEquals(ShortArrayList.newListWith((short) -1, (short) 0, (short) 4), actual);
     }
 
@@ -729,7 +729,7 @@ public class ArrayListIterateTest
             expected.add((short) i);
         }
         assertEquals(expected, actual);
-        assertSame("Target sent as parameter was not returned as result", target, actual);
+        assertSame(target, actual, "Target sent as parameter was not returned as result");
     }
 
     private ArrayList<Integer> createIntegerList()

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateNullTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateNullTest.java
@@ -21,10 +21,10 @@ import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
 import org.eclipse.collections.impl.list.mutable.primitive.ShortArrayList;
 import org.eclipse.collections.impl.utility.internal.IterableIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit test for the null handling behavior of {@link Iterate}, {@link ArrayIterate}, {@link ArrayListIterate},

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/IterateTest.java
@@ -102,26 +102,26 @@ import org.eclipse.collections.impl.multimap.set.sorted.TreeSortedSetMultimap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iBag;
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IterateTest
 {
     private MutableList<Iterable<Integer>> iterables;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         this.iterables = Lists.mutable.of();
@@ -1298,7 +1298,7 @@ public class IterateTest
             MutableBooleanCollection expected = new BooleanArrayList();
             MutableBooleanCollection actual = Iterate.collectBoolean(each, PrimitiveFunctions.integerIsPositive(), expected);
             assertTrue(expected.containsAll(true, true, true, true, true));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectBoolean(null, PrimitiveFunctions.integerIsPositive(), new BooleanArrayList()));
     }
@@ -1320,7 +1320,7 @@ public class IterateTest
             MutableByteCollection expected = new ByteArrayList();
             MutableByteCollection actual = Iterate.collectByte(each, PrimitiveFunctions.unboxIntegerToByte(), expected);
             assertTrue(actual.containsAll((byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectByte(null, PrimitiveFunctions.unboxIntegerToByte(), new ByteArrayList()));
     }
@@ -1342,7 +1342,7 @@ public class IterateTest
             MutableCharCollection expected = new CharArrayList();
             MutableCharCollection actual = Iterate.collectChar(each, PrimitiveFunctions.unboxIntegerToChar(), expected);
             assertTrue(actual.containsAll((char) 1, (char) 2, (char) 3, (char) 4, (char) 5));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectChar(null, PrimitiveFunctions.unboxIntegerToChar(), new CharArrayList()));
     }
@@ -1364,7 +1364,7 @@ public class IterateTest
             MutableDoubleCollection expected = new DoubleArrayList();
             MutableDoubleCollection actual = Iterate.collectDouble(each, PrimitiveFunctions.unboxIntegerToDouble(), expected);
             assertTrue(actual.containsAll(1.0d, 2.0d, 3.0d, 4.0d, 5.0d));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectDouble(null, PrimitiveFunctions.unboxIntegerToDouble(), new DoubleArrayList()));
     }
@@ -1386,7 +1386,7 @@ public class IterateTest
             MutableFloatCollection expected = new FloatArrayList();
             MutableFloatCollection actual = Iterate.collectFloat(each, PrimitiveFunctions.unboxIntegerToFloat(), expected);
             assertTrue(actual.containsAll(1.0f, 2.0f, 3.0f, 4.0f, 5.0f));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectFloat(null, PrimitiveFunctions.unboxIntegerToFloat(), new FloatArrayList()));
     }
@@ -1408,7 +1408,7 @@ public class IterateTest
             MutableIntCollection expected = new IntArrayList();
             MutableIntCollection actual = Iterate.collectInt(each, PrimitiveFunctions.unboxIntegerToInt(), expected);
             assertTrue(actual.containsAll(1, 2, 3, 4, 5));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectInt(null, PrimitiveFunctions.unboxIntegerToInt(), new IntArrayList()));
     }
@@ -1430,7 +1430,7 @@ public class IterateTest
             MutableLongCollection expected = new LongArrayList();
             MutableLongCollection actual = Iterate.collectLong(each, PrimitiveFunctions.unboxIntegerToLong(), expected);
             assertTrue(actual.containsAll(1L, 2L, 3L, 4L, 5L));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectLong(null, PrimitiveFunctions.unboxIntegerToLong(), new LongArrayList()));
     }
@@ -1452,7 +1452,7 @@ public class IterateTest
             MutableShortCollection expected = new ShortArrayList();
             MutableShortCollection actual = Iterate.collectShort(each, PrimitiveFunctions.unboxIntegerToShort(), expected);
             assertTrue(actual.containsAll((short) 1, (short) 2, (short) 3, (short) 4, (short) 5));
-            assertSame("Target list sent as parameter not returned", expected, actual);
+            assertSame(expected, actual, "Target list sent as parameter not returned");
         });
         assertThrows(IllegalArgumentException.class, () -> Iterate.collectShort(null, PrimitiveFunctions.unboxIntegerToShort(), new ShortArrayList()));
     }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/LazyIterateTest.java
@@ -29,9 +29,9 @@ import org.eclipse.collections.impl.math.IntegerSum;
 import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LazyIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/ListIterateTest.java
@@ -48,19 +48,19 @@ import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.iSet;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ListIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/MapIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/MapIterateTest.java
@@ -58,15 +58,15 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.sorted.mutable.TreeSortedSet;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MapIterateTest
 {
@@ -596,7 +596,7 @@ public class MapIterateTest
         BooleanHashBag target = new BooleanHashBag();
         BooleanHashBag result = MapIterate.collectBoolean(MapIterateTest.newLittleMap(), PrimitiveFunctions.integerIsPositive(), target);
         assertEquals(BooleanHashBag.newBagWith(true, true), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -612,7 +612,7 @@ public class MapIterateTest
         ByteHashBag target = new ByteHashBag();
         ByteHashBag result = MapIterate.collectByte(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToByte(), target);
         assertEquals(ByteHashBag.newBagWith((byte) 1, (byte) 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -628,7 +628,7 @@ public class MapIterateTest
         CharHashBag target = new CharHashBag();
         CharHashBag result = MapIterate.collectChar(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToChar(), target);
         assertEquals(CharHashBag.newBagWith((char) 1, (char) 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -644,7 +644,7 @@ public class MapIterateTest
         DoubleHashBag target = new DoubleHashBag();
         DoubleHashBag result = MapIterate.collectDouble(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToDouble(), target);
         assertEquals(DoubleHashBag.newBagWith(1, 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -660,7 +660,7 @@ public class MapIterateTest
         FloatHashBag target = new FloatHashBag();
         FloatHashBag result = MapIterate.collectFloat(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToFloat(), target);
         assertEquals(FloatHashBag.newBagWith(1, 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -676,7 +676,7 @@ public class MapIterateTest
         IntHashBag target = new IntHashBag();
         IntHashBag result = MapIterate.collectInt(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToInt(), target);
         assertEquals(IntHashBag.newBagWith(1, 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -692,7 +692,7 @@ public class MapIterateTest
         LongHashBag target = new LongHashBag();
         LongHashBag result = MapIterate.collectLong(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToLong(), target);
         assertEquals(LongHashBag.newBagWith(1L, 2L), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test
@@ -708,7 +708,7 @@ public class MapIterateTest
         ShortHashBag target = new ShortHashBag();
         MutableShortCollection result = MapIterate.collectShort(MapIterateTest.newLittleMap(), PrimitiveFunctions.unboxIntegerToShort(), target);
         assertEquals(ShortHashBag.newBagWith((short) 1, (short) 2), result.toBag());
-        assertSame("Target sent as parameter was not returned as result", target, result);
+        assertSame(target, result, "Target sent as parameter was not returned as result");
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/OrderedIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/OrderedIterateTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.collections.impl.utility;
 
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for {@link OrderedIterate}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/StringIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/StringIterateTest.java
@@ -41,15 +41,15 @@ import org.eclipse.collections.impl.string.immutable.CodePointAdapter;
 import org.eclipse.collections.impl.string.immutable.CodePointList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JUnit test for {@link StringIterate}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/InternalArrayIterateTest.java
@@ -26,9 +26,9 @@ import org.eclipse.collections.impl.factory.primitive.FloatLists;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.eclipse.collections.impl.factory.primitive.ShortLists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InternalArrayIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/IterableIterateTest.java
@@ -41,17 +41,17 @@ import org.eclipse.collections.impl.math.Sum;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * JUnit test for {@link IterableIterate}.

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/RandomAccessListIterateTest.java
@@ -39,17 +39,17 @@ import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.eclipse.collections.impl.factory.Iterables.iList;
 import static org.eclipse.collections.impl.factory.Iterables.mList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RandomAccessListIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterablesTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterablesTest.java
@@ -12,9 +12,9 @@ package org.eclipse.collections.impl.utility.internal;
 
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.SetIterable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SetIterablesTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/SetIterateTest.java
@@ -15,11 +15,11 @@ import java.util.Set;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SetIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIterableIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIterableIterateTest.java
@@ -15,11 +15,11 @@ import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BooleanIterableIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIteratorIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/internal/primitive/BooleanIteratorIterateTest.java
@@ -15,7 +15,7 @@ import org.eclipse.collections.impl.block.factory.primitive.BooleanPredicates;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.primitive.BooleanArrayList;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BooleanIteratorIterateTest
 {

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/utility/primitive/LazyBooleanIterateTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/utility/primitive/LazyBooleanIterateTest.java
@@ -15,10 +15,10 @@ import org.eclipse.collections.api.LazyBooleanIterable;
 import org.eclipse.collections.api.block.procedure.primitive.BooleanProcedure;
 import org.eclipse.collections.api.list.primitive.MutableBooleanList;
 import org.eclipse.collections.impl.factory.primitive.BooleanLists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LazyBooleanIterateTest
 {


### PR DESCRIPTION
Moving only **unit-tests** module to Junit5.

* Replacing imports
* Replacing annotations for some backwards incompatible changes (BeforeEach vs Before)
* Incompatible syntax for assertEquals - (bool, bool, string) in Junit5 vs (string, bool, bool) in Junit4

@motlin a long one - i'm sry! Vast majority of changes are replacing imports, and a few to fix the backwards compatibility issues where we flip the order of params.