### PR TITLE
Move bnd-maven-plugin to a profile.

### DIFF
--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -70,20 +70,6 @@
             </plugin>
 
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
@@ -106,6 +92,38 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>release-artifacts</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--region Phase 8: process-classes-->
+        <profile>
+            <id>bnd-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 8: process-classes-->
+
         <!--region Phase 17: package-->
         <profile>
             <id>maven-javadoc-plugin</id>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -79,20 +79,6 @@
             </plugin>
 
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
 
@@ -115,6 +101,38 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>release-artifacts</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--region Phase 8: process-classes-->
+        <profile>
+            <id>bnd-maven-plugin</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 8: process-classes-->
+
         <!--region Phase 17: package-->
         <profile>
             <id>maven-javadoc-plugin</id>

--- a/pom.xml
+++ b/pom.xml
@@ -484,19 +484,6 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-
-                <plugin>
-                    <groupId>biz.aQute.bnd</groupId>
-                    <artifactId>bnd-maven-plugin</artifactId>
-                    <version>6.4.0</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>bnd-process</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1064,6 +1051,36 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
             </build>
         </profile>
         <!--endregion Phase 1: validate-->
+
+        <!--region Phase 8: process-classes-->
+        <profile>
+            <id>bnd-maven-plugin</id>
+
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
+                        <version>6.4.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>bnd-process</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--endregion Phase 8: process-classes-->
 
         <!--region Phase 16: prepare-package-->
         <profile>


### PR DESCRIPTION
Moved bnd-maven-plugin configuration to the release-artifacts profile so that it will affect released jars but will otherwise not affect local development.

cc @fipro78 