### PR TITLE
Prepare unit-tests-java8 for migration

### DIFF
--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/CollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/CollectionTestCase.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertContains;
 import static org.eclipse.collections.impl.test.Verify.assertNotContains;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -71,15 +71,15 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
         assertTrue(collection.contains(3));
         assertTrue(collection.contains(2));
         assertTrue(collection.contains(1));
-        assertEquals(this.allowsDuplicates(), collection.add(4));
+        assertIterablesEqual(this.allowsDuplicates(), collection.add(4));
         assertTrue(collection.contains(4));
         if (this.allowsDuplicates())
         {
-            assertEquals(this.newWith(3, 2, 1, 4, 4), collection);
+            assertIterablesEqual(this.newWith(3, 2, 1, 4, 4), collection);
         }
         else
         {
-            assertEquals(this.newWith(3, 2, 1, 4), collection);
+            assertIterablesEqual(this.newWith(3, 2, 1, 4), collection);
         }
 
         Collection<Integer> collection2 = this.newWith();
@@ -88,7 +88,7 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
             assertFalse(collection2.contains(each));
             assertTrue(collection2.add(each));
             assertTrue(collection2.contains(each));
-            assertEquals(this.allowsDuplicates(), collection2.add(each));
+            assertIterablesEqual(this.allowsDuplicates(), collection2.add(each));
             assertTrue(collection2.contains(each));
         }
     }
@@ -99,13 +99,13 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
         {
             Collection<Integer> collection = this.newWith(3, 2, 1);
             assertFalse(collection.remove(4));
-            assertEquals(this.newWith(3, 2, 1), collection);
+            assertIterablesEqual(this.newWith(3, 2, 1), collection);
             assertTrue(collection.remove(3));
-            assertEquals(this.newWith(2, 1), collection);
+            assertIterablesEqual(this.newWith(2, 1), collection);
             assertTrue(collection.remove(2));
-            assertEquals(this.newWith(1), collection);
+            assertIterablesEqual(this.newWith(1), collection);
             assertTrue(collection.remove(1));
-            assertEquals(this.newWith(), collection);
+            assertIterablesEqual(this.newWith(), collection);
         }
 
         if (this.allowsDuplicates())
@@ -114,22 +114,22 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
             assertTrue(collection.remove(3));
             assertTrue(collection.remove(2));
             assertTrue(collection.remove(1));
-            assertEquals(this.newWith(3, 3, 2), collection);
+            assertIterablesEqual(this.newWith(3, 3, 2), collection);
 
             assertTrue(collection.remove(3));
             assertTrue(collection.remove(2));
             assertFalse(collection.remove(1));
-            assertEquals(this.newWith(3), collection);
+            assertIterablesEqual(this.newWith(3), collection);
 
             assertTrue(collection.remove(3));
             assertFalse(collection.remove(2));
             assertFalse(collection.remove(1));
-            assertEquals(this.newWith(), collection);
+            assertIterablesEqual(this.newWith(), collection);
 
             assertFalse(collection.remove(3));
             assertFalse(collection.remove(2));
             assertFalse(collection.remove(1));
-            assertEquals(this.newWith(), collection);
+            assertIterablesEqual(this.newWith(), collection);
         }
 
         Integer[] array = COLLISIONS.toArray(new Integer[]{});
@@ -164,19 +164,19 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
         {
             Collection<Integer> collection = this.newWith(3, 2, 1);
             assertTrue(collection.removeAll(Lists.mutable.with(1, 2, 4)));
-            assertEquals(this.newWith(3), collection);
+            assertIterablesEqual(this.newWith(3), collection);
 
             Collection<Integer> collection2 = this.newWith(3, 2, 1);
             assertFalse(collection2.removeAll(Lists.mutable.with(5, 4)));
-            assertEquals(this.newWith(3, 2, 1), collection2);
+            assertIterablesEqual(this.newWith(3, 2, 1), collection2);
 
             Collection<Integer> collection3 = this.newWith(3, 2, 1);
             assertFalse(collection2.removeAll(Lists.mutable.with()));
-            assertEquals(this.newWith(3, 2, 1), collection3);
+            assertIterablesEqual(this.newWith(3, 2, 1), collection3);
 
             Collection<Integer> collection4 = this.newWith(5, 4, 3, 2, 1);
             assertTrue(collection4.removeAll(Lists.mutable.with(4, 2)));
-            assertEquals(this.newWith(5, 3, 1), collection4);
+            assertIterablesEqual(this.newWith(5, 3, 1), collection4);
         }
 
         if (this.allowsDuplicates())
@@ -184,7 +184,7 @@ public interface CollectionTestCase extends IterableTestCase, CollisionsTestCase
             Collection<Integer> collection = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
             assertTrue(collection.removeAll(Lists.mutable.with(3, 1)));
             assertFalse(collection.removeAll(Lists.mutable.with(3, 1)));
-            assertEquals(this.newWith(4, 4, 4, 4, 2, 2), collection);
+            assertIterablesEqual(this.newWith(4, 4, 4, 4, 2, 2), collection);
         }
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/IterableTestCase.java
@@ -44,11 +44,12 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.list.mutable.MultiReaderFastList;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.impl.test.Verify.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
@@ -60,65 +61,65 @@ public interface IterableTestCase
 
     boolean allowsDuplicates();
 
-    static void assertEquals(Object o1, Object o2)
+    static void assertIterablesEqual(Object o1, Object o2)
     {
         if (o1 instanceof ListIterable<?> && o2 instanceof LazyIterable<?>)
         {
-            IterableTestCase.assertEquals(o1, ((LazyIterable<?>) o2).toList());
+            assertIterablesEqual(o1, ((LazyIterable<?>) o2).toList());
             return;
         }
         if (o1 instanceof BooleanList && o2 instanceof LazyBooleanIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyBooleanIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyBooleanIterable) o2).toList());
             return;
         }
         if (o1 instanceof ByteList && o2 instanceof LazyByteIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyByteIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyByteIterable) o2).toList());
             return;
         }
         if (o1 instanceof CharList && o2 instanceof LazyCharIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyCharIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyCharIterable) o2).toList());
             return;
         }
         if (o1 instanceof DoubleList && o2 instanceof LazyDoubleIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyDoubleIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyDoubleIterable) o2).toList());
             return;
         }
         if (o1 instanceof FloatList && o2 instanceof LazyFloatIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyFloatIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyFloatIterable) o2).toList());
             return;
         }
         if (o1 instanceof IntList && o2 instanceof LazyIntIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyIntIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyIntIterable) o2).toList());
             return;
         }
         if (o1 instanceof LongList && o2 instanceof LazyLongIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyLongIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyLongIterable) o2).toList());
             return;
         }
         if (o1 instanceof ShortList && o2 instanceof LazyShortIterable)
         {
-            IterableTestCase.assertEquals(o1, ((LazyShortIterable) o2).toList());
+            assertIterablesEqual(o1, ((LazyShortIterable) o2).toList());
             return;
         }
 
-        Assert.assertEquals(o1, o2);
+        assertEquals(o1, o2);
 
-        Assert.assertNotNull("Neither item should equal null", o1);
-        Assert.assertNotNull("Neither item should equal null", o2);
-        assertNotEquals("Neither item should equal new Object()", o1.equals(new Object()));
-        assertNotEquals("Neither item should equal new Object()", o2.equals(new Object()));
-        Assert.assertEquals(o1, o1);
-        Assert.assertEquals(o2, o2);
-        Assert.assertEquals(o1, o2);
-        Assert.assertEquals(o2, o1);
-        Assert.assertEquals(o1.hashCode(), o2.hashCode());
+        assertNotNull("Neither item should equal null", o1);
+        assertNotNull("Neither item should equal null", o2);
+        assertIterablesNotEqual("Neither item should equal new Object()", o1.equals(new Object()));
+        assertIterablesNotEqual("Neither item should equal new Object()", o2.equals(new Object()));
+        assertEquals(o1, o1);
+        assertEquals(o2, o2);
+        assertEquals(o1, o2);
+        assertEquals(o2, o1);
+        assertEquals(o1.hashCode(), o2.hashCode());
 
         checkNotSame(o1, o2);
 
@@ -131,7 +132,7 @@ public interface IterableTestCase
                 || o1 instanceof List<?> || o2 instanceof List<?>
                 || o1 instanceof SortedSet<?> || o2 instanceof SortedSet<?>)
         {
-            assertIterablesEqual((Iterable<?>) o1, (Iterable<?>) o2);
+            Verify.assertIterablesEqual((Iterable<?>) o1, (Iterable<?>) o2);
             if (o1 instanceof SortedIterable<?> || o2 instanceof SortedIterable<?>)
             {
                 Comparator<?> comparator1 = ((SortedIterable<?>) o1).comparator();
@@ -144,7 +145,7 @@ public interface IterableTestCase
         }
         else if (o1 instanceof SortedMap<?, ?> || o2 instanceof SortedMap<?, ?>)
         {
-            IterableTestCase.assertEquals(((SortedMap<?, ?>) o1).keySet(), ((SortedMap<?, ?>) o2).keySet());
+            assertIterablesEqual(((SortedMap<?, ?>) o1).keySet(), ((SortedMap<?, ?>) o2).keySet());
         }
     }
 
@@ -166,17 +167,17 @@ public interface IterableTestCase
         assertNotSame(o1, o2);
     }
 
-    static void assertNotEquals(Object o1, Object o2)
+    static void assertIterablesNotEqual(Object o1, Object o2)
     {
-        Assert.assertNotEquals(o1, o2);
-        Assert.assertNotEquals(o2, o1);
+        assertNotEquals(o1, o2);
+        assertNotEquals(o2, o1);
 
-        Assert.assertNotNull("Neither item should equal null", o1);
-        Assert.assertNotNull("Neither item should equal null", o2);
-        Assert.assertNotEquals("Neither item should equal new Object()", o1.equals(new Object()));
-        Assert.assertNotEquals("Neither item should equal new Object()", o2.equals(new Object()));
-        Assert.assertEquals(o1, o1);
-        Assert.assertEquals(o2, o2);
+        assertNotNull("Neither item should equal null", o1);
+        assertNotNull("Neither item should equal null", o2);
+        assertNotEquals("Neither item should equal new Object()", o1.equals(new Object()));
+        assertNotEquals("Neither item should equal new Object()", o2.equals(new Object()));
+        assertEquals(o1, o1);
+        assertEquals(o2, o2);
     }
 
     static <T> void addAllTo(T[] elements, MutableCollection<T> result)
@@ -203,17 +204,17 @@ public interface IterableTestCase
     {
         Verify.assertEqualsAndHashCode(this.newWith(3, 3, 3, 2, 2, 1), this.newWith(3, 3, 3, 2, 2, 1));
 
-        assertNotEquals(this.newWith(4, 3, 2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(4, 3, 2, 1));
+        assertIterablesNotEqual(this.newWith(4, 3, 2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(4, 3, 2, 1));
 
-        assertNotEquals(this.newWith(2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(2, 1));
+        assertIterablesNotEqual(this.newWith(2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(2, 1));
 
-        assertNotEquals(this.newWith(3, 3, 2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(3, 3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 3, 2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(3, 3, 2, 1));
 
-        assertNotEquals(this.newWith(3, 3, 2, 1), this.newWith(3, 2, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 2, 1), this.newWith(3, 3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 3, 2, 1), this.newWith(3, 2, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 2, 1), this.newWith(3, 3, 2, 1));
     }
 
     @Test
@@ -231,7 +232,7 @@ public interface IterableTestCase
         assertTrue(set.add(iterator.next()));
         assertTrue(set.add(iterator.next()));
         assertTrue(set.add(iterator.next()));
-        IterableTestCase.assertEquals(Sets.immutable.with(3, 2, 1), set);
+        assertIterablesEqual(Sets.immutable.with(3, 2, 1), set);
 
         assertThrows(NoSuchElementException.class, () -> this.newWith().iterator().next());
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableOrderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableOrderedIterableTestCase.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 
 public interface MutableOrderedIterableTestCase extends OrderedIterableTestCase
 {
@@ -26,6 +26,6 @@ public interface MutableOrderedIterableTestCase extends OrderedIterableTestCase
         Iterator<Integer> iterator = iterable.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(this.newWith(3, 3, 2, 2, 1), iterable);
+        assertIterablesEqual(this.newWith(3, 3, 2, 2, 1), iterable);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedIterableTestCase.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 
 public interface MutableSortedIterableTestCase extends MutableOrderedIterableTestCase
 {
@@ -24,8 +24,8 @@ public interface MutableSortedIterableTestCase extends MutableOrderedIterableTes
     {
         Iterable<Integer> iterable = this.newWith(3, 2, 1);
         Iterator<Integer> iterator = iterable.iterator();
-        assertEquals(Integer.valueOf(3), iterator.next());
+        assertIterablesEqual(Integer.valueOf(3), iterator.next());
         iterator.remove();
-        assertEquals(this.newWith(2, 1), iterable);
+        assertIterablesEqual(this.newWith(2, 1), iterable);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedNaturalOrderTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableSortedNaturalOrderTestCase.java
@@ -20,7 +20,7 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.test.collection.mutable.MutableCollectionTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +35,7 @@ public interface MutableSortedNaturalOrderTestCase extends SortedNaturalOrderTes
         Iterator<Integer> iterator = iterable.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(this.newWith(1, 1, 2, 2, 3), iterable);
+        assertIterablesEqual(this.newWith(1, 1, 2, 2, 3), iterable);
     }
 
     @Override
@@ -44,12 +44,12 @@ public interface MutableSortedNaturalOrderTestCase extends SortedNaturalOrderTes
     {
         MutableCollection<Integer> collection1 = this.newWith(1, 1, 2, 2, 3, 3, 4, 4, 5, 5);
         assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
-        assertEquals(this.getExpectedFiltered(1, 1, 3, 3, 5, 5), collection1);
+        assertIterablesEqual(this.getExpectedFiltered(1, 1, 3, 3, 5, 5), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
         assertFalse(collection2.removeIf(Predicates.equal(5)));
         assertTrue(collection2.removeIf(Predicates.greaterThan(0)));
-        assertEquals(this.newWith(), collection2);
+        assertIterablesEqual(this.newWith(), collection2);
         assertFalse(collection2.removeIf(Predicates.greaterThan(2)));
 
         Predicate<Object> predicate = null;
@@ -62,13 +62,13 @@ public interface MutableSortedNaturalOrderTestCase extends SortedNaturalOrderTes
     {
         MutableCollection<Integer> collection = this.newWith(1, 1, 2, 2, 3, 3, 4, 4, 5, 5);
         assertTrue(collection.removeIfWith(Predicates2.in(), Lists.immutable.with(5, 3, 1)));
-        assertEquals(this.getExpectedFiltered(2, 2, 4, 4), collection);
+        assertIterablesEqual(this.getExpectedFiltered(2, 2, 4, 4), collection);
         assertThrows(NullPointerException.class, () -> this.newWith(7, 4, 5, 1).removeIfWith(null, this));
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
         assertFalse(collection2.removeIfWith(Predicates2.equal(), 5));
         assertTrue(collection2.removeIfWith(Predicates2.greaterThan(), 0));
-        assertEquals(this.newWith(), collection2);
+        assertIterablesEqual(this.newWith(), collection2);
         assertFalse(collection2.removeIfWith(Predicates2.greaterThan(), 2));
 
         assertThrows(NullPointerException.class, () -> this.newWith(1, 4, 5, 7).removeIfWith(null, null));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableUnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/MutableUnorderedIterableTestCase.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertThat;
 
@@ -29,7 +29,7 @@ public interface MutableUnorderedIterableTestCase extends UnorderedIterableTestC
         Iterator<Integer> iterator = iterable.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(this.allowsDuplicates() ? 5 : 2, Iterate.sizeOf(iterable));
+        assertIterablesEqual(this.allowsDuplicates() ? 5 : 2, Iterate.sizeOf(iterable));
         assertThat(
                 iterable,
                 isOneOf(

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/OrderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/OrderedIterableTestCase.java
@@ -25,10 +25,10 @@ import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 
@@ -42,10 +42,10 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     {
         RichIterable<ObjectIntPair<Integer>> pairs = ((OrderedIterable<Integer>) this.newWith(3, 2, 1, 0))
                 .collectWithIndex(PrimitiveTuples::pair);
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(3, 2, 1, 0),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
     }
@@ -58,19 +58,19 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     {
         RichIterable<ObjectIntPair<Integer>> pairs = ((OrderedIterable<Integer>) this.newWith(3, 2, 1, 0))
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntLists.mutable.with(0, 1, 2, 3),
                 pairs.collectInt(ObjectIntPair::getTwo, IntLists.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Lists.mutable.with(3, 2, 1, 0),
                 pairs.collect(ObjectIntPair::getOne, Lists.mutable.empty()));
 
         RichIterable<ObjectIntPair<Integer>> setOfPairs = ((OrderedIterable<Integer>) this.newWith(3, 2, 1, 0))
                 .collectWithIndex(PrimitiveTuples::pair, Lists.mutable.empty());
-        Assert.assertEquals(
+        assertEquals(
                 IntSets.mutable.with(0, 1, 2, 3),
                 setOfPairs.collectInt(ObjectIntPair::getTwo, IntSets.mutable.empty()));
-        Assert.assertEquals(
+        assertEquals(
                 Sets.mutable.with(3, 2, 1, 0),
                 setOfPairs.collect(ObjectIntPair::getOne, Sets.mutable.empty()));
     }
@@ -78,7 +78,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     @Test
     default void OrderedIterable_getFirst()
     {
-        assertEquals(Integer.valueOf(3), this.newWith(3, 3, 3, 2, 2, 1).getFirst());
+        assertIterablesEqual(Integer.valueOf(3), this.newWith(3, 3, 3, 2, 2, 1).getFirst());
     }
 
     @Test
@@ -90,7 +90,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     @Test
     default void OrderedIterable_getFirstOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getFirstOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getFirstOptional());
     }
 
     @Test
@@ -102,7 +102,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     @Test
     default void OrderedIterable_getLast()
     {
-        assertEquals(Integer.valueOf(1), this.newWith(3, 3, 3, 2, 2, 1).getLast());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(3, 3, 3, 2, 2, 1).getLast());
     }
 
     @Test
@@ -114,7 +114,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     @Test
     default void OrderedIterable_getLastOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getLastOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getLastOptional());
     }
 
     @Test
@@ -127,9 +127,9 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     default void OrderedIterable_next()
     {
         Iterator<Integer> iterator = this.newWith(3, 2, 1).iterator();
-        assertEquals(Integer.valueOf(3), iterator.next());
-        assertEquals(Integer.valueOf(2), iterator.next());
-        assertEquals(Integer.valueOf(1), iterator.next());
+        assertIterablesEqual(Integer.valueOf(3), iterator.next());
+        assertIterablesEqual(Integer.valueOf(2), iterator.next());
+        assertIterablesEqual(Integer.valueOf(1), iterator.next());
     }
 
     @Test
@@ -168,7 +168,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
     default void OrderedIterable_zipWithIndex()
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(4, 0),
                         Tuples.pair(4, 1),
@@ -189,7 +189,7 @@ public interface OrderedIterableTestCase extends RichIterableTestCase
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         MutableList<Pair<Integer, Integer>> target = Lists.mutable.empty();
         MutableList<Pair<Integer, Integer>> result = iterable.zipWithIndex(target);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(4, 0),
                         Tuples.pair(4, 1),

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableTestCase.java
@@ -100,14 +100,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.multimap.bag.HashBagMultimap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
-import static org.eclipse.collections.test.IterableTestCase.assertNotEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesNotEqual;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -133,7 +133,7 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void newMutable_sanity()
     {
-        assertEquals(this.getExpectedFiltered(3, 2, 1), this.newMutableForFilter(3, 2, 1));
+        assertIterablesEqual(this.getExpectedFiltered(3, 2, 1), this.newMutableForFilter(3, 2, 1));
     }
 
     MutableBooleanCollection newBooleanForTransform(boolean... elements);
@@ -199,27 +199,27 @@ public interface RichIterableTestCase extends IterableTestCase
             RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
             MutableCollection<Integer> result = this.newMutableForFilter();
             iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-            assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), result);
+            assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(2, 2, 1);
             MutableCollection<Integer> result = this.newMutableForFilter();
             iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-            assertEquals(this.newMutableForFilter(12, 12, 11), result);
+            assertIterablesEqual(this.newMutableForFilter(12, 12, 11), result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(2, 1);
             MutableCollection<Integer> result = this.newMutableForFilter();
             iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-            assertEquals(this.newMutableForFilter(12, 11), result);
+            assertIterablesEqual(this.newMutableForFilter(12, 11), result);
         }
 
         RichIterable<Integer> iterable = this.newWith(1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-        assertEquals(this.newMutableForFilter(11), result);
+        assertIterablesEqual(this.newMutableForFilter(11), result);
 
         this.newWith().forEach(Procedures.cast(each -> fail()));
     }
@@ -230,7 +230,7 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.tap(result::add).forEach(Procedures.noop());
-        assertEquals(this.newMutableForFilter(3, 3, 3, 2, 2, 1), result);
+        assertIterablesEqual(this.newMutableForFilter(3, 3, 3, 2, 2, 1), result);
         this.newWith().tap(Procedures.cast(each -> fail()));
     }
 
@@ -240,13 +240,13 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), result);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), result);
     }
 
     @Test
     default void RichIterable_size_empty()
     {
-        assertEquals(0, this.newWith().size());
+        assertIterablesEqual(0, this.newWith().size());
     }
 
     @Test
@@ -281,7 +281,7 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
         Integer first = iterable.getFirst();
         assertThat(first, isOneOf(3, 2, 1));
-        assertEquals(iterable.iterator().next(), first);
+        assertIterablesEqual(iterable.iterator().next(), first);
     }
 
     @Test
@@ -296,7 +296,7 @@ public interface RichIterableTestCase extends IterableTestCase
         {
             iteratorLast = iterator.next();
         }
-        assertEquals(iteratorLast, last);
+        assertIterablesEqual(iteratorLast, last);
     }
 
     @Test
@@ -323,7 +323,7 @@ public interface RichIterableTestCase extends IterableTestCase
     default void RichIterable_getFirst_and_getLast()
     {
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
-        assertNotEquals(iterable.getFirst(), iterable.getLast());
+        assertIterablesNotEqual(iterable.getFirst(), iterable.getLast());
     }
 
     @Test
@@ -567,16 +567,16 @@ public interface RichIterableTestCase extends IterableTestCase
         {
             iterationOrder.add(iterator.next());
         }
-        assertEquals(this.expectedIterationOrder(), iterationOrder);
+        assertIterablesEqual(this.expectedIterationOrder(), iterationOrder);
 
         MutableCollection<Integer> expectedIterationOrder = this.expectedIterationOrder();
         MutableCollection<Integer> forEachWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().forEachWith((each, param) -> forEachWithIterationOrder.add(each), null);
-        assertEquals(expectedIterationOrder, forEachWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, forEachWithIterationOrder);
 
         MutableCollection<Integer> forEachWithIndexIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().forEachWithIndex((each, index) -> forEachWithIndexIterationOrder.add(each));
-        assertEquals(expectedIterationOrder, forEachWithIndexIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, forEachWithIndexIterationOrder);
     }
 
     @Test
@@ -588,80 +588,80 @@ public interface RichIterableTestCase extends IterableTestCase
 
         MutableCollection<Integer> selectIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().select(selectIterationOrder::add).forEach(noop);
-        assertEquals(expectedIterationOrder, selectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, selectIterationOrder);
 
         MutableCollection<Integer> selectTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().select(selectTargetIterationOrder::add, new HashBag<>());
-        assertEquals(expectedIterationOrder, selectTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, selectTargetIterationOrder);
 
         MutableCollection<Integer> selectWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().selectWith((each, param) -> selectWithIterationOrder.add(each), null).forEach(noop);
-        assertEquals(expectedIterationOrder, selectWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, selectWithIterationOrder);
 
         MutableCollection<Integer> selectWithTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().selectWith((each, param) -> selectWithTargetIterationOrder.add(each), null, new HashBag<>());
-        assertEquals(expectedIterationOrder, selectWithTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, selectWithTargetIterationOrder);
 
         MutableCollection<Integer> rejectIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().reject(rejectIterationOrder::add).forEach(noop);
-        assertEquals(expectedIterationOrder, rejectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, rejectIterationOrder);
 
         MutableCollection<Integer> rejectTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().reject(rejectTargetIterationOrder::add, new HashBag<>());
-        assertEquals(expectedIterationOrder, rejectTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, rejectTargetIterationOrder);
 
         MutableCollection<Integer> rejectWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().rejectWith((each, param) -> rejectWithIterationOrder.add(each), null).forEach(noop);
-        assertEquals(expectedIterationOrder, rejectWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, rejectWithIterationOrder);
 
         MutableCollection<Integer> rejectWithTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().rejectWith((each, param) -> rejectWithTargetIterationOrder.add(each), null, new HashBag<>());
-        assertEquals(expectedIterationOrder, rejectWithTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, rejectWithTargetIterationOrder);
 
         MutableCollection<Integer> partitionIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().partition(partitionIterationOrder::add);
-        assertEquals(expectedIterationOrder, partitionIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, partitionIterationOrder);
 
         MutableCollection<Integer> partitionWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().partitionWith((each, param) -> partitionWithIterationOrder.add(each), null);
-        assertEquals(expectedIterationOrder, partitionWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, partitionWithIterationOrder);
 
         MutableCollection<Integer> collectIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collect(collectIterationOrder::add).forEach(noop);
-        assertEquals(expectedIterationOrder, collectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIterationOrder);
 
         MutableCollection<Integer> collectTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collect(collectTargetIterationOrder::add, new HashBag<>());
-        assertEquals(expectedIterationOrder, collectTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectTargetIterationOrder);
 
         MutableCollection<Integer> collectWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectWith((each, param) -> collectWithIterationOrder.add(each), null).forEach(noop);
-        assertEquals(expectedIterationOrder, collectWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectWithIterationOrder);
 
         MutableCollection<Integer> collectWithTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectWith((each, param) -> collectWithTargetIterationOrder.add(each), null, new HashBag<>());
-        assertEquals(expectedIterationOrder, collectWithTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectWithTargetIterationOrder);
 
         MutableCollection<Integer> collectIfPredicateIterationOrder = this.newMutableForFilter();
         MutableCollection<Integer> collectIfFunctionIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectIf(collectIfPredicateIterationOrder::add, collectIfFunctionIterationOrder::add).forEach(noop);
-        assertEquals(expectedIterationOrder, collectIfPredicateIterationOrder);
-        assertEquals(expectedIterationOrder, collectIfFunctionIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIfPredicateIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIfFunctionIterationOrder);
 
         MutableCollection<Integer> collectIfPredicateTargetIterationOrder = this.newMutableForFilter();
         MutableCollection<Integer> collectIfFunctionTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectIf(collectIfPredicateTargetIterationOrder::add, collectIfFunctionTargetIterationOrder::add, new HashBag<>());
-        assertEquals(expectedIterationOrder, collectIfPredicateTargetIterationOrder);
-        assertEquals(expectedIterationOrder, collectIfFunctionTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIfPredicateTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIfFunctionTargetIterationOrder);
 
         MutableCollection<Integer> collectBooleanIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectBoolean(collectBooleanIterationOrder::add).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectBooleanIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectBooleanIterationOrder);
 
         MutableCollection<Integer> collectBooleanTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectBoolean(collectBooleanTargetIterationOrder::add, new BooleanHashBag());
-        assertEquals(expectedIterationOrder, collectBooleanTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectBooleanTargetIterationOrder);
 
         MutableCollection<Integer> collectByteIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectByte((Integer each) ->
@@ -670,7 +670,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return (byte) 0;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectByteIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectByteIterationOrder);
 
         MutableCollection<Integer> collectByteTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectByte((Integer each) ->
@@ -678,7 +678,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectByteTargetIterationOrder.add(each);
             return (byte) 0;
         }, new ByteHashBag());
-        assertEquals(expectedIterationOrder, collectByteTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectByteTargetIterationOrder);
 
         MutableCollection<Integer> collectCharIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectChar((Integer each) ->
@@ -687,7 +687,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return ' ';
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectCharIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectCharIterationOrder);
 
         MutableCollection<Integer> collectCharTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectChar((Integer each) ->
@@ -695,7 +695,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectCharTargetIterationOrder.add(each);
             return ' ';
         }, new CharHashBag());
-        assertEquals(expectedIterationOrder, collectCharTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectCharTargetIterationOrder);
 
         MutableCollection<Integer> collectDoubleIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectDouble((Integer each) ->
@@ -704,7 +704,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return 0.0;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectDoubleIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectDoubleIterationOrder);
 
         MutableCollection<Integer> collectDoubleTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectDouble((Integer each) ->
@@ -712,7 +712,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectDoubleTargetIterationOrder.add(each);
             return 0.0;
         }, new DoubleHashBag());
-        assertEquals(expectedIterationOrder, collectDoubleTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectDoubleTargetIterationOrder);
 
         MutableCollection<Integer> collectFloatIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectFloat((Integer each) ->
@@ -721,7 +721,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return 0.0f;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectFloatIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectFloatIterationOrder);
 
         MutableCollection<Integer> collectFloatTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectFloat((Integer each) ->
@@ -729,7 +729,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectFloatTargetIterationOrder.add(each);
             return 0.0f;
         }, new FloatHashBag());
-        assertEquals(expectedIterationOrder, collectFloatTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectFloatTargetIterationOrder);
 
         MutableCollection<Integer> collectIntIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectInt((Integer each) ->
@@ -738,7 +738,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return 0;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectIntIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIntIterationOrder);
 
         MutableCollection<Integer> collectIntTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectInt((Integer each) ->
@@ -746,7 +746,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectIntTargetIterationOrder.add(each);
             return 0;
         }, new IntHashBag());
-        assertEquals(expectedIterationOrder, collectIntTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectIntTargetIterationOrder);
 
         MutableCollection<Integer> collectLongIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectLong((Integer each) ->
@@ -755,7 +755,7 @@ public interface RichIterableTestCase extends IterableTestCase
             return 0L;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectLongIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectLongIterationOrder);
 
         MutableCollection<Integer> collectLongTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectLong((Integer each) ->
@@ -763,7 +763,7 @@ public interface RichIterableTestCase extends IterableTestCase
             collectLongTargetIterationOrder.add(each);
             return 0L;
         }, new LongHashBag());
-        assertEquals(expectedIterationOrder, collectLongTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectLongTargetIterationOrder);
 
         MutableCollection<Integer> collectShortIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectShort((ShortFunction<Integer>) each -> {
@@ -771,100 +771,100 @@ public interface RichIterableTestCase extends IterableTestCase
             return (short) 0;
         }).forEach(each -> {
         });
-        assertEquals(expectedIterationOrder, collectShortIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectShortIterationOrder);
 
         MutableCollection<Integer> collectShortTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().collectShort((ShortFunction<Integer>) each -> {
             collectShortTargetIterationOrder.add(each);
             return (short) 0;
         }, new ShortHashBag());
-        assertEquals(expectedIterationOrder, collectShortTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, collectShortTargetIterationOrder);
 
         MutableCollection<Integer> flatCollectIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().flatCollect(each -> Lists.immutable.with(flatCollectIterationOrder.add(each))).forEach(noop);
-        assertEquals(expectedIterationOrder, flatCollectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, flatCollectIterationOrder);
 
         MutableCollection<Integer> flatCollectTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().flatCollect(each -> Lists.immutable.with(flatCollectTargetIterationOrder.add(each)), new HashBag<>());
-        assertEquals(expectedIterationOrder, flatCollectTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, flatCollectTargetIterationOrder);
 
         MutableCollection<Integer> countIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().count(countIterationOrder::add);
-        assertEquals(expectedIterationOrder, countIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, countIterationOrder);
 
         MutableCollection<Integer> countWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().countWith((each, param) -> countWithIterationOrder.add(each), null);
-        assertEquals(expectedIterationOrder, countWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, countWithIterationOrder);
 
         MutableCollection<Integer> anySatisfyIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().anySatisfy(each -> {
             anySatisfyIterationOrder.add(each);
             return false;
         });
-        assertEquals(expectedIterationOrder, anySatisfyIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, anySatisfyIterationOrder);
 
         MutableCollection<Integer> anySatisfyWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().anySatisfyWith((each, param) -> {
             anySatisfyWithIterationOrder.add(each);
             return false;
         }, null);
-        assertEquals(expectedIterationOrder, anySatisfyWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, anySatisfyWithIterationOrder);
 
         MutableCollection<Integer> allSatisfyIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().allSatisfy(each -> {
             allSatisfyIterationOrder.add(each);
             return true;
         });
-        assertEquals(expectedIterationOrder, allSatisfyIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, allSatisfyIterationOrder);
 
         MutableCollection<Integer> allSatisfyWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().allSatisfyWith((each, param) -> {
             allSatisfyWithIterationOrder.add(each);
             return true;
         }, null);
-        assertEquals(expectedIterationOrder, allSatisfyWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, allSatisfyWithIterationOrder);
 
         MutableCollection<Integer> noneSatisfyIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().noneSatisfy(each -> {
             noneSatisfyIterationOrder.add(each);
             return false;
         });
-        assertEquals(expectedIterationOrder, noneSatisfyIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, noneSatisfyIterationOrder);
 
         MutableCollection<Integer> noneSatisfyWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().noneSatisfyWith((each, param) -> {
             noneSatisfyWithIterationOrder.add(each);
             return false;
         }, null);
-        assertEquals(expectedIterationOrder, noneSatisfyWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, noneSatisfyWithIterationOrder);
 
         MutableCollection<Integer> detectIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().detect(each -> {
             detectIterationOrder.add(each);
             return false;
         });
-        assertEquals(expectedIterationOrder, detectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectIterationOrder);
 
         MutableCollection<Integer> detectWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().detectWith((each, param) -> {
             detectWithIterationOrder.add(each);
             return false;
         }, null);
-        assertEquals(expectedIterationOrder, detectWithIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectWithIterationOrder);
 
         MutableCollection<Integer> detectIfNoneIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().detectIfNone(each -> {
             detectIfNoneIterationOrder.add(each);
             return false;
         }, () -> 0);
-        assertEquals(expectedIterationOrder, detectIfNoneIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectIfNoneIterationOrder);
 
         MutableCollection<Integer> detectWithIfNoneIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().detectWithIfNone((each, param) -> {
             detectWithIfNoneIterationOrder.add(each);
             return false;
         }, null, () -> 0);
-        assertEquals(expectedIterationOrder, detectWithIfNoneIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectWithIfNoneIterationOrder);
 
         MutableCollection<Integer> minComparatorIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().min((o1, o2) -> {
@@ -875,7 +875,7 @@ public interface RichIterableTestCase extends IterableTestCase
             minComparatorIterationOrder.add(o1);
             return 0;
         });
-        assertEquals(expectedIterationOrder, minComparatorIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, minComparatorIterationOrder);
 
         MutableCollection<Integer> maxComparatorIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().max((o1, o2) -> {
@@ -886,65 +886,65 @@ public interface RichIterableTestCase extends IterableTestCase
             maxComparatorIterationOrder.add(o1);
             return 0;
         });
-        assertEquals(expectedIterationOrder, maxComparatorIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, maxComparatorIterationOrder);
 
         MutableCollection<Integer> minByIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().minBy(minByIterationOrder::add);
-        assertEquals(expectedIterationOrder, minByIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, minByIterationOrder);
 
         MutableCollection<Integer> maxByIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().maxBy(maxByIterationOrder::add);
-        assertEquals(expectedIterationOrder, maxByIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, maxByIterationOrder);
 
         MutableCollection<Integer> groupByIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().groupBy(groupByIterationOrder::add);
-        assertEquals(expectedIterationOrder, groupByIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, groupByIterationOrder);
 
         MutableCollection<Integer> groupByTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().groupBy(groupByTargetIterationOrder::add, new HashBagMultimap<>());
-        assertEquals(expectedIterationOrder, groupByTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, groupByTargetIterationOrder);
 
         MutableCollection<Integer> groupByEachIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().groupByEach(each -> {
             groupByEachIterationOrder.add(each);
             return Lists.immutable.with(each);
         });
-        assertEquals(expectedIterationOrder, groupByEachIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, groupByEachIterationOrder);
 
         MutableCollection<Integer> groupByEachTargetIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().groupByEach(each -> {
             groupByEachTargetIterationOrder.add(each);
             return Lists.immutable.with(each);
         }, new HashBagMultimap<>());
-        assertEquals(expectedIterationOrder, groupByEachTargetIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, groupByEachTargetIterationOrder);
 
         MutableCollection<Integer> sumOfFloatIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().sumOfFloat(each -> {
             sumOfFloatIterationOrder.add(each);
             return each.floatValue();
         });
-        assertEquals(expectedIterationOrder, sumOfFloatIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, sumOfFloatIterationOrder);
 
         MutableCollection<Integer> sumOfDoubleIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().sumOfDouble(each -> {
             sumOfDoubleIterationOrder.add(each);
             return each.doubleValue();
         });
-        assertEquals(expectedIterationOrder, sumOfDoubleIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, sumOfDoubleIterationOrder);
 
         MutableCollection<Integer> sumOfIntIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().sumOfInt(each -> {
             sumOfIntIterationOrder.add(each);
             return each.intValue();
         });
-        assertEquals(expectedIterationOrder, sumOfIntIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, sumOfIntIterationOrder);
 
         MutableCollection<Integer> sumOfLongIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().sumOfLong(each -> {
             sumOfLongIterationOrder.add(each);
             return each.longValue();
         });
-        assertEquals(expectedIterationOrder, sumOfLongIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, sumOfLongIterationOrder);
 
         /*
          * TODO: Fix sumByDouble and sumByFloat methods for bags, to only iterate once per item, not per occurrence.
@@ -988,8 +988,8 @@ public interface RichIterableTestCase extends IterableTestCase
                     sumByIntIterationOrder2.add(each);
                     return 0;
                 });
-        assertEquals(expectedIterationOrder, sumByIntIterationOrder1);
-        assertEquals(expectedIterationOrder, sumByIntIterationOrder2);
+        assertIterablesEqual(expectedIterationOrder, sumByIntIterationOrder1);
+        assertIterablesEqual(expectedIterationOrder, sumByIntIterationOrder2);
 
         MutableCollection<Integer> sumByLongIterationOrder1 = this.newMutableForFilter();
         MutableCollection<Integer> sumByLongIterationOrder2 = this.newMutableForFilter();
@@ -1002,8 +1002,8 @@ public interface RichIterableTestCase extends IterableTestCase
                     sumByLongIterationOrder2.add(each);
                     return 0L;
                 });
-        assertEquals(expectedIterationOrder, sumByLongIterationOrder1);
-        assertEquals(expectedIterationOrder, sumByLongIterationOrder2);
+        assertIterablesEqual(expectedIterationOrder, sumByLongIterationOrder1);
+        assertIterablesEqual(expectedIterationOrder, sumByLongIterationOrder2);
 
         MutableCollection<Integer> expectedInjectIntoIterationOrder = this.allowsDuplicates()
                 ? this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3, 2, 2, 1)
@@ -1014,84 +1014,84 @@ public interface RichIterableTestCase extends IterableTestCase
             injectIntoIterationOrder.add(argument2);
             return argument1 + argument2;
         });
-        assertEquals(expectedInjectIntoIterationOrder, injectIntoIterationOrder);
+        assertIterablesEqual(expectedInjectIntoIterationOrder, injectIntoIterationOrder);
 
         MutableCollection<Integer> injectIntoIntIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().injectInto(0, (IntObjectToIntFunction<Integer>) (intParameter, objectParameter) -> {
             injectIntoIntIterationOrder.add(objectParameter);
             return intParameter + objectParameter;
         });
-        assertEquals(expectedInjectIntoIterationOrder, injectIntoIntIterationOrder);
+        assertIterablesEqual(expectedInjectIntoIterationOrder, injectIntoIntIterationOrder);
 
         MutableCollection<Integer> injectIntoLongIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().injectInto(0L, (LongObjectToLongFunction<Integer>) (longParameter, objectParameter) -> {
             injectIntoLongIterationOrder.add(objectParameter);
             return longParameter + objectParameter;
         });
-        assertEquals(expectedInjectIntoIterationOrder, injectIntoLongIterationOrder);
+        assertIterablesEqual(expectedInjectIntoIterationOrder, injectIntoLongIterationOrder);
 
         MutableCollection<Integer> injectIntoDoubleIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().injectInto(0L, (DoubleObjectToDoubleFunction<Integer>) (doubleParameter, objectParameter) -> {
             injectIntoDoubleIterationOrder.add(objectParameter);
             return doubleParameter + objectParameter;
         });
-        assertEquals(expectedInjectIntoIterationOrder, injectIntoDoubleIterationOrder);
+        assertIterablesEqual(expectedInjectIntoIterationOrder, injectIntoDoubleIterationOrder);
 
         MutableCollection<Integer> injectIntoFloatIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().injectInto(0L, (FloatObjectToFloatFunction<Integer>) (floatParameter, objectParameter) -> {
             injectIntoFloatIterationOrder.add(objectParameter);
             return floatParameter + objectParameter;
         });
-        assertEquals(expectedInjectIntoIterationOrder, injectIntoFloatIterationOrder);
+        assertIterablesEqual(expectedInjectIntoIterationOrder, injectIntoFloatIterationOrder);
 
         Counter toSortedListCount = new Counter();
         this.getInstanceUnderTest().toSortedList((o1, o2) -> {
             toSortedListCount.increment();
             return 0;
         });
-        assertEquals(expectedIterationOrder.size() - 1, toSortedListCount.getCount());
+        assertIterablesEqual(expectedIterationOrder.size() - 1, toSortedListCount.getCount());
 
         Counter toSortedSetCount = new Counter();
         this.getInstanceUnderTest().toSortedSet((o1, o2) -> {
             toSortedSetCount.increment();
             return 0;
         });
-        assertEquals(expectedIterationOrder.size(), toSortedSetCount.getCount());
+        assertIterablesEqual(expectedIterationOrder.size(), toSortedSetCount.getCount());
 
         Counter toSortedBagCount = new Counter();
         this.getInstanceUnderTest().toSortedBag((o1, o2) -> {
             toSortedBagCount.increment();
             return 0;
         });
-        assertEquals(expectedIterationOrder.size(), toSortedBagCount.getCount());
+        assertIterablesEqual(expectedIterationOrder.size(), toSortedBagCount.getCount());
 
         MutableCollection<Integer> summarizeIntOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().summarizeInt(each -> {
             summarizeIntOrder.add(each);
             return 0;
         });
-        assertEquals(expectedIterationOrder, summarizeIntOrder);
+        assertIterablesEqual(expectedIterationOrder, summarizeIntOrder);
 
         MutableCollection<Integer> summarizeFloatOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().summarizeFloat(each -> {
             summarizeFloatOrder.add(each);
             return 0;
         });
-        assertEquals(expectedIterationOrder, summarizeFloatOrder);
+        assertIterablesEqual(expectedIterationOrder, summarizeFloatOrder);
 
         MutableCollection<Integer> summarizeLongOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().summarizeLong(each -> {
             summarizeLongOrder.add(each);
             return 0;
         });
-        assertEquals(expectedIterationOrder, summarizeLongOrder);
+        assertIterablesEqual(expectedIterationOrder, summarizeLongOrder);
 
         MutableCollection<Integer> summarizeDoubleOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().summarizeDouble(each -> {
             summarizeDoubleOrder.add(each);
             return 0;
         });
-        assertEquals(expectedIterationOrder, summarizeDoubleOrder);
+        assertIterablesEqual(expectedIterationOrder, summarizeDoubleOrder);
     }
 
     default MutableCollection<Integer> expectedIterationOrder()
@@ -1113,46 +1113,46 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(4, 4, 4, 4, 2, 2),
                 iterable.select(IntegerPredicates.isEven()));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-            assertEquals(this.newMutableForFilter(4, 4, 4, 4, 2, 2), result);
+            assertIterablesEqual(this.newMutableForFilter(4, 4, 4, 4, 2, 2), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(4, 4, 4, 4, 3, 3, 3),
                 iterable.selectWith(Predicates2.greaterThan(), 2));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-            assertEquals(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3), result);
+            assertIterablesEqual(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(4, 4, 4, 4, 2, 2),
                 iterable.reject(IntegerPredicates.isOdd()));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-            assertEquals(this.newMutableForFilter(4, 4, 4, 4, 2, 2), result);
+            assertIterablesEqual(this.newMutableForFilter(4, 4, 4, 4, 2, 2), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(4, 4, 4, 4, 3, 3, 3),
                 iterable.rejectWith(Predicates2.lessThan(), 3));
 
         MutableCollection<Integer> target = this.newMutableForFilter();
         MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-        assertEquals(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3), result);
+        assertIterablesEqual(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3), result);
         assertSame(target, result);
     }
 
@@ -1161,20 +1161,20 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(-3, -3, -3, -2, -2, -1, 0, 1, 2, 2, 3, 3, 3);
         PartitionIterable<Integer> partition = iterable.partition(IntegerPredicates.isEven());
-        assertEquals(this.getExpectedFiltered(-2, -2, 0, 2, 2), partition.getSelected());
-        assertEquals(this.getExpectedFiltered(-3, -3, -3, -1, 1, 3, 3, 3), partition.getRejected());
+        assertIterablesEqual(this.getExpectedFiltered(-2, -2, 0, 2, 2), partition.getSelected());
+        assertIterablesEqual(this.getExpectedFiltered(-3, -3, -3, -1, 1, 3, 3, 3), partition.getRejected());
 
         PartitionIterable<Integer> partitionWith = iterable.partitionWith(Predicates2.greaterThan(), 0);
-        assertEquals(this.getExpectedFiltered(1, 2, 2, 3, 3, 3), partitionWith.getSelected());
-        assertEquals(this.getExpectedFiltered(-3, -3, -3, -2, -2, -1, 0), partitionWith.getRejected());
+        assertIterablesEqual(this.getExpectedFiltered(1, 2, 2, 3, 3, 3), partitionWith.getSelected());
+        assertIterablesEqual(this.getExpectedFiltered(-3, -3, -3, -2, -2, -1, 0), partitionWith.getRejected());
     }
 
     @Test
     default void RichIterable_selectInstancesOf()
     {
         RichIterable<Number> iterable = this.newWith(1, 2.0, 2.0, 3, 3, 3, 4.0, 4.0, 4.0, 4.0);
-        assertEquals(this.getExpectedFiltered(1, 3, 3, 3), iterable.selectInstancesOf(Integer.class));
-        assertEquals(this.getExpectedFiltered(1, 2.0, 2.0, 3, 3, 3, 4.0, 4.0, 4.0, 4.0), iterable.selectInstancesOf(Number.class));
+        assertIterablesEqual(this.getExpectedFiltered(1, 3, 3, 3), iterable.selectInstancesOf(Integer.class));
+        assertIterablesEqual(this.getExpectedFiltered(1, 2.0, 2.0, 3, 3, 3, 4.0, 4.0, 4.0, 4.0), iterable.selectInstancesOf(Number.class));
     }
 
     @Test
@@ -1182,24 +1182,24 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(13, 13, 12, 12, 11, 11, 3, 3, 2, 2, 1, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                 iterable.collect(i -> i % 10));
 
         {
             MutableCollection<Integer> target = this.newMutableForTransform();
             MutableCollection<Integer> result = iterable.collect(i -> i % 10, target);
-            assertEquals(this.newMutableForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
+            assertIterablesEqual(this.newMutableForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                 iterable.collectWith((i, mod) -> i % mod, 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = iterable.collectWith((i, mod) -> i % mod, 10, target);
-        assertEquals(this.newMutableForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
+        assertIterablesEqual(this.newMutableForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
         assertSame(target, result);
     }
 
@@ -1208,124 +1208,124 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(13, 13, 12, 12, 11, 11, 3, 3, 2, 2, 1, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 3, 1, 1, 3, 3, 1, 1),
                 iterable.collectIf(i -> i % 2 != 0, i -> i % 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = iterable.collectIf(i -> i % 2 != 0, i -> i % 10, target);
-        assertEquals(this.newMutableForTransform(3, 3, 1, 1, 3, 3, 1, 1), result);
+        assertIterablesEqual(this.newMutableForTransform(3, 3, 1, 1, 3, 3, 1, 1), result);
         assertSame(target, result);
     }
 
     @Test
     default void RichIterable_collectPrimitive()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedBoolean(false, false, true, true, false, false),
                 this.newWith(3, 3, 2, 2, 1, 1).collectBoolean(each -> each % 2 == 0));
 
         {
             MutableBooleanCollection target = this.newBooleanForTransform();
             MutableBooleanCollection result = this.newWith(3, 3, 2, 2, 1, 1).collectBoolean(each -> each % 2 == 0, target);
-            assertEquals(this.newBooleanForTransform(false, false, true, true, false, false), result);
+            assertIterablesEqual(this.newBooleanForTransform(false, false, true, true, false, false), result);
             assertSame(target, result);
         }
 
         RichIterable<Integer> iterable = this.newWith(13, 13, 12, 12, 11, 11, 3, 3, 2, 2, 1, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedByte((byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1),
                 iterable.collectByte(each -> (byte) (each % 10)));
 
         {
             MutableByteCollection target = this.newByteForTransform();
             MutableByteCollection result = iterable.collectByte(each -> (byte) (each % 10), target);
-            assertEquals(this.newByteForTransform((byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1), result);
+            assertIterablesEqual(this.newByteForTransform((byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedChar((char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1, (char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1),
                 iterable.collectChar(each -> (char) (each % 10)));
 
         {
             MutableCharCollection target = this.newCharForTransform();
             MutableCharCollection result = iterable.collectChar(each -> (char) (each % 10), target);
-            assertEquals(this.newCharForTransform((char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1, (char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1), result);
+            assertIterablesEqual(this.newCharForTransform((char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1, (char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedDouble(3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0),
                 iterable.collectDouble(each -> (double) (each % 10)));
 
         {
             MutableDoubleCollection target = this.newDoubleForTransform();
             MutableDoubleCollection result = iterable.collectDouble(each -> (double) (each % 10), target);
-            assertEquals(this.newDoubleForTransform(3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0), result);
+            assertIterablesEqual(this.newDoubleForTransform(3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFloat(3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f, 3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f),
                 iterable.collectFloat(each -> (float) (each % 10)));
 
         {
             MutableFloatCollection target = this.newFloatForTransform();
             MutableFloatCollection result = iterable.collectFloat(each -> (float) (each % 10), target);
-            assertEquals(this.newFloatForTransform(3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f, 3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f), result);
+            assertIterablesEqual(this.newFloatForTransform(3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f, 3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedInt(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                 iterable.collectInt(each -> each % 10));
 
         {
             MutableIntCollection target = this.newIntForTransform();
             MutableIntCollection result = iterable.collectInt(each -> each % 10, target);
-            assertEquals(this.newIntForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
+            assertIterablesEqual(this.newIntForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedLong(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                 iterable.collectLong(each -> each % 10));
 
         {
             MutableLongCollection target = this.newLongForTransform();
             MutableLongCollection result = iterable.collectLong(each -> each % 10, target);
-            assertEquals(this.newLongForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
+            assertIterablesEqual(this.newLongForTransform(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedShort((short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1, (short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1),
                 iterable.collectShort(each -> (short) (each % 10)));
 
         MutableShortCollection target = this.newShortForTransform();
         MutableShortCollection result = iterable.collectShort(each -> (short) (each % 10), target);
-        assertEquals(this.newShortForTransform((short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1, (short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1), result);
+        assertIterablesEqual(this.newShortForTransform((short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1, (short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1), result);
         assertSame(target, result);
     }
 
     @Test
     default void RichIterable_flatCollect()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 2, 3, 1, 2, 1, 2, 1),
                 this.newWith(3, 2, 2, 1).flatCollect(Interval::oneTo));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newMutableForTransform(1, 2, 3, 1, 2, 1, 2, 1),
                 this.newWith(3, 2, 2, 1).flatCollect(Interval::oneTo, this.newMutableForTransform()));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 4, 5, 2, 3, 4, 5, 2, 3, 4, 5, 1, 2, 3, 4, 5),
                 this.newWith(3, 2, 2, 1).flatCollectWith(Interval::fromTo, 5));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newMutableForTransform(3, 2, 1, 2, 1, 2, 1, 1),
                 this.newWith(3, 2, 2, 1).flatCollectWith(Interval::fromTo, 1, this.newMutableForTransform()));
     }
@@ -1338,7 +1338,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableBooleanCollection result = this.newWith(3, 3, 2, 2, 1, 1).flatCollectBoolean(
                     each -> BooleanLists.immutable.with(each % 2 == 0, each % 2 == 0),
                     target);
-            assertEquals(this.newBooleanForTransform(false, false, false, false, true, true, true, true, false, false, false, false), result);
+            assertIterablesEqual(this.newBooleanForTransform(false, false, false, false, true, true, true, true, false, false, false, false), result);
             assertSame(target, result);
         }
 
@@ -1349,7 +1349,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableByteCollection result = iterable.flatCollectByte(
                     each -> ByteLists.immutable.with((byte) (each % 10), (byte) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newByteForTransform((byte) 3, (byte) 3, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 1, (byte) 1, (byte) 3, (byte) 3, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 1, (byte) 1),
                     result);
             assertSame(target, result);
@@ -1360,7 +1360,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableCharCollection result = iterable.flatCollectChar(
                     each -> CharLists.immutable.with((char) (each % 10), (char) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newCharForTransform((char) 3, (char) 3, (char) 3, (char) 3, (char) 2, (char) 2, (char) 2, (char) 2, (char) 1, (char) 1, (char) 1, (char) 1, (char) 3, (char) 3, (char) 3, (char) 3, (char) 2, (char) 2, (char) 2, (char) 2, (char) 1, (char) 1, (char) 1, (char) 1),
                     result);
             assertSame(target, result);
@@ -1371,7 +1371,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableDoubleCollection result = iterable.flatCollectDouble(
                     each -> DoubleLists.immutable.with((double) (each % 10), (double) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newDoubleForTransform(3.0, 3.0, 3.0, 3.0, 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0, 3.0, 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0),
                     result);
             assertSame(target, result);
@@ -1382,7 +1382,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableFloatCollection result = iterable.flatCollectFloat(
                     each -> FloatLists.immutable.with((float) (each % 10), (float) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newFloatForTransform(3.0f, 3.0f, 3.0f, 3.0f, 2.0f, 2.0f, 2.0f, 2.0f, 1.0f, 1.0f, 1.0f, 1.0f, 3.0f, 3.0f, 3.0f, 3.0f, 2.0f, 2.0f, 2.0f, 2.0f, 1.0f, 1.0f, 1.0f, 1.0f),
                     result);
             assertSame(target, result);
@@ -1393,7 +1393,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableIntCollection result = iterable.flatCollectInt(
                     each -> IntLists.immutable.with(each % 10, each % 10),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newIntForTransform(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1),
                     result);
             assertSame(target, result);
@@ -1404,7 +1404,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableLongCollection result = iterable.flatCollectLong(
                     each -> LongLists.immutable.with(each % 10, each % 10),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newLongForTransform(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1),
                     result);
             assertSame(target, result);
@@ -1415,7 +1415,7 @@ public interface RichIterableTestCase extends IterableTestCase
             MutableShortCollection result = iterable.flatCollectShort(
                     each -> ShortLists.immutable.with((short) (each % 10), (short) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newShortForTransform((short) 3, (short) 3, (short) 3, (short) 3, (short) 2, (short) 2, (short) 2, (short) 2, (short) 1, (short) 1, (short) 1, (short) 1, (short) 3, (short) 3, (short) 3, (short) 3, (short) 2, (short) 2, (short) 2, (short) 2, (short) 1, (short) 1, (short) 1, (short) 1),
                     result);
             assertSame(target, result);
@@ -1427,18 +1427,18 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
 
-        assertEquals(3, iterable.count(Integer.valueOf(3)::equals));
-        assertEquals(2, iterable.count(Integer.valueOf(2)::equals));
-        assertEquals(1, iterable.count(Integer.valueOf(1)::equals));
-        assertEquals(0, iterable.count(Integer.valueOf(0)::equals));
-        assertEquals(4, iterable.count(i -> i % 2 != 0));
-        assertEquals(6, iterable.count(i -> i > 0));
+        assertIterablesEqual(3, iterable.count(Integer.valueOf(3)::equals));
+        assertIterablesEqual(2, iterable.count(Integer.valueOf(2)::equals));
+        assertIterablesEqual(1, iterable.count(Integer.valueOf(1)::equals));
+        assertIterablesEqual(0, iterable.count(Integer.valueOf(0)::equals));
+        assertIterablesEqual(4, iterable.count(i -> i % 2 != 0));
+        assertIterablesEqual(6, iterable.count(i -> i > 0));
 
-        assertEquals(3, iterable.countWith(Object::equals, 3));
-        assertEquals(2, iterable.countWith(Object::equals, 2));
-        assertEquals(1, iterable.countWith(Object::equals, 1));
-        assertEquals(0, iterable.countWith(Object::equals, 0));
-        assertEquals(6, iterable.countWith(Predicates2.greaterThan(), 0));
+        assertIterablesEqual(3, iterable.countWith(Object::equals, 3));
+        assertIterablesEqual(2, iterable.countWith(Object::equals, 2));
+        assertIterablesEqual(1, iterable.countWith(Object::equals, 1));
+        assertIterablesEqual(0, iterable.countWith(Object::equals, 0));
+        assertIterablesEqual(6, iterable.countWith(Predicates2.greaterThan(), 0));
     }
 
     @Test
@@ -1625,20 +1625,20 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void RichIterable_min_max()
     {
-        assertEquals(Integer.valueOf(-1), this.newWith(-1, 0, 1).min());
-        assertEquals(Integer.valueOf(-1), this.newWith(1, 0, -1).min());
+        assertIterablesEqual(Integer.valueOf(-1), this.newWith(-1, 0, 1).min());
+        assertIterablesEqual(Integer.valueOf(-1), this.newWith(1, 0, -1).min());
         assertThrows(NoSuchElementException.class, () -> this.newWith().min());
 
-        assertEquals(Integer.valueOf(1), this.newWith(-1, 0, 1).max());
-        assertEquals(Integer.valueOf(1), this.newWith(1, 0, -1).max());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(-1, 0, 1).max());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(1, 0, -1).max());
         assertThrows(NoSuchElementException.class, () -> this.newWith().max());
 
-        assertEquals(Integer.valueOf(1), this.newWith(-1, 0, 1).min(Comparators.reverseNaturalOrder()));
-        assertEquals(Integer.valueOf(1), this.newWith(1, 0, -1).min(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(-1, 0, 1).min(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(1, 0, -1).min(Comparators.reverseNaturalOrder()));
         assertThrows(NoSuchElementException.class, () -> this.newWith().min(Comparators.reverseNaturalOrder()));
 
-        assertEquals(Integer.valueOf(-1), this.newWith(-1, 0, 1).max(Comparators.reverseNaturalOrder()));
-        assertEquals(Integer.valueOf(-1), this.newWith(1, 0, -1).max(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Integer.valueOf(-1), this.newWith(-1, 0, 1).max(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Integer.valueOf(-1), this.newWith(1, 0, -1).max(Comparators.reverseNaturalOrder()));
         assertThrows(NoSuchElementException.class, () -> this.newWith().max(Comparators.reverseNaturalOrder()));
     }
 
@@ -1663,23 +1663,23 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void RichIterable_minOptional_maxOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).minOptional());
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).minOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).minOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).minOptional());
         assertSame(Optional.empty(), this.newWith().minOptional());
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).minOptional());
 
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).maxOptional());
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).maxOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).maxOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).maxOptional());
         assertSame(Optional.empty(), this.newWith().maxOptional());
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).maxOptional());
 
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).minOptional(Comparators.reverseNaturalOrder()));
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).minOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).minOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).minOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith().minOptional(Comparators.reverseNaturalOrder()));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).minOptional(Comparators.reverseNaturalOrder()));
 
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).maxOptional(Comparators.reverseNaturalOrder()));
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).maxOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).maxOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).maxOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith().maxOptional(Comparators.reverseNaturalOrder()));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).maxOptional(Comparators.reverseNaturalOrder()));
     }
@@ -1689,37 +1689,37 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         Object sentinel = new Object();
 
-        assertEquals(Optional.of(sentinel), this.newWith(sentinel).minOptional());
+        assertIterablesEqual(Optional.of(sentinel), this.newWith(sentinel).minOptional());
         assertThrows(ClassCastException.class, () -> this.newWith(new Object(), new Object()).minOptional());
 
-        assertEquals(Optional.of(sentinel), this.newWith(sentinel).maxOptional());
+        assertIterablesEqual(Optional.of(sentinel), this.newWith(sentinel).maxOptional());
         assertThrows(ClassCastException.class, () -> this.newWith(new Object(), new Object()).maxOptional());
 
-        assertEquals(Optional.of(sentinel), this.newWith(sentinel).minOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(sentinel), this.newWith(sentinel).minOptional(Comparators.reverseNaturalOrder()));
         assertThrows(ClassCastException.class, () -> this.newWith(new Object(), new Object()).minOptional(Comparators.reverseNaturalOrder()));
 
-        assertEquals(Optional.of(sentinel), this.newWith(sentinel).maxOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(sentinel), this.newWith(sentinel).maxOptional(Comparators.reverseNaturalOrder()));
         assertThrows(ClassCastException.class, () -> this.newWith(new Object(), new Object()).maxOptional(Comparators.reverseNaturalOrder()));
     }
 
     @Test
     default void RichIterable_minBy_maxBy()
     {
-        assertEquals("da", this.newWith("ed", "da", "ca", "bc", "ab").minBy(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual("da", this.newWith("ed", "da", "ca", "bc", "ab").minBy(string -> string.charAt(string.length() - 1)));
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().minBy(string -> string.charAt(string.length() - 1)));
 
-        assertEquals("dz", this.newWith("ew", "dz", "cz", "bx", "ay").maxBy(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual("dz", this.newWith("ew", "dz", "cz", "bx", "ay").maxBy(string -> string.charAt(string.length() - 1)));
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().maxBy(string -> string.charAt(string.length() - 1)));
     }
 
     @Test
     default void RichIterable_minByOptional_maxByOptional()
     {
-        assertEquals(Optional.of("da"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("da"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().minByOptional(string -> string.charAt(string.length() - 1)));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).minByOptional(Objects::isNull));
 
-        assertEquals(Optional.of("dz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("dz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().maxByOptional(string -> string.charAt(string.length() - 1)));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).maxByOptional(Objects::isNull));
     }
@@ -1735,12 +1735,12 @@ public interface RichIterableTestCase extends IterableTestCase
                         Boolean.TRUE, this.newMutableForFilter(3, 3, 3, 1),
                         Boolean.FALSE, this.newMutableForFilter(4, 4, 4, 4, 2, 2));
 
-        assertEquals(expectedGroupBy, iterable.groupBy(groupByFunction).toMap());
+        assertIterablesEqual(expectedGroupBy, iterable.groupBy(groupByFunction).toMap());
 
         Function<Integer, Boolean> function = (Integer object) -> true;
         MutableMultimap<Boolean, Integer> target = this.<Integer>newWith().groupBy(function).toMutable();
         MutableMultimap<Boolean, Integer> multimap2 = iterable.groupBy(groupByFunction, target);
-        assertEquals(expectedGroupBy, multimap2.toMap());
+        assertIterablesEqual(expectedGroupBy, multimap2.toMap());
         assertSame(target, multimap2);
 
         Function<Integer, Iterable<Integer>> groupByEachFunction = integer -> Interval.fromTo(-1, -integer);
@@ -1752,11 +1752,11 @@ public interface RichIterableTestCase extends IterableTestCase
                         -2, this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3, 2, 2),
                         -1, this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3, 2, 2, 1));
 
-        assertEquals(expectedGroupByEach, iterable.groupByEach(groupByEachFunction).toMap());
+        assertIterablesEqual(expectedGroupByEach, iterable.groupByEach(groupByEachFunction).toMap());
 
         MutableMultimap<Integer, Integer> target2 = this.<Integer>newWith().groupByEach(groupByEachFunction).toMutable();
         Multimap<Integer, Integer> actualWithTarget = iterable.groupByEach(groupByEachFunction, target2);
-        assertEquals(expectedGroupByEach, actualWithTarget.toMap());
+        assertIterablesEqual(expectedGroupByEach, actualWithTarget.toMap());
         assertSame(target2, actualWithTarget);
     }
 
@@ -1768,11 +1768,11 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4, 5, 6);
         Bag<Integer> evensAndOdds = integers.countBy(each -> Integer.valueOf(each % 2));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(0));
+        assertEquals(3, evensAndOdds.occurrencesOf(1));
+        assertEquals(3, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 = integers.countBy(each -> Integer.valueOf(each % 2), Bags.mutable.empty());
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(0));
+        assertEquals(3, evensAndOdds2.occurrencesOf(1));
+        assertEquals(3, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1783,11 +1783,11 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> integers = this.newWith(1, 2, 3, 4, 5, 6);
         Bag<Integer> evensAndOdds = integers.countByWith((each, parm) -> Integer.valueOf(each % parm), 2);
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds.occurrencesOf(0));
+        assertEquals(3, evensAndOdds.occurrencesOf(1));
+        assertEquals(3, evensAndOdds.occurrencesOf(0));
         Bag<Integer> evensAndOdds2 = integers.countByWith((each, parm) -> Integer.valueOf(each % parm), 2, Bags.mutable.empty());
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(1));
-        Assert.assertEquals(3, evensAndOdds2.occurrencesOf(0));
+        assertEquals(3, evensAndOdds2.occurrencesOf(1));
+        assertEquals(3, evensAndOdds2.occurrencesOf(0));
     }
 
     /**
@@ -1798,17 +1798,17 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> integerList = this.newWith(1, 2, 4);
         Bag<Integer> integerBag1 = integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i));
-        assertEquals(1, integerBag1.occurrencesOf(1));
-        assertEquals(2, integerBag1.occurrencesOf(2));
-        assertEquals(3, integerBag1.occurrencesOf(4));
-        assertEquals(2, integerBag1.occurrencesOf(8));
-        assertEquals(1, integerBag1.occurrencesOf(12));
+        assertIterablesEqual(1, integerBag1.occurrencesOf(1));
+        assertIterablesEqual(2, integerBag1.occurrencesOf(2));
+        assertIterablesEqual(3, integerBag1.occurrencesOf(4));
+        assertIterablesEqual(2, integerBag1.occurrencesOf(8));
+        assertIterablesEqual(1, integerBag1.occurrencesOf(12));
         Bag<Integer> integerBag2 = integerList.countByEach(each -> IntInterval.oneTo(5).collect(i -> each * i), Bags.mutable.empty());
-        assertEquals(1, integerBag2.occurrencesOf(1));
-        assertEquals(2, integerBag2.occurrencesOf(2));
-        assertEquals(3, integerBag2.occurrencesOf(4));
-        assertEquals(2, integerBag2.occurrencesOf(8));
-        assertEquals(1, integerBag2.occurrencesOf(12));
+        assertIterablesEqual(1, integerBag2.occurrencesOf(1));
+        assertIterablesEqual(2, integerBag2.occurrencesOf(2));
+        assertIterablesEqual(3, integerBag2.occurrencesOf(4));
+        assertIterablesEqual(2, integerBag2.occurrencesOf(8));
+        assertIterablesEqual(1, integerBag2.occurrencesOf(12));
     }
 
     @Test
@@ -1821,28 +1821,28 @@ public interface RichIterableTestCase extends IterableTestCase
                 () -> 0,
                 (integer1, integer2) -> integer1 + integer2);
 
-        assertEquals(16, aggregateBy.get("4").intValue());
-        assertEquals(9, aggregateBy.get("3").intValue());
-        assertEquals(4, aggregateBy.get("2").intValue());
-        assertEquals(1, aggregateBy.get("1").intValue());
+        assertIterablesEqual(16, aggregateBy.get("4").intValue());
+        assertIterablesEqual(9, aggregateBy.get("3").intValue());
+        assertIterablesEqual(4, aggregateBy.get("2").intValue());
+        assertIterablesEqual(1, aggregateBy.get("1").intValue());
 
         MapIterable<String, AtomicInteger> aggregateInPlaceBy = iterable.aggregateInPlaceBy(
                 String::valueOf,
                 AtomicInteger::new,
                 AtomicInteger::addAndGet);
-        assertEquals(16, aggregateInPlaceBy.get("4").intValue());
-        assertEquals(9, aggregateInPlaceBy.get("3").intValue());
-        assertEquals(4, aggregateInPlaceBy.get("2").intValue());
-        assertEquals(1, aggregateInPlaceBy.get("1").intValue());
+        assertIterablesEqual(16, aggregateInPlaceBy.get("4").intValue());
+        assertIterablesEqual(9, aggregateInPlaceBy.get("3").intValue());
+        assertIterablesEqual(4, aggregateInPlaceBy.get("2").intValue());
+        assertIterablesEqual(1, aggregateInPlaceBy.get("1").intValue());
 
         MapIterable<String, Integer> reduceBy = iterable.reduceBy(
                 Object::toString,
                 (integer1, integer2) -> integer1 + integer2);
 
-        assertEquals(16, reduceBy.get("4").intValue());
-        assertEquals(9, reduceBy.get("3").intValue());
-        assertEquals(4, reduceBy.get("2").intValue());
-        assertEquals(1, reduceBy.get("1").intValue());
+        assertIterablesEqual(16, reduceBy.get("4").intValue());
+        assertIterablesEqual(9, reduceBy.get("3").intValue());
+        assertIterablesEqual(4, reduceBy.get("2").intValue());
+        assertIterablesEqual(1, reduceBy.get("1").intValue());
     }
 
     @Test
@@ -1850,10 +1850,10 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        Assert.assertEquals(30.0f, iterable.sumOfFloat(Integer::floatValue), 0.001);
-        Assert.assertEquals(30.0, iterable.sumOfDouble(Integer::doubleValue), 0.001);
-        Assert.assertEquals(30, iterable.sumOfInt(Integer::intValue));
-        Assert.assertEquals(30L, iterable.sumOfLong(Integer::longValue));
+        assertEquals(30.0f, iterable.sumOfFloat(Integer::floatValue), 0.001);
+        assertEquals(30.0, iterable.sumOfDouble(Integer::doubleValue), 0.001);
+        assertEquals(30, iterable.sumOfInt(Integer::intValue));
+        assertEquals(30L, iterable.sumOfLong(Integer::longValue));
     }
 
     @Test
@@ -1861,19 +1861,19 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<String> iterable = this.newWith("4", "4", "4", "4", "3", "3", "3", "2", "2", "1");
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectLongMaps.immutable.with(0, 20L).newWithKeyValue(1, 10L),
                 iterable.sumByInt(s -> Integer.parseInt(s) % 2, Integer::parseInt));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectLongMaps.immutable.with(0, 20L).newWithKeyValue(1, 10L),
                 iterable.sumByLong(s -> Integer.parseInt(s) % 2, Long::parseLong));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectDoubleMaps.immutable.with(0, 20.0d).newWithKeyValue(1, 10.0d),
                 iterable.sumByDouble(s -> Integer.parseInt(s) % 2, Double::parseDouble));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectDoubleMaps.immutable.with(0, 20.0d).newWithKeyValue(1, 10.0d),
                 iterable.sumByFloat(s -> Integer.parseInt(s) % 2, Float::parseFloat));
     }
@@ -1883,17 +1883,17 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> bigIterable = this.newWith(5, 5, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        Assert.assertEquals(55.0f, bigIterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
-        Assert.assertEquals(55.0, bigIterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
-        Assert.assertEquals(55, bigIterable.summarizeInt(Integer::intValue).getSum());
-        Assert.assertEquals(55L, bigIterable.summarizeLong(Integer::longValue).getSum());
+        assertEquals(55.0f, bigIterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
+        assertEquals(55.0, bigIterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
+        assertEquals(55, bigIterable.summarizeInt(Integer::intValue).getSum());
+        assertEquals(55L, bigIterable.summarizeLong(Integer::longValue).getSum());
 
         RichIterable<Integer> littleIterable = this.newWith(5, 4, 3, 2, 1);
 
-        Assert.assertEquals(15.0f, littleIterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
-        Assert.assertEquals(15.0, littleIterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
-        Assert.assertEquals(15, littleIterable.summarizeInt(Integer::intValue).getSum());
-        Assert.assertEquals(15L, littleIterable.summarizeLong(Integer::longValue).getSum());
+        assertEquals(15.0f, littleIterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
+        assertEquals(15.0, littleIterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
+        assertEquals(15, littleIterable.summarizeInt(Integer::intValue).getSum());
+        assertEquals(15L, littleIterable.summarizeLong(Integer::longValue).getSum());
     }
 
     @Test
@@ -1902,37 +1902,37 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> littleIterable = this.newWith(1, 2, 3, 1, 2, 3);
         MutableBag<Integer> result =
                 littleIterable.reduceInPlace(Collectors.toCollection(Bags.mutable::empty));
-        Assert.assertEquals(Bags.immutable.with(1, 1, 2, 2, 3, 3), result);
+        assertEquals(Bags.immutable.with(1, 1, 2, 2, 3, 3), result);
 
         RichIterable<Integer> bigIterable = this.newWith(Interval.oneTo(20).toArray());
         MutableBag<Integer> bigResult =
                 bigIterable.reduceInPlace(Collectors.toCollection(Bags.mutable::empty));
-        Assert.assertEquals(Interval.oneTo(20).toBag(), bigResult);
+        assertEquals(Interval.oneTo(20).toBag(), bigResult);
 
         String joining =
                 result.collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(result.collect(Object::toString).makeString(","), joining);
+        assertEquals(result.collect(Object::toString).makeString(","), joining);
 
         ImmutableBag<Integer> immutableBag = result.toImmutable();
         String joining2 =
                 immutableBag.collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(immutableBag.collect(Object::toString).makeString(","), joining2);
+        assertEquals(immutableBag.collect(Object::toString).makeString(","), joining2);
 
         String joining3 =
                 result.asLazy().collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(result.asLazy().collect(Object::toString).makeString(","), joining3);
+        assertEquals(result.asLazy().collect(Object::toString).makeString(","), joining3);
 
         Map<Boolean, List<Integer>> expected =
                 littleIterable.toList().stream().collect(Collectors.partitioningBy(each -> each % 2 == 0));
         Map<Boolean, List<Integer>> actual =
                 littleIterable.reduceInPlace(Collectors.partitioningBy(each -> each % 2 == 0));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Map<String, List<Integer>> groupByJDK =
                 littleIterable.toList().stream().collect(Collectors.groupingBy(Object::toString));
         Map<String, List<Integer>> groupByEC =
                 result.reduceInPlace(Collectors.groupingBy(Object::toString));
-        Assert.assertEquals(groupByJDK, groupByEC);
+        assertEquals(groupByJDK, groupByEC);
     }
 
     @Test
@@ -1941,28 +1941,28 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> littleIterable = this.newWith(1, 2, 3, 1, 2, 3);
         MutableBag<Integer> result =
                 littleIterable.reduceInPlace(Bags.mutable::empty, MutableBag::add);
-        Assert.assertEquals(Bags.immutable.with(1, 1, 2, 2, 3, 3), result);
+        assertEquals(Bags.immutable.with(1, 1, 2, 2, 3, 3), result);
 
         RichIterable<Integer> bigIterable = this.newWith(Interval.oneTo(20).toArray());
         MutableBag<Integer> bigResult =
                 bigIterable.reduceInPlace(Bags.mutable::empty, MutableBag::add);
-        Assert.assertEquals(Interval.oneTo(20).toBag(), bigResult);
+        assertEquals(Interval.oneTo(20).toBag(), bigResult);
 
         String joining =
                 result.collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(result.collect(Object::toString).makeString(""), joining);
+        assertEquals(result.collect(Object::toString).makeString(""), joining);
 
         ImmutableBag<Integer> immutableBag = result.toImmutable();
         String joining2 =
                 immutableBag.collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(immutableBag.collect(Object::toString).makeString(""), joining2);
+        assertEquals(immutableBag.collect(Object::toString).makeString(""), joining2);
 
         String joining3 =
                 result.asLazy().collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(result.asLazy().collect(Object::toString).makeString(""), joining3);
+        assertEquals(result.asLazy().collect(Object::toString).makeString(""), joining3);
 
         int atomicAdd = littleIterable.reduceInPlace(AtomicInteger::new, AtomicInteger::addAndGet).get();
-        Assert.assertEquals(12, atomicAdd);
+        assertEquals(12, atomicAdd);
     }
 
     @Test
@@ -1971,20 +1971,20 @@ public interface RichIterableTestCase extends IterableTestCase
         RichIterable<Integer> littleIterable = this.newWith(1, 2, 3, 1, 2, 3);
         Optional<Integer> result =
                 littleIterable.reduce(Integer::sum);
-        Assert.assertEquals(12, result.get().intValue());
+        assertEquals(12, result.get().intValue());
 
         RichIterable<Integer> bigIterable = this.newWith(Interval.oneTo(20).toArray());
         Optional<Integer> bigResult =
                 bigIterable.reduce(Integer::max);
-        Assert.assertEquals(20, bigResult.get().intValue());
+        assertEquals(20, bigResult.get().intValue());
 
         Optional<Integer> max =
                 littleIterable.reduce(Integer::max);
-        Assert.assertEquals(3, max.get().intValue());
+        assertEquals(3, max.get().intValue());
 
         Optional<Integer> min =
                 littleIterable.reduce(Integer::min);
-        Assert.assertEquals(1, min.get().intValue());
+        assertEquals(1, min.get().intValue());
 
         RichIterable<Integer> iterableEmpty = this.newWith();
         Optional<Integer> resultEmpty =
@@ -1997,8 +1997,8 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        assertEquals(Integer.valueOf(31), iterable.injectInto(1, AddFunction.INTEGER));
-        assertEquals(Integer.valueOf(30), iterable.injectInto(0, AddFunction.INTEGER));
+        assertIterablesEqual(Integer.valueOf(31), iterable.injectInto(1, AddFunction.INTEGER));
+        assertIterablesEqual(Integer.valueOf(30), iterable.injectInto(0, AddFunction.INTEGER));
     }
 
     @Test
@@ -2006,17 +2006,17 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        Assert.assertEquals(31, iterable.injectIntoInt(1, AddFunction.INTEGER_TO_INT));
-        Assert.assertEquals(30, iterable.injectIntoInt(0, AddFunction.INTEGER_TO_INT));
+        assertEquals(31, iterable.injectIntoInt(1, AddFunction.INTEGER_TO_INT));
+        assertEquals(30, iterable.injectIntoInt(0, AddFunction.INTEGER_TO_INT));
 
-        Assert.assertEquals(31L, iterable.injectIntoLong(1, AddFunction.INTEGER_TO_LONG));
-        Assert.assertEquals(30L, iterable.injectIntoLong(0, AddFunction.INTEGER_TO_LONG));
+        assertEquals(31L, iterable.injectIntoLong(1, AddFunction.INTEGER_TO_LONG));
+        assertEquals(30L, iterable.injectIntoLong(0, AddFunction.INTEGER_TO_LONG));
 
-        Assert.assertEquals(31.0d, iterable.injectIntoDouble(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
-        Assert.assertEquals(30.0d, iterable.injectIntoDouble(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        assertEquals(31.0d, iterable.injectIntoDouble(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        assertEquals(30.0d, iterable.injectIntoDouble(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
 
-        Assert.assertEquals(31.0f, iterable.injectIntoFloat(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
-        Assert.assertEquals(30.0f, iterable.injectIntoFloat(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        assertEquals(31.0f, iterable.injectIntoFloat(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        assertEquals(30.0f, iterable.injectIntoFloat(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
     }
 
     @Test
@@ -2024,7 +2024,7 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(0, 1, 8);
 
-        assertEquals(
+        assertIterablesEqual(
                 iterable.asLazy().collect(Integer::toUnsignedString).makeString("[", ",", "]"),
                 iterable.makeString(Integer::toUnsignedString, "[", ",", "]"));
     }
@@ -2033,45 +2033,45 @@ public interface RichIterableTestCase extends IterableTestCase
     default void RichIterable_makeString_appendString()
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        assertEquals(
+        assertIterablesEqual(
                 "4, 4, 4, 4, 3, 3, 3, 2, 2, 1",
                 iterable.makeString());
 
-        assertEquals(
+        assertIterablesEqual(
                 iterable.makeString(),
                 iterable.reduceInPlace(Collectors2.makeString()));
 
-        assertEquals(
+        assertIterablesEqual(
                 "4/4/4/4/3/3/3/2/2/1",
                 iterable.makeString("/"));
 
-        assertEquals(
+        assertIterablesEqual(
                 iterable.makeString("/"),
                 iterable.reduceInPlace(Collectors2.makeString("/")));
 
-        assertEquals(
+        assertIterablesEqual(
                 "[4/4/4/4/3/3/3/2/2/1]",
                 iterable.makeString("[", "/", "]"));
 
-        assertEquals(
+        assertIterablesEqual(
                 iterable.makeString("[", "/", "]"),
                 iterable.reduceInPlace(Collectors2.makeString("[", "/", "]")));
 
         StringBuilder builder1 = new StringBuilder();
         iterable.appendString(builder1);
-        assertEquals(
+        assertIterablesEqual(
                 "4, 4, 4, 4, 3, 3, 3, 2, 2, 1",
                 builder1.toString());
 
         StringBuilder builder2 = new StringBuilder();
         iterable.appendString(builder2, "/");
-        assertEquals(
+        assertIterablesEqual(
                 "4/4/4/4/3/3/3/2/2/1",
                 builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         iterable.appendString(builder3, "[", "/", "]");
-        assertEquals(
+        assertIterablesEqual(
                 "[4/4/4/4/3/3/3/2/2/1]",
                 builder3.toString());
     }
@@ -2080,10 +2080,10 @@ public interface RichIterableTestCase extends IterableTestCase
     default void Iterable_toString()
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        assertEquals(
+        assertIterablesEqual(
                 "[4, 4, 4, 4, 3, 3, 3, 2, 2, 1]",
                 iterable.toString());
-        assertEquals(
+        assertIterablesEqual(
                 "[4, 4, 4, 4, 3, 3, 3, 2, 2, 1]",
                 iterable.asLazy().toString());
     }
@@ -2092,13 +2092,13 @@ public interface RichIterableTestCase extends IterableTestCase
     default void RichIterable_toList()
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 iterable.toList());
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }
@@ -2106,7 +2106,7 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void RichIterable_into()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(0, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).into(Lists.mutable.with(0)));
     }
@@ -2116,19 +2116,19 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 iterable.toSortedList());
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 iterable.toSortedList(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 iterable.toSortedListBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 iterable.toSortedListBy(each -> each * -1));
     }
@@ -2136,7 +2136,7 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void RichIterable_toSet()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Sets.immutable.with(4, 3, 2, 1),
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).toSet());
     }
@@ -2146,19 +2146,19 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(1, 2, 3, 4),
                 iterable.toSortedSet());
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.reverseNaturalOrder(), 4, 3, 2, 1),
                 iterable.toSortedSet(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.byFunction(Functions.identity()), 1, 2, 3, 4),
                 iterable.toSortedSetBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.byFunction((Integer each) -> each * -1), 4, 3, 2, 1),
                 iterable.toSortedSetBy(each -> each * -1));
     }
@@ -2166,7 +2166,7 @@ public interface RichIterableTestCase extends IterableTestCase
     @Test
     default void RichIterable_toBag()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Bags.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).toBag());
     }
@@ -2176,19 +2176,19 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 iterable.toSortedBag());
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 iterable.toSortedBag(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.byFunction(Functions.identity()), 1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 iterable.toSortedBagBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.byFunction((Integer each) -> each * -1), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1),
                 iterable.toSortedBagBy(each -> each * -1));
     }
@@ -2198,7 +2198,7 @@ public interface RichIterableTestCase extends IterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(13, 13, 12, 12, 11, 11, 3, 3, 2, 2, 1, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 UnifiedMap.newMapWith(
                         Tuples.pair("13", 3),
                         Tuples.pair("12", 2),
@@ -2222,7 +2222,7 @@ public interface RichIterableTestCase extends IterableTestCase
         jdkMap.put("2", 2);
         jdkMap.put("1", 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 jdkMap,
                 iterable.toMap(Object::toString, each -> each % 10, new HashMap<>()));
     }
@@ -2241,17 +2241,17 @@ public interface RichIterableTestCase extends IterableTestCase
                         Tuples.pair("2", 2),
                         Tuples.pair("1", 1),
                 };
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(pairs),
                 iterable.toSortedMap(Object::toString, each -> each % 10));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(
                         Comparators.reverseNaturalOrder(),
                         pairs),
                 iterable.toSortedMap(Comparators.reverseNaturalOrder(), Object::toString, each -> each % 10));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(
                         Comparators.naturalOrder(),
                         pairs),
@@ -2262,7 +2262,7 @@ public interface RichIterableTestCase extends IterableTestCase
     default void RichIterable_toArray()
     {
         Object[] array = this.newWith(3, 3, 3, 2, 2, 1).toArray();
-        assertEquals(Bags.immutable.with(3, 3, 3, 2, 2, 1), HashBag.newBagWith(array));
+        assertIterablesEqual(Bags.immutable.with(3, 3, 3, 2, 2, 1), HashBag.newBagWith(array));
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableUniqueTestCase.java
@@ -63,13 +63,14 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertPostSerializedEqualsAndHashCode;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
-import static org.eclipse.collections.test.IterableTestCase.assertNotEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesNotEqual;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
@@ -100,14 +101,14 @@ public interface RichIterableUniqueTestCase
     {
         assertPostSerializedEqualsAndHashCode(this.newWith(3, 2, 1));
 
-        assertNotEquals(this.newWith(4, 3, 2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(4, 3, 2, 1));
+        assertIterablesNotEqual(this.newWith(4, 3, 2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(4, 3, 2, 1));
 
-        assertNotEquals(this.newWith(2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(2, 1));
+        assertIterablesNotEqual(this.newWith(2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(2, 1));
 
-        assertNotEquals(this.newWith(4, 2, 1), this.newWith(3, 2, 1));
-        assertNotEquals(this.newWith(3, 2, 1), this.newWith(4, 2, 1));
+        assertIterablesNotEqual(this.newWith(4, 2, 1), this.newWith(3, 2, 1));
+        assertIterablesNotEqual(this.newWith(3, 2, 1), this.newWith(4, 2, 1));
     }
 
     @Test
@@ -121,8 +122,8 @@ public interface RichIterableUniqueTestCase
     default void Iterable_toString()
     {
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
-        Assert.assertEquals("[3, 2, 1]", iterable.toString());
-        Assert.assertEquals("[3, 2, 1]", iterable.asLazy().toString());
+        assertEquals("[3, 2, 1]", iterable.toString());
+        assertEquals("[3, 2, 1]", iterable.asLazy().toString());
     }
 
     @Override
@@ -133,20 +134,20 @@ public interface RichIterableUniqueTestCase
             RichIterable<Integer> iterable = this.newWith(3, 2, 1);
             MutableCollection<Integer> result = this.newMutableForFilter();
             iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-            assertEquals(this.newMutableForFilter(13, 12, 11), result);
+            assertIterablesEqual(this.newMutableForFilter(13, 12, 11), result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(2, 1);
             MutableCollection<Integer> result = this.newMutableForFilter();
             iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-            assertEquals(this.newMutableForFilter(12, 11), result);
+            assertIterablesEqual(this.newMutableForFilter(12, 11), result);
         }
 
         RichIterable<Integer> iterable = this.newWith(1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.forEach(Procedures.cast(i -> result.add(i + 10)));
-        assertEquals(this.newMutableForFilter(11), result);
+        assertIterablesEqual(this.newMutableForFilter(11), result);
 
         this.newWith().forEach(Procedures.cast(each -> fail()));
     }
@@ -158,7 +159,7 @@ public interface RichIterableUniqueTestCase
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.tap(result::add).forEach(Procedures.noop());
-        assertEquals(this.newMutableForFilter(3, 2, 1), result);
+        assertIterablesEqual(this.newMutableForFilter(3, 2, 1), result);
         this.newWith().tap(Procedures.cast(each -> fail()));
     }
 
@@ -169,13 +170,13 @@ public interface RichIterableUniqueTestCase
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
         MutableCollection<Integer> result = this.newMutableForFilter();
         iterable.forEachWith((argument1, argument2) -> result.add(argument1 + argument2), 10);
-        assertEquals(this.newMutableForFilter(13, 12, 11), result);
+        assertIterablesEqual(this.newMutableForFilter(13, 12, 11), result);
     }
 
     @Test
     default void RichIterable_size()
     {
-        assertEquals(3, this.newWith(3, 2, 1).size());
+        assertIterablesEqual(3, this.newWith(3, 2, 1).size());
     }
 
     @Override
@@ -193,273 +194,273 @@ public interface RichIterableUniqueTestCase
         {
             RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(4, 2),
                     iterable.select(IntegerPredicates.isEven()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-                assertEquals(this.getExpectedFiltered(4, 2), result);
+                assertIterablesEqual(this.getExpectedFiltered(4, 2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(4, 3),
                     iterable.selectWith(Predicates2.greaterThan(), 2));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-                assertEquals(this.getExpectedFiltered(4, 3), result);
+                assertIterablesEqual(this.getExpectedFiltered(4, 3), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(4, 2),
                     iterable.reject(IntegerPredicates.isOdd()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-                assertEquals(this.getExpectedFiltered(4, 2), result);
+                assertIterablesEqual(this.getExpectedFiltered(4, 2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(4, 3),
                     iterable.rejectWith(Predicates2.lessThan(), 3));
 
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-            assertEquals(this.getExpectedFiltered(4, 3), result);
+            assertIterablesEqual(this.getExpectedFiltered(4, 3), result);
             assertSame(target, result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(3, 2, 1);
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(2),
                     iterable.select(IntegerPredicates.isEven()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-                assertEquals(this.getExpectedFiltered(2), result);
+                assertIterablesEqual(this.getExpectedFiltered(2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(3),
                     iterable.selectWith(Predicates2.greaterThan(), 2));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-                assertEquals(this.getExpectedFiltered(3), result);
+                assertIterablesEqual(this.getExpectedFiltered(3), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(2),
                     iterable.reject(IntegerPredicates.isOdd()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-                assertEquals(this.getExpectedFiltered(2), result);
+                assertIterablesEqual(this.getExpectedFiltered(2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(3),
                     iterable.rejectWith(Predicates2.lessThan(), 3));
 
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-            assertEquals(this.getExpectedFiltered(3), result);
+            assertIterablesEqual(this.getExpectedFiltered(3), result);
             assertSame(target, result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(2, 1);
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(2),
                     iterable.select(IntegerPredicates.isEven()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-                assertEquals(this.getExpectedFiltered(2), result);
+                assertIterablesEqual(this.getExpectedFiltered(2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.selectWith(Predicates2.greaterThan(), 2));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-                assertEquals(this.getExpectedFiltered(), result);
+                assertIterablesEqual(this.getExpectedFiltered(), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(2),
                     iterable.reject(IntegerPredicates.isOdd()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-                assertEquals(this.getExpectedFiltered(2), result);
+                assertIterablesEqual(this.getExpectedFiltered(2), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.rejectWith(Predicates2.lessThan(), 3));
 
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-            assertEquals(this.getExpectedFiltered(), result);
+            assertIterablesEqual(this.getExpectedFiltered(), result);
             assertSame(target, result);
         }
 
         {
             RichIterable<Integer> iterable = this.newWith(1);
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.select(IntegerPredicates.isEven()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-                assertEquals(this.getExpectedFiltered(), result);
+                assertIterablesEqual(this.getExpectedFiltered(), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(1),
                     iterable.select(IntegerPredicates.isOdd()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.select(IntegerPredicates.isOdd(), target);
-                assertEquals(this.getExpectedFiltered(1), result);
+                assertIterablesEqual(this.getExpectedFiltered(1), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.selectWith(Predicates2.greaterThan(), 2));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-                assertEquals(this.getExpectedFiltered(), result);
+                assertIterablesEqual(this.getExpectedFiltered(), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(1),
                     iterable.selectWith(Predicates2.greaterThan(), 0));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 0, target);
-                assertEquals(this.getExpectedFiltered(1), result);
+                assertIterablesEqual(this.getExpectedFiltered(1), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.reject(IntegerPredicates.isOdd()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-                assertEquals(this.getExpectedFiltered(), result);
+                assertIterablesEqual(this.getExpectedFiltered(), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(1),
                     iterable.reject(IntegerPredicates.isEven()));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isEven(), target);
-                assertEquals(this.getExpectedFiltered(1), result);
+                assertIterablesEqual(this.getExpectedFiltered(1), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(),
                     iterable.rejectWith(Predicates2.lessThan(), 3));
 
             {
                 MutableCollection<Integer> target = this.newMutableForFilter();
                 MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-                assertEquals(this.getExpectedFiltered(), result);
+                assertIterablesEqual(this.getExpectedFiltered(), result);
                 assertSame(target, result);
             }
 
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFiltered(1),
                     iterable.rejectWith(Predicates2.lessThan(), 0));
 
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 0, target);
-            assertEquals(this.getExpectedFiltered(1), result);
+            assertIterablesEqual(this.getExpectedFiltered(1), result);
             assertSame(target, result);
         }
 
         RichIterable<Integer> iterable = this.newWith();
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(),
                 iterable.select(IntegerPredicates.isEven()));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.select(IntegerPredicates.isEven(), target);
-            assertEquals(this.getExpectedFiltered(), result);
+            assertIterablesEqual(this.getExpectedFiltered(), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(),
                 iterable.selectWith(Predicates2.greaterThan(), 2));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.selectWith(Predicates2.greaterThan(), 2, target);
-            assertEquals(this.getExpectedFiltered(), result);
+            assertIterablesEqual(this.getExpectedFiltered(), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(),
                 iterable.reject(IntegerPredicates.isOdd()));
 
         {
             MutableCollection<Integer> target = this.newMutableForFilter();
             MutableCollection<Integer> result = iterable.reject(IntegerPredicates.isOdd(), target);
-            assertEquals(this.getExpectedFiltered(), result);
+            assertIterablesEqual(this.getExpectedFiltered(), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(),
                 iterable.rejectWith(Predicates2.lessThan(), 3));
 
         MutableCollection<Integer> target = this.newMutableForFilter();
         MutableCollection<Integer> result = iterable.rejectWith(Predicates2.lessThan(), 3, target);
-        assertEquals(this.getExpectedFiltered(), result);
+        assertIterablesEqual(this.getExpectedFiltered(), result);
         assertSame(target, result);
     }
 
@@ -470,12 +471,12 @@ public interface RichIterableUniqueTestCase
         RichIterable<Integer> iterable = this.newWith(-3, -2, -1, 0, 1, 2, 3);
 
         PartitionIterable<Integer> partition = iterable.partition(IntegerPredicates.isEven());
-        assertEquals(this.getExpectedFiltered(-2, 0, 2), partition.getSelected());
-        assertEquals(this.getExpectedFiltered(-3, -1, 1, 3), partition.getRejected());
+        assertIterablesEqual(this.getExpectedFiltered(-2, 0, 2), partition.getSelected());
+        assertIterablesEqual(this.getExpectedFiltered(-3, -1, 1, 3), partition.getRejected());
 
         PartitionIterable<Integer> partitionWith = iterable.partitionWith(Predicates2.greaterThan(), 0);
-        assertEquals(this.getExpectedFiltered(1, 2, 3), partitionWith.getSelected());
-        assertEquals(this.getExpectedFiltered(-3, -2, -1, 0), partitionWith.getRejected());
+        assertIterablesEqual(this.getExpectedFiltered(1, 2, 3), partitionWith.getSelected());
+        assertIterablesEqual(this.getExpectedFiltered(-3, -2, -1, 0), partitionWith.getRejected());
     }
 
     @Override
@@ -484,9 +485,9 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Number> iterable = this.newWith(1, 2.0, 3, 4.0);
 
-        assertEquals(this.getExpectedFiltered(), iterable.selectInstancesOf(String.class));
-        assertEquals(this.getExpectedFiltered(1, 3), iterable.selectInstancesOf(Integer.class));
-        assertEquals(this.getExpectedFiltered(1, 2.0, 3, 4.0), iterable.selectInstancesOf(Number.class));
+        assertIterablesEqual(this.getExpectedFiltered(), iterable.selectInstancesOf(String.class));
+        assertIterablesEqual(this.getExpectedFiltered(1, 3), iterable.selectInstancesOf(Integer.class));
+        assertIterablesEqual(this.getExpectedFiltered(1, 2.0, 3, 4.0), iterable.selectInstancesOf(Number.class));
     }
 
     @Override
@@ -495,24 +496,24 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(13, 12, 11, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 2, 1, 3, 2, 1),
                 iterable.collect(i -> i % 10));
 
         {
             MutableCollection<Integer> target = this.newMutableForTransform();
             MutableCollection<Integer> result = iterable.collect(i -> i % 10, target);
-            assertEquals(this.getExpectedTransformed(3, 2, 1, 3, 2, 1), result);
+            assertIterablesEqual(this.getExpectedTransformed(3, 2, 1, 3, 2, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 2, 1, 3, 2, 1),
                 iterable.collectWith((i, mod) -> i % mod, 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = iterable.collectWith((i, mod) -> i % mod, 10, target);
-        assertEquals(this.getExpectedTransformed(3, 2, 1, 3, 2, 1), result);
+        assertIterablesEqual(this.getExpectedTransformed(3, 2, 1, 3, 2, 1), result);
         assertSame(target, result);
     }
 
@@ -520,13 +521,13 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_collectIf()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 1, 3, 1),
                 this.newWith(13, 12, 11, 3, 2, 1).collectIf(i -> i % 2 != 0, i -> i % 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = this.newWith(13, 12, 11, 3, 2, 1).collectIf(i -> i % 2 != 0, i -> i % 10, target);
-        assertEquals(this.newMutableForTransform(3, 1, 3, 1), result);
+        assertIterablesEqual(this.newMutableForTransform(3, 1, 3, 1), result);
         assertSame(target, result);
     }
 
@@ -534,92 +535,92 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_collectPrimitive()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedBoolean(false, true, false),
                 this.newWith(3, 2, 1).collectBoolean(each -> each % 2 == 0));
 
         {
             MutableBooleanCollection target = this.newBooleanForTransform();
             MutableBooleanCollection result = this.newWith(3, 2, 1).collectBoolean(each -> each % 2 == 0, target);
-            assertEquals(this.getExpectedBoolean(false, true, false), result);
+            assertIterablesEqual(this.getExpectedBoolean(false, true, false), result);
             assertSame(target, result);
         }
 
         RichIterable<Integer> iterable = this.newWith(13, 12, 11, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedByte((byte) 3, (byte) 2, (byte) 1, (byte) 3, (byte) 2, (byte) 1),
                 iterable.collectByte(each -> (byte) (each % 10)));
 
         {
             MutableByteCollection target = this.newByteForTransform();
             MutableByteCollection result = iterable.collectByte(each -> (byte) (each % 10), target);
-            assertEquals(this.getExpectedByte((byte) 3, (byte) 2, (byte) 1, (byte) 3, (byte) 2, (byte) 1), result);
+            assertIterablesEqual(this.getExpectedByte((byte) 3, (byte) 2, (byte) 1, (byte) 3, (byte) 2, (byte) 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedChar((char) 3, (char) 2, (char) 1, (char) 3, (char) 2, (char) 1),
                 iterable.collectChar(each -> (char) (each % 10)));
 
         {
             MutableCharCollection target = this.newCharForTransform();
             MutableCharCollection result = iterable.collectChar(each -> (char) (each % 10), target);
-            assertEquals(this.getExpectedChar((char) 3, (char) 2, (char) 1, (char) 3, (char) 2, (char) 1), result);
+            assertIterablesEqual(this.getExpectedChar((char) 3, (char) 2, (char) 1, (char) 3, (char) 2, (char) 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedDouble(3.0, 2.0, 1.0, 3.0, 2.0, 1.0),
                 iterable.collectDouble(each -> (double) (each % 10)));
 
         {
             MutableDoubleCollection target = this.newDoubleForTransform();
             MutableDoubleCollection result = iterable.collectDouble(each -> (double) (each % 10), target);
-            assertEquals(this.getExpectedDouble(3.0, 2.0, 1.0, 3.0, 2.0, 1.0), result);
+            assertIterablesEqual(this.getExpectedDouble(3.0, 2.0, 1.0, 3.0, 2.0, 1.0), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFloat(3.0f, 2.0f, 1.0f, 3.0f, 2.0f, 1.0f),
                 iterable.collectFloat(each -> (float) (each % 10)));
 
         {
             MutableFloatCollection target = this.newFloatForTransform();
             MutableFloatCollection result = iterable.collectFloat(each -> (float) (each % 10), target);
-            assertEquals(this.getExpectedFloat(3.0f, 2.0f, 1.0f, 3.0f, 2.0f, 1.0f), result);
+            assertIterablesEqual(this.getExpectedFloat(3.0f, 2.0f, 1.0f, 3.0f, 2.0f, 1.0f), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedInt(3, 2, 1, 3, 2, 1),
                 iterable.collectInt(each -> each % 10));
 
         {
             MutableIntCollection target = this.newIntForTransform();
             MutableIntCollection result = iterable.collectInt(each -> each % 10, target);
-            assertEquals(this.getExpectedInt(3, 2, 1, 3, 2, 1), result);
+            assertIterablesEqual(this.getExpectedInt(3, 2, 1, 3, 2, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedLong(3, 2, 1, 3, 2, 1),
                 iterable.collectLong(each -> each % 10));
 
         {
             MutableLongCollection target = this.newLongForTransform();
             MutableLongCollection result = iterable.collectLong(each -> each % 10, target);
-            assertEquals(this.getExpectedLong(3, 2, 1, 3, 2, 1), result);
+            assertIterablesEqual(this.getExpectedLong(3, 2, 1, 3, 2, 1), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedShort((short) 3, (short) 2, (short) 1, (short) 3, (short) 2, (short) 1),
                 iterable.collectShort(each -> (short) (each % 10)));
 
         MutableShortCollection target = this.newShortForTransform();
         MutableShortCollection result = iterable.collectShort(each -> (short) (each % 10), target);
-        assertEquals(this.getExpectedShort((short) 3, (short) 2, (short) 1, (short) 3, (short) 2, (short) 1), result);
+        assertIterablesEqual(this.getExpectedShort((short) 3, (short) 2, (short) 1, (short) 3, (short) 2, (short) 1), result);
         assertSame(target, result);
     }
 
@@ -627,19 +628,19 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_flatCollect()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 2, 3, 1, 2, 1),
                 this.newWith(3, 2, 1).flatCollect(Interval::oneTo));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 2, 3, 1, 2, 1),
                 this.newWith(3, 2, 1).flatCollect(Interval::oneTo, this.newMutableForTransform()));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(3, 2, 1, 2, 1, 1),
                 this.newWith(3, 2, 1).flatCollectWith(Interval::fromTo, 1));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newMutableForTransform(3, 2, 1, 2, 1, 1),
                 this.newWith(3, 2, 1).flatCollectWith(Interval::fromTo, 1, this.newMutableForTransform()));
     }
@@ -653,7 +654,7 @@ public interface RichIterableUniqueTestCase
             MutableBooleanCollection result = this
                     .newWith(3, 2, 1)
                     .flatCollectBoolean(each -> BooleanLists.immutable.with(each % 2 == 0, each % 2 == 0), target);
-            assertEquals(this.getExpectedBoolean(false, false, true, true, false, false), result);
+            assertIterablesEqual(this.getExpectedBoolean(false, false, true, true, false, false), result);
             assertSame(target, result);
         }
 
@@ -664,7 +665,7 @@ public interface RichIterableUniqueTestCase
             MutableByteCollection result = iterable.flatCollectByte(
                     each -> ByteLists.immutable.with((byte) (each % 10), (byte) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedByte((byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1, (byte) 3, (byte) 3, (byte) 2, (byte) 2, (byte) 1, (byte) 1),
                     result);
             assertSame(target, result);
@@ -675,7 +676,7 @@ public interface RichIterableUniqueTestCase
             MutableCharCollection result = iterable.flatCollectChar(
                     each -> CharLists.immutable.with((char) (each % 10), (char) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedChar((char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1, (char) 3, (char) 3, (char) 2, (char) 2, (char) 1, (char) 1),
                     result);
             assertSame(target, result);
@@ -686,7 +687,7 @@ public interface RichIterableUniqueTestCase
             MutableDoubleCollection result = iterable.flatCollectDouble(each -> DoubleLists.immutable.with(
                     (double) (each % 10),
                     (double) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedDouble(3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0),
                     result);
             assertSame(target, result);
@@ -697,7 +698,7 @@ public interface RichIterableUniqueTestCase
             MutableFloatCollection result = iterable.flatCollectFloat(each -> FloatLists.immutable.with(
                     (float) (each % 10),
                     (float) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedFloat(3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f, 3.0f, 3.0f, 2.0f, 2.0f, 1.0f, 1.0f),
                     result);
             assertSame(target, result);
@@ -707,7 +708,7 @@ public interface RichIterableUniqueTestCase
             MutableIntCollection target = this.newIntForTransform();
             MutableIntCollection result =
                     iterable.flatCollectInt(each -> IntLists.immutable.with(each % 10, each % 10), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedInt(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                     result);
             assertSame(target, result);
@@ -717,7 +718,7 @@ public interface RichIterableUniqueTestCase
             MutableLongCollection target = this.newLongForTransform();
             MutableLongCollection result =
                     iterable.flatCollectLong(each -> LongLists.immutable.with(each % 10, each % 10), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedLong(3, 3, 2, 2, 1, 1, 3, 3, 2, 2, 1, 1),
                     result);
             assertSame(target, result);
@@ -728,7 +729,7 @@ public interface RichIterableUniqueTestCase
             MutableShortCollection result = iterable.flatCollectShort(each -> ShortLists.immutable.with(
                     (short) (each % 10),
                     (short) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.getExpectedShort((short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1, (short) 3, (short) 3, (short) 2, (short) 2, (short) 1, (short) 1),
                     result);
             assertSame(target, result);
@@ -741,18 +742,18 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(3, 2, 1);
 
-        assertEquals(1, iterable.count(Integer.valueOf(3)::equals));
-        assertEquals(1, iterable.count(Integer.valueOf(2)::equals));
-        assertEquals(1, iterable.count(Integer.valueOf(1)::equals));
-        assertEquals(0, iterable.count(Integer.valueOf(0)::equals));
-        assertEquals(2, iterable.count(i -> i % 2 != 0));
-        assertEquals(3, iterable.count(i -> i > 0));
+        assertIterablesEqual(1, iterable.count(Integer.valueOf(3)::equals));
+        assertIterablesEqual(1, iterable.count(Integer.valueOf(2)::equals));
+        assertIterablesEqual(1, iterable.count(Integer.valueOf(1)::equals));
+        assertIterablesEqual(0, iterable.count(Integer.valueOf(0)::equals));
+        assertIterablesEqual(2, iterable.count(i -> i % 2 != 0));
+        assertIterablesEqual(3, iterable.count(i -> i > 0));
 
-        assertEquals(1, iterable.countWith(Object::equals, 3));
-        assertEquals(1, iterable.countWith(Object::equals, 2));
-        assertEquals(1, iterable.countWith(Object::equals, 1));
-        assertEquals(0, iterable.countWith(Object::equals, 0));
-        assertEquals(3, iterable.countWith(Predicates2.greaterThan(), 0));
+        assertIterablesEqual(1, iterable.countWith(Object::equals, 3));
+        assertIterablesEqual(1, iterable.countWith(Object::equals, 2));
+        assertIterablesEqual(1, iterable.countWith(Object::equals, 1));
+        assertIterablesEqual(0, iterable.countWith(Object::equals, 0));
+        assertIterablesEqual(3, iterable.countWith(Predicates2.greaterThan(), 0));
     }
 
     @Override
@@ -767,12 +768,12 @@ public interface RichIterableUniqueTestCase
                         Boolean.TRUE, this.newMutableForFilter(3, 1),
                         Boolean.FALSE, this.newMutableForFilter(4, 2));
 
-        assertEquals(groupByExpected, iterable.groupBy(groupByFunction).toMap());
+        assertIterablesEqual(groupByExpected, iterable.groupBy(groupByFunction).toMap());
 
         Function<Integer, Boolean> function = (Integer object) -> true;
         MutableMultimap<Boolean, Integer> target = this.<Integer>newWith().groupBy(function).toMutable();
         MutableMultimap<Boolean, Integer> multimap2 = iterable.groupBy(groupByFunction, target);
-        assertEquals(groupByExpected, multimap2.toMap());
+        assertIterablesEqual(groupByExpected, multimap2.toMap());
         assertSame(target, multimap2);
 
         Function<Integer, Iterable<Integer>> groupByEachFunction = integer -> Interval.fromTo(-1, -integer);
@@ -784,11 +785,11 @@ public interface RichIterableUniqueTestCase
                         -2, this.newMutableForFilter(4, 3, 2),
                         -1, this.newMutableForFilter(4, 3, 2, 1));
 
-        assertEquals(expectedGroupByEach, iterable.groupByEach(groupByEachFunction).toMap());
+        assertIterablesEqual(expectedGroupByEach, iterable.groupByEach(groupByEachFunction).toMap());
 
         MutableMultimap<Integer, Integer> target2 = this.<Integer>newWith().groupByEach(groupByEachFunction).toMutable();
         Multimap<Integer, Integer> actualWithTarget = iterable.groupByEach(groupByEachFunction, target2);
-        assertEquals(expectedGroupByEach, actualWithTarget.toMap());
+        assertIterablesEqual(expectedGroupByEach, actualWithTarget.toMap());
         assertSame(target2, actualWithTarget);
     }
 
@@ -803,28 +804,28 @@ public interface RichIterableUniqueTestCase
                 () -> 0,
                 (integer1, integer2) -> integer1 + integer2);
 
-        assertEquals(4, aggregateBy.get("4").intValue());
-        assertEquals(3, aggregateBy.get("3").intValue());
-        assertEquals(2, aggregateBy.get("2").intValue());
-        assertEquals(1, aggregateBy.get("1").intValue());
+        assertIterablesEqual(4, aggregateBy.get("4").intValue());
+        assertIterablesEqual(3, aggregateBy.get("3").intValue());
+        assertIterablesEqual(2, aggregateBy.get("2").intValue());
+        assertIterablesEqual(1, aggregateBy.get("1").intValue());
 
         MapIterable<String, AtomicInteger> aggregateInPlaceBy = iterable.aggregateInPlaceBy(
                 String::valueOf,
                 AtomicInteger::new,
                 AtomicInteger::addAndGet);
-        assertEquals(4, aggregateInPlaceBy.get("4").intValue());
-        assertEquals(3, aggregateInPlaceBy.get("3").intValue());
-        assertEquals(2, aggregateInPlaceBy.get("2").intValue());
-        assertEquals(1, aggregateInPlaceBy.get("1").intValue());
+        assertIterablesEqual(4, aggregateInPlaceBy.get("4").intValue());
+        assertIterablesEqual(3, aggregateInPlaceBy.get("3").intValue());
+        assertIterablesEqual(2, aggregateInPlaceBy.get("2").intValue());
+        assertIterablesEqual(1, aggregateInPlaceBy.get("1").intValue());
 
         MapIterable<String, Integer> reduceBy = iterable.reduceBy(
                 Object::toString,
                 (integer1, integer2) -> integer1 + integer2);
 
-        assertEquals(4, reduceBy.get("4").intValue());
-        assertEquals(3, reduceBy.get("3").intValue());
-        assertEquals(2, reduceBy.get("2").intValue());
-        assertEquals(1, reduceBy.get("1").intValue());
+        assertIterablesEqual(4, reduceBy.get("4").intValue());
+        assertIterablesEqual(3, reduceBy.get("3").intValue());
+        assertIterablesEqual(2, reduceBy.get("2").intValue());
+        assertIterablesEqual(1, reduceBy.get("1").intValue());
     }
 
     @Override
@@ -833,10 +834,10 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        Assert.assertEquals(10.0f, iterable.sumOfFloat(Integer::floatValue), 0.001);
-        Assert.assertEquals(10.0, iterable.sumOfDouble(Integer::doubleValue), 0.001);
-        Assert.assertEquals(10, iterable.sumOfInt(integer -> integer));
-        Assert.assertEquals(10L, iterable.sumOfLong(Integer::longValue));
+        assertEquals(10.0f, iterable.sumOfFloat(Integer::floatValue), 0.001);
+        assertEquals(10.0, iterable.sumOfDouble(Integer::doubleValue), 0.001);
+        assertEquals(10, iterable.sumOfInt(integer -> integer));
+        assertEquals(10L, iterable.sumOfLong(Integer::longValue));
     }
 
     @Override
@@ -844,19 +845,19 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<String> iterable = this.newWith("4", "3", "2", "1");
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectLongMaps.immutable.with(0, 6L).newWithKeyValue(1, 4L),
                 iterable.sumByInt(s -> Integer.parseInt(s) % 2, Integer::parseInt));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectLongMaps.immutable.with(0, 6L).newWithKeyValue(1, 4L),
                 iterable.sumByLong(s -> Integer.parseInt(s) % 2, Long::parseLong));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectDoubleMaps.immutable.with(0, 6.0d).newWithKeyValue(1, 4.0d),
                 iterable.sumByDouble(s -> Integer.parseInt(s) % 2, Double::parseDouble));
 
-        assertEquals(
+        assertIterablesEqual(
                 ObjectDoubleMaps.immutable.with(0, 6.0d).newWithKeyValue(1, 4.0d),
                 iterable.sumByFloat(s -> Integer.parseInt(s) % 2, Float::parseFloat));
     }
@@ -867,10 +868,10 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        Assert.assertEquals(10.0f, iterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
-        Assert.assertEquals(10.0, iterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
-        Assert.assertEquals(10, iterable.summarizeInt(Integer::intValue).getSum());
-        Assert.assertEquals(10L, iterable.summarizeLong(Integer::longValue).getSum());
+        assertEquals(10.0f, iterable.summarizeFloat(Integer::floatValue).getSum(), 0.001);
+        assertEquals(10.0, iterable.summarizeDouble(Integer::doubleValue).getSum(), 0.001);
+        assertEquals(10, iterable.summarizeInt(Integer::intValue).getSum());
+        assertEquals(10L, iterable.summarizeLong(Integer::longValue).getSum());
     }
 
     @Override
@@ -879,28 +880,28 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(1, 2, 3);
         MutableBag<Integer> result = iterable.reduceInPlace(Collectors.toCollection(Bags.mutable::empty));
-        Assert.assertEquals(Bags.immutable.with(1, 2, 3), result);
+        assertEquals(Bags.immutable.with(1, 2, 3), result);
 
         String joining = result.collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(result.collect(Object::toString).makeString(","), joining);
+        assertEquals(result.collect(Object::toString).makeString(","), joining);
 
         String joining2 = result.toImmutable().collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(result.toImmutable().collect(Object::toString).makeString(","), joining2);
+        assertEquals(result.toImmutable().collect(Object::toString).makeString(","), joining2);
 
         String joining3 = result.asLazy().collect(Object::toString).reduceInPlace(Collectors.joining(","));
-        Assert.assertEquals(result.asLazy().collect(Object::toString).makeString(","), joining3);
+        assertEquals(result.asLazy().collect(Object::toString).makeString(","), joining3);
 
         Map<Boolean, List<Integer>> expected =
                 iterable.toList().stream().collect(Collectors.partitioningBy(each -> each % 2 == 0));
         Map<Boolean, List<Integer>> actual =
                 iterable.reduceInPlace(Collectors.partitioningBy(each -> each % 2 == 0));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Map<String, List<Integer>> groupByJDK =
                 iterable.toList().stream().collect(Collectors.groupingBy(Object::toString));
         Map<String, List<Integer>> groupByEC =
                 result.reduceInPlace(Collectors.groupingBy(Object::toString));
-        Assert.assertEquals(groupByJDK, groupByEC);
+        assertEquals(groupByJDK, groupByEC);
     }
 
     @Override
@@ -910,23 +911,23 @@ public interface RichIterableUniqueTestCase
         RichIterable<Integer> iterable = this.newWith(1, 2, 3);
         MutableBag<Integer> result =
                 iterable.reduceInPlace(Bags.mutable::empty, MutableBag::add);
-        Assert.assertEquals(Bags.immutable.with(1, 2, 3), result);
+        assertEquals(Bags.immutable.with(1, 2, 3), result);
 
         String joining =
                 result.collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(result.collect(Object::toString).makeString(""), joining);
+        assertEquals(result.collect(Object::toString).makeString(""), joining);
 
         ImmutableBag<Integer> immutableBag = result.toImmutable();
         String joining2 =
                 immutableBag.collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(immutableBag.collect(Object::toString).makeString(""), joining2);
+        assertEquals(immutableBag.collect(Object::toString).makeString(""), joining2);
 
         String joining3 =
                 result.asLazy().collect(Object::toString).reduceInPlace(StringBuilder::new, StringBuilder::append).toString();
-        Assert.assertEquals(result.asLazy().collect(Object::toString).makeString(""), joining3);
+        assertEquals(result.asLazy().collect(Object::toString).makeString(""), joining3);
 
         int atomicAdd = iterable.reduceInPlace(AtomicInteger::new, AtomicInteger::addAndGet).get();
-        Assert.assertEquals(6, atomicAdd);
+        assertEquals(6, atomicAdd);
     }
 
     @Override
@@ -936,20 +937,20 @@ public interface RichIterableUniqueTestCase
         RichIterable<Integer> iterable = this.newWith(1, 2, 3);
         Optional<Integer> result =
                 iterable.reduce(Integer::sum);
-        Assert.assertEquals(6, result.get().intValue());
+        assertEquals(6, result.get().intValue());
 
         Optional<Integer> max =
                 iterable.reduce(Integer::max);
-        Assert.assertEquals(3, max.get().intValue());
+        assertEquals(3, max.get().intValue());
 
         Optional<Integer> min =
                 iterable.reduce(Integer::min);
-        Assert.assertEquals(1, min.get().intValue());
+        assertEquals(1, min.get().intValue());
 
         RichIterable<Integer> iterableEmpty = this.newWith();
         Optional<Integer> resultEmpty =
                 iterableEmpty.reduce(Integer::sum);
-        Assert.assertFalse(resultEmpty.isPresent());
+        assertFalse(resultEmpty.isPresent());
     }
 
     @Override
@@ -958,7 +959,7 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        assertEquals(Integer.valueOf(11), iterable.injectInto(1, new Function2<Integer, Integer, Integer>()
+        assertIterablesEqual(Integer.valueOf(11), iterable.injectInto(1, new Function2<Integer, Integer, Integer>()
         {
             private static final long serialVersionUID = 1L;
 
@@ -967,7 +968,7 @@ public interface RichIterableUniqueTestCase
                 return argument1 + argument2;
             }
         }));
-        assertEquals(Integer.valueOf(10), iterable.injectInto(0, new Function2<Integer, Integer, Integer>()
+        assertIterablesEqual(Integer.valueOf(10), iterable.injectInto(0, new Function2<Integer, Integer, Integer>()
         {
             private static final long serialVersionUID = 1L;
 
@@ -984,17 +985,17 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        Assert.assertEquals(11, iterable.injectInto(1, AddFunction.INTEGER_TO_INT));
-        Assert.assertEquals(10, iterable.injectInto(0, AddFunction.INTEGER_TO_INT));
+        assertEquals(11, iterable.injectInto(1, AddFunction.INTEGER_TO_INT));
+        assertEquals(10, iterable.injectInto(0, AddFunction.INTEGER_TO_INT));
 
-        Assert.assertEquals(11L, iterable.injectInto(1, AddFunction.INTEGER_TO_LONG));
-        Assert.assertEquals(10L, iterable.injectInto(0, AddFunction.INTEGER_TO_LONG));
+        assertEquals(11L, iterable.injectInto(1, AddFunction.INTEGER_TO_LONG));
+        assertEquals(10L, iterable.injectInto(0, AddFunction.INTEGER_TO_LONG));
 
-        Assert.assertEquals(11.0d, iterable.injectInto(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
-        Assert.assertEquals(10.0d, iterable.injectInto(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        assertEquals(11.0d, iterable.injectInto(1, AddFunction.INTEGER_TO_DOUBLE), 0.001);
+        assertEquals(10.0d, iterable.injectInto(0, AddFunction.INTEGER_TO_DOUBLE), 0.001);
 
-        Assert.assertEquals(11.0f, iterable.injectInto(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
-        Assert.assertEquals(10.0f, iterable.injectInto(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        assertEquals(11.0f, iterable.injectInto(1, AddFunction.INTEGER_TO_FLOAT), 0.001f);
+        assertEquals(10.0f, iterable.injectInto(0, AddFunction.INTEGER_TO_FLOAT), 0.001f);
     }
 
     @Override
@@ -1003,21 +1004,21 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        assertEquals("4, 3, 2, 1", iterable.makeString());
-        assertEquals("4/3/2/1", iterable.makeString("/"));
-        assertEquals("[4/3/2/1]", iterable.makeString("[", "/", "]"));
+        assertIterablesEqual("4, 3, 2, 1", iterable.makeString());
+        assertIterablesEqual("4/3/2/1", iterable.makeString("/"));
+        assertIterablesEqual("[4/3/2/1]", iterable.makeString("[", "/", "]"));
 
         StringBuilder stringBuilder1 = new StringBuilder();
         iterable.appendString(stringBuilder1);
-        assertEquals("4, 3, 2, 1", stringBuilder1.toString());
+        assertIterablesEqual("4, 3, 2, 1", stringBuilder1.toString());
 
         StringBuilder stringBuilder2 = new StringBuilder();
         iterable.appendString(stringBuilder2, "/");
-        assertEquals("4/3/2/1", stringBuilder2.toString());
+        assertIterablesEqual("4/3/2/1", stringBuilder2.toString());
 
         StringBuilder stringBuilder3 = new StringBuilder();
         iterable.appendString(stringBuilder3, "[", "/", "]");
-        assertEquals("[4/3/2/1]", stringBuilder3.toString());
+        assertIterablesEqual("[4/3/2/1]", stringBuilder3.toString());
     }
 
     @Override
@@ -1025,13 +1026,13 @@ public interface RichIterableUniqueTestCase
     default void RichIterable_toList()
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 3, 2, 1),
                 iterable.toList());
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }
@@ -1040,7 +1041,7 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_into()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 3, 2, 1),
                 this.newWith(4, 3, 2, 1).into(Lists.mutable.empty()));
     }
@@ -1051,19 +1052,19 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 3, 4),
                 iterable.toSortedList());
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 3, 2, 1),
                 iterable.toSortedList(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 3, 4),
                 iterable.toSortedListBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(4, 3, 2, 1),
                 iterable.toSortedListBy(each -> each * -1));
     }
@@ -1072,7 +1073,7 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_toSet()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Sets.immutable.with(4, 3, 2, 1),
                 this.newWith(4, 3, 2, 1).toSet());
     }
@@ -1083,19 +1084,19 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(1, 2, 3, 4),
                 iterable.toSortedSet());
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.reverseNaturalOrder(), 4, 3, 2, 1),
                 iterable.toSortedSet(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.byFunction(Functions.identity()), 1, 2, 3, 4),
                 iterable.toSortedSetBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 SortedSets.immutable.with(Comparators.byFunction((Integer each) -> each * -1), 4, 3, 2, 1),
                 iterable.toSortedSetBy(each -> each * -1));
     }
@@ -1104,7 +1105,7 @@ public interface RichIterableUniqueTestCase
     @Test
     default void RichIterable_toBag()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Bags.immutable.with(4, 3, 2, 1),
                 this.newWith(4, 3, 2, 1).toBag());
     }
@@ -1115,19 +1116,19 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(1, 2, 3, 4),
                 iterable.toSortedBag());
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 3, 2, 1),
                 iterable.toSortedBag(Comparators.reverseNaturalOrder()));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.byFunction(Functions.identity()), 1, 2, 3, 4),
                 iterable.toSortedBagBy(Functions.identity()));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeBag.newBagWith(Comparators.byFunction((Integer each) -> each * -1), 4, 3, 2, 1),
                 iterable.toSortedBagBy(each -> each * -1));
     }
@@ -1138,7 +1139,7 @@ public interface RichIterableUniqueTestCase
     {
         RichIterable<Integer> iterable = this.newWith(13, 12, 11, 3, 2, 1);
 
-        assertEquals(
+        assertIterablesEqual(
                 UnifiedMap.newMapWith(
                         Tuples.pair("13", 3),
                         Tuples.pair("12", 2),
@@ -1164,17 +1165,17 @@ public interface RichIterableUniqueTestCase
                         Tuples.pair("2", 2),
                         Tuples.pair("1", 1),
                 };
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(pairs),
                 iterable.toSortedMap(Object::toString, each -> each % 10));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(
                         Comparators.reverseNaturalOrder(),
                         pairs),
                 iterable.toSortedMap(Comparators.reverseNaturalOrder(), Object::toString, each -> each % 10));
 
-        assertEquals(
+        assertIterablesEqual(
                 TreeSortedMap.newMapWith(
                         Comparators.naturalOrder(),
                         pairs),

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableWithDuplicatesTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/RichIterableWithDuplicatesTestCase.java
@@ -12,6 +12,8 @@ package org.eclipse.collections.test;
 
 import org.junit.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+
 public interface RichIterableWithDuplicatesTestCase extends RichIterableTestCase
 {
     @Override
@@ -26,12 +28,12 @@ public interface RichIterableWithDuplicatesTestCase extends RichIterableTestCase
         String s = "";
         Iterable<String> oneCopy = this.newWith(s);
         Iterable<String> twoCopies = this.newWith(s, s);
-        IterableTestCase.assertEquals(!this.allowsDuplicates(), twoCopies.equals(oneCopy));
+        assertIterablesEqual(!this.allowsDuplicates(), twoCopies.equals(oneCopy));
     }
 
     @Test
     default void RichIterable_size()
     {
-        IterableTestCase.assertEquals(6, this.newWith(3, 3, 3, 2, 2, 1).size());
+        assertIterablesEqual(6, this.newWith(3, 3, 3, 2, 2, 1).size());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/SortedNaturalOrderTestCase.java
@@ -42,12 +42,12 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.list.Interval;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -60,10 +60,10 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void Iterable_toString()
     {
         RichIterable<Integer> iterable = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        assertEquals(
+        assertIterablesEqual(
                 "[1, 2, 2, 3, 3, 3, 4, 4, 4, 4]",
                 iterable.toString());
-        assertEquals(
+        assertIterablesEqual(
                 "[1, 2, 2, 3, 3, 3, 4, 4, 4, 4]",
                 iterable.asLazy().toString());
     }
@@ -74,24 +74,24 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3),
                 iterable.collect(i -> i % 10));
 
         {
             MutableCollection<Integer> target = this.newMutableForTransform();
             MutableCollection<Integer> result = iterable.collect(i -> i % 10, target);
-            assertEquals(this.newMutableForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
+            assertIterablesEqual(this.newMutableForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3),
                 iterable.collectWith((i, mod) -> i % mod, 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = iterable.collectWith((i, mod) -> i % mod, 10, target);
-        assertEquals(this.newMutableForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
+        assertIterablesEqual(this.newMutableForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
         assertSame(target, result);
     }
 
@@ -101,13 +101,13 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     {
         RichIterable<Integer> iterable = this.newWith(1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 1, 3, 3, 1, 1, 3, 3),
                 iterable.collectIf(i -> i % 2 != 0, i -> i % 10));
 
         MutableCollection<Integer> target = this.newMutableForTransform();
         MutableCollection<Integer> result = iterable.collectIf(i -> i % 2 != 0, i -> i % 10, target);
-        assertEquals(this.newMutableForTransform(1, 1, 3, 3, 1, 1, 3, 3), result);
+        assertIterablesEqual(this.newMutableForTransform(1, 1, 3, 3, 1, 1, 3, 3), result);
         assertSame(target, result);
     }
 
@@ -115,92 +115,92 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     @Test
     default void RichIterable_collectPrimitive()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedBoolean(false, false, true, true, false, false),
                 this.newWith(1, 1, 2, 2, 3, 3).collectBoolean(each -> each % 2 == 0));
 
         {
             MutableBooleanCollection target = this.newBooleanForTransform();
             MutableBooleanCollection result = this.newWith(1, 1, 2, 2, 3, 3).collectBoolean(each -> each % 2 == 0, target);
-            assertEquals(this.newBooleanForTransform(false, false, true, true, false, false), result);
+            assertIterablesEqual(this.newBooleanForTransform(false, false, true, true, false, false), result);
             assertSame(target, result);
         }
 
         RichIterable<Integer> iterable = this.newWith(1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13);
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedByte((byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3),
                 iterable.collectByte(each -> (byte) (each % 10)));
 
         {
             MutableByteCollection target = this.newByteForTransform();
             MutableByteCollection result = iterable.collectByte(each -> (byte) (each % 10), target);
-            assertEquals(this.newByteForTransform((byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3), result);
+            assertIterablesEqual(this.newByteForTransform((byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 3, (byte) 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedChar((char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3, (char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3),
                 iterable.collectChar(each -> (char) (each % 10)));
 
         {
             MutableCharCollection target = this.newCharForTransform();
             MutableCharCollection result = iterable.collectChar(each -> (char) (each % 10), target);
-            assertEquals(this.newCharForTransform((char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3, (char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3), result);
+            assertIterablesEqual(this.newCharForTransform((char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3, (char) 1, (char) 1, (char) 2, (char) 2, (char) 3, (char) 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedDouble(1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0),
                 iterable.collectDouble(each -> (double) (each % 10)));
 
         {
             MutableDoubleCollection target = this.newDoubleForTransform();
             MutableDoubleCollection result = iterable.collectDouble(each -> (double) (each % 10), target);
-            assertEquals(this.newDoubleForTransform(1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0), result);
+            assertIterablesEqual(this.newDoubleForTransform(1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFloat(1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f),
                 iterable.collectFloat(each -> (float) (each % 10)));
 
         {
             MutableFloatCollection target = this.newFloatForTransform();
             MutableFloatCollection result = iterable.collectFloat(each -> (float) (each % 10), target);
-            assertEquals(this.newFloatForTransform(1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f), result);
+            assertIterablesEqual(this.newFloatForTransform(1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 3.0f), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedInt(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3),
                 iterable.collectInt(each -> each % 10));
 
         {
             MutableIntCollection target = this.newIntForTransform();
             MutableIntCollection result = iterable.collectInt(each -> each % 10, target);
-            assertEquals(this.newIntForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
+            assertIterablesEqual(this.newIntForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedLong(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3),
                 iterable.collectLong(each -> each % 10));
 
         {
             MutableLongCollection target = this.newLongForTransform();
             MutableLongCollection result = iterable.collectLong(each -> each % 10, target);
-            assertEquals(this.newLongForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
+            assertIterablesEqual(this.newLongForTransform(1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 3, 3), result);
             assertSame(target, result);
         }
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedShort((short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3, (short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3),
                 iterable.collectShort(each -> (short) (each % 10)));
 
         MutableShortCollection target = this.newShortForTransform();
         MutableShortCollection result = iterable.collectShort(each -> (short) (each % 10), target);
-        assertEquals(this.newShortForTransform((short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3, (short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3), result);
+        assertIterablesEqual(this.newShortForTransform((short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3, (short) 1, (short) 1, (short) 2, (short) 2, (short) 3, (short) 3), result);
         assertSame(target, result);
     }
 
@@ -208,19 +208,19 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     @Test
     default void RichIterable_flatCollect()
     {
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 1, 2, 1, 2, 1, 2, 3),
                 this.newWith(1, 2, 2, 3).flatCollect(Interval::oneTo));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newMutableForTransform(1, 1, 2, 1, 2, 1, 2, 3),
                 this.newWith(1, 2, 2, 3).flatCollect(Interval::oneTo, this.newMutableForTransform()));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedTransformed(1, 2, 3, 4, 5, 2, 3, 4, 5, 2, 3, 4, 5, 3, 4, 5),
                 this.newWith(1, 2, 2, 3).flatCollectWith(Interval::fromTo, 5));
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newMutableForTransform(1, 2, 1, 2, 1, 3, 2, 1),
                 this.newWith(1, 2, 2, 3).flatCollectWith(Interval::fromTo, 1, this.newMutableForTransform()));
     }
@@ -233,7 +233,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableBooleanCollection result = this.newWith(1, 1, 2, 2, 3, 3).flatCollectBoolean(
                     each -> BooleanLists.immutable.with(each % 2 == 0, each % 2 == 0),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newBooleanForTransform(false, false, false, false, true, true, true, true, false, false, false, false),
                     result);
             assertSame(target, result);
@@ -246,7 +246,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableByteCollection result = iterable.flatCollectByte(
                     each -> ByteLists.immutable.with((byte) (each % 10), (byte) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newByteForTransform((byte) 1, (byte) 1, (byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 3, (byte) 3, (byte) 1, (byte) 1, (byte) 1, (byte) 1, (byte) 2, (byte) 2, (byte) 2, (byte) 2, (byte) 3, (byte) 3, (byte) 3, (byte) 3),
                     result);
             assertSame(target, result);
@@ -257,7 +257,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableCharCollection result = iterable.flatCollectChar(
                     each -> CharLists.immutable.with((char) (each % 10), (char) (each % 10)),
                     target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newCharForTransform((char) 1, (char) 1, (char) 1, (char) 1, (char) 2, (char) 2, (char) 2, (char) 2, (char) 3, (char) 3, (char) 3, (char) 3, (char) 1, (char) 1, (char) 1, (char) 1, (char) 2, (char) 2, (char) 2, (char) 2, (char) 3, (char) 3, (char) 3, (char) 3),
                     result);
             assertSame(target, result);
@@ -268,7 +268,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableDoubleCollection result = iterable.flatCollectDouble(each -> DoubleLists.immutable.with(
                     (double) (each % 10),
                     (double) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newDoubleForTransform(1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0),
                     result);
             assertSame(target, result);
@@ -279,7 +279,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableFloatCollection result = iterable.flatCollectFloat(each -> FloatLists.immutable.with(
                     (float) (each % 10),
                     (float) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newFloatForTransform(
                             1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f, 1.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f, 2.0f, 3.0f, 3.0f, 3.0f, 3.0f),
                     result);
@@ -290,7 +290,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableIntCollection target = this.newIntForTransform();
             MutableIntCollection result =
                     iterable.flatCollectInt(each -> IntLists.immutable.with(each % 10, each % 10), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newIntForTransform(1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3),
                     result);
             assertSame(target, result);
@@ -300,7 +300,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableLongCollection target = this.newLongForTransform();
             MutableLongCollection result =
                     iterable.flatCollectLong(each -> LongLists.immutable.with(each % 10, each % 10), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newLongForTransform(1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3),
                     result);
             assertSame(target, result);
@@ -311,7 +311,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
             MutableShortCollection result = iterable.flatCollectShort(each -> ShortLists.immutable.with(
                     (short) (each % 10),
                     (short) (each % 10)), target);
-            assertEquals(
+            assertIterablesEqual(
                     this.newShortForTransform((short) 1, (short) 1, (short) 1, (short) 1, (short) 2, (short) 2, (short) 2, (short) 2, (short) 3, (short) 3, (short) 3, (short) 3, (short) 1, (short) 1, (short) 1, (short) 1, (short) 2, (short) 2, (short) 2, (short) 2, (short) 3, (short) 3, (short) 3, (short) 3),
                     result);
             assertSame(target, result);
@@ -389,10 +389,10 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     @Test
     default void RichIterable_minBy_maxBy()
     {
-        assertEquals("ca", this.newWith("ab", "bc", "ca", "da", "ed").minBy(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual("ca", this.newWith("ab", "bc", "ca", "da", "ed").minBy(string -> string.charAt(string.length() - 1)));
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().minBy(string -> string.charAt(string.length() - 1)));
 
-        assertEquals("cz", this.newWith("ew", "dz", "cz", "bx", "ay").maxBy(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual("cz", this.newWith("ew", "dz", "cz", "bx", "ay").maxBy(string -> string.charAt(string.length() - 1)));
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().maxBy(string -> string.charAt(string.length() - 1)));
     }
 
@@ -401,33 +401,33 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void RichIterable_makeString_appendString()
     {
         RichIterable<Integer> iterable = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        assertEquals(
+        assertIterablesEqual(
                 "1, 2, 2, 3, 3, 3, 4, 4, 4, 4",
                 iterable.makeString());
 
-        assertEquals(
+        assertIterablesEqual(
                 "1/2/2/3/3/3/4/4/4/4",
                 iterable.makeString("/"));
 
-        assertEquals(
+        assertIterablesEqual(
                 "[1/2/2/3/3/3/4/4/4/4]",
                 iterable.makeString("[", "/", "]"));
 
         StringBuilder builder1 = new StringBuilder();
         iterable.appendString(builder1);
-        assertEquals(
+        assertIterablesEqual(
                 "1, 2, 2, 3, 3, 3, 4, 4, 4, 4",
                 builder1.toString());
 
         StringBuilder builder2 = new StringBuilder();
         iterable.appendString(builder2, "/");
-        assertEquals(
+        assertIterablesEqual(
                 "1/2/2/3/3/3/4/4/4/4",
                 builder2.toString());
 
         StringBuilder builder3 = new StringBuilder();
         iterable.appendString(builder3, "[", "/", "]");
-        assertEquals(
+        assertIterablesEqual(
                 "[1/2/2/3/3/3/4/4/4/4]",
                 builder3.toString());
     }
@@ -437,13 +437,13 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void RichIterable_toList()
     {
         RichIterable<Integer> iterable = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 iterable.toList());
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }
@@ -452,7 +452,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     @Test
     default void RichIterable_into()
     {
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4),
                 this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4).into(Lists.mutable.empty()));
     }
@@ -461,14 +461,14 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     @Test
     default void OrderedIterable_getFirst()
     {
-        assertEquals(Integer.valueOf(1), this.newWith(1, 2, 2, 3, 3, 3).getFirst());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(1, 2, 2, 3, 3, 3).getFirst());
     }
 
     @Override
     @Test
     default void OrderedIterable_getLast()
     {
-        assertEquals(Integer.valueOf(3), this.newWith(1, 2, 2, 3, 3, 3).getLast());
+        assertIterablesEqual(Integer.valueOf(3), this.newWith(1, 2, 2, 3, 3, 3).getLast());
     }
 
     @Override
@@ -476,9 +476,9 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void OrderedIterable_next()
     {
         Iterator<Integer> iterator = this.newWith(1, 2, 3).iterator();
-        assertEquals(Integer.valueOf(1), iterator.next());
-        assertEquals(Integer.valueOf(2), iterator.next());
-        assertEquals(Integer.valueOf(3), iterator.next());
+        assertIterablesEqual(Integer.valueOf(1), iterator.next());
+        assertIterablesEqual(Integer.valueOf(2), iterator.next());
+        assertIterablesEqual(Integer.valueOf(3), iterator.next());
     }
 
     /**
@@ -489,7 +489,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void OrderedIterable_collectWithIndex()
     {
         OrderedIterable<Integer> iterable = (OrderedIterable<Integer>) this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(1), 0),
                         PrimitiveTuples.pair(Integer.valueOf(2), 1),
@@ -512,7 +512,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void OrderedIterable_collectWithIndexWithTarget()
     {
         OrderedIterable<Integer> iterable = (OrderedIterable<Integer>) this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         PrimitiveTuples.pair(Integer.valueOf(1), 0),
                         PrimitiveTuples.pair(Integer.valueOf(2), 1),
@@ -532,7 +532,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
     default void OrderedIterable_zipWithIndex()
     {
         RichIterable<Integer> iterable = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(1, 0),
                         Tuples.pair(2, 1),
@@ -554,7 +554,7 @@ public interface SortedNaturalOrderTestCase extends OrderedIterableTestCase
         RichIterable<Integer> iterable = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
         MutableList<Pair<Integer, Integer>> target = Lists.mutable.empty();
         MutableList<Pair<Integer, Integer>> result = iterable.zipWithIndex(target);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(1, 0),
                         Tuples.pair(2, 1),

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnmodifiableMutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnmodifiableMutableCollectionTestCase.java
@@ -17,7 +17,7 @@ import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.test.collection.mutable.MutableCollectionTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertThrows;
 
 public interface UnmodifiableMutableCollectionTestCase extends FixedSizeCollectionTestCase, MutableCollectionTestCase
@@ -38,7 +38,7 @@ public interface UnmodifiableMutableCollectionTestCase extends FixedSizeCollecti
         String s = "";
         if (this.allowsDuplicates())
         {
-            assertEquals(2, this.newWith(s, s).size());
+            assertIterablesEqual(2, this.newWith(s, s).size());
         }
         else
         {

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnorderedIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/UnorderedIterableTestCase.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.junit.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
@@ -45,7 +46,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
             mutableCollection.add(integer);
         }
 
-        IterableTestCase.assertEquals(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
+        assertIterablesEqual(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
         assertFalse(iterator.hasNext());
     }
 
@@ -63,7 +64,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         RichIterable<Integer> integers = this.newWith(3, 2, 1);
         Integer first = integers.getFirst();
         assertThat(first, isOneOf(3, 2, 1));
-        IterableTestCase.assertEquals(integers.iterator().next(), first);
+        assertIterablesEqual(integers.iterator().next(), first);
 
         assertNotEquals(integers.getLast(), first);
     }
@@ -82,7 +83,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         {
             iteratorLast = iterator.next();
         }
-        IterableTestCase.assertEquals(iteratorLast, last);
+        assertIterablesEqual(iteratorLast, last);
 
         assertNotEquals(integers.getFirst(), last);
     }
@@ -162,7 +163,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         RichIterable<String> minIterable = this.newWith("ed", "da", "ca", "bc", "ab");
         String actualMin = minIterable.minBy(string -> string.charAt(string.length() - 1));
         assertThat(actualMin, isOneOf("ca", "da"));
-        IterableTestCase.assertEquals(minIterable.detect(each -> each.equals("ca") || each.equals("da")), actualMin);
+        assertIterablesEqual(minIterable.detect(each -> each.equals("ca") || each.equals("da")), actualMin);
 
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().minBy(string -> string.charAt(string.length() - 1)));
 
@@ -170,7 +171,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         RichIterable<String> maxIterable = this.newWith("ew", "dz", "cz", "bx", "ay");
         String actualMax = maxIterable.maxBy(string -> string.charAt(string.length() - 1));
         assertThat(actualMax, isOneOf("cz", "dz"));
-        IterableTestCase.assertEquals(maxIterable.detect(each -> each.equals("cz") || each.equals("dz")), actualMax);
+        assertIterablesEqual(maxIterable.detect(each -> each.equals("cz") || each.equals("dz")), actualMax);
 
         assertThrows(NoSuchElementException.class, () -> this.<String>newWith().maxBy(string -> string.charAt(string.length() - 1)));
     }
@@ -183,7 +184,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         RichIterable<String> minIterable = this.newWith("ed", "da", "ca", "bc", "ab");
         String actualMin = minIterable.minByOptional(string -> string.charAt(string.length() - 1)).get();
         assertThat(actualMin, isOneOf("ca", "da"));
-        IterableTestCase.assertEquals(minIterable.detect(each -> each.equals("ca") || each.equals("da")), actualMin);
+        assertIterablesEqual(minIterable.detect(each -> each.equals("ca") || each.equals("da")), actualMin);
 
         assertThat(this.<String>newWith().minByOptional(string -> string.charAt(string.length() - 1)), is(Optional.empty()));
 
@@ -191,7 +192,7 @@ public interface UnorderedIterableTestCase extends RichIterableTestCase
         RichIterable<String> maxIterable = this.newWith("ew", "dz", "cz", "bx", "ay");
         String actualMax = maxIterable.maxByOptional(string -> string.charAt(string.length() - 1)).get();
         assertThat(actualMax, isOneOf("cz", "dz"));
-        IterableTestCase.assertEquals(maxIterable.detect(each -> each.equals("cz") || each.equals("dz")), actualMax);
+        assertIterablesEqual(maxIterable.detect(each -> each.equals("cz") || each.equals("dz")), actualMax);
 
         assertThat(this.<String>newWith().maxByOptional(string -> string.charAt(string.length() - 1)), is(Optional.empty()));
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/BagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/BagTestCase.java
@@ -21,11 +21,11 @@ import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.eclipse.collections.test.RichIterableWithDuplicatesTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -54,15 +54,15 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
         {
             iterationOrder.add(iterator.next());
         }
-        assertEquals(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), iterationOrder);
+        assertIterablesEqual(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), iterationOrder);
 
         MutableCollection<Integer> forEachWithIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().forEachWith((each, param) -> forEachWithIterationOrder.add(each), null);
-        assertEquals(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), forEachWithIterationOrder);
+        assertIterablesEqual(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), forEachWithIterationOrder);
 
         MutableCollection<Integer> forEachWithIndexIterationOrder = this.newMutableForFilter();
         this.getInstanceUnderTest().forEachWithIndex((each, index) -> forEachWithIndexIterationOrder.add(each));
-        assertEquals(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), forEachWithIndexIterationOrder);
+        assertIterablesEqual(RichIterableWithDuplicatesTestCase.super.expectedIterationOrder(), forEachWithIndexIterationOrder);
     }
 
     @Test
@@ -108,9 +108,9 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
     default void Bag_detectWithOccurrences()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(3, bag.detectWithOccurrences((object, value) -> object.equals(3) && value == 3));
-        assertEquals(3, bag.detectWithOccurrences((object, value) -> object.equals(3)));
-        assertEquals(1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
+        assertIterablesEqual(3, bag.detectWithOccurrences((object, value) -> object.equals(3) && value == 3));
+        assertIterablesEqual(3, bag.detectWithOccurrences((object, value) -> object.equals(3)));
+        assertIterablesEqual(1, bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 1));
         assertNull(bag.detectWithOccurrences((object, value) -> object.equals(1) && value == 10));
         assertNull(bag.detectWithOccurrences((object, value) -> object.equals(10) && value == 5));
         assertNull(bag.detectWithOccurrences((object, value) -> object.equals(100)));
@@ -120,23 +120,23 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
     default void Bag_sizeDistinct()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(3, bag.sizeDistinct());
+        assertIterablesEqual(3, bag.sizeDistinct());
     }
 
     @Test
     default void Bag_occurrencesOf()
     {
         Bag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(0, bag.occurrencesOf(0));
-        assertEquals(1, bag.occurrencesOf(1));
-        assertEquals(2, bag.occurrencesOf(2));
-        assertEquals(3, bag.occurrencesOf(3));
+        assertIterablesEqual(0, bag.occurrencesOf(0));
+        assertIterablesEqual(1, bag.occurrencesOf(1));
+        assertIterablesEqual(2, bag.occurrencesOf(2));
+        assertIterablesEqual(3, bag.occurrencesOf(3));
     }
 
     @Test
     default void Bag_toStringOfItemToCount()
     {
-        assertEquals("{}", this.newWith().toStringOfItemToCount());
+        assertIterablesEqual("{}", this.newWith().toStringOfItemToCount());
         assertThat(this.newWith(2, 2, 1).toStringOfItemToCount(), isOneOf("{1=1, 2=2}", "{2=2, 1=1}"));
     }
 
@@ -154,7 +154,7 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<ObjectIntPair<Integer>> actual2 =
                 bag.collectWithOccurrences(PrimitiveTuples::pair, Sets.mutable.empty());
@@ -163,6 +163,6 @@ public interface BagTestCase extends RichIterableWithDuplicatesTestCase
                         PrimitiveTuples.pair(Integer.valueOf(3), 3),
                         PrimitiveTuples.pair(Integer.valueOf(2), 2),
                         PrimitiveTuples.pair(Integer.valueOf(1), 1));
-        Assert.assertEquals(expected2, actual2);
+        assertEquals(expected2, actual2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/UnsortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/UnsortedBagTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.test.UnorderedIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertSame;
@@ -51,7 +51,7 @@ public interface UnsortedBagTestCase extends UnorderedIterableTestCase, BagTestC
             result.add(argument1);
             assertSame(sentinel, argument2);
         }, sentinel);
-        assertEquals(Bags.immutable.with(3, 3, 3, 2, 2, 1), result);
+        assertIterablesEqual(Bags.immutable.with(3, 3, 3, 2, 2, 1), result);
     }
 
     @Override
@@ -90,7 +90,7 @@ public interface UnsortedBagTestCase extends UnorderedIterableTestCase, BagTestC
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/MultiReaderHashBagTest.java
@@ -22,7 +22,7 @@ import org.eclipse.collections.test.collection.mutable.MultiReaderMutableCollect
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -85,7 +85,7 @@ public class MultiReaderHashBagTest implements MutableBagTestCase, MultiReaderMu
 
         // TODO Report to JetBrains
         // assertEquals(MultiReaderMutableCollectionTestCase.super.expectedIterationOrder(), iterationOrder);
-        assertEquals(expectedIterationOrder, iterationOrder);
+        assertIterablesEqual(expectedIterationOrder, iterationOrder);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class MultiReaderHashBagTest implements MutableBagTestCase, MultiReaderMu
                 mutableCollection.add(integer);
             }
 
-            assertEquals(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
+            assertIterablesEqual(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
             assertFalse(iterator.hasNext());
         });
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableBagIterableTestCase.java
@@ -15,7 +15,7 @@ import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.test.collection.mutable.MutableCollectionTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -29,10 +29,10 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
     default void MutableBagIterable_addOccurrences()
     {
         MutableBagIterable<Integer> mutableBag = this.newWith(1, 2, 2, 3, 3, 3);
-        assertEquals(4, mutableBag.addOccurrences(4, 4));
-        assertEquals(Bags.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
-        assertEquals(3, mutableBag.addOccurrences(1, 2));
-        assertEquals(Bags.immutable.with(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
+        assertIterablesEqual(4, mutableBag.addOccurrences(4, 4));
+        assertIterablesEqual(Bags.immutable.with(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
+        assertIterablesEqual(3, mutableBag.addOccurrences(1, 2));
+        assertIterablesEqual(Bags.immutable.with(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableBag);
 
         assertThrows(
                 IllegalArgumentException.class,
@@ -44,13 +44,13 @@ public interface MutableBagIterableTestCase extends MutableCollectionTestCase
     {
         MutableBagIterable<Integer> mutableBag = this.newWith(1, 2, 2, 3, 3, 3);
         assertFalse(mutableBag.removeOccurrences(4, 4));
-        assertEquals(Bags.immutable.with(1, 2, 2, 3, 3, 3), mutableBag);
+        assertIterablesEqual(Bags.immutable.with(1, 2, 2, 3, 3, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(1, 2));
-        assertEquals(Bags.immutable.with(2, 2, 3, 3, 3), mutableBag);
+        assertIterablesEqual(Bags.immutable.with(2, 2, 3, 3, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(3, 2));
-        assertEquals(Bags.immutable.with(2, 2, 3), mutableBag);
+        assertIterablesEqual(Bags.immutable.with(2, 2, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 1));
-        assertEquals(Bags.immutable.with(2, 3), mutableBag);
+        assertIterablesEqual(Bags.immutable.with(2, 3), mutableBag);
 
         assertThrows(
                 IllegalArgumentException.class,

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagNoComparatorTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.test.MutableSortedNaturalOrderTestCase;
 import org.junit.Test;
 
 import static org.eclipse.collections.test.IterableTestCase.addAllTo;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -46,8 +46,8 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
     @Test
     default void Bag_toStringOfItemToCount()
     {
-        assertEquals("{}", this.newWith().toStringOfItemToCount());
-        assertEquals("{1=1, 2=2, 3=3}", this.newWith(3, 3, 3, 2, 2, 1).toStringOfItemToCount());
+        assertIterablesEqual("{}", this.newWith().toStringOfItemToCount());
+        assertIterablesEqual("{1=1, 2=2, 3=3}", this.newWith(3, 3, 3, 2, 2, 1).toStringOfItemToCount());
     }
 
     @Override
@@ -55,12 +55,12 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
     default void MutableBagIterable_addOccurrences()
     {
         MutableSortedBag<Integer> mutableSortedBag = this.newWith(1, 2, 2, 3, 3, 3);
-        assertEquals(4, mutableSortedBag.addOccurrences(4, 4));
-        assertEquals(TreeBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
-        assertEquals(3, mutableSortedBag.addOccurrences(1, 2));
-        assertEquals(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
-        assertEquals(3, mutableSortedBag.addOccurrences(1, 0));
-        assertEquals(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
+        assertIterablesEqual(4, mutableSortedBag.addOccurrences(4, 4));
+        assertIterablesEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
+        assertIterablesEqual(3, mutableSortedBag.addOccurrences(1, 2));
+        assertIterablesEqual(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
+        assertIterablesEqual(3, mutableSortedBag.addOccurrences(1, 0));
+        assertIterablesEqual(TreeBag.newBagWith(1, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4), mutableSortedBag);
     }
 
     @Override
@@ -69,17 +69,17 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
     {
         MutableSortedBag<Integer> mutableBag = this.newWith(1, 2, 2, 3, 3, 3);
         assertFalse(mutableBag.removeOccurrences(4, 4));
-        assertEquals(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), mutableBag);
         assertFalse(mutableBag.removeOccurrences(3, 0));
-        assertEquals(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(1, 2, 2, 3, 3, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(1, 2));
-        assertEquals(TreeBag.newBagWith(2, 2, 3, 3, 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(2, 2, 3, 3, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(3, 2));
-        assertEquals(TreeBag.newBagWith(2, 2, 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(2, 2, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 1));
-        assertEquals(TreeBag.newBagWith(2, 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(2, 3), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 2));
-        assertEquals(TreeBag.newBagWith(3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(3), mutableBag);
     }
 
     @Override
@@ -92,7 +92,7 @@ public interface MutableSortedBagNoComparatorTestCase extends SortedBagTestCase,
             result.add(argument1);
             result.add(argument2);
         }, 0);
-        assertEquals(Lists.immutable.with(1, 0, 2, 0, 2, 0, 3, 0, 3, 0, 3, 0), result);
+        assertIterablesEqual(Lists.immutable.with(1, 0, 2, 0, 2, 0, 3, 0, 3, 0, 3, 0), result);
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/MutableSortedBagTestCase.java
@@ -16,7 +16,7 @@ import org.eclipse.collections.impl.block.factory.Comparators;
 import org.eclipse.collections.test.MutableOrderedIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -31,12 +31,12 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
     default void MutableBagIterable_addOccurrences()
     {
         MutableSortedBag<Integer> mutableSortedBag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(4, mutableSortedBag.addOccurrences(4, 4));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1), mutableSortedBag);
-        assertEquals(3, mutableSortedBag.addOccurrences(1, 2));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
-        assertEquals(3, mutableSortedBag.addOccurrences(1, 0));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
+        assertIterablesEqual(4, mutableSortedBag.addOccurrences(4, 4));
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1), mutableSortedBag);
+        assertIterablesEqual(3, mutableSortedBag.addOccurrences(1, 2));
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
+        assertIterablesEqual(3, mutableSortedBag.addOccurrences(1, 0));
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, 1, 1), mutableSortedBag);
 
         assertThrows(IllegalArgumentException.class, () -> mutableSortedBag.addOccurrences(4, -1));
     }
@@ -47,17 +47,17 @@ public interface MutableSortedBagTestCase extends SortedBagTestCase, MutableOrde
     {
         MutableSortedBag<Integer> mutableBag = this.newWith(3, 3, 3, 2, 2, 1);
         assertFalse(mutableBag.removeOccurrences(4, 4));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1), mutableBag);
         assertFalse(mutableBag.removeOccurrences(3, 0));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2, 1), mutableBag);
         assertTrue(mutableBag.removeOccurrences(1, 2));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 3, 3, 2, 2), mutableBag);
         assertTrue(mutableBag.removeOccurrences(3, 2));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 2, 2), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 2, 2), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 1));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 2), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3, 2), mutableBag);
         assertTrue(mutableBag.removeOccurrences(2, 2));
-        assertEquals(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3), mutableBag);
+        assertIterablesEqual(TreeBag.newBagWith(Comparators.reverseNaturalOrder(), 3), mutableBag);
 
         assertThrows(IllegalArgumentException.class, () -> mutableBag.removeOccurrences(4, -1));
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/SortedBagTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/SortedBagTestCase.java
@@ -24,7 +24,7 @@ import org.eclipse.collections.test.domain.C;
 import org.eclipse.collections.test.list.TransformsToListTrait;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 
 // TODO linked bag
 public interface SortedBagTestCase extends SortedIterableTestCase, BagTestCase, TransformsToListTrait
@@ -55,10 +55,10 @@ public interface SortedBagTestCase extends SortedIterableTestCase, BagTestCase, 
                 new B(3), new B(3), new B(3),
                 new C(2.0), new C(2.0),
                 new B(1));
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(new B(3), new B(3), new B(3), new B(1)),
                 numbers.selectInstancesOf(B.class));
-        assertEquals(
+        assertIterablesEqual(
                 this.getExpectedFiltered(
                         new C(4.0), new C(4.0), new C(4.0), new C(4.0),
                         new B(3), new B(3), new B(3),
@@ -72,7 +72,7 @@ public interface SortedBagTestCase extends SortedIterableTestCase, BagTestCase, 
     default void Bag_sizeDistinct()
     {
         SortedBag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(3, bag.sizeDistinct());
+        assertIterablesEqual(3, bag.sizeDistinct());
     }
 
     @Override
@@ -80,18 +80,18 @@ public interface SortedBagTestCase extends SortedIterableTestCase, BagTestCase, 
     default void Bag_occurrencesOf()
     {
         SortedBag<Integer> bag = this.newWith(3, 3, 3, 2, 2, 1);
-        assertEquals(0, bag.occurrencesOf(0));
-        assertEquals(1, bag.occurrencesOf(1));
-        assertEquals(2, bag.occurrencesOf(2));
-        assertEquals(3, bag.occurrencesOf(3));
+        assertIterablesEqual(0, bag.occurrencesOf(0));
+        assertIterablesEqual(1, bag.occurrencesOf(1));
+        assertIterablesEqual(2, bag.occurrencesOf(2));
+        assertIterablesEqual(3, bag.occurrencesOf(3));
     }
 
     @Override
     @Test
     default void Bag_toStringOfItemToCount()
     {
-        assertEquals("{}", this.newWith().toStringOfItemToCount());
-        assertEquals("{3=3, 2=2, 1=1}", this.newWith(3, 3, 3, 2, 2, 1).toStringOfItemToCount());
+        assertIterablesEqual("{}", this.newWith().toStringOfItemToCount());
+        assertIterablesEqual("{3=3, 2=2, 1=1}", this.newWith(3, 3, 3, 2, 2, 1).toStringOfItemToCount());
     }
 
     @Test
@@ -103,6 +103,6 @@ public interface SortedBagTestCase extends SortedIterableTestCase, BagTestCase, 
             result.add(argument1);
             result.add(argument2);
         }, 0);
-        assertEquals(Lists.immutable.with(3, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0), result);
+        assertIterablesEqual(Lists.immutable.with(3, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0), result);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/TreeBagNoComparatorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bag/mutable/sorted/TreeBagNoComparatorTest.java
@@ -21,7 +21,7 @@ import org.eclipse.collections.test.IterableTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 
@@ -41,25 +41,25 @@ public class TreeBagNoComparatorTest implements MutableSortedBagNoComparatorTest
     @Test
     public void OrderedIterable_getFirstOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getFirstOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getFirstOptional());
     }
 
     @Override
     @Test
     public void OrderedIterable_getLastOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getLastOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 3, 3, 2, 2, 1)).getLastOptional());
     }
 
     @Override
     @Test
     public void RichIterable_minByOptional_maxByOptional()
     {
-        assertEquals(Optional.of("ca"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("ca"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().minByOptional(string -> string.charAt(string.length() - 1)));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).minByOptional(Objects::isNull));
 
-        assertEquals(Optional.of("cz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("cz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().maxByOptional(string -> string.charAt(string.length() - 1)));
         assertThrows(NullPointerException.class, () -> this.newWith(new Object[]{null}).maxByOptional(Objects::isNull));
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/BiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/BiMapTestCase.java
@@ -16,10 +16,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.test.RichIterableUniqueTestCase;
 import org.eclipse.collections.test.map.MapIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 
 public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTestCase
 {
@@ -47,22 +47,22 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         RichIterableUniqueTestCase.super.Iterable_toString();
 
         BiMap<String, Integer> bimap = this.newWithKeysValues("Two", 2, "One", 1);
-        Assert.assertEquals("{Two=2, One=1}", bimap.toString());
-        Assert.assertEquals("[Two, One]", bimap.keysView().toString());
-        Assert.assertEquals("[2, 1]", bimap.valuesView().toString());
-        Assert.assertEquals("[Two:2, One:1]", bimap.keyValuesView().toString());
-        Assert.assertEquals("[2, 1]", bimap.asLazy().toString());
+        assertEquals("{Two=2, One=1}", bimap.toString());
+        assertEquals("[Two, One]", bimap.keysView().toString());
+        assertEquals("[2, 1]", bimap.valuesView().toString());
+        assertEquals("[Two:2, One:1]", bimap.keyValuesView().toString());
+        assertEquals("[2, 1]", bimap.asLazy().toString());
 
-        Assert.assertEquals(
+        assertEquals(
                 "{10=4, 9=4, 8=4, 7=4, 6=3, 5=3, 4=3, 3=2, 2=2, 1=1}",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).keysView().toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[4, 4, 4, 4, 3, 3, 3, 2, 2, 1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).valuesView().toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[10:4, 9:4, 8:4, 7:4, 6:3, 5:3, 4:3, 3:2, 2:2, 1:1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).keyValuesView().toString());
     }
@@ -73,20 +73,20 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         BiMap<Object, Integer> bimap = this.newWith(3, 2, 1);
         MutableCollection<Integer> forEachKeyValue = this.newMutableForFilter();
         bimap.forEachKeyValue((key, value) -> forEachKeyValue.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachKeyValue);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachKeyValue);
 
         BiMap<Integer, String> bimap2 = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         MutableCollection<String> forEachKeyValue2 = this.newMutableForFilter();
         bimap2.forEachKeyValue((key, value) -> forEachKeyValue2.add(key + value));
-        assertEquals(this.newMutableForFilter("3Three", "2Two", "1One"), forEachKeyValue2);
+        assertIterablesEqual(this.newMutableForFilter("3Three", "2Two", "1One"), forEachKeyValue2);
 
         MutableCollection<Integer> forEachValue = this.newMutableForFilter();
         bimap.forEachValue(value -> forEachValue.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachValue);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachValue);
 
         MutableCollection<Object> forEachKey = this.newMutableForFilter();
         bimap2.forEachKey(key -> forEachKey.add(key + 1));
-        assertEquals(this.newMutableForFilter(4, 3, 2), forEachKey);
+        assertIterablesEqual(this.newMutableForFilter(4, 3, 2), forEachKey);
     }
 
     @Override
@@ -95,7 +95,7 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         BiMap<String, Integer> bimap = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);
         BiMap<Integer, String> result = bimap.flipUniqueValues();
 
-        assertEquals(
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "Three", 2, "Two", 1, "One"),
                 result);
     }
@@ -113,14 +113,14 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         {
             MutableList<Integer> target = Lists.mutable.empty();
             iterable.forEachValue(target::add);
-            assertEquals(
+            assertIterablesEqual(
                     target,
                     iterable.toList());
         }
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.forEachKeyValue((key, value) -> target.add(value));
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }
@@ -131,11 +131,11 @@ public interface BiMapTestCase extends RichIterableUniqueTestCase, MapIterableTe
         BiMap<Object, Integer> bimap = this.newWith(3, 2, 1);
         MutableCollection<Integer> forEach = this.newMutableForFilter();
         bimap.forEach((key, value) -> forEach.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEach);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEach);
 
         BiMap<Integer, String> bimap2 = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         MutableCollection<String> forEach2 = this.newMutableForFilter();
         bimap2.forEach((key, value) -> forEach2.add(key + value));
-        assertEquals(this.newMutableForFilter("3Three", "2Two", "1One"), forEach2);
+        assertIterablesEqual(this.newMutableForFilter("3Three", "2Two", "1One"), forEach2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/UnsortedBiMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/bimap/UnsortedBiMapTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.test.bag.TransformsToBagTrait;
 import org.eclipse.collections.test.set.UnsortedSetLikeTestTrait;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
 
@@ -48,7 +48,7 @@ public interface UnsortedBiMapTestCase extends BiMapTestCase, TransformsToBagTra
         Iterator<Integer> iterator = iterable.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(2, iterable.size());
+        assertIterablesEqual(2, iterable.size());
         MutableSet<Integer> valuesSet = iterable.inverse().keysView().toSet();
         assertThat(
                 valuesSet,

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/immutable/ImmutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/immutable/ImmutableCollectionTestCase.java
@@ -16,7 +16,7 @@ import org.eclipse.collections.api.collection.ImmutableCollection;
 import org.eclipse.collections.test.RichIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -34,7 +34,7 @@ public interface ImmutableCollectionTestCase extends RichIterableTestCase
         String s = "";
         if (this.allowsDuplicates())
         {
-            assertEquals(2, this.newWith(s, s).size());
+            assertIterablesEqual(2, this.newWith(s, s).size());
         }
         else
         {
@@ -45,12 +45,12 @@ public interface ImmutableCollectionTestCase extends RichIterableTestCase
         ImmutableCollection<String> newCollection = collection.newWith(s);
         if (this.allowsDuplicates())
         {
-            assertEquals(2, newCollection.size());
-            assertEquals(this.newWith(s, s), newCollection);
+            assertIterablesEqual(2, newCollection.size());
+            assertIterablesEqual(this.newWith(s, s), newCollection);
         }
         else
         {
-            assertEquals(1, newCollection.size());
+            assertIterablesEqual(1, newCollection.size());
             assertSame(collection, newCollection);
         }
     }
@@ -71,12 +71,12 @@ public interface ImmutableCollectionTestCase extends RichIterableTestCase
         ImmutableCollection<Integer> immutableCollection = this.newWith(3, 3, 3, 2, 2, 1);
         ImmutableCollection<Integer> newWith = immutableCollection.newWith(4);
 
-        assertEquals(this.newWith(3, 3, 3, 2, 2, 1, 4), newWith);
+        assertIterablesEqual(this.newWith(3, 3, 3, 2, 2, 1, 4), newWith);
         assertNotSame(immutableCollection, newWith);
         assertThat(newWith, instanceOf(ImmutableCollection.class));
 
         ImmutableCollection<Integer> newWith2 = newWith.newWith(4);
 
-        assertEquals(this.newWith(3, 3, 3, 2, 2, 1, 4, 4), newWith2);
+        assertIterablesEqual(this.newWith(3, 3, 3, 2, 2, 1, 4, 4), newWith2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionTestCase.java
@@ -16,10 +16,10 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.test.CollectionTestCase;
-import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.RichIterableTestCase;
 import org.junit.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -42,7 +42,7 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
                     return 0;
                 },
                 0);
-        IterableTestCase.assertEquals(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), injectIntoWithIterationOrder);
+        assertIterablesEqual(this.newMutableForFilter(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), injectIntoWithIterationOrder);
     }
 
     // TODO try to make the return type of newWith and getInstanceUnderTest a generic parameter
@@ -61,8 +61,8 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
 
         MutableCollection<String> collection = this.newWith();
         assertTrue(collection.add(s));
-        IterableTestCase.assertEquals(this.allowsDuplicates(), collection.add(s));
-        IterableTestCase.assertEquals(this.allowsDuplicates() ? 2 : 1, collection.size());
+        assertIterablesEqual(this.allowsDuplicates(), collection.add(s));
+        assertIterablesEqual(this.allowsDuplicates() ? 2 : 1, collection.size());
     }
 
     @Test
@@ -77,20 +77,20 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 5, 4, 4, 3, 3, 2, 2, 1, 1);
         assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(5, 5, 3, 3, 1, 1), collection1);
+        assertIterablesEqual(this.getExpectedFiltered(5, 5, 3, 3, 1, 1), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3);
         assertFalse(collection2.removeIf(Predicates.cast(each -> each > 4)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(1, 2, 3), collection2);
+        assertIterablesEqual(this.getExpectedFiltered(1, 2, 3), collection2);
         assertTrue(collection2.removeIf(Predicates.cast(each -> each > 0)));
 
         MutableCollection<Integer> collection3 = this.newWith();
         assertFalse(collection3.removeIf(Predicates.cast(each -> each % 2 == 0)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(), collection3);
+        assertIterablesEqual(this.getExpectedFiltered(), collection3);
 
         MutableCollection<Integer> collection4 = this.newWith(2, 2, 4, 6);
         assertTrue(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(), collection4);
+        assertIterablesEqual(this.getExpectedFiltered(), collection4);
         assertFalse(collection4.removeIf(Predicates.cast(each -> each % 2 == 0)));
     }
 
@@ -99,20 +99,20 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 5, 4, 4, 3, 3, 2, 2, 1, 1);
         assertTrue(collection1.removeIfWith(Predicates2.in(), Lists.immutable.with(5, 3, 1)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(4, 4, 2, 2), collection1);
+        assertIterablesEqual(this.getExpectedFiltered(4, 4, 2, 2), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3);
         assertFalse(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(4)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(1, 2, 3), collection2);
+        assertIterablesEqual(this.getExpectedFiltered(1, 2, 3), collection2);
         assertTrue(collection2.removeIfWith(Predicates2.in(), Lists.immutable.with(1, 2, 3)));
 
         MutableCollection<Integer> collection3 = this.newWith();
         assertFalse(collection3.removeIfWith(Predicates2.in(), Lists.immutable.with()));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(), collection3);
+        assertIterablesEqual(this.getExpectedFiltered(), collection3);
 
         MutableCollection<Integer> collection4 = this.newWith(2, 2, 4, 6);
         assertTrue(collection4.removeIfWith(Predicates2.greaterThan(), 1));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(), collection4);
+        assertIterablesEqual(this.getExpectedFiltered(), collection4);
         assertFalse(collection4.removeIfWith(Predicates2.greaterThan(), 1));
     }
 
@@ -120,6 +120,6 @@ public interface MutableCollectionTestCase extends CollectionTestCase, RichItera
     default void MutableCollection_injectIntoWith()
     {
         MutableCollection<Integer> collection = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
-        IterableTestCase.assertEquals(Integer.valueOf(81), collection.injectIntoWith(1, (a, b, c) -> a + b + c, 5));
+        assertIterablesEqual(Integer.valueOf(81), collection.injectIntoWith(1, (a, b, c) -> a + b + c, 5));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionUniqueTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/collection/mutable/MutableCollectionUniqueTestCase.java
@@ -15,10 +15,10 @@ import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.block.factory.Predicates2;
-import org.eclipse.collections.test.IterableTestCase;
 import org.eclipse.collections.test.RichIterableUniqueTestCase;
 import org.junit.Test;
 
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +34,7 @@ public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCa
     {
         MutableCollection<Integer> collection1 = this.newWith(5, 4, 3, 2, 1);
         assertTrue(collection1.removeIf(Predicates.cast(each -> each % 2 == 0)));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(5, 3, 1), collection1);
+        assertIterablesEqual(this.getExpectedFiltered(5, 3, 1), collection1);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
         assertFalse(collection2.removeIf(Predicates.equal(5)));
@@ -54,7 +54,7 @@ public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCa
     {
         MutableCollection<Integer> collection = this.newWith(5, 4, 3, 2, 1);
         collection.removeIfWith(Predicates2.in(), Lists.immutable.with(5, 3, 1));
-        IterableTestCase.assertEquals(this.getExpectedFiltered(4, 2), collection);
+        assertIterablesEqual(this.getExpectedFiltered(4, 2), collection);
 
         MutableCollection<Integer> collection2 = this.newWith(1, 2, 3, 4);
         assertFalse(collection2.removeIf(Predicates.equal(5)));
@@ -72,6 +72,6 @@ public interface MutableCollectionUniqueTestCase extends MutableCollectionTestCa
     default void MutableCollection_injectIntoWith()
     {
         MutableCollection<Integer> collection = this.newWith(4, 3, 2, 1);
-        IterableTestCase.assertEquals(Integer.valueOf(51), collection.injectIntoWith(1, (argument1, argument2, argument3) -> argument1 + argument2 + argument3, 10));
+        assertIterablesEqual(Integer.valueOf(51), collection.injectIntoWith(1, (argument1, argument2, argument3) -> argument1 + argument2 + argument3, 10));
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/SelectInstancesOfIterableTestNoIteratorTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/lazy/SelectInstancesOfIterableTestNoIteratorTest.java
@@ -23,7 +23,7 @@ import org.eclipse.collections.test.list.mutable.FastListNoIterator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertSame;
 
 @RunWith(Java8Runner.class)
@@ -39,23 +39,23 @@ public class SelectInstancesOfIterableTestNoIteratorTest implements LazyNoIterat
     @Test
     public void RichIterable_minOptional_maxOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).minOptional());
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).minOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).minOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).minOptional());
         assertSame(Optional.empty(), this.newWith().minOptional());
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).minOptional());
 
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).maxOptional());
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).maxOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).maxOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).maxOptional());
         assertSame(Optional.empty(), this.newWith().maxOptional());
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).maxOptional());
 
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).minOptional(Comparators.reverseNaturalOrder()));
-        assertEquals(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).minOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(-1, 0, 1).minOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), this.newWith(1, 0, -1).minOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith().minOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).minOptional(Comparators.reverseNaturalOrder()));
 
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).maxOptional(Comparators.reverseNaturalOrder()));
-        assertEquals(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).maxOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(-1, 0, 1).maxOptional(Comparators.reverseNaturalOrder()));
+        assertIterablesEqual(Optional.of(Integer.valueOf(-1)), this.newWith(1, 0, -1).maxOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith().maxOptional(Comparators.reverseNaturalOrder()));
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).maxOptional(Comparators.reverseNaturalOrder()));
     }
@@ -64,11 +64,11 @@ public class SelectInstancesOfIterableTestNoIteratorTest implements LazyNoIterat
     @Test
     public void RichIterable_minByOptional_maxByOptional()
     {
-        assertEquals(Optional.of("da"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("da"), this.newWith("ed", "da", "ca", "bc", "ab").minByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().minByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).minByOptional(Objects::isNull));
 
-        assertEquals(Optional.of("dz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
+        assertIterablesEqual(Optional.of("dz"), this.newWith("ew", "dz", "cz", "bx", "ay").maxByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.<String>newWith().maxByOptional(string -> string.charAt(string.length() - 1)));
         assertSame(Optional.empty(), this.newWith(new Object[]{null}).maxByOptional(Objects::isNull));
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/FixedSizeListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/FixedSizeListTestCase.java
@@ -16,7 +16,7 @@ import java.util.ListIterator;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.test.FixedSizeCollectionTestCase;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertThrows;
 
 public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, ListTestCase
@@ -33,14 +33,14 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         assertThrows(UnsupportedOperationException.class, () -> sublist2.remove(1));
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
-        assertEquals(Lists.immutable.with("A", "B", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D"), list);
     }
 
     @Override
@@ -49,21 +49,21 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         ListIterator<String> iterator = sublist2.listIterator();
         assertThrows(UnsupportedOperationException.class, () -> iterator.add("X"));
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         ListIterator<String> iterator2 = sublist2.listIterator();
         iterator2.next();
         assertThrows(UnsupportedOperationException.class, iterator2::remove);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
-        assertEquals(Lists.immutable.with("A", "B", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D"), list);
     }
 
     @Override
@@ -72,18 +72,18 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         assertThrows(UnsupportedOperationException.class, () -> sublist2.addAll(Lists.mutable.of("D", "E")));
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         assertThrows(UnsupportedOperationException.class, sublist2::clear);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
-        assertEquals(Lists.immutable.with("A", "B", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D"), list);
     }
 
     @Override
@@ -92,12 +92,12 @@ public interface FixedSizeListTestCase extends FixedSizeCollectionTestCase, List
         List<String> list = this.newWith("A", "B", "C", "D", "E", "F");
         List<String> sublist = list.subList(3, 6);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("D", "E", "F"), sublist);
-        assertEquals(Lists.immutable.with("D", "E"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("D", "E", "F"), sublist);
+        assertIterablesEqual(Lists.immutable.with("D", "E"), sublist2);
 
         assertThrows(UnsupportedOperationException.class, sublist2::clear);
-        assertEquals(Lists.immutable.with("A", "B", "C", "D", "E", "F"), list);
-        assertEquals(Lists.immutable.with("D", "E", "F"), sublist);
-        assertEquals(Lists.immutable.with("D", "E"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D", "E", "F"), list);
+        assertIterablesEqual(Lists.immutable.with("D", "E", "F"), sublist);
+        assertIterablesEqual(Lists.immutable.with("D", "E"), sublist2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListIterableTestCase.java
@@ -24,7 +24,7 @@ import org.eclipse.collections.test.OrderedIterableWithDuplicatesTestCase;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertThrows;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 
 public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestCase, TransformsToListTrait
 {
@@ -55,7 +55,7 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
         RichIterable<Integer> integers = this.newWith(1, 2, 3);
         MutableCollection<Pair<Integer, Integer>> result = Lists.mutable.with();
         integers.forEachWithIndex((each, index) -> result.add(Tuples.pair(each, index)));
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(Tuples.pair(1, 0), Tuples.pair(2, 1), Tuples.pair(3, 2)),
                 result);
     }
@@ -69,7 +69,7 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
         integers.forEachInBoth(
                 strings,
                 (integer, string) -> result.add(Tuples.pair(integer, string)));
-        assertEquals(
+        assertIterablesEqual(
                 Lists.immutable.with(Tuples.pair(1, "1"), Tuples.pair(2, "2"), Tuples.pair(3, "3")),
                 result);
     }
@@ -78,22 +78,22 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
     default void ListIterable_indexOf()
     {
         ListIterable<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        assertEquals(3, integers.indexOf(3));
-        assertEquals(-1, integers.indexOf(0));
-        assertEquals(-1, integers.indexOf(null));
+        assertIterablesEqual(3, integers.indexOf(3));
+        assertIterablesEqual(-1, integers.indexOf(0));
+        assertIterablesEqual(-1, integers.indexOf(null));
         ListIterable<Integer> integers2 = this.newWith(1, 2, 2, null, 3, 3, 3, null, 4, 4, 4, 4);
-        assertEquals(3, integers2.indexOf(null));
+        assertIterablesEqual(3, integers2.indexOf(null));
     }
 
     @Test
     default void ListIterable_lastIndexOf()
     {
         ListIterable<Integer> integers = this.newWith(1, 2, 2, 3, 3, 3, 4, 4, 4, 4);
-        assertEquals(5, integers.lastIndexOf(3));
-        assertEquals(-1, integers.lastIndexOf(0));
-        assertEquals(-1, integers.lastIndexOf(null));
+        assertIterablesEqual(5, integers.lastIndexOf(3));
+        assertIterablesEqual(-1, integers.lastIndexOf(0));
+        assertIterablesEqual(-1, integers.lastIndexOf(null));
         ListIterable<Integer> integers2 = this.newWith(1, 2, 2, null, 3, 3, 3, null, 4, 4, 4, 4);
-        assertEquals(7, integers2.lastIndexOf(null));
+        assertIterablesEqual(7, integers2.lastIndexOf(null));
     }
 
     @Test
@@ -103,32 +103,32 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
 
         MutableList<Integer> result = Lists.mutable.empty();
         integers.forEach(5, 7, result::add);
-        assertEquals(Lists.immutable.with(3, 3, 2), result);
+        assertIterablesEqual(Lists.immutable.with(3, 3, 2), result);
 
         MutableList<Integer> result2 = Lists.mutable.empty();
         integers.forEach(0, 9, result2::add);
-        assertEquals(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result2);
+        assertIterablesEqual(Lists.immutable.with(4, 4, 4, 4, 3, 3, 3, 2, 2, 1), result2);
 
         ListIterable<Integer> integers2 = this.newWith(4, 4, 4, 4, 3, 3, 3);
         MutableList<Integer> result3 = Lists.mutable.empty();
         integers2.forEach(5, 6, result3::add);
-        assertEquals(Lists.immutable.with(3, 3), result3);
+        assertIterablesEqual(Lists.immutable.with(3, 3), result3);
 
         MutableList<Integer> result4 = Lists.mutable.empty();
         integers2.forEach(3, 3, result4::add);
-        assertEquals(Lists.immutable.with(4), result4);
+        assertIterablesEqual(Lists.immutable.with(4), result4);
 
         MutableList<Integer> result5 = Lists.mutable.empty();
         integers2.forEach(4, 4, result5::add);
-        assertEquals(Lists.immutable.with(3), result5);
+        assertIterablesEqual(Lists.immutable.with(3), result5);
 
         MutableList<Integer> result6 = Lists.mutable.empty();
         integers2.forEach(5, 5, result6::add);
-        assertEquals(Lists.immutable.with(3), result6);
+        assertIterablesEqual(Lists.immutable.with(3), result6);
 
         MutableList<Integer> result7 = Lists.mutable.empty();
         integers2.forEach(6, 6, result7::add);
-        assertEquals(Lists.immutable.with(3), result7);
+        assertIterablesEqual(Lists.immutable.with(3), result7);
 
         assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
         assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));
@@ -142,7 +142,7 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
         ListIterable<Integer> integers = this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1);
         MutableList<Integer> result = Lists.mutable.empty();
         integers.forEach(7, 5, result::add);
-        assertEquals(Lists.immutable.with(2, 3, 3), result);
+        assertIterablesEqual(Lists.immutable.with(2, 3, 3), result);
     }
 
     @Test
@@ -150,9 +150,9 @@ public interface ListIterableTestCase extends OrderedIterableWithDuplicatesTestC
     {
         ListIterable<String> letters = this.newWith("A", "a", "b", "c", "B", "D", "e", "e", "E", "D").distinct(HashingStrategies.fromFunction(String::toLowerCase));
         ListIterable<String> expected = FastList.newListWith("A", "b", "c", "D", "e");
-        assertEquals(letters, expected);
+        assertIterablesEqual(letters, expected);
 
         ListIterable<String> empty = this.<String>newWith().distinct(HashingStrategies.fromFunction(String::toLowerCase));
-        assertEquals(empty, this.newWith());
+        assertIterablesEqual(empty, this.newWith());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/ListTestCase.java
@@ -16,10 +16,10 @@ import java.util.ListIterator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.test.CollectionTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public interface ListTestCase extends CollectionTestCase
@@ -41,23 +41,23 @@ public interface ListTestCase extends CollectionTestCase
         Iterator<Integer> iterator = list.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(this.newWith(3, 3, 2, 2, 1), list);
+        assertIterablesEqual(this.newWith(3, 3, 2, 2, 1), list);
     }
 
     @Override
     default void Iterable_toString()
     {
         Iterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
-        Assert.assertEquals("[3, 3, 3, 2, 2, 1]", iterable.toString());
+        assertEquals("[3, 3, 3, 2, 2, 1]", iterable.toString());
     }
 
     @Test
     default void List_get()
     {
         List<Integer> list = this.newWith(1, 2, 3);
-        assertEquals(Integer.valueOf(1), list.get(0));
-        assertEquals(Integer.valueOf(2), list.get(1));
-        assertEquals(Integer.valueOf(3), list.get(2));
+        assertIterablesEqual(Integer.valueOf(1), list.get(0));
+        assertIterablesEqual(Integer.valueOf(2), list.get(1));
+        assertIterablesEqual(Integer.valueOf(3), list.get(2));
     }
 
     @Test
@@ -76,17 +76,17 @@ public interface ListTestCase extends CollectionTestCase
     default void List_set()
     {
         List<Integer> list = this.newWith(3, 2, 1);
-        assertEquals(3, list.set(0, 4));
-        assertEquals(this.newWith(4, 2, 1), list);
-        assertEquals(2, list.set(1, 4));
-        assertEquals(this.newWith(4, 4, 1), list);
-        assertEquals(1, list.set(2, 4));
-        assertEquals(this.newWith(4, 4, 4), list);
+        assertIterablesEqual(3, list.set(0, 4));
+        assertIterablesEqual(this.newWith(4, 2, 1), list);
+        assertIterablesEqual(2, list.set(1, 4));
+        assertIterablesEqual(this.newWith(4, 4, 1), list);
+        assertIterablesEqual(1, list.set(2, 4));
+        assertIterablesEqual(this.newWith(4, 4, 4), list);
 
         assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, 4));
-        assertEquals(this.newWith(4, 4, 4), list);
+        assertIterablesEqual(this.newWith(4, 4, 4), list);
         assertThrows(IndexOutOfBoundsException.class, () -> list.set(3, 4));
-        assertEquals(this.newWith(4, 4, 4), list);
+        assertIterablesEqual(this.newWith(4, 4, 4), list);
     }
 
     @Test
@@ -95,19 +95,19 @@ public interface ListTestCase extends CollectionTestCase
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         sublist2.add("X");
 
-        assertEquals(Lists.immutable.with("A", "B", "X", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B", "X"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "X", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "X"), sublist2);
 
-        assertEquals("B", sublist2.remove(1));
-        assertEquals(Lists.immutable.with("A", "X", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "X"), sublist2);
+        assertIterablesEqual("B", sublist2.remove(1));
+        assertIterablesEqual(Lists.immutable.with("A", "X", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "X"), sublist2);
 
-        assertEquals(Lists.immutable.with("A", "X", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "X", "C", "D"), list);
     }
 
     @Test
@@ -116,21 +116,21 @@ public interface ListTestCase extends CollectionTestCase
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         ListIterator<String> iterator = sublist2.listIterator();
         iterator.add("X");
-        assertEquals(Lists.immutable.with("X", "A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("X", "A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("X", "A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("X", "A", "B"), sublist2);
 
         ListIterator<String> iterator2 = sublist2.listIterator();
         iterator2.next();
         iterator2.remove();
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
-        assertEquals(Lists.immutable.with("A", "B", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D"), list);
     }
 
     @Test
@@ -139,18 +139,18 @@ public interface ListTestCase extends CollectionTestCase
         List<String> list = this.newWith("A", "B", "C", "D");
         List<String> sublist = list.subList(0, 3);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
 
         sublist2.addAll(Lists.mutable.of("D", "E"));
-        assertEquals(Lists.immutable.with("A", "B", "D", "E", "C"), sublist);
-        assertEquals(Lists.immutable.with("A", "B", "D", "E"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "D", "E", "C"), sublist);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "D", "E"), sublist2);
 
         sublist2.clear();
-        assertEquals(Lists.immutable.with("C"), sublist);
-        assertEquals(Lists.immutable.with(), sublist2);
+        assertIterablesEqual(Lists.immutable.with("C"), sublist);
+        assertIterablesEqual(Lists.immutable.with(), sublist2);
 
-        assertEquals(Lists.immutable.with("C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("C", "D"), list);
     }
 
     @Test
@@ -159,17 +159,17 @@ public interface ListTestCase extends CollectionTestCase
         List<String> list = this.newWith("A", "B", "C", "D", "E", "F");
         List<String> sublist = list.subList(3, 6);
         List<String> sublist2 = sublist.subList(0, 2);
-        assertEquals(Lists.immutable.with("D", "E", "F"), sublist);
-        assertEquals(Lists.immutable.with("D", "E"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("D", "E", "F"), sublist);
+        assertIterablesEqual(Lists.immutable.with("D", "E"), sublist2);
 
         sublist2.clear();
-        assertEquals(Lists.immutable.with("A", "B", "C", "F"), list);
-        assertEquals(Lists.immutable.with("F"), sublist);
-        assertEquals(Lists.immutable.with(), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "F"), list);
+        assertIterablesEqual(Lists.immutable.with("F"), sublist);
+        assertIterablesEqual(Lists.immutable.with(), sublist2);
 
         sublist2.add("J");
-        assertEquals(Lists.immutable.with("A", "B", "C", "J", "F"), list);
-        assertEquals(Lists.immutable.with("J", "F"), sublist);
-        assertEquals(Lists.immutable.with("J"), sublist2);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "J", "F"), list);
+        assertIterablesEqual(Lists.immutable.with("J", "F"), sublist);
+        assertIterablesEqual(Lists.immutable.with("J"), sublist2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MultiReaderFastListTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MultiReaderFastListTest.java
@@ -25,7 +25,7 @@ import org.eclipse.collections.test.collection.mutable.MultiReaderMutableCollect
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -62,7 +62,7 @@ public class MultiReaderFastListTest implements MutableListTestCase, MultiReader
                 iterationOrder.add(iterator.next());
             }
         });
-        assertEquals(this.expectedIterationOrder(), iterationOrder);
+        assertIterablesEqual(this.expectedIterationOrder(), iterationOrder);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class MultiReaderFastListTest implements MutableListTestCase, MultiReader
                 mutableCollection.add(integer);
             }
 
-            assertEquals(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
+            assertIterablesEqual(this.getExpectedFiltered(3, 3, 3, 2, 2, 1), mutableCollection);
             assertFalse(iterator.hasNext());
         });
     }
@@ -134,16 +134,16 @@ public class MultiReaderFastListTest implements MutableListTestCase, MultiReader
             List<String> sublist2 = sublist.subList(0, 2);
             ListIterator<String> iterator = sublist2.listIterator();
             iterator.add("X");
-            assertEquals(Lists.immutable.with("X", "A", "B", "C"), sublist);
-            assertEquals(Lists.immutable.with("X", "A", "B"), sublist2);
+            assertIterablesEqual(Lists.immutable.with("X", "A", "B", "C"), sublist);
+            assertIterablesEqual(Lists.immutable.with("X", "A", "B"), sublist2);
 
             ListIterator<String> iterator2 = sublist2.listIterator();
             iterator2.next();
             iterator2.remove();
-            assertEquals(Lists.immutable.with("A", "B", "C"), sublist);
-            assertEquals(Lists.immutable.with("A", "B"), sublist2);
+            assertIterablesEqual(Lists.immutable.with("A", "B", "C"), sublist);
+            assertIterablesEqual(Lists.immutable.with("A", "B"), sublist2);
         });
 
-        assertEquals(Lists.immutable.with("A", "B", "C", "D"), list);
+        assertIterablesEqual(Lists.immutable.with("A", "B", "C", "D"), list);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MutableListTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/list/mutable/MutableListTestCase.java
@@ -25,7 +25,7 @@ import org.eclipse.collections.test.list.ListIterableTestCase;
 import org.eclipse.collections.test.list.ListTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertSame;
 
 public interface MutableListTestCase extends MutableCollectionTestCase, ListTestCase, ListIterableTestCase, MutableOrderedIterableTestCase
@@ -57,7 +57,7 @@ public interface MutableListTestCase extends MutableCollectionTestCase, ListTest
         MutableList<Integer> mutableList = this.newWith(5, 1, 4, 2, 3);
         MutableList<Integer> sortedList = mutableList.sortThis();
         assertSame(mutableList, sortedList);
-        assertEquals(Lists.immutable.with(1, 2, 3, 4, 5), sortedList);
+        assertIterablesEqual(Lists.immutable.with(1, 2, 3, 4, 5), sortedList);
     }
 
     @Test
@@ -67,7 +67,7 @@ public interface MutableListTestCase extends MutableCollectionTestCase, ListTest
         MutableList<Integer> mutableList1 = this.newWith(integers);
         MutableList<Integer> mutableList2 = this.newWith(integers);
         Collections.shuffle(mutableList1, new Random(10));
-        assertEquals(mutableList1, mutableList2.shuffleThis(new Random(10)));
+        assertIterablesEqual(mutableList1, mutableList2.shuffleThis(new Random(10)));
 
         MutableList<Integer> list = this.newWith(1, 2, 3);
         UnifiedSet<ImmutableList<Integer>> objects = UnifiedSet.newSet();
@@ -80,11 +80,11 @@ public interface MutableListTestCase extends MutableCollectionTestCase, ListTest
         MutableList<Integer> bigList = this.newWith(interval.toArray());
         MutableList<Integer> shuffledBigList = bigList.shuffleThis(new Random(8));
         MutableList<Integer> integers1 = this.newWith(interval.toArray());
-        assertEquals(integers1.shuffleThis(new Random(8)), bigList);
+        assertIterablesEqual(integers1.shuffleThis(new Random(8)), bigList);
         assertSame(bigList, shuffledBigList);
         assertSame(bigList, bigList.shuffleThis());
         assertSame(bigList, bigList.shuffleThis(new Random(8)));
-        assertEquals(interval.toBag(), bigList.toBag());
+        assertIterablesEqual(interval.toBag(), bigList.toBag());
     }
 
     @Test
@@ -93,6 +93,6 @@ public interface MutableListTestCase extends MutableCollectionTestCase, ListTest
         MutableList<Integer> mutableList = this.newWith(5, 1, 4, 2, 3);
         MutableList<Integer> sortedList = mutableList.sortThis(Comparators.reverseNaturalOrder());
         assertSame(mutableList, sortedList);
-        assertEquals(Lists.immutable.with(5, 4, 3, 2, 1), sortedList);
+        assertIterablesEqual(Lists.immutable.with(5, 4, 3, 2, 1), sortedList);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/MapIterableTestCase.java
@@ -24,10 +24,10 @@ import org.eclipse.collections.impl.test.SerializeTestHelper;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.test.RichIterableWithDuplicatesTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -56,29 +56,29 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     {
         MapIterable<Object, String> original = this.newWith("Three", "Two", "One");
         MapIterable<Object, String> copy = SerializeTestHelper.serializeDeserialize(original);
-        assertEquals(copy, original);
+        assertIterablesEqual(copy, original);
     }
 
     @Override
     default void Iterable_toString()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Two", 2, "One", 1);
-        Assert.assertEquals("{Two=2, One=1}", map.toString());
-        Assert.assertEquals("[Two, One]", map.keysView().toString());
-        Assert.assertEquals("[2, 1]", map.valuesView().toString());
-        Assert.assertEquals("[Two:2, One:1]", map.keyValuesView().toString());
-        Assert.assertEquals("[2, 1]", map.asLazy().toString());
+        assertEquals("{Two=2, One=1}", map.toString());
+        assertEquals("[Two, One]", map.keysView().toString());
+        assertEquals("[2, 1]", map.valuesView().toString());
+        assertEquals("[Two:2, One:1]", map.keyValuesView().toString());
+        assertEquals("[2, 1]", map.asLazy().toString());
 
-        Assert.assertEquals(
+        assertEquals(
                 "{10=4, 9=4, 8=4, 7=4, 6=3, 5=3, 4=3, 3=2, 2=2, 1=1}",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).keysView().toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[4, 4, 4, 4, 3, 3, 3, 2, 2, 1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).valuesView().toString());
-        Assert.assertEquals(
+        assertEquals(
                 "[10:4, 9:4, 8:4, 7:4, 6:3, 5:3, 4:3, 3:2, 2:2, 1:1]",
                 this.newWith(4, 4, 4, 4, 3, 3, 3, 2, 2, 1).keyValuesView().toString());
     }
@@ -87,11 +87,11 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     default void MapIterable_ifPresentApply()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);
-        assertEquals(13, map.ifPresentApply("Three", x -> x + 10));
-        assertEquals(12, map.ifPresentApply("Two", x -> x + 10));
-        assertEquals(11, map.ifPresentApply("One", x -> x + 10));
+        assertIterablesEqual(13, map.ifPresentApply("Three", x -> x + 10));
+        assertIterablesEqual(12, map.ifPresentApply("Two", x -> x + 10));
+        assertIterablesEqual(11, map.ifPresentApply("One", x -> x + 10));
         assertNull(map.ifPresentApply("Zero", x -> x + 10));
-        assertEquals(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
+        assertIterablesEqual(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
     }
 
     @Test
@@ -118,30 +118,30 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<String, Long> expected =
                 Maps.mutable.with(lessThanTen, Interval.fromTo(1, 9).sumOfInt(Integer::intValue),
                         greaterOrEqualsToTen, Interval.fromTo(10, 20).sumOfInt(Integer::intValue));
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Test
     default void MapIterable_getIfAbsent()
     {
         MapIterable<String, Integer> map = this.newWithKeysValues("Three", 3, "Two", 2, "One", 1);
-        assertEquals(3, map.getIfAbsentValue("Three", 0));
-        assertEquals(2, map.getIfAbsentValue("Two", 0));
-        assertEquals(1, map.getIfAbsentValue("One", 0));
-        assertEquals(0, map.getIfAbsentValue("Zero", 0));
-        assertEquals(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
+        assertIterablesEqual(3, map.getIfAbsentValue("Three", 0));
+        assertIterablesEqual(2, map.getIfAbsentValue("Two", 0));
+        assertIterablesEqual(1, map.getIfAbsentValue("One", 0));
+        assertIterablesEqual(0, map.getIfAbsentValue("Zero", 0));
+        assertIterablesEqual(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
 
-        assertEquals(3, map.getIfAbsent("Three", () -> 0));
-        assertEquals(2, map.getIfAbsent("Two", () -> 0));
-        assertEquals(1, map.getIfAbsent("One", () -> 0));
-        assertEquals(0, map.getIfAbsent("Zero", () -> 0));
-        assertEquals(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
+        assertIterablesEqual(3, map.getIfAbsent("Three", () -> 0));
+        assertIterablesEqual(2, map.getIfAbsent("Two", () -> 0));
+        assertIterablesEqual(1, map.getIfAbsent("One", () -> 0));
+        assertIterablesEqual(0, map.getIfAbsent("Zero", () -> 0));
+        assertIterablesEqual(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
 
-        assertEquals(3, map.getIfAbsentWith("Three", x -> x + 1, 13));
-        assertEquals(2, map.getIfAbsentWith("Two", x -> x + 1, 12));
-        assertEquals(1, map.getIfAbsentWith("One", x -> x + 1, 11));
-        assertEquals(11, map.getIfAbsentWith("Zero", x -> x + 1, 10));
-        assertEquals(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
+        assertIterablesEqual(3, map.getIfAbsentWith("Three", x -> x + 1, 13));
+        assertIterablesEqual(2, map.getIfAbsentWith("Two", x -> x + 1, 12));
+        assertIterablesEqual(1, map.getIfAbsentWith("One", x -> x + 1, 11));
+        assertIterablesEqual(11, map.getIfAbsentWith("Zero", x -> x + 1, 10));
+        assertIterablesEqual(map, this.newWithKeysValues("Three", 3, "Two", 2, "One", 1));
     }
 
     @Test
@@ -168,20 +168,20 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<Object, Integer> map = this.newWith(3, 3, 3, 2, 2, 1);
         MutableCollection<Integer> forEachKeyValue = this.newMutableForFilter();
         map.forEachKeyValue((key, value) -> forEachKeyValue.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachKeyValue);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachKeyValue);
 
         MapIterable<Integer, String> map2 = this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three");
         MutableCollection<String> forEachKeyValue2 = this.newMutableForFilter();
         map2.forEachKeyValue((key, value) -> forEachKeyValue2.add(key + value));
-        assertEquals(this.newMutableForFilter("3Three", "2Two", "1Three"), forEachKeyValue2);
+        assertIterablesEqual(this.newMutableForFilter("3Three", "2Two", "1Three"), forEachKeyValue2);
 
         MutableCollection<Integer> forEachValue = this.newMutableForFilter();
         map.forEachValue(value -> forEachValue.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachValue);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEachValue);
 
         MutableCollection<Object> forEachKey = this.newMutableForFilter();
         map2.forEachKey(key -> forEachKey.add(key + 1));
-        assertEquals(this.newMutableForFilter(4, 3, 2), forEachKey);
+        assertIterablesEqual(this.newMutableForFilter(4, 3, 2), forEachKey);
     }
 
     @Test
@@ -189,11 +189,11 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     {
         MapIterable<Integer, Integer> map1 = this.newWithKeysValues(3, 3, 2, 2, 1, 1);
         Integer sum1 = map1.injectIntoKeyValue(0, (sum, key, value) -> sum + key + value);
-        assertEquals(12, sum1);
+        assertIterablesEqual(12, sum1);
 
         MutableMap<Integer, String> result = map1.injectIntoKeyValue(Maps.mutable.empty(),
                 (map, key, value) -> map.withKeyValue(key, value.toString()));
-        assertEquals(Maps.mutable.with(3, "3", 2, "2", 1, "1"), result);
+        assertIterablesEqual(Maps.mutable.with(3, "3", 2, "2", 1, "1"), result);
     }
 
     @Test
@@ -203,7 +203,7 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<Integer, String> result = map.flipUniqueValues();
 
         // TODO: Set up methods like getExpectedTransformed, but for maps.
-        assertEquals(
+        assertIterablesEqual(
                 UnifiedMap.newWithKeysValues(3, "Three", 2, "Two", 1, "One"),
                 result);
 
@@ -219,7 +219,7 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         MapIterable<Integer, String> actual = map.collect((key, value) -> Tuples.pair(key + 1, key + value));
         // TODO: Use IterableTestCase.assertEquals instead, after setting up methods like getExpectedTransformed, but for maps.
-        Assert.assertEquals(Maps.mutable.with(4, "3Three", 3, "2Two", 2, "1One"), actual);
+        assertEquals(Maps.mutable.with(4, "3Three", 3, "2Two", 2, "1One"), actual);
     }
 
     @Test
@@ -227,7 +227,7 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     {
         MapIterable<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         MapIterable<Integer, String> actual = map.collectValues((argument1, argument2) -> new StringBuilder(argument2).reverse().toString());
-        assertEquals(
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "eerhT", 2, "owT", 1, "enO"),
                 actual);
     }
@@ -238,11 +238,11 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         MapIterable<Object, Object> expected = this.newWithKeysValues(2, "Two", 1, "One");
 
-        assertEquals(
+        assertIterablesEqual(
                 expected,
                 map.select((key1, value1) -> key1.equals(1) || value1.equals("Two")));
 
-        assertEquals(
+        assertIterablesEqual(
                 expected,
                 map.reject((key, value) -> !key.equals(1) && !value.equals("Two")));
     }
@@ -251,8 +251,8 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
     default void MapIterable_detect()
     {
         MapIterable<String, String> map = this.newWithKeysValues("1", "One", "2", "Two", "3", "Three");
-        assertEquals(Tuples.pair("1", "One"), map.detect((key1, value1) -> "1".equals(key1)));
-        assertEquals(Tuples.pair("2", "Two"), map.detect((key1, value1) -> "Two".equals(value1)));
+        assertIterablesEqual(Tuples.pair("1", "One"), map.detect((key1, value1) -> "1".equals(key1)));
+        assertIterablesEqual(Tuples.pair("2", "Two"), map.detect((key1, value1) -> "Two".equals(value1)));
         assertNull(map.detect((ignored1, ignored2) -> false));
 
         MutableCollection<Integer> expectedIterationOrder = this.expectedIterationOrder();
@@ -262,15 +262,15 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
             detectIterationOrder.add(value);
             return false;
         });
-        assertEquals(expectedIterationOrder, detectIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectIterationOrder);
     }
 
     @Test
     default void MapIterable_detectOptional()
     {
         MapIterable<String, String> map = this.newWithKeysValues("1", "One", "2", "Two", "3", "Three");
-        assertEquals(Optional.of(Tuples.pair("1", "One")), map.detectOptional((key1, value1) -> "1".equals(key1)));
-        assertEquals(Optional.of(Tuples.pair("2", "Two")), map.detectOptional((key1, value1) -> "Two".equals(value1)));
+        assertIterablesEqual(Optional.of(Tuples.pair("1", "One")), map.detectOptional((key1, value1) -> "1".equals(key1)));
+        assertIterablesEqual(Optional.of(Tuples.pair("2", "Two")), map.detectOptional((key1, value1) -> "Two".equals(value1)));
         assertSame(Optional.empty(), map.detectOptional((ignored1, ignored2) -> false));
 
         MutableCollection<Integer> expectedIterationOrder = this.expectedIterationOrder();
@@ -280,7 +280,7 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
             detectOptionalIterationOrder.add(value);
             return false;
         });
-        assertEquals(expectedIterationOrder, detectOptionalIterationOrder);
+        assertIterablesEqual(expectedIterationOrder, detectOptionalIterationOrder);
     }
 
     @Test
@@ -326,11 +326,11 @@ public interface MapIterableTestCase extends RichIterableWithDuplicatesTestCase
         MapIterable<Object, Integer> map = this.newWith(3, 3, 3, 2, 2, 1);
         MutableCollection<Integer> forEach = this.newMutableForFilter();
         map.forEach((key, value) -> forEach.add(value + 10));
-        assertEquals(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEach);
+        assertIterablesEqual(this.newMutableForFilter(13, 13, 13, 12, 12, 11), forEach);
 
         MapIterable<Integer, String> map2 = this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three");
         MutableCollection<String> forEach2 = this.newMutableForFilter();
         map2.forEach((key, value) -> forEach2.add(key + value));
-        assertEquals(this.newMutableForFilter("3Three", "2Two", "1Three"), forEach2);
+        assertIterablesEqual(this.newMutableForFilter("3Three", "2Two", "1Three"), forEach2);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/OrderedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/OrderedMapIterableTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.test.OrderedIterableTestCase;
 import org.eclipse.collections.test.list.TransformsToListTrait;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertThrows;
 
 public interface OrderedMapIterableTestCase extends MapIterableTestCase, OrderedIterableTestCase, TransformsToListTrait
@@ -46,12 +46,12 @@ public interface OrderedMapIterableTestCase extends MapIterableTestCase, Ordered
     default void take()
     {
         OrderedMap<Integer, String> orderedMap = this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three");
-        assertEquals(this.newWithKeysValues(), orderedMap.take(0));
-        assertEquals(this.newWithKeysValues(3, "Three"), orderedMap.take(1));
-        assertEquals(this.newWithKeysValues(3, "Three", 2, "Two"), orderedMap.take(2));
-        assertEquals(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(3));
-        assertEquals(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(4));
-        assertEquals(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(Integer.MAX_VALUE));
+        assertIterablesEqual(this.newWithKeysValues(), orderedMap.take(0));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three"), orderedMap.take(1));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two"), orderedMap.take(2));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(3));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(4));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.take(Integer.MAX_VALUE));
         assertThrows(IllegalArgumentException.class, () -> orderedMap.take(-1));
     }
 
@@ -59,12 +59,12 @@ public interface OrderedMapIterableTestCase extends MapIterableTestCase, Ordered
     default void drop()
     {
         OrderedMap<Integer, String> orderedMap = this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three");
-        assertEquals(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.drop(0));
-        assertEquals(this.newWithKeysValues(2, "Two", 1, "Three"), orderedMap.drop(1));
-        assertEquals(this.newWithKeysValues(1, "Three"), orderedMap.drop(2));
-        assertEquals(this.newWithKeysValues(), orderedMap.drop(3));
-        assertEquals(this.newWithKeysValues(), orderedMap.drop(4));
-        assertEquals(this.newWithKeysValues(), orderedMap.drop(Integer.MAX_VALUE));
+        assertIterablesEqual(this.newWithKeysValues(3, "Three", 2, "Two", 1, "Three"), orderedMap.drop(0));
+        assertIterablesEqual(this.newWithKeysValues(2, "Two", 1, "Three"), orderedMap.drop(1));
+        assertIterablesEqual(this.newWithKeysValues(1, "Three"), orderedMap.drop(2));
+        assertIterablesEqual(this.newWithKeysValues(), orderedMap.drop(3));
+        assertIterablesEqual(this.newWithKeysValues(), orderedMap.drop(4));
+        assertIterablesEqual(this.newWithKeysValues(), orderedMap.drop(Integer.MAX_VALUE));
         assertThrows(IllegalArgumentException.class, () -> orderedMap.drop(-1));
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/UnsortedMapIterableTestCase.java
@@ -22,7 +22,7 @@ import org.eclipse.collections.test.UnorderedIterableTestCase;
 import org.eclipse.collections.test.bag.TransformsToBagTrait;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
 
@@ -92,7 +92,7 @@ public interface UnsortedMapIterableTestCase
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/ImmutableUnifiedMapTest.java
@@ -17,11 +17,11 @@ import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -67,7 +67,7 @@ public class ImmutableUnifiedMapTest implements ImmutableMapTestCase
         MapIterable<Integer, String> result = map.flipUniqueValues();
 
         // TODO: Use IterableTestCase.assertEquals instead, after setting up methods like getExpectedTransformed, but for maps.
-        Assert.assertEquals(
+        assertEquals(
                 UnifiedMap.newWithKeysValues(3, "Three", 2, "Two", 1, "One"),
                 result);
 
@@ -79,6 +79,6 @@ public class ImmutableUnifiedMapTest implements ImmutableMapTestCase
     @Test
     public void sanity()
     {
-        assertEquals("ImmutableUnifiedMap", this.newWith(1, 2, 3, 4, 5).getClass().getSimpleName());
+        assertIterablesEqual("ImmutableUnifiedMap", this.newWith(1, 2, 3, 4, 5).getClass().getSimpleName());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/strategy/ImmutableUnifiedMapWithHashingStrategyTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/immutable/strategy/ImmutableUnifiedMapWithHashingStrategyTest.java
@@ -21,7 +21,7 @@ import org.eclipse.collections.test.map.immutable.ImmutableMapTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -69,6 +69,6 @@ public class ImmutableUnifiedMapWithHashingStrategyTest implements ImmutableMapT
     @Test
     public void sanity()
     {
-        assertEquals("ImmutableUnifiedMapWithHashingStrategy", this.newWith(1, 2, 3, 4, 5).getClass().getSimpleName());
+        assertIterablesEqual("ImmutableUnifiedMapWithHashingStrategy", this.newWith(1, 2, 3, 4, 5).getClass().getSimpleName());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
@@ -14,10 +14,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -43,9 +43,9 @@ public interface MapTestCase
     default void Iterable_toString()
     {
         Map<String, Integer> map = this.newWithKeysValues("Two", 2, "One", 1);
-        Assert.assertEquals("[Two, One]", map.keySet().toString());
-        Assert.assertEquals("[2, 1]", map.values().toString());
-        Assert.assertEquals("[Two=2, One=1]", map.entrySet().toString());
+        assertEquals("[Two, One]", map.keySet().toString());
+        assertEquals("[2, 1]", map.values().toString());
+        assertEquals("[Two=2, One=1]", map.entrySet().toString());
     }
 
     @Test
@@ -53,32 +53,32 @@ public interface MapTestCase
     {
         Map<Object, String> map = this.newWith("Three", "Two", "One");
         map.clear();
-        assertEquals(this.newWith(), map);
+        assertIterablesEqual(this.newWith(), map);
 
         Map<Object, Object> map2 = this.newWith();
         map2.clear();
-        assertEquals(this.newWith(), map2);
+        assertIterablesEqual(this.newWith(), map2);
     }
 
     @Test
     default void Map_remove()
     {
         Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
-        assertEquals("Two", map.remove(2));
-        assertEquals(
+        assertIterablesEqual("Two", map.remove(2));
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "Three", 1, "One"),
                 map);
 
         if (this.supportsNullKeys())
         {
             assertNull(map.remove(null));
-            assertEquals(
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map);
 
             Map<Integer, String> map2 = this.newWithKeysValues(3, "Three", null, "Two", 1, "One");
-            assertEquals("Two", map2.remove(null));
-            assertEquals(
+            assertIterablesEqual("Two", map2.remove(null));
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map2);
         }
@@ -89,25 +89,25 @@ public interface MapTestCase
     {
         Map<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
         assertTrue(map.entrySet().remove(ImmutableEntry.of(2, "Two")));
-        assertEquals(
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "Three", 1, "One"),
                 map);
 
         assertFalse(map.entrySet().remove(ImmutableEntry.of(4, "Four")));
-        assertEquals(
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "Three", 1, "One"),
                 map);
 
         if (this.supportsNullKeys())
         {
             assertFalse(map.entrySet().remove(null));
-            assertEquals(
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map);
 
             Map<Integer, String> map2 = this.newWithKeysValues(3, "Three", null, "Two", 1, "One");
             assertTrue(map2.entrySet().remove(ImmutableEntry.of(null, "Two")));
-            assertEquals(
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map2);
         }
@@ -130,7 +130,7 @@ public interface MapTestCase
                 2, "Two",
                 1, "One");
 
-        assertEquals(expected, map);
+        assertIterablesEqual(expected, map);
 
         //Testing JDK map
         Map<Integer, String> map2 = this.newWithKeysValues(
@@ -141,7 +141,7 @@ public interface MapTestCase
         hashMaptoAdd.put(1, "One");
         map2.putAll(hashMaptoAdd);
 
-        assertEquals(expected, map2);
+        assertIterablesEqual(expected, map2);
     }
 
     @Test
@@ -154,43 +154,43 @@ public interface MapTestCase
             fail("Expected no merge to be performed since the value is null");
             return null;
         }));
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
 
         // null remapping function
         assertThrows(NullPointerException.class, () -> map.merge(1, "4", null));
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
 
         // new key, remapping function isn't called
         String value1 = map.merge(4, "4", (v1, v2) -> {
             fail("Expected no merge to be performed since the key is not present in the map");
             return null;
         });
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
-        assertEquals("4", value1);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3", 4, "4"), map);
+        assertIterablesEqual("4", value1);
 
         // exiting key
         String value2 = map.merge(2, "Two", (v1, v2) -> {
-            assertEquals("2", v1);
-            assertEquals("Two", v2);
+            assertIterablesEqual("2", v1);
+            assertIterablesEqual("Two", v2);
             return v1 + v2;
         });
-        Assert.assertEquals("2Two", value2);
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 3, "3", 4, "4"), map);
+        assertEquals("2Two", value2);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 3, "3", 4, "4"), map);
 
         // existing key, null returned from remapping function, removes key
         String value3 = map.merge(3, "Three", (v1, v2) -> null);
         assertNull(value3);
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4"), map);
 
         // new key, null returned from remapping function
         String value4 = map.merge(5, "5", (v1, v2) -> null);
-        Assert.assertEquals("5", value4);
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
+        assertEquals("5", value4);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
 
         // existing key, remapping function throws exception
         assertThrows(IllegalArgumentException.class, () -> map.merge(4, "Four", (v1, v2) -> {
             throw new IllegalArgumentException();
         }));
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
@@ -18,12 +18,12 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.impl.block.factory.Predicates2;
 import org.eclipse.collections.impl.list.Interval;
+import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.test.CollisionsTestCase;
 import org.eclipse.collections.test.map.MapIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.impl.test.Verify.assertIterablesEqual;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -57,21 +57,21 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
     default void MutableMapIterable_removeKey()
     {
         MutableMapIterable<Integer, String> map = this.newWithKeysValues(3, "Three", 2, "Two", 1, "One");
-        assertEquals("Two", map.removeKey(2));
-        assertEquals(
+        assertIterablesEqual("Two", map.removeKey(2));
+        assertIterablesEqual(
                 this.newWithKeysValues(3, "Three", 1, "One"),
                 map);
 
         if (this.supportsNullKeys())
         {
             assertNull(map.removeKey(null));
-            assertEquals(
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map);
 
             MutableMapIterable<Integer, String> map2 = this.newWithKeysValues(3, "Three", null, "Two", 1, "One");
-            assertEquals("Two", map2.removeKey(null));
-            assertEquals(
+            assertIterablesEqual("Two", map2.removeKey(null));
+            assertIterablesEqual(
                     this.newWithKeysValues(3, "Three", 1, "One"),
                     map2);
         }
@@ -83,68 +83,68 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
         MutableMapIterable<Integer, String> map1 = this.newWithKeysValues(1, "1", 2, "Two", 3, "Three");
 
         assertFalse(map1.removeIf(Predicates2.alwaysFalse()));
-        assertEquals(this.newWithKeysValues(1, "1", 2, "Two", 3, "Three"), map1);
+        assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "Two", 3, "Three"), map1);
         assertTrue(map1.removeIf(Predicates2.alwaysTrue()));
-        assertEquals(this.newWithKeysValues(), map1);
+        assertIterablesEqual(this.newWithKeysValues(), map1);
 
         MutableMapIterable<Integer, String> map2 = this.newWithKeysValues(1, "One", 2, "TWO", 3, "THREE", 4, "four", 5, "Five", 6, "Six", 7, "Seven", 8, "Eight");
         assertTrue(map2.removeIf((each, value) -> each % 2 == 0 && value.length() < 4));
-        assertEquals(this.newWithKeysValues(1, "One", 3, "THREE", 4, "four", 5, "Five", 7, "Seven", 8, "Eight"), map2);
+        assertIterablesEqual(this.newWithKeysValues(1, "One", 3, "THREE", 4, "four", 5, "Five", 7, "Seven", 8, "Eight"), map2);
 
         assertTrue(map2.removeIf((each, value) -> each % 2 != 0 && value.equals("THREE")));
-        assertEquals(this.newWithKeysValues(1, "One", 4, "four", 5, "Five", 7, "Seven", 8, "Eight"), map2);
+        assertIterablesEqual(this.newWithKeysValues(1, "One", 4, "four", 5, "Five", 7, "Seven", 8, "Eight"), map2);
 
         assertTrue(map2.removeIf((each, value) -> each % 2 != 0));
         assertFalse(map2.removeIf((each, value) -> each % 2 != 0));
-        assertEquals(this.newWithKeysValues(4, "four", 8, "Eight"), map2);
+        assertIterablesEqual(this.newWithKeysValues(4, "four", 8, "Eight"), map2);
 
         MutableMapIterable<Integer, String> map3 = this.newWithKeysValues(CollisionsTestCase.COLLISION_1, "0", CollisionsTestCase.COLLISION_2, "17", CollisionsTestCase.COLLISION_3, "34", 100, "100");
         assertTrue(map3.removeIf((key, value) -> CollisionsTestCase.COLLISION_1.equals(key) || CollisionsTestCase.COLLISION_2.equals(key) || CollisionsTestCase.COLLISION_3.equals(key)));
-        assertEquals(this.newWithKeysValues(100, "100"), map3);
+        assertIterablesEqual(this.newWithKeysValues(100, "100"), map3);
 
         MutableMapIterable<Integer, String> map4 = this.newWithKeysValues(CollisionsTestCase.COLLISION_1, "0", CollisionsTestCase.COLLISION_2, "17", CollisionsTestCase.COLLISION_3, "34", 100, "100");
         assertTrue(map4.removeIf(Predicates2.alwaysTrue()));
-        assertEquals(this.newWithKeysValues(), map4);
+        assertIterablesEqual(this.newWithKeysValues(), map4);
 
         MutableMapIterable<Integer, String> map5 = this.newWithKeysValues(CollisionsTestCase.COLLISION_1, "0", CollisionsTestCase.COLLISION_2, "17", CollisionsTestCase.COLLISION_3, "34", 100, "100");
         assertTrue(map5.removeIf((key, value) -> CollisionsTestCase.COLLISION_1.equals(key) || CollisionsTestCase.COLLISION_3.equals(key)));
-        assertEquals(this.newWithKeysValues(CollisionsTestCase.COLLISION_2, "17", 100, "100"), map5);
+        assertIterablesEqual(this.newWithKeysValues(CollisionsTestCase.COLLISION_2, "17", 100, "100"), map5);
     }
 
     @Test
     default void MutableMapIterable_getIfAbsentPut()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map.getIfAbsentPut("3", () -> {
+        assertIterablesEqual(3, map.getIfAbsentPut("3", () -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
-        assertEquals(4, map.getIfAbsentPut("4", () -> 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 4), map);
+        assertIterablesEqual(4, map.getIfAbsentPut("4", () -> 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 4), map);
 
         MutableMapIterable<String, Integer> map2 = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map2.getIfAbsentPut("3", 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map2);
+        assertIterablesEqual(3, map2.getIfAbsentPut("3", 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map2);
 
-        assertEquals(4, map2.getIfAbsentPut("4", 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 4), map2);
+        assertIterablesEqual(4, map2.getIfAbsentPut("4", 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 4), map2);
 
         MutableMapIterable<String, Integer> map3 = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map3.getIfAbsentPutWithKey("3", key -> {
+        assertIterablesEqual(3, map3.getIfAbsentPutWithKey("3", key -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map3);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map3);
 
-        assertEquals(14, map3.getIfAbsentPutWithKey("4", key -> Integer.parseInt(key) + 10));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 14), map3);
+        assertIterablesEqual(14, map3.getIfAbsentPutWithKey("4", key -> Integer.parseInt(key) + 10));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 14), map3);
 
         MutableMapIterable<String, Integer> map4 = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map4.getIfAbsentPutWith("3", x -> x + 10, 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map4);
+        assertIterablesEqual(3, map4.getIfAbsentPutWith("3", x -> x + 10, 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map4);
 
-        assertEquals(14, map4.getIfAbsentPutWith("4", x -> x + 10, 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 14), map4);
+        assertIterablesEqual(14, map4.getIfAbsentPutWith("4", x -> x + 10, 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1, "4", 14), map4);
     }
 
     @Test
@@ -152,33 +152,33 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
     {
         MutableMapIterable<Integer, Integer> map = this.newWithKeysValues();
         Interval.oneTo(1000).each(each -> map.updateValue(each % 10, () -> 0, integer -> integer + 1));
-        assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
-        assertIterablesEqual(Collections.nCopies(10, 100), map.values());
+        assertIterablesEqual(Interval.zeroTo(9).toSet(), map.keySet());
+        Verify.assertIterablesEqual(Collections.nCopies(10, 100), map.values());
 
         MutableMapIterable<Integer, Integer> map2 = this.newWithKeysValues();
         MutableList<Integer> list = Interval.oneTo(2000).toList().shuffleThis();
         list.each(each -> map2.updateValue(each % 1000, () -> 0, integer -> integer + 1));
-        assertEquals(Interval.zeroTo(999).toSet(), map2.keySet());
-        assertIterablesEqual(
+        assertIterablesEqual(Interval.zeroTo(999).toSet(), map2.keySet());
+        Verify.assertIterablesEqual(
                 Bags.mutable.withAll(map2.values()).toStringOfItemToCount(),
                 Collections.nCopies(1000, 2),
                 map2.values());
 
         MutableMapIterable<Integer, Integer> map3 = this.newWithKeysValues();
         Function2<Integer, String, Integer> increment = (integer, parameter) -> {
-            assertEquals("test", parameter);
+            assertIterablesEqual("test", parameter);
             return integer + 1;
         };
 
         Interval.oneTo(1000).each(each -> map3.updateValueWith(each % 10, () -> 0, increment, "test"));
-        assertEquals(Interval.zeroTo(9).toSet(), map3.keySet());
-        assertIterablesEqual(Collections.nCopies(10, 100), map3.values());
+        assertIterablesEqual(Interval.zeroTo(9).toSet(), map3.keySet());
+        Verify.assertIterablesEqual(Collections.nCopies(10, 100), map3.values());
 
         MutableMapIterable<Integer, Integer> map4 = this.newWithKeysValues();
         MutableList<Integer> list2 = Interval.oneTo(2000).toList().shuffleThis();
         list2.each(each -> map4.updateValueWith(each % 1000, () -> 0, increment, "test"));
-        assertEquals(Interval.zeroTo(999).toSet(), map4.keySet());
-        assertIterablesEqual(
+        assertIterablesEqual(Interval.zeroTo(999).toSet(), map4.keySet());
+        Verify.assertIterablesEqual(
                 Bags.mutable.withAll(map4.values()).toStringOfItemToCount(),
                 Collections.nCopies(1000, 2),
                 map4.values());

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapTestCase.java
@@ -17,7 +17,7 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.test.MutableUnorderedIterableTestCase;
 import org.eclipse.collections.test.map.UnsortedMapIterableTestCase;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
 
@@ -47,7 +47,7 @@ public interface MutableMapTestCase extends UnsortedMapIterableTestCase, Mutable
         Iterator<Integer> iterator = iterable.iterator();
         iterator.next();
         iterator.remove();
-        assertEquals(this.allowsDuplicates() ? 5 : 2, Iterate.sizeOf(iterable));
+        assertIterablesEqual(this.allowsDuplicates() ? 5 : 2, Iterate.sizeOf(iterable));
         assertThat(iterable.toBag(), isOneOf(
                 this.getExpectedFiltered(3, 3, 3, 2, 2),
                 this.getExpectedFiltered(3, 3, 3, 2, 1),

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/UnmodifiableMutableMapTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.impl.map.mutable.UnmodifiableMutableMap;
 import org.eclipse.collections.impl.test.junit.Java8Runner;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -121,31 +121,31 @@ public class UnmodifiableMutableMapTest implements MutableMapTestCase, FixedSize
     public void MutableMapIterable_getIfAbsentPut()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map.getIfAbsentPut("3", () -> {
+        assertIterablesEqual(3, map.getIfAbsentPut("3", () -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut("4", () -> {
             throw new AssertionError();
         }));
 
-        assertEquals(3, map.getIfAbsentPut("3", 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(3, map.getIfAbsentPut("3", 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut("4", 4));
 
-        assertEquals(3, map.getIfAbsentPutWithKey("3", key -> {
+        assertIterablesEqual(3, map.getIfAbsentPutWithKey("3", key -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWithKey("4", key -> {
             throw new AssertionError();
         }));
 
-        assertEquals(3, map.getIfAbsentPutWith("3", x -> x + 10, 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(3, map.getIfAbsentPutWith("3", x -> x + 10, 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith("4", x -> x + 10, 4));
     }
@@ -189,6 +189,6 @@ public class UnmodifiableMutableMapTest implements MutableMapTestCase, FixedSize
             fail("Expected lambda not to be called on unmodifiable map");
             return null;
         }));
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/ordered/UnmodifiableMutableOrderedMapTest.java
@@ -20,11 +20,11 @@ import org.eclipse.collections.impl.map.ordered.mutable.UnmodifiableMutableOrder
 import org.eclipse.collections.impl.test.junit.Java8Runner;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
 import org.eclipse.collections.test.FixedSizeIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -129,31 +129,31 @@ public class UnmodifiableMutableOrderedMapTest implements MutableOrderedMapTestC
     public void MutableMapIterable_getIfAbsentPut()
     {
         MutableMapIterable<String, Integer> map = this.newWithKeysValues("3", 3, "2", 2, "1", 1);
-        assertEquals(3, map.getIfAbsentPut("3", () -> {
+        assertIterablesEqual(3, map.getIfAbsentPut("3", () -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut("4", () -> {
             throw new AssertionError();
         }));
 
-        assertEquals(3, map.getIfAbsentPut("3", 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(3, map.getIfAbsentPut("3", 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPut("4", 4));
 
-        assertEquals(3, map.getIfAbsentPutWithKey("3", key -> {
+        assertIterablesEqual(3, map.getIfAbsentPutWithKey("3", key -> {
             throw new AssertionError();
         }));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWithKey("4", key -> {
             throw new AssertionError();
         }));
 
-        assertEquals(3, map.getIfAbsentPutWith("3", x -> x + 10, 4));
-        assertEquals(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
+        assertIterablesEqual(3, map.getIfAbsentPutWith("3", x -> x + 10, 4));
+        assertIterablesEqual(this.newWithKeysValues("3", 3, "2", 2, "1", 1), map);
 
         assertThrows(UnsupportedOperationException.class, () -> map.getIfAbsentPutWith("4", x -> x + 10, 4));
     }
@@ -197,6 +197,6 @@ public class UnmodifiableMutableOrderedMapTest implements MutableOrderedMapTestC
             fail("Expected lambda not to be called on unmodifiable map");
             return null;
         }));
-        Assert.assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
+        assertEquals(this.newWithKeysValues(1, "1", 2, "2", 3, "3"), map);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetIterableTestCase.java
@@ -17,12 +17,12 @@ import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.test.CollisionsTestCase;
 import org.eclipse.collections.test.RichIterableUniqueTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
-import static org.eclipse.collections.test.IterableTestCase.assertNotEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesNotEqual;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public interface SetIterableTestCase extends RichIterableUniqueTestCase, CollisionsTestCase
 {
@@ -46,33 +46,33 @@ public interface SetIterableTestCase extends RichIterableUniqueTestCase, Collisi
         for (Integer collision : COLLISIONS)
         {
             list.add(collision);
-            assertEquals(
+            assertIterablesEqual(
                     this.newWith(list.toArray()),
                     this.newWith(list.toArray()));
         }
 
         Verify.assertEqualsAndHashCode(this.newWith(), this.newWith());
 
-        assertNotEquals(this.newWith(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4));
-        assertNotEquals(this.newWith(1, 2, 3, 4), this.newWith(1, 2, 3));
-        assertNotEquals(this.newWith(1, 2, 3), this.newWith(1, 2));
-        assertNotEquals(this.newWith(1, 2), this.newWith(1));
-        assertNotEquals(this.newWith(1), this.newWith());
+        assertIterablesNotEqual(this.newWith(1, 2, 3, 4, 5), this.newWith(1, 2, 3, 4));
+        assertIterablesNotEqual(this.newWith(1, 2, 3, 4), this.newWith(1, 2, 3));
+        assertIterablesNotEqual(this.newWith(1, 2, 3), this.newWith(1, 2));
+        assertIterablesNotEqual(this.newWith(1, 2), this.newWith(1));
+        assertIterablesNotEqual(this.newWith(1), this.newWith());
 
         SetIterable<Integer> expected = Sets.mutable.with(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4);
-        assertNotEquals(expected, this.newWith(COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5));
-        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_3, COLLISION_4, COLLISION_5));
-        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_4, COLLISION_5));
-        assertNotEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_5));
+        assertIterablesNotEqual(expected, this.newWith(COLLISION_2, COLLISION_3, COLLISION_4, COLLISION_5));
+        assertIterablesNotEqual(expected, this.newWith(COLLISION_1, COLLISION_3, COLLISION_4, COLLISION_5));
+        assertIterablesNotEqual(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_4, COLLISION_5));
+        assertIterablesNotEqual(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_5));
 
-        Assert.assertEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4));
+        assertEquals(expected, this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, COLLISION_4));
 
         if (this.allowsNull())
         {
-            assertEquals(this.newWith(null, COLLISION_1, COLLISION_2, COLLISION_3), this.newWith(null, COLLISION_1, COLLISION_2, COLLISION_3));
-            assertEquals(this.newWith(COLLISION_1, null, COLLISION_2, COLLISION_3), this.newWith(COLLISION_1, null, COLLISION_2, COLLISION_3));
-            assertEquals(this.newWith(COLLISION_1, COLLISION_2, null, COLLISION_3), this.newWith(COLLISION_1, COLLISION_2, null, COLLISION_3));
-            assertEquals(this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, null), this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, null));
+            assertIterablesEqual(this.newWith(null, COLLISION_1, COLLISION_2, COLLISION_3), this.newWith(null, COLLISION_1, COLLISION_2, COLLISION_3));
+            assertIterablesEqual(this.newWith(COLLISION_1, null, COLLISION_2, COLLISION_3), this.newWith(COLLISION_1, null, COLLISION_2, COLLISION_3));
+            assertIterablesEqual(this.newWith(COLLISION_1, COLLISION_2, null, COLLISION_3), this.newWith(COLLISION_1, COLLISION_2, null, COLLISION_3));
+            assertIterablesEqual(this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, null), this.newWith(COLLISION_1, COLLISION_2, COLLISION_3, null));
         }
     }
 
@@ -88,6 +88,6 @@ public interface SetIterableTestCase extends RichIterableUniqueTestCase, Collisi
     default void SetIterable_union()
     {
         SetIterable<Integer> union = this.newWith(3, 2, 1).union(this.newWith(5, 4, 3));
-        assertEquals(this.newWith(5, 4, 3, 2, 1), union);
+        assertIterablesEqual(this.newWith(5, 4, 3, 2, 1), union);
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/SetTestCase.java
@@ -21,7 +21,7 @@ import org.eclipse.collections.test.CollectionTestCase;
 import org.junit.Test;
 
 import static org.eclipse.collections.impl.test.Verify.assertPostSerializedEqualsAndHashCode;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isOneOf;
@@ -89,7 +89,7 @@ public interface SetTestCase extends CollectionTestCase
             assertTrue(mutableSet.add(integer));
         }
 
-        assertEquals(iterable, mutableSet);
+        assertIterablesEqual(iterable, mutableSet);
         assertFalse(iterator.hasNext());
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/UnsortedSetLikeTestTrait.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/UnsortedSetLikeTestTrait.java
@@ -23,7 +23,7 @@ import org.eclipse.collections.test.RichIterableUniqueTestCase;
 import org.eclipse.collections.test.UnorderedIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -66,7 +66,7 @@ public interface UnsortedSetLikeTestTrait extends RichIterableUniqueTestCase, Un
             mutableCollection.add(integer);
         }
 
-        assertEquals(this.getExpectedFiltered(3, 2, 1), mutableCollection);
+        assertIterablesEqual(this.getExpectedFiltered(3, 2, 1), mutableCollection);
         assertFalse(iterator.hasNext());
     }
 
@@ -77,7 +77,7 @@ public interface UnsortedSetLikeTestTrait extends RichIterableUniqueTestCase, Un
         RichIterable<Integer> integers = this.newWith(3, 2, 1);
         Integer first = integers.getFirst();
         assertThat(first, isOneOf(3, 2, 1));
-        assertEquals(integers.iterator().next(), first);
+        assertIterablesEqual(integers.iterator().next(), first);
     }
 
     @Override
@@ -178,7 +178,7 @@ public interface UnsortedSetLikeTestTrait extends RichIterableUniqueTestCase, Un
 
         MutableList<Integer> target = Lists.mutable.empty();
         iterable.each(target::add);
-        assertEquals(
+        assertIterablesEqual(
                 target,
                 iterable.toList());
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/ImmutableSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/ImmutableSetTestCase.java
@@ -18,7 +18,7 @@ import org.eclipse.collections.test.collection.immutable.ImmutableCollectionUniq
 import org.eclipse.collections.test.set.UnsortedSetIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -42,13 +42,13 @@ public interface ImmutableSetTestCase extends ImmutableCollectionUniqueTestCase,
         ImmutableCollection<Integer> immutableCollection = this.newWith(3, 2, 1);
         ImmutableCollection<Integer> newWith = immutableCollection.newWith(4);
 
-        assertEquals(this.newWith(3, 2, 1, 4), newWith);
+        assertIterablesEqual(this.newWith(3, 2, 1, 4), newWith);
         assertNotSame(immutableCollection, newWith);
         assertThat(newWith, instanceOf(ImmutableCollection.class));
 
         ImmutableCollection<Integer> newWith2 = newWith.newWith(4);
 
-        assertEquals(this.newWith(3, 2, 1, 4), newWith2);
+        assertIterablesEqual(this.newWith(3, 2, 1, 4), newWith2);
         assertSame(newWith, newWith2);
     }
 

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/sorted/ImmutableSortedSetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/immutable/sorted/ImmutableSortedSetIterableTestCase.java
@@ -15,7 +15,7 @@ import org.eclipse.collections.test.collection.immutable.ImmutableCollectionTest
 import org.eclipse.collections.test.set.sorted.SortedSetIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -33,12 +33,12 @@ public interface ImmutableSortedSetIterableTestCase extends SortedSetIterableTes
         ImmutableSortedSet<Integer> immutableCollection = this.newWith(3, 2, 1);
         ImmutableSortedSet<Integer> newWith = immutableCollection.newWith(4);
 
-        assertEquals(this.newWith(4, 3, 2, 1).castToSortedSet(), newWith.castToSortedSet());
+        assertIterablesEqual(this.newWith(4, 3, 2, 1).castToSortedSet(), newWith.castToSortedSet());
         assertNotSame(immutableCollection, newWith);
         assertThat(newWith, instanceOf(ImmutableSortedSet.class));
 
         ImmutableSortedSet<Integer> newWith2 = newWith.newWith(4);
         assertSame(newWith, newWith2);
-        assertEquals(this.newWith(4, 3, 2, 1).castToSortedSet(), newWith2.castToSortedSet());
+        assertIterablesEqual(this.newWith(4, 3, 2, 1).castToSortedSet(), newWith2.castToSortedSet());
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MultiReaderUnifiedSetTest.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MultiReaderUnifiedSetTest.java
@@ -21,7 +21,7 @@ import org.eclipse.collections.test.collection.mutable.MultiReaderMutableCollect
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -79,7 +79,7 @@ public class MultiReaderUnifiedSetTest implements MutableSetTestCase, MultiReade
                 iterationOrder.add(iterator.next());
             }
         });
-        assertEquals(this.expectedIterationOrder(), iterationOrder);
+        assertIterablesEqual(this.expectedIterationOrder(), iterationOrder);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class MultiReaderUnifiedSetTest implements MutableSetTestCase, MultiReade
                 mutableCollection.add(integer);
             }
 
-            assertEquals(this.getExpectedFiltered(3, 2, 1), mutableCollection);
+            assertIterablesEqual(this.getExpectedFiltered(3, 2, 1), mutableCollection);
             assertFalse(iterator.hasNext());
         });
     }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/mutable/MutableSetTestCase.java
@@ -16,7 +16,7 @@ import org.eclipse.collections.test.set.SetTestCase;
 import org.eclipse.collections.test.set.UnsortedSetIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 
 public interface MutableSetTestCase extends SetTestCase, UnsortedSetIterableTestCase, MutableCollectionUniqueTestCase
 {
@@ -70,7 +70,7 @@ public interface MutableSetTestCase extends SetTestCase, UnsortedSetIterableTest
         {
             MutableSet<Integer> singleCollisionBucket = this.newWith(COLLISION_1, COLLISION_2);
             singleCollisionBucket.remove(COLLISION_2);
-            assertEquals(singleCollisionBucket, this.newWith(COLLISION_1));
+            assertIterablesEqual(singleCollisionBucket, this.newWith(COLLISION_1));
         }
     }
 }

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetIterableTestCase.java
@@ -29,11 +29,11 @@ import org.eclipse.collections.test.domain.B;
 import org.eclipse.collections.test.domain.C;
 import org.eclipse.collections.test.list.TransformsToListTrait;
 import org.eclipse.collections.test.set.SetIterableTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
-import static org.eclipse.collections.impl.test.Verify.assertThrows;
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIterableTestCase, TransformsToListTrait
 {
@@ -62,21 +62,21 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     default void SortedSetIterable_union()
     {
         SortedSetIterable<Integer> union = this.newWith(1, 2, 3).union(this.newWith(3, 4, 5));
-        assertEquals(SortedSets.immutable.with(Comparators.reverseNaturalOrder(), 5, 4, 3, 2, 1), union);
+        assertIterablesEqual(SortedSets.immutable.with(Comparators.reverseNaturalOrder(), 5, 4, 3, 2, 1), union);
     }
 
     @Override
     @Test
     default void RichIterable_getFirst_empty_null()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().getFirst());
+        assertThrows(NoSuchElementException.class, () -> this.newWith().getFirst());
     }
 
     @Override
     @Test
     default void RichIterable_getLast_empty_null()
     {
-        Assert.assertThrows(NoSuchElementException.class, () -> this.newWith().getLast());
+        assertThrows(NoSuchElementException.class, () -> this.newWith().getLast());
     }
 
     @Override
@@ -86,46 +86,46 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
         // Must test with two classes that are mutually Comparable
 
         SortedSetIterable<A> numbers = this.newWith(new C(4.0), new B(3), new C(2.0), new B(1));
-        assertEquals(this.getExpectedFiltered(new B(3), new B(1)), numbers.selectInstancesOf(B.class));
-        assertEquals(this.getExpectedFiltered(new C(4.0), new B(3), new C(2.0), new B(1)), numbers.selectInstancesOf(A.class));
+        assertIterablesEqual(this.getExpectedFiltered(new B(3), new B(1)), numbers.selectInstancesOf(B.class));
+        assertIterablesEqual(this.getExpectedFiltered(new C(4.0), new B(3), new C(2.0), new B(1)), numbers.selectInstancesOf(A.class));
     }
 
     @Override
     default void OrderedIterable_getFirst()
     {
-        assertEquals(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
+        assertIterablesEqual(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
     }
 
     @Override
     @Test
     default void OrderedIterable_getFirstOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 2, 1)).getFirstOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(3)), ((OrderedIterable<?>) this.newWith(3, 2, 1)).getFirstOptional());
     }
 
     @Override
     default void OrderedIterable_getLast()
     {
-        assertEquals(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
     }
 
     @Override
     @Test
     default void OrderedIterable_getLastOptional()
     {
-        assertEquals(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 2, 1)).getLastOptional());
+        assertIterablesEqual(Optional.of(Integer.valueOf(1)), ((OrderedIterable<?>) this.newWith(3, 2, 1)).getLastOptional());
     }
 
     @Override
     default void RichIterable_getFirst()
     {
-        assertEquals(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
+        assertIterablesEqual(Integer.valueOf(3), this.newWith(3, 2, 1).getFirst());
     }
 
     @Override
     default void RichIterable_getLast()
     {
-        assertEquals(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(3, 2, 1).getLast());
     }
 
     @Override
@@ -157,7 +157,7 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     default void OrderedIterable_zipWithIndex()
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(4, 0),
                         Tuples.pair(3, 1),
@@ -171,7 +171,7 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
     default void OrderedIterable_zipWithIndex_target()
     {
         RichIterable<Integer> iterable = this.newWith(4, 3, 2, 1);
-        Assert.assertEquals(
+        assertEquals(
                 Lists.immutable.with(
                         Tuples.pair(4, 0),
                         Tuples.pair(3, 1),
@@ -187,23 +187,23 @@ public interface SortedSetIterableTestCase extends SetIterableTestCase, SortedIt
 
         MutableList<Integer> result = Lists.mutable.empty();
         integers.forEach(5, 7, result::add);
-        assertEquals(Lists.immutable.with(4, 3, 2), result);
+        assertIterablesEqual(Lists.immutable.with(4, 3, 2), result);
 
         MutableList<Integer> result2 = Lists.mutable.empty();
         integers.forEach(5, 5, result2::add);
-        assertEquals(Lists.immutable.with(4), result2);
+        assertIterablesEqual(Lists.immutable.with(4), result2);
 
         MutableList<Integer> result3 = Lists.mutable.empty();
         integers.forEach(0, 9, result3::add);
-        assertEquals(Lists.immutable.with(9, 8, 7, 6, 5, 4, 3, 2, 1, 0), result3);
+        assertIterablesEqual(Lists.immutable.with(9, 8, 7, 6, 5, 4, 3, 2, 1, 0), result3);
 
         MutableList<Integer> result4 = Lists.mutable.empty();
         integers.forEach(0, 0, result4::add);
-        assertEquals(Lists.immutable.with(9), result4);
+        assertIterablesEqual(Lists.immutable.with(9), result4);
 
         MutableList<Integer> result5 = Lists.mutable.empty();
         integers.forEach(9, 9, result5::add);
-        assertEquals(Lists.immutable.with(0), result5);
+        assertIterablesEqual(Lists.immutable.with(0), result5);
 
         assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(-1, 0, result::add));
         assertThrows(IndexOutOfBoundsException.class, () -> integers.forEach(0, -1, result::add));

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/set/sorted/SortedSetTestCase.java
@@ -18,7 +18,7 @@ import java.util.SortedSet;
 import org.eclipse.collections.test.CollectionTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -37,11 +37,11 @@ public interface SortedSetTestCase extends CollectionTestCase
 
         Iterator<Integer> iterator = iterable.iterator();
         assertTrue(iterator.hasNext());
-        assertEquals(Integer.valueOf(3), iterator.next());
+        assertIterablesEqual(Integer.valueOf(3), iterator.next());
         assertTrue(iterator.hasNext());
-        assertEquals(Integer.valueOf(2), iterator.next());
+        assertIterablesEqual(Integer.valueOf(2), iterator.next());
         assertTrue(iterator.hasNext());
-        assertEquals(Integer.valueOf(1), iterator.next());
+        assertIterablesEqual(Integer.valueOf(1), iterator.next());
         assertFalse(iterator.hasNext());
     }
 
@@ -51,9 +51,9 @@ public interface SortedSetTestCase extends CollectionTestCase
     {
         Iterable<Integer> iterable = this.newWith(3, 2, 1);
         Iterator<Integer> iterator = iterable.iterator();
-        assertEquals(Integer.valueOf(3), iterator.next());
+        assertIterablesEqual(Integer.valueOf(3), iterator.next());
         iterator.remove();
-        assertEquals(this.newWith(2, 1), iterable);
+        assertIterablesEqual(this.newWith(2, 1), iterable);
     }
 
     @Override

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/StackIterableTestCase.java
@@ -22,7 +22,7 @@ import org.eclipse.collections.impl.block.factory.Procedures;
 import org.eclipse.collections.test.OrderedIterableWithDuplicatesTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -56,7 +56,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
         RichIterable<Integer> integers = this.newWith(3, 3, 3, 2, 2, 1);
         MutableStack<Integer> result = Stacks.mutable.with();
         integers.forEach(Procedures.cast(result::push));
-        assertEquals(this.newWith(1, 2, 2, 3, 3, 3), result);
+        assertIterablesEqual(this.newWith(1, 2, 2, 3, 3, 3), result);
     }
 
     @Override
@@ -66,7 +66,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
         MutableStack<Integer> result = Stacks.mutable.with();
         iterable.tap(result::push).forEach(Procedures.noop());
-        assertEquals(this.newWith(1, 2, 2, 3, 3, 3), result);
+        assertIterablesEqual(this.newWith(1, 2, 2, 3, 3, 3), result);
 
         this.newWith().tap(Procedures.cast(each -> fail()));
     }
@@ -77,7 +77,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
         RichIterable<Integer> iterable = this.newWith(3, 3, 3, 2, 2, 1);
         MutableStack<Integer> result = Stacks.mutable.with();
         iterable.forEachWith((argument1, argument2) -> result.push(argument1 + argument2), 10);
-        assertEquals(this.getExpectedFiltered(11, 12, 12, 13, 13, 13), result);
+        assertIterablesEqual(this.getExpectedFiltered(11, 12, 12, 13, 13, 13), result);
     }
 
     @Override
@@ -97,7 +97,7 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
     @Test
     default void StackIterable_peek()
     {
-        assertEquals(Integer.valueOf(5), this.newWith(5, 1, 4, 2, 3).peek());
+        assertIterablesEqual(Integer.valueOf(5), this.newWith(5, 1, 4, 2, 3).peek());
     }
 
     @Test
@@ -109,11 +109,11 @@ public interface StackIterableTestCase extends OrderedIterableWithDuplicatesTest
     @Test
     default void StackIterable_peekAt()
     {
-        assertEquals(Integer.valueOf(5), this.newWith(5, 1, 4, 2, 3).peekAt(0));
-        assertEquals(Integer.valueOf(1), this.newWith(5, 1, 4, 2, 3).peekAt(1));
-        assertEquals(Integer.valueOf(4), this.newWith(5, 1, 4, 2, 3).peekAt(2));
-        assertEquals(Integer.valueOf(2), this.newWith(5, 1, 4, 2, 3).peekAt(3));
-        assertEquals(Integer.valueOf(3), this.newWith(5, 1, 4, 2, 3).peekAt(4));
+        assertIterablesEqual(Integer.valueOf(5), this.newWith(5, 1, 4, 2, 3).peekAt(0));
+        assertIterablesEqual(Integer.valueOf(1), this.newWith(5, 1, 4, 2, 3).peekAt(1));
+        assertIterablesEqual(Integer.valueOf(4), this.newWith(5, 1, 4, 2, 3).peekAt(2));
+        assertIterablesEqual(Integer.valueOf(2), this.newWith(5, 1, 4, 2, 3).peekAt(3));
+        assertIterablesEqual(Integer.valueOf(3), this.newWith(5, 1, 4, 2, 3).peekAt(4));
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/immutable/ImmutableStackTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/immutable/ImmutableStackTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.test.stack.StackIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 
@@ -43,8 +43,8 @@ public interface ImmutableStackTestCase extends StackIterableTestCase
     {
         ImmutableStack<Integer> immutableStack = this.newWith(5, 1, 4, 2, 3);
         ImmutableStack<Integer> poppedStack = immutableStack.pop();
-        assertEquals(Stacks.immutable.withReversed(1, 4, 2, 3), poppedStack);
-        assertEquals(Stacks.immutable.withReversed(5, 1, 4, 2, 3), immutableStack);
+        assertIterablesEqual(Stacks.immutable.withReversed(1, 4, 2, 3), poppedStack);
+        assertIterablesEqual(Stacks.immutable.withReversed(5, 1, 4, 2, 3), immutableStack);
     }
 
     @Test
@@ -63,9 +63,9 @@ public interface ImmutableStackTestCase extends StackIterableTestCase
         Pair<Integer, ImmutableStack<Integer>> elementAndStack = immutableStack.peekAndPop();
         Integer poppedElement = elementAndStack.getOne();
         ImmutableStack<Integer> poppedStack = elementAndStack.getTwo();
-        assertEquals(5, poppedElement);
-        assertEquals(Stacks.immutable.withReversed(1, 4, 2, 3), poppedStack);
-        assertEquals(Stacks.immutable.withReversed(5, 1, 4, 2, 3), immutableStack);
+        assertIterablesEqual(5, poppedElement);
+        assertIterablesEqual(Stacks.immutable.withReversed(1, 4, 2, 3), poppedStack);
+        assertIterablesEqual(Stacks.immutable.withReversed(5, 1, 4, 2, 3), immutableStack);
     }
 
     @Test

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/mutable/MutableStackTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/stack/mutable/MutableStackTestCase.java
@@ -18,7 +18,7 @@ import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.test.stack.StackIterableTestCase;
 import org.junit.Test;
 
-import static org.eclipse.collections.test.IterableTestCase.assertEquals;
+import static org.eclipse.collections.test.IterableTestCase.assertIterablesEqual;
 import static org.junit.Assert.assertThrows;
 
 public interface MutableStackTestCase extends StackIterableTestCase
@@ -40,19 +40,19 @@ public interface MutableStackTestCase extends StackIterableTestCase
     default void MutableStack_pop()
     {
         MutableStack<Integer> mutableStack = this.newWith(5, 1, 4, 2, 3);
-        assertEquals(Integer.valueOf(5), mutableStack.pop());
-        assertEquals(Stacks.immutable.withReversed(1, 4, 2, 3), mutableStack);
+        assertIterablesEqual(Integer.valueOf(5), mutableStack.pop());
+        assertIterablesEqual(Stacks.immutable.withReversed(1, 4, 2, 3), mutableStack);
     }
 
     @Test
     default void MutableStack_pop_throws()
     {
         MutableStack<Integer> mutableStack = this.newWith(5, 1, 4, 2, 3);
-        assertEquals(Integer.valueOf(5), mutableStack.pop());
-        assertEquals(Integer.valueOf(1), mutableStack.pop());
-        assertEquals(Integer.valueOf(4), mutableStack.pop());
-        assertEquals(Integer.valueOf(2), mutableStack.pop());
-        assertEquals(Integer.valueOf(3), mutableStack.pop());
+        assertIterablesEqual(Integer.valueOf(5), mutableStack.pop());
+        assertIterablesEqual(Integer.valueOf(1), mutableStack.pop());
+        assertIterablesEqual(Integer.valueOf(4), mutableStack.pop());
+        assertIterablesEqual(Integer.valueOf(2), mutableStack.pop());
+        assertIterablesEqual(Integer.valueOf(3), mutableStack.pop());
         assertThrows(EmptyStackException.class, mutableStack::pop);
     }
 }


### PR DESCRIPTION
This PR is a preparation for the **unit-tests-java8** module for migration to Junit5. 

- Moves all junit4 assertions to static imports
- Renames a few helper methods from **assertXXX** to **assertIterables(Equal/NotEqual)** as it makes the refactoring easier

cc @motlin 